### PR TITLE
docs(bspline): settle ownership, lifetime and derived-cache placement for the bspline port

### DIFF
--- a/design/bspline_derived_caches.md
+++ b/design/bspline_derived_caches.md
@@ -451,10 +451,14 @@ Three prohibitions, each with the concrete failure behind it rather than as a ma
 - **#396 `BsplineSpace1D` / `BsplineSpace`.** The whole of the above. Its `AC` set should say
   **one** memo, not fourteen; should require the `lru_cache` deleted *before* the C++ scan is
   dispatched (F6); and should include a TSan leg over the C++ unit tests, because that is the
-  only gate that can see F3. The repo already has a sanitizer job
-  (`origin/ci/sanitizer-job` exists as a branch), so what #396 owes is a *thread* leg over the
-  memo tests specifically, not new infrastructure -- confirm what that job already runs before
-  adding to it.
+  only gate that can see F3. **That is new infrastructure, and the note should not pretend
+  otherwise.** CI's existing sanitizer job is ASan + UBSan through the `gcc-debug` preset
+  (`.github/workflows/cpp.yaml:243`, `CMakePresets.json:36-41`), and
+  `-fsanitize=address` cannot be combined with `-fsanitize=thread`, so TSan needs its own preset
+  and its own job. #396 should weigh a permanent fourth `cpp.yaml` leg against a `gcc-tsan` preset
+  run from `scripts/ci_local.sh` and recorded per PR that adds a memo. Either is defensible; what
+  is not defensible is claiming the memo is race-free with nothing having looked, since F3 shows
+  60 clean runs prove nothing.
 - **#397 `THBSplineSpace`.** The CSR conversion, the footprint measurement it is contingent on,
   and the `span`-returning accessor that retires the "callers must not mutate" convention.
 - **#398 `Bspline`.** One derived block replaced wholesale by an in-place method; the three

--- a/design/bspline_derived_caches.md
+++ b/design/bspline_derived_caches.md
@@ -136,10 +136,15 @@ within a row unchanged. **Read the ratios, not the absolutes.**
   allocations, and at small `n` the allocations, not the scan, are the cost. My own first estimate
   -- "a small constant factor on an already-O(n) constructor" -- was wrong, and the measurement is
   what refuted it.
-- **`std::call_once` costs about 1.6 microseconds on its first call**, and the cost is
-  size-independent (1793 - 173 = 1620 ns at n=11; 1955 - 446 = 1509 ns at n=39), which is the
-  signature of glibc's `pthread_once` issuing a `FUTEX_WAKE` after running the initialiser even
-  with no waiters. At n=11 that is **ten times the entire construction**.
+- **`std::call_once` costs one to a few microseconds on its first call, and the cost is
+  size-independent.** The table's differences give 1620 ns at n=11 (1793 - 173) and 1509 ns at
+  n=39; an independent re-measurement on a differently-loaded machine gave 1.4 to 3.6 microseconds
+  across the same four sizes with no trend in `n`. **The mechanism was confirmed directly rather
+  than inferred**: `strace` on a minimal `call_once` program shows
+  `futex(..., FUTEX_WAKE_PRIVATE, 2147483647) = 0` on the first call with zero waiters, which is
+  glibc's `pthread_once` waking a queue that is empty. At n=11 that is roughly **ten times the
+  entire construction**. Take the microsecond order, not the figure: this box is shared and the
+  spread above is what concurrent load does to it.
 - **Double-checked locking over an `atomic<bool>` costs, on first use, within noise of computing
   eagerly** (188 vs 173, 484 vs 446, 3165 vs 3178, 22025 vs 18058) **and 2.9 to 8.0 ns per access
   thereafter.** It is free when the derived data is never touched and free when it is.
@@ -162,7 +167,12 @@ env, warm cache:
 | 263 | 1487 ns | 8075 ns | 4247 ns | 1.9x |
 | 2055 | 2738 ns | 23051 ns | 16894 ns | 1.4x |
 
-A factor of 1.4 to 2.1, against a kernel whose 4.3 microseconds for an eleven-element scan is
+An independent re-measurement gave 1.3x to 3.2x over the same sizes, on a box that was
+simultaneously running two other agents' sweeps. **The claim to carry is the order, not the
+figure: a modest constant factor, not an order of magnitude**, and the reason is structural rather
+than incidental -- the hit's own key handling is O(n), so it cannot be much cheaper than the scan.
+
+A factor of roughly 1.4 to 3.2, against a kernel whose 4.3 microseconds for an eleven-element scan is
 Numba dispatch overhead rather than work. **The port removes the thing the cache is hiding.** For
 comparison, the same three arrays computed in C++ inside the constructor cost 137 ns at n=11 and
 about 14.7 microseconds at n=2055 (the eager-arrays column minus the construct-only column above),
@@ -555,6 +565,12 @@ main decision is reversed.
   size-independent across two sizes. The construct-and-destroy benchmarks moved by up to 2x
   between runs of the same binary while every within-row ratio held; the tables report one run and
   the text says which readings survive that.
+- **Re-measured independently, same day, on the same shared box under other agents' load:** the
+  `call_once` first call at 1.4 to 3.6 microseconds with no trend in `n`, the DCLP-tracks-eager
+  result, the TSan races and the 60 clean runs without it, and F5's ratio at 1.3x to 3.2x. Two of
+  the four figures moved outside the range this note first stated, which is why the text now carries
+  the order rather than the number. **The `FUTEX_WAKE` mechanism was added by that pass**, from
+  `strace`, and it is the part that does not depend on the machine.
 - **Measured under ThreadSanitizer (g++ 14.4 `-fsanitize=thread`), 8 threads:** 4 data races in
   the bare `mutable std::optional` variant, all frames in its accessor; 0 in the `call_once` and
   eager variants in the same binary. **And measured without TSan: 60 of 60 runs produced the

--- a/design/bspline_derived_caches.md
+++ b/design/bspline_derived_caches.md
@@ -1,0 +1,602 @@
+# Where a derived cache lives once the spaces are C++-owned
+
+**Status:** proposed, 2026-08-31. Written for ticket #394, and binding on #395 to #401 if
+adopted.
+**Date:** 2026-08-31.
+**Scope:** which side of the seam a memoised derived quantity lives on, whether the Python
+wrapper keeps `__slots__`, how a lazy memo is made thread-safe, and the fate of the
+process-global knot cache. Not what an accessor hands back, which is
+`design/bspline_ownership_lifetime.md`. Not how the two backends are compared, which is
+`design/backend_parity.md`.
+**Companions:** `design/cross_backend_types.md` (the ownership ruling this obeys),
+`design/grid_hierarchy_port.md` (whose `D-a` this adopts and whose lazy-BVH shape this
+declines to copy), `design/bspline_ownership_lifetime.md` (the wrapper memo slots this note
+authorises and bounds).
+
+**Validated against:** `proto/cpp` at `a45e935`, worktree `design/393-394-bspline-decisions`,
+plus `feat/387-tensor-product-grid` at `d7b8654` read through `git show`. Python timings on the
+`pantr` env, CPython **3.14.6**, GIL enabled. C++ timings g++ **14.4.0** `-O2`, one pinned core.
+TSan is g++ 14.4's `-fsanitize=thread`.
+
+## The decision in one paragraph
+
+**A derived quantity of a domain type's frozen state lives in the C++ type. The Python wrapper
+memoises presentation and nothing else** -- the wrapper object standing in front of a nested
+C++-owned type, per `design/bspline_ownership_lifetime.md` -- and it keeps `__slots__` with a
+raising `__setattr__`; **`functools.cached_property` does not survive the port and the wrapper
+does not relax.** That is not "both", because the two memos hold different kinds of thing: the
+C++ memo holds the value, the wrapper's slot holds the Python object presenting it, and there is
+exactly one value. **The fourteen `cached_property` sites do not become fourteen
+`mutable std::optional`s**: seven of them (all of `BsplineSpace`'s) stop being memos at all, six
+become ordinary eager fields, and the one that allocates joins the other allocating derived
+arrays in **a single grouped memo behind one flag**. A lazy memo is guarded by
+**double-checked locking over an `std::atomic<bool>`** -- not a bare `mutable std::optional`,
+which is a data race demonstrated under TSan, and not `std::call_once`, whose first call was
+measured at about 1.6 microseconds, ten times the whole construction of a small space. The
+`lru_cache(128)` at `src/pantr/bspline/_bspline_space_1d.py:40` **is deleted as part of #396**,
+because it carries the same latent backend-collision defect that
+`src/pantr/_backend.py:525-555` already documents for a sibling, and its measured saving is a
+factor of 1.4 to 2.1 against a Numba dispatch the port removes anyway.
+
+## Findings against the ticket as written
+
+### F1 (important). The count is right and the framing is not: seven of the fourteen are not caches
+
+Verified by reading both classes. `BsplineSpace1D` has 7 `cached_property` and `BsplineSpace`
+has 7, so the ticket's fourteen is exact. (`src/pantr/bspline/` has 16 in total; the other two
+are on `SpanwiseElementExtraction`, outside the ticket's scope and inside #399's.)
+
+But **all seven of `BsplineSpace`'s are O(dim) reductions over its own children**, with `dim`
+at most 3 in every use in the tree: `degrees`, `tolerance`, `num_basis`, `num_total_basis`,
+`num_intervals`, `num_total_intervals`, `domain`
+(`src/pantr/bspline/_bspline_space_nd.py:76,85,108,117,126,135,144`). Each reads a scalar off
+each 1D space and combines them. In C++ they are either fields set in the constructor or
+three-iteration loops in the accessor. **They are memos only because a Python attribute read
+that walks three objects costs more than a `__dict__` hit** -- measured, 56 to 60 ns for a warm
+`cached_property` hit -- which is a fact about CPython, not about the mathematics.
+
+So: **`BsplineSpace` acquires zero memos.** That removes half the problem before any mechanism
+is chosen, and it should be said in #396's acceptance criteria, because "port fourteen memos" and
+"port one" are different tickets.
+
+### F2 (critical). The GIL is not available as the memo's protection, and the tree already proves it
+
+The obvious reasoning -- nanobind holds the GIL for the duration of a bound call, so a memo
+filled inside one is serialised against every other Python thread -- is true of a call that does
+not release it. **The extension releases the GIL at 19 sites already**
+(`basis.cpp` 1, `change_basis.cpp` 3, `quad.cpp` 5, `bezier.cpp` 10, counted under `cpp/bindings/` at `a45e935`),
+and `src/pantr/_backend.py:551-552` states the intent in the same breath as the hazard: *"use_backend
+is scoped per thread precisely so callers may thread, and the extension releases the GIL to invite
+it."*
+
+Every one of those 19 is a kernel binding rather than a method of a domain type, so **no bound
+method releases the GIL today**. That is the honest state. It is also not a place to build on: the
+method that fills the biggest of these memos, `get_unique_knots_and_multiplicity`, was measured
+at 16.9 microseconds on a 2055-knot vector, and a 17-microsecond bound call holding the GIL is
+exactly what gets a `gil_scoped_release` at the first performance pass. A memo whose safety
+depends on nobody adding one line to its binding is not safe.
+
+And the ruling settles it regardless: *"En el futuro, solo C++."* There is no GIL in the future
+this port is for.
+
+**Numba is not the hazard here, and the ticket's framing should be corrected.** A
+`parallel=True` kernel runs with the GIL released, but a `nopython` kernel receives arrays and
+never calls into the extension, so those threads cannot reach a C++ memo. The hazards are, in
+order of likelihood: a Python-level thread pool over Layer 1 (serialised by the GIL only while
+no binding releases it), a `gil_scoped_release` added to a space method, a free-threaded CPython
+build (no CI leg today: `.github/workflows/ci.yaml:20,80,131` list `3.11`, `3.13`, `3.14`), and
+the interpreter-free C++ consumer, where nothing is serialised by anything.
+
+### F3 (critical). A bare `mutable std::optional` memo is a data race, and no value test will find it
+
+Measured. A struct with `mutable std::optional<std::vector<double>> memo` filled on first const
+access, hammered by 8 threads:
+
+- **Under TSan: 4 data races reported, every stack frame in the unsynchronised accessor.** The
+  first is a read of the `optional`'s engaged flag racing a write of it; the rest are on the
+  contained `vector`'s pointer triple. Zero races reported for the `call_once` and eager variants
+  in the same binary.
+- **Without TSan: 60 runs of 8 threads each produced the correct answer 60 times.**
+
+So the failure is real -- concurrent conflicting non-atomic accesses are a data race and
+therefore undefined behaviour under the C++ standard's `[intro.races]` rule -- and it is
+invisible to every test that checks a value. It is not a "lost update, costing redundant
+construction": two threads assigning one `std::optional<std::vector<double>>` can leave a torn
+pointer triple, double-free the loser's buffer, or leak it.
+
+**Two consequences for the tree.** `cpp/include/pantr/grid/grid.hpp`'s
+`mutable std::optional<BVH<scalar_type>> bvh_` is that construct. And
+`src/pantr/grid/_grid.py`'s `cell_bvh` docstring says concurrent first calls *"may each build a
+valid tree and one write wins, costing redundant construction"* -- which is a correct description
+of the **Python** implementation, where the GIL makes the write atomic, written into the contract
+of a method both backends implement. Both are recorded under "Bad practices flagged"; neither is
+this note's to fix.
+
+### F4 (important). Laziness is nearly free if it is done right, and eager is nearly free only for what does not allocate
+
+Measured, g++ 14.4 `-O2`, one pinned core, constructor bodies in a separate translation unit,
+best of 5 over 2e5 (or 2e4 for the largest) iterations. Each column constructs a fresh object and
+then uses one thing from it. `p = 3` throughout; `n_knots` is the whole vector.
+
+| n_knots | construct only | + eager scalars | + eager arrays | `call_once`, then one use | DCLP, then one use | DCLP, hot path per access |
+|---|---|---|---|---|---|---|
+| 11 | 36 ns | 42 ns | 173 ns | 1793 ns | 188 ns | 7.99 ns |
+| 39 | 62 ns | 69 ns | 446 ns | 1955 ns | 484 ns | 4.44 ns |
+| 263 | 588 ns | 535 ns | 3178 ns | 4620 ns | 3165 ns | 2.94 ns |
+| 2055 | 3326 ns | 3465 ns | 18058 ns | 24323 ns | 22025 ns | 2.93 ns |
+
+These are construct-and-destroy microbenchmarks, so they are allocator-sensitive: a second run of
+the same binary moved every absolute number by up to a factor of two while leaving every ratio
+within a row unchanged. **Read the ratios, not the absolutes.**
+
+- **Eager scalars are free.** Within noise of bare construction at every size, in both directions
+  (`535 < 588` and `3465 > 3326` are the same noise). What they cost is two bounded scans of at
+  most `degree + 1` knots each, plus arithmetic.
+- **Eager arrays cost 4.8x to 7.2x the bare construction**, because they are three more heap
+  allocations, and at small `n` the allocations, not the scan, are the cost. My own first estimate
+  -- "a small constant factor on an already-O(n) constructor" -- was wrong, and the measurement is
+  what refuted it.
+- **`std::call_once` costs about 1.6 microseconds on its first call**, and the cost is
+  size-independent (1793 - 173 = 1620 ns at n=11; 1955 - 446 = 1509 ns at n=39), which is the
+  signature of glibc's `pthread_once` issuing a `FUTEX_WAKE` after running the initialiser even
+  with no waiters. At n=11 that is **ten times the entire construction**.
+- **Double-checked locking over an `atomic<bool>` costs, on first use, within noise of computing
+  eagerly** (188 vs 173, 484 vs 446, 3165 vs 3178, 22025 vs 18058) **and 2.9 to 8.0 ns per access
+  thereafter.** It is free when the derived data is never touched and free when it is.
+
+So the rule is not "eager because laziness is dangerous". It is: **eager where there is nothing to
+allocate, DCLP-lazy where there is, and never `call_once`.**
+
+### F5 (important). The `lru_cache`'s own key handling is the same order as the computation it caches
+
+`_cached_unique_knots_and_multiplicity` (`_bspline_space_1d.py:40`, `maxsize=128`) is keyed on
+`(self._knots.tobytes(), dtype.str, size)`, built fresh at every call site
+(`_bspline_space_1d.py:320`). So a cache **hit** pays an O(n) buffer copy, an O(n) hash of a
+never-before-seen `bytes`, and an O(n) comparison against the stored key. Measured in the `pantr`
+env, warm cache:
+
+| n_knots | `tobytes` + tuple, alone | kernel called directly | the cached method (a hit) | what the cache saves |
+|---|---|---|---|---|
+| 11 | 671 ns | 4303 ns | 2384 ns | 1.8x |
+| 39 | 605 ns | 4743 ns | 2214 ns | 2.1x |
+| 263 | 1487 ns | 8075 ns | 4247 ns | 1.9x |
+| 2055 | 2738 ns | 23051 ns | 16894 ns | 1.4x |
+
+A factor of 1.4 to 2.1, against a kernel whose 4.3 microseconds for an eleven-element scan is
+Numba dispatch overhead rather than work. **The port removes the thing the cache is hiding.** For
+comparison, the same three arrays computed in C++ inside the constructor cost 137 ns at n=11 and
+about 14.7 microseconds at n=2055 (the eager-arrays column minus the construct-only column above),
+and that is with the allocations included.
+
+The saving is real but small, it is bought with a process-global 128-entry cache, and it is
+strictly dominated by owning the derived data per object: once `BsplineSpace1D` holds it, the
+scan runs **once per space** rather than once per call, with no key to build.
+
+### F6 (critical). The `lru_cache` carries the exact latent defect a sibling cache was already fixed for, and #396 is when it becomes live
+
+`src/pantr/_backend.py:525-555` documents `backend_keyed_cache` and why a plain `lru_cache` was
+not enough for `_cached_lagrange_to_bernstein_matrix`: the key omitted the backend, so *"the first
+backend to populate an entry serves every later caller"*, with a measured consequence -- a parity
+test handed the same object twice, reporting agreement it never measured, with `A is B` true and
+the matrices differing only after a cache clear.
+
+`_cached_unique_knots_and_multiplicity` has the same key shape and the same omission. It is
+**not** a live bug today: `_get_unique_knots_and_multiplicity_impl`
+(`src/pantr/bspline/_bspline_knots.py:286`) is a plain Numba function with no backend dispatch,
+verified by reading its definition. It becomes live the moment #396 gives that scan a C++
+implementation, which is #396's whole point.
+
+**So the removal is not cleanup after the port; it is a step inside #396, ahead of the C++
+dispatch.** Doing it the other way round means a parity test that cannot fail.
+
+## The decision
+
+### Where each kind of thing lives
+
+| what | lives | mechanism | why not the other side |
+|---|---|---|---|
+| a derived quantity of the type's own frozen state | **C++** | an eager field, or a member of the single grouped lazy block | the interpreter-free consumer needs it; a Python-side memo is a memo the ruling deletes |
+| the Python wrapper object for a nested C++-owned domain type | **the wrapper** | a named `__slots__` memo slot, filled through `object.__setattr__` | C++ cannot hold a `PyObject*` without inverting the dependency, and the identity contracts are Python-level facts |
+| a numpy view over C++ storage | **neither** | constructed per access from a `std::span`, with the owner as the array's owner | it is not a cache; it is a presentation, and it is cheap (`bezier_type.cpp:43-56`) |
+| anything else | **nowhere** | -- | see "What must never appear" |
+
+**Nothing is cached on both sides**, and the reason is worth stating precisely because "both" is
+the trap the ticket names: the C++ memo holds a **value**, the wrapper's slot holds the **Python
+object presenting that value**. There is one value. A wrapper slot holding a *number* or an
+*array copy* would be the second truth, and it is forbidden -- which is exactly what dropping
+`cached_property` enforces, since `cached_property` caches values and nothing else.
+
+### The wrapper keeps `__slots__`. `cached_property` does not survive
+
+`__slots__` naming every memo slot, a raising `__setattr__` and `__delattr__`, and
+`object.__setattr__` for the memo fills -- `feat/387`'s
+`src/pantr/grid/_tensor_product_grid.py:660,704-731` verbatim. Three reasons, and the first is
+the one that decides it:
+
+1. **The memo slots have to be named, because must-pass tests read them.**
+   `design/grid_hierarchy_port.md` W3 records `tests/test_grid_tags.py:149-150` reading
+   `g._cell_tags` and `g._facet_tags` directly and asserting they are `None` before first use, in
+   a file on #387's must-pass-unedited list. A `__dict__` gives you `cached_property` and takes
+   away the guarantee that the slot exists under a known name before it is filled.
+2. **A `__dict__` silently returns settable attributes to a type documented immutable.** It is
+   the same failure `design/grid_hierarchy_port.md` F3 measured for a `Protocol` missing
+   `__slots__ = ()`: nothing in the suite asserts the absence of `__dict__`, so the regression is
+   invisible.
+3. **`cached_property` caches values**, which is the second truth. Its per-hit cost, 56 to 60 ns
+   measured, is also not an argument for it: a forwarded C++ field read is the same order.
+
+The cost of keeping `__slots__` is that each memo is three lines instead of a decorator, and that
+`mypy` needs a `# type: ignore[misc]` on the `object.__setattr__` fill. #387 already pays both.
+
+### What the fourteen become
+
+`BsplineSpace1D`, 7 sites:
+
+| today | becomes | why |
+|---|---|---|
+| `num_basis` (`:293`) | eager `std::int64_t` field | size arithmetic with a periodic branch; today it is a Numba call |
+| `num_intervals` (`:325`) | eager `std::int64_t` field | one non-allocating count of distinct interior knots, **fused into the validation scan the constructor already runs** |
+| `domain` (`:404`) | eager `std::array<double, 2>` | two indexed reads |
+| `_left_end_open` (`:421`) | eager `bool` | a bounded scan of at most `degree + 1` knots |
+| `_right_end_open` (`:439`) | eager `bool` | as above |
+| `_bezier_like_knots` (`:457`) | eager `bool` | derived from the three above |
+| `_first_basis_per_interval_cached` (`:340`) | **the grouped lazy block** | allocates `O(num_intervals)` |
+
+plus the public `get_unique_knots_and_multiplicity` (`:298`), whose two arrays join the same
+block. `in_domain=True` is a subrange of `in_domain=False`, so the block stores the full pair once
+and the in-domain form is a subspan -- one memo, two views, and no second flag.
+
+`BsplineSpace`, 7 sites: **all seven become eager fields or three-iteration accessors, and none
+becomes a memo** (F1).
+
+So the milestone's memo count for the two space classes is **one**, not fourteen. Say so in
+#396's acceptance criteria.
+
+### The grouped lazy block, and its guard
+
+```cpp
+class BsplineSpace1D {
+  public:
+    /// The distinct knots and their multiplicities, over the whole vector.
+    [[nodiscard]] std::pair<std::span<const double>, std::span<const std::int64_t>>
+    unique_knots() const;
+
+    /// The same, restricted to the domain: a subrange of `unique_knots()`.
+    [[nodiscard]] std::pair<std::span<const double>, std::span<const std::int64_t>>
+    unique_knots_in_domain() const;
+
+    /// First supported basis index per interval.
+    [[nodiscard]] std::span<const std::int64_t> first_basis_per_interval() const;
+
+  private:
+    /// Everything derived that allocates.  One struct, one flag, one fill.
+    struct Derived {
+        std::vector<double> unique;
+        std::vector<std::int64_t> mult;
+        std::vector<std::int64_t> first_basis;
+        std::size_t domain_begin, domain_end;   ///< the in-domain subrange of `unique`
+    };
+
+    /// Fill `derived_` at most once, from any number of threads.
+    const Derived& derived() const {
+        if (!derived_ready_.load(std::memory_order_acquire)) {
+            const std::lock_guard<std::mutex> guard(derived_mutex_);
+            if (!derived_ready_.load(std::memory_order_relaxed)) {
+                derived_ = build_derived(knots_, degree_, tol_);
+                derived_ready_.store(true, std::memory_order_release);
+            }
+        }
+        return *derived_;
+    }
+
+    std::vector<double> knots_;
+    std::int64_t degree_, num_basis_, num_intervals_;
+    /* ... the eager scalars ... */
+    mutable std::mutex derived_mutex_;
+    mutable std::atomic<bool> derived_ready_{false};
+    mutable std::optional<Derived> derived_;
+};
+```
+
+Four things about it that are load-bearing rather than decorative:
+
+- **The `acquire` load and the `release` store are the pair that makes it correct.** The release
+  store publishes every write `build_derived` made; the acquire load is what a reader
+  synchronises with. Dropping either, or using `relaxed` for both, restores F3's race with the
+  ceremony still visible. The second, `relaxed` load is inside the lock and is correct as such.
+- **The memo slot is `private` and no accessor hands it out.** That is #386's `D-a` generalised:
+  base state and memo slots stay private, and nothing outside the class can reach the slot to
+  invalidate it. The Python analogue -- `HierarchicalGrid._rebuild` writing its base's private
+  slots (`_hierarchical_grid.py:541-544` against `_grid.py:71`) -- is the shape this removes.
+- **One block, one mutex.** Fourteen flags would be fourteen mutexes at 40 bytes each on Linux
+  and fourteen chances to get the ordering wrong. Group by "computed by the same scan", which for
+  `BsplineSpace1D` is all of it.
+- **`build_derived` is a free function taking the frozen state**, so it can be tested without an
+  object and cannot accidentally read a half-initialised `this`.
+
+**The public contract, stated so that it is a contract and not a habit:**
+
+> Every non-mutating public accessor on a C++-owned pantr domain type is safe to call
+> concurrently from any number of threads on the same object, with no external locking. A lazy
+> memo behind such an accessor is filled at most once and published atomically.
+
+The exception, and there is exactly one: a **mutating** accessor is not, and the only mutable
+members left in the domain layer are a grid's `CellTags` and `FacetTags`, which
+`cpp/include/pantr/grid/tags.hpp:14-19` already reasons as the accumulating-container exception
+and which say plainly *"Nothing here is thread-safe; the shared pointer buys lifetime, not
+concurrency."* That sentence is correct and should stay.
+
+### Does #386's shape generalise? Half of it
+
+The ticket asks directly. The answer is that #386 made two separable decisions and they
+generalise differently.
+
+- **`D-a` -- base state passed up from the derived constructor, memo slot private in the mixin --
+  generalises and should be copied.** It is why `HierarchicalGrid` needs no
+  `invalidate_caches()`, and the same reasoning applies here: a `BsplineSpace1D`'s derived block
+  is a function of its constructor arguments, so it never needs invalidating and nothing outside
+  needs to reach it.
+- **The unsynchronised `mutable std::optional<BVH>` does not generalise**, and by F3 it is a race
+  in `#386`'s own code rather than a shape to imitate. The repair is the three lines above:
+  an `atomic<bool>` and a `std::mutex` beside the existing `optional`. Measured cost, first use
+  within noise of eager and 2.9 to 8.0 ns per subsequent access -- against a BVH build that is
+  `O(num_cells)`. **#395 should make that change** (it is the ticket that edits both the mixin and
+  the grid wrapper) rather than each later type deciding locally.
+
+And **construct-then-freeze does hold for the spaces, more cleanly than for the grids.** With
+#378, a grid is immutable after construction except for the BVH memo *and* its two tag
+registries. A `BsplineSpace1D` or `BsplineSpace` is immutable after construction except for one
+memo whose fill is unobservable -- same value, same span, every time. That is the strongest form
+of the rule available: **the only mutation is one that no caller can observe**, which is the test
+`CLAUDE.md` sets for a reasoned exception, rather than "it is fast".
+
+`Bspline` is the type where it does not hold, because two of its methods take `in_place=True` and
+reseat its space. Under `design/bspline_ownership_lifetime.md`'s storage the repair is available
+and should be taken: **an in-place method replaces the whole derived block rather than
+invalidating pieces of it**, so there is no `_beziers_cache = None` path and no way to reseat one
+without the other. Today's two invalidation sites (`_bspline.py:1037-1038,1104-1105`) become one
+assignment. #398 owns it, and it is the shape to prefer even if `in_place=` survives.
+
+### The rest of the caches, by ticket
+
+Not part of the fourteen, but governed by the same rule, and each one is a decision a ticket would
+otherwise take alone.
+
+| cache | today | becomes | ticket |
+|---|---|---|---|
+| `_cached_unique_knots_and_multiplicity`, `lru_cache(128)` | `_bspline_space_1d.py:40`, process-global, byte-keyed | **deleted**, ahead of the C++ dispatch (F5, F6) | #396 |
+| `THBSplineSpace._contrib_cache` | `dict[int, list[tuple]]`, unbounded, per cell id, `:492` | **one flat CSR table** (offsets + entries) filled for *all* cells behind one DCLP flag | #397 |
+| `THBSplineSpace._max_active_per_cell` | `int \| None` slot, `:493`, first call sweeps every cell | a field of that table, computed by the same sweep | #397 |
+| `MultiLevelExtraction._ext` | `dict[int, SpanwiseElementExtraction]`, `:114` | `std::vector<std::shared_ptr<const SpanwiseElementExtraction>>` indexed by level, one DCLP fill; levels are few | #400 |
+| `MultiLevelExtraction._coeffs_cache` | `dict[(int, tuple[int,...], int), ...]`, unbounded, `:112` | a hash map -- **legitimately**, its keys are data -- but it **needs a stated bound** and has none | #400 |
+| `Bspline._beziers_cache`, `_locate_cache` | `None`-guarded slots, three invalidation sites | two members of one derived block, replaced wholesale by an in-place method | #398 |
+| `SpanwiseElementExtraction.ops_1d` | `cached_property`, decompresses compact storage, `:273` | DCLP-lazy block; the accessor returns a **read-only view of the memo**, never a copy | #399 |
+| `SpanwiseElementExtraction.num_identity_elements` | `cached_property`, `:391` | eager field | #399 |
+| the grid mixin's `bvh_` | `mutable std::optional`, unsynchronised | DCLP, three lines (F3) | #395 |
+
+Three of these deserve a sentence beyond the row.
+
+**`_contrib_cache` is the only one where the shape change is large**, and it buys three things at
+once: a flat CSR table is a fraction of the footprint of a dict of lists of tuples; filling all
+cells at once removes the per-cell locking question entirely; and returning a `span` removes the
+unenforced convention its own docstring carries today, *"the returned list is the cached object;
+callers must not mutate it"* (`_thb_spline_space.py:770-773`), read directly by two external call
+sites. **#397 owes a footprint measurement on a realistic adaptive hierarchy** before it commits,
+because a lazy-all-cells fill trades memory for the dict's incrementality; the fallback if it is
+too large is per-level rather than per-cell granularity, not a return to per-cell.
+
+**`_coeffs_cache` is the one cache in the milestone that is genuinely a mapping over data**, which
+`CLAUDE.md` permits, and it is also the one with no bound at all: its key includes a basis
+multi-index, so its size is bounded by the number of distinct queries a caller makes, not by
+anything about the object. Under a long-lived process that is leak-shaped. #400 must state the
+bound or add one; this note declines to pick a number, because the right bound is a function of
+the access pattern in `_element_coeffs` and nobody has measured it.
+
+**`ops_1d` returning a view of its memo rather than a copy is not an optimisation**, it is what
+keeps `tests/test_spanwise_element_extraction.py:1681`'s `np.shares_memory` assertion true and
+what stops an `O(n_elements * p^2)` array being rebuilt per access.
+
+### What must never appear
+
+Three prohibitions, each with the concrete failure behind it rather than as a matter of taste.
+
+1. **No process-global cache in the C++ layer.** It has no owner, so no bound is tied to
+   anything, and it is the shape that produced the measured backend collision
+   (`_backend.py:539-547`). If the same knot vector is genuinely built into many spaces and the
+   scan is genuinely hot, the answer is to share the *space* -- which
+   `design/bspline_ownership_lifetime.md`'s `shared_ptr<const BsplineSpace1D>` makes a one-line
+   thing to do -- not to cache the scan behind everybody's back.
+2. **No cache keyed on a domain object.** None exists today: verified, none of `BsplineSpace1D`,
+   `BsplineSpace`, `THBSplineSpace`, `Bspline`, `THBSpline`, `TensorProductGrid` or
+   `HierarchicalGrid` defines `__eq__` or `__hash__`, and every memoisation site in `bspline` and
+   `grid` deliberately keys on a primitive or on a byte serialisation instead. The port must not
+   create the need for one, because it would require value equality on a type whose equality
+   semantics nobody has specified and which two backends would then have to agree on exactly.
+3. **No cached value handed out writable.** `BsplineSpace.domain`
+   (`_bspline_space_nd.py:144-156`) does exactly that today: it is the only array-shaped memo in
+   `src/pantr/bspline/` that is not frozen with `.flags.writeable = False`, and a caller writing
+   through it corrupts the cache for the object's whole life. Reproduced by execution:
+   `d = s.domain; d[0, 0] = 999.0; s.domain[0, 0]` reads `999.0`, and no test in `tests/`
+   inspects `domain.flags`. That is a bug in today's Python, not something the port introduces,
+   and the port removes it -- a C++-side `std::array<double, 2>` presented as a `const`-scalar
+   view cannot be written. **It is worth its own ticket so the fix is deliberate and gets a
+   regression test**, rather than arriving as an unremarked side effect of #396.
+
+## What it costs at the call site
+
+- **In the wrapper, per access:** one `None` check plus a forwarded attribute read, against the
+  56 to 60 ns a `cached_property` hit costs today. Same order; no measurable change to Layer 1.
+- **In C++, per access to a memoised quantity:** 2.9 to 8.0 ns for the DCLP acquire load and the
+  `optional` dereference, against 0 for an eager field. The spread is a cache-locality artefact
+  of the microbenchmark, not a size effect.
+- **In C++, at construction:** free for the eager scalars; the grouped block is not paid unless
+  it is touched, and costs within noise of eager when it is (F4).
+- **In a hot loop:** the memo is a design object here in the same sense the loop is. A de Boor
+  or Cox-de Boor sweep should hoist `derived()` out of the loop into a local reference **once**,
+  and take `first_basis_per_interval()` as a `span` before the loop rather than per element. 3 ns
+  per element over a `num_intervals * (p+1)` sweep is a measurable tax for no reason, and the
+  fix is a local, not a mechanism. Say it in the header next to the accessor, because the
+  accessor looks free and is not.
+- **What the port removes from the hot path:** the `tobytes()` key. Today every call of the
+  public `get_unique_knots_and_multiplicity` builds an O(n) copy of the knot vector and hashes it
+  -- 671 ns at 11 knots, 2738 ns at 2055 -- and there are 94 call sites of that name and its
+  underlying impl across `src/` and `tests/`. That cost goes to zero, and it goes to zero because
+  the data is owned rather than because anything was tuned.
+
+## What each ticket in the milestone inherits
+
+- **#395 `HierarchicalGrid`.** The three-line DCLP repair to the mixin's `bvh_`, and the
+  correction to `_grid.py`'s `cell_bvh` docstring. Also `D-a` confirmed: no
+  `invalidate_caches()`, because with #378 there is nothing to invalidate.
+- **#396 `BsplineSpace1D` / `BsplineSpace`.** The whole of the above. Its `AC` set should say
+  **one** memo, not fourteen; should require the `lru_cache` deleted *before* the C++ scan is
+  dispatched (F6); and should include a TSan leg over the C++ unit tests, because that is the
+  only gate that can see F3.
+- **#397 `THBSplineSpace`.** The CSR conversion, the footprint measurement it is contingent on,
+  and the `span`-returning accessor that retires the "callers must not mutate" convention.
+- **#398 `Bspline`.** One derived block replaced wholesale by an in-place method; the three
+  invalidation sites collapse to one assignment.
+- **#399 the extraction machinery.** Two memos, one eager and one DCLP-lazy, plus the
+  view-not-copy rule on `ops_1d`.
+- **#400 `THBSpline` / `MultiLevelExtraction`.** The level-indexed vector, and a stated bound on
+  `_coeffs_cache` -- which is a genuine open question, not a mechanical port.
+- **#401 scaffolding removal.** Nothing from this note is scaffolding; the memos are the design.
+  What #401 should check is that no `cached_property` came back and no `__dict__` reappeared:
+  a one-line test asserting `not hasattr(obj, "__dict__")` on each ported wrapper.
+
+## Alternatives rejected
+
+**Relax the wrapper: give it a `__dict__` and keep the fourteen `cached_property` sites.** By far
+the cheapest to write, and it would leave Layer 1 untouched. Rejected because the resulting
+memos are on the Python side of a seam the ruling deletes -- an interpreter-free consumer gets
+none of them and must recompute -- and because a `__dict__` silently returns settable attributes
+to a type documented immutable, which nothing in the suite would catch.
+**What would change it:** a decision that the Python layer is permanent. It is not.
+
+**Cache on both sides: C++ for the value, the wrapper for the numpy presentation of it.** Looks
+cheapest of all and is what the ticket predicts someone will reach for. Rejected on a concrete
+scenario rather than on principle: `BsplineSpace1D.get_unique_knots_and_multiplicity` returns two
+arrays. If the wrapper caches the numpy views and the C++ caches the buffers, then the arrays are
+correct exactly as long as nobody adds a second path that rebuilds the C++ block -- and the day
+someone does, the wrapper serves views into freed storage. The cost of *not* caching the
+presentation is one `nb::ndarray` construction per access, about 200 ns, which is the same order
+as the Python call that asked for it.
+
+**Eager everything.** No `mutable`, no flag, no mutex, and construct-then-freeze in its purest
+form. Rejected on F4's measurement: the allocating derived arrays cost 4.8x to 7.2x the bare
+construction, and a `THBSplineSpace` builds one `BsplineSpace` per level whose derived arrays may
+never be touched. **What would change it:** a measurement showing the block is touched on
+essentially every space that gets built, which would make the flag pure overhead. #396 is where
+that could be measured; the DCLP form costs so little when it *is* touched that the answer
+probably would not move.
+
+**`std::call_once`.** The idiomatic spelling, and correct. Rejected on the measured 1.6
+microsecond first call -- ten times the whole construction of a small space -- which is a
+`FUTEX_WAKE` glibc issues even with no waiters. DCLP is the same guarantee with that cost removed.
+**What would change it:** a C++ standard library whose `call_once` fast-path-initialises without
+the syscall. Worth re-measuring if the toolchain floor moves.
+
+**`std::shared_mutex`, or an atomic pointer published with `compare_exchange`.** Both correct; the
+first is heavier than a plain mutex for a fill that happens once, and the second requires the
+memo to be heap-allocated so that a pointer can be published, which adds an indirection to every
+subsequent read. DCLP over `optional` keeps the value inline.
+
+**Keep the `lru_cache` and key it on the backend, as `backend_keyed_cache` does.** The
+conservative option: it closes F6 with a one-line decorator swap and leaves the measured 1.4-2.1x
+saving in place. Rejected because it preserves a process-global cache whose hit costs an O(n) key
+build (F5) in order to memoise a scan that, once owned, runs once per object. It is the right
+answer only if the derived data does **not** move into the type -- that is, only if this note's
+main decision is reversed.
+
+## Bad practices flagged, for the user's inspection rather than for fixing here
+
+- **`cpp/include/pantr/grid/grid.hpp`'s `mutable std::optional<BVH<scalar_type>> bvh_` is a data
+  race** for any consumer without a GIL (F3). **Cost of keeping:** undefined behaviour reachable
+  by the interpreter-free consumer the port exists for, invisible to every value test, and the
+  shape gets copied by the next nine types. **Cost of fixing:** three lines and a measured 2.9 to
+  8.0 ns per access. #395 is the ticket that already edits that file.
+- **`src/pantr/grid/_grid.py`'s `cell_bvh` docstring states a Python implementation detail as the
+  method's contract** -- *"may each build a valid tree and one write wins"* -- for a method both
+  backends implement, where it is false of one of them. **Cost of keeping:** a reader concludes
+  the race is benign and writes the same shape into a space. **Cost of fixing:** one docstring, no
+  behaviour change.
+- **`BsplineSpace.domain` hands out its cached array unfrozen** while every other array-shaped
+  memo in `src/pantr/bspline/` is frozen, and nothing tests it (prohibition 3 above). Reproduced.
+  Wants a ticket and a regression test, not a silent fix inside #396.
+- **`THBSplineSpace._contrib_cache` and `MultiLevelExtraction._coeffs_cache` are unbounded
+  dicts**, and `_contrib_cache`'s docstring carries an unenforced "callers must not mutate the
+  returned list" contract that two external call sites rely on. Both are pre-existing; both are
+  removed by the port if #397 and #400 take the rows above, which is the argument for taking them.
+- **`CLAUDE.md`'s "Performance notes" say "change-of-basis matrices and unique knots are cached to
+  avoid recomputation across calls".** After #396 that is no longer how unique knots work, and
+  the sentence is the kind that outlives its subject. One line, when #396 lands.
+
+## Epistemic status
+
+- **Measured, 2026-08-31, on this machine:** F4's six-column table (g++ 14.4 `-O2`, one pinned
+  core, constructor bodies in a separate translation unit, best of 5); F5's four-column table
+  (CPython 3.14.6 in the `pantr` env, best of 5 over 2e4 accesses); the DCLP hot-path 2.9 to
+  8.0 ns; the `cached_property` hit at 56 to 60 ns; the `call_once` first-call cost isolated as
+  size-independent across two sizes. The construct-and-destroy benchmarks moved by up to 2x
+  between runs of the same binary while every within-row ratio held; the tables report one run and
+  the text says which readings survive that.
+- **Measured under ThreadSanitizer (g++ 14.4 `-fsanitize=thread`), 8 threads:** 4 data races in
+  the bare `mutable std::optional` variant, all frames in its accessor; 0 in the `call_once` and
+  eager variants in the same binary. **And measured without TSan: 60 of 60 runs produced the
+  correct total**, which is the point of the finding.
+- **Verified by reading the tree at `a45e935`:** all 16 `cached_property` sites and the 7 + 7
+  split; the `lru_cache`'s key construction at `_bspline_space_1d.py:320` and its definition at
+  `:40`; that `_get_unique_knots_and_multiplicity_impl` is not backend-dispatched
+  (`_bspline_knots.py:286`); the 19 `gil_scoped_release` sites, their four files, and that all are kernel bindings rather than methods of a domain type;
+  `backend_keyed_cache`'s recorded measurement (`_backend.py:525-555`); that no domain class in
+  `bspline` or `grid` defines `__eq__` or `__hash__`; `_contrib_cache`'s and `_coeffs_cache`'s
+  shapes and unboundedness; the CI Python matrix.
+- **Verified by execution in the `pantr` env:** that `BsplineSpace.domain` hands out a writable
+  array and a write through it persists in the cache; that `functools.cached_property` on a
+  `__slots__` class raises `TypeError: No '__dict__' attribute ... to cache`.
+- **Derived, not measured:** that fusing `num_intervals`'s distinct-knot count into the
+  constructor's validation scan is free. It is one comparison per knot inside a loop that already
+  reads every knot, so it cannot be more than a constant factor on a pass that is already there;
+  the eager-scalars column supports the conclusion for two bounded scans, not for a full one.
+- **Asserted, not measured:** that the CSR form of `_contrib_cache` is smaller than the dict of
+  lists of tuples. It is very likely -- a `list[tuple[int,int,tuple[int,...]]]` per cell is
+  several PyObjects per entry -- but nobody has weighed either, and **#397 owes the measurement
+  before it commits to a lazy-all-cells fill.**
+- **Not investigated:** whether the not-yet-public downstream consumer calls
+  `BsplineSpace1D.get_unique_knots_and_multiplicity` in a loop, which is the one place the
+  `lru_cache`'s removal could be felt as a regression rather than as a cleanup. It is on the
+  exposure list as a method of `BsplineSpace1D`, and the check is owed before #396 lands. Also
+  not investigated: the footprint or hit rate of `_coeffs_cache` under any real workload, which
+  is what #400 needs to state its bound.
+
+## What was compiled, and how to reproduce it
+
+Not committed.
+
+**The C++ construction benchmark** is four structs over one knot vector, differing only in what
+the constructor computes: nothing derived; the O(1) scalars; the scalars plus the three arrays;
+and the scalars plus a lazily-filled block behind `std::call_once` or behind double-checked
+locking. All four constructors and the `build_derived` helper live in a translation unit the
+benchmark does not include, so no body can inline into the loop -- the precaution
+`design/grid_hierarchy_port.md` records getting wrong the first time. `-O2`, no LTO, `taskset` to
+one core.
+
+```bash
+g++ -O2 -std=c++20 -pthread -c impl.cpp -o impl.o
+g++ -O2 -std=c++20 -pthread bench.cpp impl.o -o bench && taskset -c 2 ./bench
+```
+
+**The race demonstration** is the same three memo shapes in one binary, each hammered by N
+threads that all first-touch the memo:
+
+```bash
+g++ -O1 -g -std=c++20 -fsanitize=thread -pthread memo.cpp -o memo_tsan && ./memo_tsan 8
+g++ -O2    -std=c++20                  -pthread memo.cpp -o memo_fast
+for i in $(seq 1 60); do ./memo_fast 8; done   # every total correct; this is the point
+```
+
+One thing to check before believing a null result from the TSan run, by analogy with the
+devirtualisation trap: if it reports nothing at all, confirm the threads really do race by
+checking that at least one race is reported for the deliberately-bare variant. A TSan build that
+optimised the accessor into the constructor, or a run where one thread finishes before the next
+starts, reports clean for the wrong reason.

--- a/design/bspline_derived_caches.md
+++ b/design/bspline_derived_caches.md
@@ -448,6 +448,14 @@ Three prohibitions, each with the concrete failure behind it rather than as a ma
 - **#395 `HierarchicalGrid`.** The three-line DCLP repair to the mixin's `bvh_`, and the
   correction to `_grid.py`'s `cell_bvh` docstring. Also `D-a` confirmed: no
   `invalidate_caches()`, because with #378 there is nothing to invalidate.
+A memo test is subject to the same Rule 12 caveat as the lifetime tests in the companion note:
+`Backend.PYTHON` is the process default (`src/pantr/_backend.py:363-370`), so under a plain
+`pytest` run a test aimed at the C++ memo exercises `cached_property` instead and passes without
+touching the thing it names. Take the `cpp_backend` fixture
+(`tests/parity/conftest.py:18-27`), which is a skip-or-fail rather than a silent skip. And the
+thread-safety property is not reachable from Python at all -- the GIL hides it (F2) -- so its gate
+is a C++ unit test under a sanitizer and nothing in `tests/` can stand in.
+
 - **#396 `BsplineSpace1D` / `BsplineSpace`.** The whole of the above. Its `AC` set should say
   **one** memo, not fourteen; should require the `lru_cache` deleted *before* the C++ scan is
   dispatched (F6); and should include a TSan leg over the C++ unit tests, because that is the

--- a/design/bspline_derived_caches.md
+++ b/design/bspline_derived_caches.md
@@ -451,7 +451,10 @@ Three prohibitions, each with the concrete failure behind it rather than as a ma
 - **#396 `BsplineSpace1D` / `BsplineSpace`.** The whole of the above. Its `AC` set should say
   **one** memo, not fourteen; should require the `lru_cache` deleted *before* the C++ scan is
   dispatched (F6); and should include a TSan leg over the C++ unit tests, because that is the
-  only gate that can see F3.
+  only gate that can see F3. The repo already has a sanitizer job
+  (`origin/ci/sanitizer-job` exists as a branch), so what #396 owes is a *thread* leg over the
+  memo tests specifically, not new infrastructure -- confirm what that job already runs before
+  adding to it.
 - **#397 `THBSplineSpace`.** The CSR conversion, the footprint measurement it is contingent on,
   and the `span`-returning accessor that retires the "callers must not mutate" convention.
 - **#398 `Bspline`.** One derived block replaced wholesale by an in-place method; the three

--- a/design/bspline_ownership_lifetime.md
+++ b/design/bspline_ownership_lifetime.md
@@ -225,14 +225,25 @@ Four reasons, in the order they decide it.
    precisely so a handed-out view outlives a replacement, and says so: *"the port would otherwise
    have introduced a use-after-free the pre-port class could not have."* This note generalises
    that ruling from a tag's arrays to a nested space.
-3. **It is the only mechanism that reproduces `Bspline`'s in-place semantics.**
+3. **It is the only mechanism that reproduces `Bspline`'s in-place semantics, and the
+   alternatives fail in two different silent ways.**
    `Bspline.reverse(direction, in_place=True)` and `permute_directions(..., in_place=True)`
    **replace** `self._space` (`_bspline.py:1035-1039`, `1101-1106`) -- verified by execution:
-   `before = b.space; b.reverse(0, in_place=True); before is b.space` is `False`. Under
-   `reference_internal` the escaped Python object points at the *address* of the owner's member,
-   so after the reseat it would silently start reporting the **new** space -- a wrong answer with
-   no diagnostic. Under `shared_ptr` the escapee holds the old value, which is today's behaviour
-   exactly.
+   `before = b.space; b.reverse(0, in_place=True); before is b.space` is `False`, and `before`
+   keeps the old space. That is the contract to preserve. Measured, three storage shapes, an
+   escaped nested object across one in-place reseat:
+
+   | owner stores | accessor returns | escapee reads after the reseat | nested destructor ran during the reseat | `escapee is owner.space` |
+   |---|---|---|---|---|
+   | the space **by value** | `Space&`, `reference_internal` | **`2`** -- the *new* space | yes | **`True`** |
+   | `shared_ptr<const Space>` | `const Space&`, `reference_internal` | `1` -- correct | **yes** | `False` |
+   | `shared_ptr<const Space>` | `shared_ptr<const Space>` | `1` -- correct | no | `False` |
+
+   The first row is a **silent wrong answer**: the escaped object becomes the new space, with no
+   error and with `is` still reporting identity. The second row is the shape someone will propose
+   as the best of both -- store the handle, hand out a reference, name the policy -- and it is a
+   **use-after-free that returned the correct value**, which is F4's pattern again. Only the third
+   row reproduces today's Python.
 4. **It composes, and `reference_internal` does not compose cleanly.**
    `Bspline` -> `BsplineSpace` -> `BsplineSpace1D` is two levels. Under `shared_ptr` each level
    hands out one atomic increment and no level knows about any other. Under `reference_internal`
@@ -523,6 +534,13 @@ every bound class, adds a weak-map lookup to every nested access, and introduces
 cannot have. **What would change it:** propagation sites multiplying past a handful. There is one
 today.
 
+**Store `shared_ptr<const T>` but hand out `const T&` with `reference_internal`.** The
+apparent best of both: ownership in the type, no atomic per access, and a policy that pins the
+owner. Rejected on the measurement in reason 3's table: reseating the pointer frees the pointee
+while the escaped Python object still aliases it, and the escapee then read the *correct* value,
+so nothing announces it. The keep-alive pins the **owner**, which is not what needs to stay
+alive.
+
 **`std::enable_shared_from_this` on the nested types, with `reference_internal` on the binding.**
 nanobind supports it -- `nb_type_put_common` checks `has_shared_from_this` and takes out a second
 `shared_ptr` sharing ownership (`nb_type.cpp:2024-2030`) -- so this would give the shared-lifetime
@@ -627,6 +645,8 @@ between mechanisms:**
 - **Verified by execution in the `pantr` env:** that `b.space` changes identity across
   `reverse(direction=0, in_place=True)`; that `b.control_points is b._control_points` and the
   array is writable.
+- **Measured, 2026-08-31:** the three-row reseat table in reason 3, with a destructor counter
+  in the nested type, so the middle row's use-after-free is a count and not an inference.
 - **Asserted, not measured:** that a raw-reference version of a class-H accessor is a
   use-after-free for a C++ consumer. The Python-side analogue was measured (F4); the C++ analogue
   follows from the object model and was not put under ASAN, because the design does not contain

--- a/design/bspline_ownership_lifetime.md
+++ b/design/bspline_ownership_lifetime.md
@@ -422,6 +422,22 @@ and its wrong versions do not announce themselves.
 | M8 | the wrapper builds its `spaces` tuple lazily and forgets to seed from the constructor | `space.spaces[0] is space_1d` fails; values all agree | `tests/test_bspline_space.py:89`, unedited |
 | M9 | a `_ref` accessor gets bound | a dangling reference reachable from Python with no policy anywhere to blame | the bound-surface test: no exported method name ends in `_ref` |
 
+**Every one of these tests is inert under the default backend, and this is `design/backend_parity.md`
+Rule 12's shape rather than a new hazard.** `Backend.PYTHON` is the process default
+(`src/pantr/_backend.py:363-370`), so a plain `pytest` run exercises the oracle -- where
+`BsplineSpace` stores the caller's actual Python objects, `space.spaces[0] is space_1d` is
+trivially true, and a `sys.getrefcount` delta reports whatever CPython does with a tuple. The test
+passes for reasons that have nothing to do with the binding, and nothing in the output says so.
+Rule 12's general form applies verbatim: *the interpreted path is a different object, so a test
+that pins a configuration-dependent defect is inert there, silently.* So **every assertion in the
+table above must take the `cpp_backend` fixture** (`tests/parity/conftest.py:18-27`), whose
+`demand_cpp_backend()` is a skip-or-fail rather than a silent skip, and none of them belongs in a
+file that runs under the default.
+
+Note also that none of these is a *numerical* parity claim, so Rule 8 does not bite and no
+tolerance is owed: identity, a refcount delta and `np.shares_memory` are exact facts about the
+binding, and the right assertion for each is `==` or `is`.
+
 **Where these tests live.** `tests/parity/test_bezier_binding_contract.py` is the established
 shape -- a parity file whose subject is what the *binding* guarantees rather than what the
 mathematics does, gated on a `cpp_backend` fixture, with one test per refusal and the silent

--- a/design/bspline_ownership_lifetime.md
+++ b/design/bspline_ownership_lifetime.md
@@ -133,9 +133,21 @@ whose bytes are still intact).
 
 Two deterministic detectors, measured:
 
-- **`sys.getrefcount` on the owner's handle, before and after the access.** The delta is `1`
-  exactly when a keep-alive was installed and `0` otherwise -- measured across all seven
-  binding shapes above, with no C++ change and no annotation. This is the detector to use.
+- **`sys.getrefcount` on the owner's handle, before and after the access.** The delta is
+  **`0` exactly when no keep-alive was installed, and the number of keep-alives installed
+  otherwise** -- which is `1` for a scalar accessor and **`N` for an `N`-element container under
+  `reference_internal`**, because F3's per-element keep-alive really is per element. Measured
+  across eight binding shapes, with no C++ change and no annotation. This is the detector to use.
+
+  **The count is worth stating carefully, because two correct measurements of it disagree.** A
+  first pass here measured `1` for the container case and wrote the rule as a bare "exactly 1"; an
+  independent second pass measured `3` on a three-element vector and refuted it. Both runs were
+  right. The first held only the *escaped element* (`x.all_refint()[0]`), so the temporary list
+  died and released the other two elements' keep-alives before the second `getrefcount`; the second
+  retained the whole list. So the delta is a function of **how many returned elements are still
+  alive at the moment it is read**, and a test must fix that explicitly rather than let a temporary
+  decide it. For class H the assertion is `delta == 0` and the question does not arise, which is a
+  further small reason to prefer that shape.
 - **`weakref.ref` on the owner's handle**, which needs `nb::is_weak_referenceable()` on the
   bound class; without it, `weakref.ref` on a nanobind instance raises
   `TypeError: cannot create weak reference` (measured), and `gc.get_referents(child)` is `[]`,
@@ -649,7 +661,10 @@ between mechanisms:**
 - **Measured, 2026-08-31, on this machine, nanobind 2.14.0 / CPython 3.14.6 / g++ 14.4 `-O2`:**
   every row of F1's, F2's, F3's and F4's tables; that `reference_internal` on a by-value return
   is a no-op, on the pair `copy_at` / `copy_at_refint`; that `sys.getrefcount` on the owner moves
-  by exactly 1 under a keep-alive and 0 without; that a `weakref` on a nanobind instance raises
+  by 0 when no keep-alive is installed, by 1 for a scalar keep-alive, and by `N` for an
+  `N`-element container under `reference_internal` with the whole list retained -- the last of
+  these refuting a first pass that measured 1 while holding a single element, which F4 now
+  records; that a `weakref` on a nanobind instance raises
   unless the class is annotated; that a bare `rv_policy::reference` escapee read the correct value
   in the scalar case and garbage in the container case; the seven-row cost table; the 5.83 ns
   against 14.92 ns `space_ref` / `space` difference. The harness is described under "What was

--- a/design/bspline_ownership_lifetime.md
+++ b/design/bspline_ownership_lifetime.md
@@ -376,10 +376,14 @@ is discoverable:
   `type(self)._wrap(new_impl, space=self.space)`. In the current suite there is exactly one site
   that needs this, `Bspline.transform` (non-in-place), pinned by
   `tests/test_transform.py:634`. Every other `is` assertion in the suite is constructor
-  identity, which seeding covers: `tests/test_bspline.py:22,241`,
-  `tests/test_multilevel_extraction.py:103`, `tests/test_quasi_interpolation.py:314`,
-  `tests/test_mpi_collocation.py:188,202`, `tests/test_mpi_qi.py:153`,
-  `tests/test_mpi_l2.py:251`, `tests/test_mpi_thb_qi.py:151`.
+  identity, which seeding covers: `tests/test_bspline_space.py:89`,
+  `tests/test_bspline.py:22,241`, `tests/test_multilevel_extraction.py:103`,
+  `tests/test_quasi_interpolation.py:314`, `tests/test_grid_hierarchical.py:199`
+  (`assert g.root is root`, which is #395's), `tests/test_mpi_collocation.py:188,202`,
+  `tests/test_mpi_qi.py:153`, `tests/test_mpi_l2.py:251`, `tests/test_mpi_thb_qi.py:151`.
+  The three `dfn.local.space is ds.local.space` assertions
+  (`tests/test_mpi_qi.py:164`, `test_mpi_l2.py:262`, `test_mpi_thb_qi.py:162`) compare two Python
+  `LocalSpace` records and are untouched by any of this.
 
 There is no reference cycle to worry about under class H: the child holds no Python reference to
 the owner, so the owner's wrapper -> child wrapper -> child handle chain is acyclic and plain
@@ -417,6 +421,14 @@ and its wrong versions do not announce themselves.
 | M7 | the C++ constructor copies its nested spaces instead of sharing | two Python objects that compare identical over two different C++ objects (F6) | a parity assertion that `space.spaces[0]._impl is space_1d._impl` under the C++ backend |
 | M8 | the wrapper builds its `spaces` tuple lazily and forgets to seed from the constructor | `space.spaces[0] is space_1d` fails; values all agree | `tests/test_bspline_space.py:89`, unedited |
 | M9 | a `_ref` accessor gets bound | a dangling reference reachable from Python with no policy anywhere to blame | the bound-surface test: no exported method name ends in `_ref` |
+
+**Where these tests live.** `tests/parity/test_bezier_binding_contract.py` is the established
+shape -- a parity file whose subject is what the *binding* guarantees rather than what the
+mathematics does, gated on a `cpp_backend` fixture, with one test per refusal and the silent
+failure it prevents named in the docstring. Each of #395 to #400 owes a
+`tests/parity/test_<type>_binding_contract.py` section carrying M1 to M9's assertions for the
+accessors it adds. That file is also the natural home for the bound-surface test (M9), since it is
+already the file that asserts things about the extension rather than about a result.
 
 **The one test shape to require per held accessor**, because it is deterministic, needs no C++
 instrumentation, and fails on the design error rather than on the weather:

--- a/design/bspline_ownership_lifetime.md
+++ b/design/bspline_ownership_lifetime.md
@@ -1,0 +1,660 @@
+# Holding another domain type across the binding: who owns it, and who keeps it alive
+
+**Status:** proposed, 2026-08-31. Written for ticket #393, and binding on #395 to #401 if
+adopted.
+**Date:** 2026-08-31.
+**Scope:** what an accessor hands back when a C++-owned domain type holds another one, how the
+returned value's lifetime is guaranteed, which `rv_policy` each binding owes, and what the
+Python wrapper must memoise. Not where derived caches live, which is
+`design/bspline_derived_caches.md`. Not how the two backends are compared, which is
+`design/backend_parity.md`.
+**Companions:** `design/cross_backend_types.md` (the ownership ruling this obeys),
+`design/grid_hierarchy_port.md` (the wrapper pattern this extends, and whose `W1` this
+corrects), `design/bspline_derived_caches.md` (the memo slots this note's identity contracts
+require).
+
+**Validated against:** `proto/cpp` at `a45e935`, worktree `design/393-394-bspline-decisions`,
+plus `feat/387-tensor-product-grid` at `d7b8654` read through `git show` for the one shipped
+wrapper precedent. Every Python line number below was read in one of those two trees and says
+which. **nanobind 2.14.0**, CPython **3.14.6** (GIL enabled: `sys._is_gil_enabled()` is `True`
+and `sysconfig.get_config_var("Py_GIL_DISABLED")` is `0`), g++ **14.4.0** at `-O2`.
+
+## The decision in one paragraph
+
+**Classify the accessor, not the type.** Every accessor that returns a domain object falls into
+one of three classes, and the class settles the C++ storage, the `rv_policy`, the wrapper's memo
+and the test: **V**, the accessor *constructs* its result (about 31 of the roughly 40 accessors
+in `pantr.bspline`) -- return by value, no policy, no lifetime relationship; **H**, the accessor
+hands out a subobject the owner *holds* (eight sites, plus `HierarchicalGrid.root`) -- the owner
+stores **`std::shared_ptr<const T>`** and returns a copy of it, so the *value* is shared and the
+owner's death is irrelevant; **A**, the accessor hands out the owner's numeric storage -- a
+`const`-scalar `nb::ndarray` view with the owner's Python object as its owner, which is
+`bezier_type.cpp`'s shipped precedent. **No accessor in `pantr.bspline` uses
+`rv_policy::reference_internal`**, and that is the decision's whole content: `reference_internal`
+puts the lifetime guarantee in the *binding*, and the standing ruling is that the binding goes
+away. A `shared_ptr<const T>` puts it in the *type*, where the interpreter-free C++ consumer
+gets it too. `THBSplineSpace.grid` is the single exception to `const`, for a reason
+`grid/tags.hpp` already argued.
+
+## Findings against the ticket as written
+
+Five of these are measured. They are first because three of them change what the dependent
+tickets must do, and one of them corrects a claim already in the tree.
+
+### F1 (critical). The `rv_policy` fact this ticket hands me is true of a method and false of a property -- and the tree states it of a property
+
+The brief, `design/grid_hierarchy_port.md` W1, and `cpp/bindings/grid_types.cpp`'s header (on
+`feat/387-tensor-product-grid`, lines 16-30) all say: for a function returning an lvalue
+reference, `automatic` and `automatic_reference` resolve to `rv_policy::copy`, so under the
+default policy a write through such an accessor mutates a temporary and is silently lost.
+
+**The mechanism is real** -- `nanobind/nb_cast.h:455-473`, `infer_policy<T>`, does exactly that
+for `std::is_lvalue_reference_v<T>`. **The conclusion does not reach a property.**
+`nb::class_::def_prop_ro` delegates to `def_prop_rw` (`nanobind/nb_class.h:732-735`), and
+`def_prop_rw` builds the getter with `rv_policy::reference_internal` passed **positionally,
+ahead of the caller's `extra...`** (`nb_class.h:693-703`). So a property getter never sees
+`automatic`, and its default is already `reference_internal`.
+
+Measured, both directions:
+
+| binding of a method returning `Inner&` | aliases the member | write visible | `Inner` copies per access | owner kept alive |
+|---|---|---|---|---|
+| `.def("m", &Outer::single)` | **no** | **no** | 1 | no |
+| `.def("m", &Outer::single, nb::rv_policy::reference_internal)` | yes | yes | 0 | yes |
+| `.def_prop_ro("p", &Outer::single)` -- no policy named | **yes** | **yes** | 0 | **yes** |
+| `.def_prop_ro("p", &Outer::single, nb::rv_policy::copy)` | no | no | 1 | no |
+
+The consequence for the tree: of the three names in `grid_types.cpp`'s paragraph, `cell_tags`
+and `facet_tags` are `def_prop_ro` (lines 379-382), where the explicit `reference_internal` is
+**documentation rather than a repair**, and `cell_bvh` is a plain `.def` (line 383), where it is
+the repair. Nothing there is wrong-behaving; the *rule* an engineer would carry forward from it
+is. Naming the policy on a property remains the right style -- it is the only spelling that
+survives someone changing `def_prop_ro` to `.def` -- but it must be documented as belt-and-braces,
+not as the thing that makes the write land.
+
+`def_prop_ro_static` is a third case worth one line: it routes through `def_prop_rw_static`,
+which uses `rv_policy::reference` (`nb_class.h:712-729`) -- aliasing with **no** keep-alive,
+because a static getter has no self. Nothing in pantr uses one; a future one returning a
+reference would dangle silently.
+
+### F2 (critical). `nb::keep_alive<0, 1>` does not repair the copy, and it silences the symptom that would have found it
+
+Measured: `.def("m", &Outer::single, nb::keep_alive<0, 1>())` -- no `rv_policy` -- keeps the
+owner alive **and still hands back a copy**. The write through it is still lost, and one
+`Inner` copy is still made per access.
+
+This is the worst available combination, and it is the one a reader reaches for. The natural
+diagnosis of "my child object dangled" is "add a keep-alive", and doing that makes the
+lifetime test pass while leaving the aliasing broken. `keep_alive` and `rv_policy` are
+orthogonal: the first is applied post-call in the function dispatcher, the second decides
+whether an instance is created and copied into or made to point at existing storage
+(`nb_type.cpp:1963-2050`).
+
+So: **a keep-alive annotation is never evidence that an accessor aliases.** Under this note's
+decision the point is moot for `pantr.bspline`, because no accessor there uses either
+mechanism -- but #395 inherits a grid whose `cell_tags` genuinely must alias, and that is where
+the trap is live.
+
+### F3 (important). The policy propagates into a container, and each element gets its own keep-alive
+
+`nanobind/stl/detail/nb_list.h:60-67` forwards the caller's `rv_policy` to every element's
+caster. So a method returning `const std::vector<Inner>&`:
+
+| binding | elements alias | copies per access | an escaped *element* blocks the owner's destructor |
+|---|---|---|---|
+| default policy | no | 3 (one per element) | no |
+| `reference_internal` | yes | 0 | **yes** |
+| `rv_policy::reference` | yes | 0 | no |
+
+Measured with a destructor counter in the C++ and with `sys.getrefcount` in the Python. The
+third column is the part that is not obvious: the keep-alive is installed on each *element*, not
+only on the returned list, so `x = space.spaces[0]` alone is enough to pin the owner. The
+container therefore is **not** a separate hazard from the scalar case under
+`reference_internal`, which was the open question in #393's own wording.
+
+It stays a separate hazard under the default policy, and worse than the scalar one: at 16384
+doubles per nested object, one access of a 3-element container cost 109 microseconds against
+0.44 microseconds for the aliasing form (table under "What it costs").
+
+### F4 (critical). A value assertion does not detect a broken lifetime. A refcount assertion does, for free
+
+Measured, with `rv_policy::reference` (aliases, no keep-alive), after destroying the owner and
+running `gc.collect()`:
+
+| escaped child | reads back |
+|---|---|
+| a single member (`Inner&` into the owner) | `100` -- **the correct value** |
+| an element of the owner's `std::vector<Inner>` | `1096836676` -- garbage |
+
+Both are use-after-free. The first one *passed*. So the obvious test -- escape the child, drop
+the owner, assert the value -- is exactly the test that reports success on a broken design, and
+it reports it in the case a reviewer is most likely to write by hand (a scalar member, small,
+whose bytes are still intact).
+
+Two deterministic detectors, measured:
+
+- **`sys.getrefcount` on the owner's handle, before and after the access.** The delta is `1`
+  exactly when a keep-alive was installed and `0` otherwise -- measured across all seven
+  binding shapes above, with no C++ change and no annotation. This is the detector to use.
+- **`weakref.ref` on the owner's handle**, which needs `nb::is_weak_referenceable()` on the
+  bound class; without it, `weakref.ref` on a nanobind instance raises
+  `TypeError: cannot create weak reference` (measured), and `gc.get_referents(child)` is `[]`,
+  so the keep-alive edge is invisible to the GC module.
+
+`sys.getrefcount`'s *absolute* value is a CPython implementation detail; the delta is not, and
+the delta is what to assert. On a free-threaded build the function is documented as unreliable
+for immortalised objects; a bound instance is an ordinary heap object, and no CI leg is
+free-threaded today (verified: `.github/workflows/ci.yaml:20,80,131` list `3.11`, `3.13`,
+`3.14`, none of them `t`).
+
+### F5 (important). The nine accessors the ticket names are not the nine that matter, and the real count is about forty
+
+Verified by reading each site.
+
+**Three of the nine carry no lifetime question at all**, because they hold a freshly constructed
+object rather than a subobject of anything: `BsplineSpaceRestriction.space` (the field is filled
+at `src/pantr/bspline/_bspline_space_nd.py:390` from a `BsplineSpace(...)` built on the spot),
+`THBSplineSpaceRestriction.space` (`_thb_spline_space.py:1064`), and `LocalSpace.space`
+(`_local_space.py:353,478`, from `global_space.restrict(window)`).
+
+**A fourth is not the aggregation case at all.** `ExtractionStructView`
+(`spanwise_element_extraction.py:1119-1196`) has **no `space` field** -- its fields
+(`:1152-1158`) are three per-direction array bundles plus integer shape metadata. So #399's
+premise, that its lifetime "is exactly what the aggregation-lifetime note settles", is half
+right: it is class **A** below, the array-view case that `cpp/bindings/bezier_type.cpp:43-56`
+already settled, and it needs nothing from the aggregation rule.
+
+**What is left is eight held accessors**, and the ticket misses three of them:
+`BsplineSpace.spaces` (`_bspline_space_nd.py:68-74`), `Bspline.space` (`_bspline.py:126-136`),
+`THBSpline.space` (`_thb_spline.py:87-94`), `MultiLevelExtraction.space`
+(`multilevel_extraction.py:121-128`), `SpanwiseElementExtraction.space`
+(`spanwise_element_extraction.py:210-217`), `THBSplineSpace.grid`
+(`_thb_spline_space.py:809-816`), and -- not in the ticket -- `THBSplineSpace.root_space`
+(`:818-825`), `THBSplineSpace.level_space` (`:917-934`), plus `HierarchicalGrid.root`
+(`_hierarchical_grid.py:477-484`) on the grid side of #395.
+
+**And roughly thirty-one more accessors return a domain object by construction**, which is the
+number that matters for effort: 17 on `Bspline`, 3 on `BsplineSpace1D`, 6 on `THBSplineSpace`,
+2 on `THBSpline`, 1 on `BsplineSpace`, plus the module-level factories. They are all class **V**
+and none of them needs a decision. **Restate #393's "at least nine accessors qualify" as "eight
+hold, about thirty-one construct, and the classification is the deliverable."**
+
+### F6 (critical). Two identity assertions in the suite are stronger than "the same object twice", and one of them fixes the C++ constructor's signature
+
+- `tests/test_bspline_space.py:89` is `assert space.spaces[0] is space_1d`. The object that
+  comes back is **the constructor argument's own Python object**. No C++ object can supply
+  that; only the wrapper can, by keeping what it was built from.
+- `tests/test_transform.py:634` is `assert s2.space is s.space  # same space object`, where
+  `s2 = s.transform(...)`. A **derived** object hands back the **source's** space wrapper.
+  Wrapping `s2._impl.space` afresh gives a different Python object even when the C++ pointer is
+  identical, so this one cannot be satisfied by memoisation alone.
+
+The first has a consequence one level down. If `space.spaces[0] is space_1d` holds at the
+wrapper level, then `space.spaces[0]._impl is space_1d._impl` holds too -- so a C++
+`BsplineSpace` that *copied* its 1D spaces would present two Python objects agreeing on identity
+over two different C++ objects, which is a divergence a parity test would eventually find and
+nobody would enjoy diagnosing. **The identity contract, not performance, is what requires the
+C++ constructor to share rather than copy.**
+
+## The decision
+
+### The three classes
+
+| | what the accessor does | C++ storage and signature | binding | wrapper | lifetime guarantee |
+|---|---|---|---|---|---|
+| **V** *value* | constructs its result | returns `T` by value | default policy (resolves to `move`) | `_wrap` the fresh handle | none needed; the owner may die immediately |
+| **H** *held* | hands out a subobject the owner keeps | stores `std::shared_ptr<const T>`; returns a copy of it | default policy, plus `#include <nanobind/stl/shared_ptr.h>` | memoise the wrapper in a named `__slots__` slot | the **value** is shared; the owner is irrelevant |
+| **A** *array view* | hands out the owner's numeric storage | returns `std::span<const T>` | `nb::ndarray<const T, ...>(ptr, shape, self)` | pass through unchanged | the array holds a reference to the owner's Python object |
+
+**No `rv_policy::reference_internal` anywhere in `pantr.bspline`.** State it as a rule so that a
+reviewer can grep for a violation.
+
+### Why H is `shared_ptr<const T>` and not `reference_internal`
+
+Four reasons, in the order they decide it.
+
+1. **`reference_internal` is a guarantee that lives in the binding, and the binding is
+   scheduled for deletion.** The standing ruling on this port is the user's, verbatim: *"mi idea
+   sobre el backend de pantr es que sea solo C++. La idea de tener python o C++ es solo temporal,
+   para que sirva de oraculo durante el desarrollo. En el futuro, solo C++."* A C++ consumer
+   writing `const BsplineSpace1D& s = sp.space(0);` and then letting `sp` go out of scope gets no
+   protection from a nanobind policy, and nothing in the type warned it. `shared_ptr<const T>` is
+   a guarantee the type carries, so both consumers get the same one.
+2. **The tree already made this exact call once, for the same reason.**
+   `cpp/include/pantr/grid/tags.hpp:20-29` holds each tag behind `std::shared_ptr<const Tag>`
+   precisely so a handed-out view outlives a replacement, and says so: *"the port would otherwise
+   have introduced a use-after-free the pre-port class could not have."* This note generalises
+   that ruling from a tag's arrays to a nested space.
+3. **It is the only mechanism that reproduces `Bspline`'s in-place semantics.**
+   `Bspline.reverse(direction, in_place=True)` and `permute_directions(..., in_place=True)`
+   **replace** `self._space` (`_bspline.py:1035-1039`, `1101-1106`) -- verified by execution:
+   `before = b.space; b.reverse(0, in_place=True); before is b.space` is `False`. Under
+   `reference_internal` the escaped Python object points at the *address* of the owner's member,
+   so after the reseat it would silently start reporting the **new** space -- a wrong answer with
+   no diagnostic. Under `shared_ptr` the escapee holds the old value, which is today's behaviour
+   exactly.
+4. **It composes, and `reference_internal` does not compose cleanly.**
+   `Bspline` -> `BsplineSpace` -> `BsplineSpace1D` is two levels. Under `shared_ptr` each level
+   hands out one atomic increment and no level knows about any other. Under `reference_internal`
+   the keep-alive is installed against `cleanup->self()`, so `b.space.spaces[0]` pins the
+   `BsplineSpace` and the `BsplineSpace` pins the `Bspline` -- correct, but only because each
+   intermediate Python object exists long enough to be the `self` of the next call, which is a
+   property of the expression the caller wrote rather than of the design.
+
+Immutability is what makes sharing safe, and it is already true: verified by reading, every
+domain type in `src/pantr/bspline/` is immutable after construction except `Bspline` (whose
+`_space` slot is *reseated*, never mutated) and the `HierarchicalGrid` reachable through
+`THBSplineSpace.grid`. `shared_ptr<const T>` over an immutable `T` is a value with a cheap copy;
+it is construct-then-freeze with sharing added, not mutation added.
+
+### The one exception to `const`
+
+`THBSplineSpace` stores **`std::shared_ptr<HierarchicalGrid>`**, non-const, and hands out a copy
+of it. The reason is narrow and is not "grids are special": a grid holds `CellTags` and
+`FacetTags`, which `cpp/include/pantr/grid/tags.hpp:14-19` already reasons as the accumulating-
+container exception to construct-then-freeze, and `thb.grid.cell_tags.set(...)` works today. A
+`shared_ptr<const HierarchicalGrid>` would reach only the `const` overload of `cell_tags()` and
+would silently remove the ability to tag cells through a THB space's grid.
+
+This is safe only because **#378 makes refinement return a new grid**. Until #378 lands, sharing
+a mutable grid between a `THBSplineSpace` and its caller is what the staleness counter exists to
+police (`_hierarchical_grid.py:505-517`, read by `_thb_spline_space.py:745-757`). **If #378 is
+dropped, this exception must be revisited** and the grid must go out as a copy instead. That is
+the one thing that would reverse it. #393 and #394 are both already blocked on #378 in the DAG,
+so the ordering is guaranteed.
+
+### The C++ shape, and the accessor pair
+
+```cpp
+class BsplineSpace {
+  public:
+    /// Share direction `d`'s 1D space.  The returned handle keeps its value alive
+    /// independently of this space, so a caller may outlive the owner.
+    [[nodiscard]] std::shared_ptr<const BsplineSpace1D> space(std::int64_t d) const;
+
+    /// Borrow direction `d`'s 1D space.  Valid while `*this` is, and NOT bound: an
+    /// inner loop must not pay an atomic pair per access.  See the `_ref` rule below.
+    [[nodiscard]] const BsplineSpace1D& space_ref(std::int64_t d) const noexcept;
+
+    /// Share every direction, in axis order.
+    [[nodiscard]] std::span<const std::shared_ptr<const BsplineSpace1D>> spaces() const noexcept;
+
+  private:
+    std::vector<std::shared_ptr<const BsplineSpace1D>> spaces_;
+};
+```
+
+Two constructors, and the first is the one the binding calls:
+
+```cpp
+/// Share the given 1D spaces.  This is what preserves the wrapper's identity contract.
+explicit BsplineSpace(std::vector<std::shared_ptr<const BsplineSpace1D>> spaces);
+
+/// Copy the given 1D spaces, for a C++ caller holding values rather than handles.
+explicit BsplineSpace(std::span<const BsplineSpace1D> spaces);
+```
+
+**The `_ref` rule.** An owning accessor and a borrowing accessor exist side by side; the
+borrowing one carries the `_ref` suffix and **is never bound**. Measured, g++ 14.4 `-O2`, one
+pinned core, accessor bodies in a separate translation unit so the call is real: `space_ref(d)`
+costs **5.83 ns** per access and `space(d)` costs **14.92 ns**, a difference of **9.1 ns** which
+is the uncontended atomic increment/decrement pair. Nine nanoseconds is nothing next to a 200 ns
+Python call and everything next to a de Boor step, so the pair is load-bearing rather than
+decorative. Enforce "never bound" with a test over the bound surface -- assert that no method
+name exposed by `pantr._pantr_cpp` ends in `_ref` -- because there is no `static_assert` for
+absence and review alone will not hold across nine tickets.
+
+### The binding rules, in the form a binding author needs
+
+```
+class V (constructs)     .def("insert_knots", &BsplineSpace1D::insert_knots, nb::arg(...))
+                         -> no policy.  infer_policy resolves a by-value return to `move`.
+                            Declaring reference_internal here is a SILENT NO-OP for lifetime
+                            (measured: the policy is downgraded to `move` and no keep-alive
+                            is installed), so do not write it.
+
+class H (holds)          .def_prop_ro("spaces", &BsplineSpace::spaces_shared)
+                         -> no policy.  The value is a shared_ptr; ownership travels in the
+                            return value.  #include <nanobind/stl/shared_ptr.h>.
+
+class A (array view)      .def_prop_ro("knots", [](nb::handle self) { ... })
+                         -> nb::ndarray<const T, nb::numpy, nb::ndim<N>>(ptr, shape, self).
+                            `const T` is what sets the read-only flag; `self` is what keeps
+                            the storage alive.  Precedent: cpp/bindings/bezier_type.cpp:43-56.
+```
+
+For class H the binding hands back `std::shared_ptr<const T>`, not `const T&`, so nanobind's
+`shared_ptr` caster runs and no policy question arises. Measured: the returned Python object is
+identity-stable while alive (`so.at(0) is so.at(0)` is `True`, because `nb_type_put` looks the
+pointer up in `inst_c2p` before creating an instance -- `nb_type.cpp:2077-2116`), the C++
+`use_count` goes from 1 to 2 on the way out, and the element reads correctly after the owner is
+destroyed with only the owner's own destructor having run.
+
+### The wrapper's shape
+
+`#387`'s pattern verbatim, with one addition. Each wrapper declares
+`__slots__ = ("_impl", "_spaces", ...)`, a raising `__setattr__`/`__delattr__`, and fills memo
+slots through `object.__setattr__` (`src/pantr/grid/_tensor_product_grid.py:660,704-731` on
+`feat/387-tensor-product-grid`).
+
+The addition is **seeding**, and it is what satisfies F6:
+
+```python
+def __init__(self, spaces):
+    validated = _validated_spaces(spaces)          # a tuple of BsplineSpace1D wrappers
+    self._take(_impl_class()([s._impl for s in validated]), spaces=validated)
+
+@classmethod
+def _wrap(cls, impl, *, spaces=None):
+    """Adopt an already-valid implementation, optionally with its nested wrappers."""
+
+def _take(self, impl, *, spaces=None):
+    object.__setattr__(self, "_impl", impl)
+    object.__setattr__(self, "_spaces", spaces)    # None => build lazily on first read
+```
+
+Two rules follow from it, and both must be written into the wrapper's docstring because neither
+is discoverable:
+
+- **Seed from the constructor.** A wrapper built from Python arguments keeps those arguments'
+  wrappers, so `space.spaces[0] is space_1d` holds. A wrapper built by `_wrap` from a C++ handle
+  seeds `None` and builds the tuple on first read, because there is nothing for it to be
+  identical to.
+- **Propagate when the nested object is known unchanged.** A method that returns a derived object
+  sharing this one's nested object passes its own wrapper down:
+  `type(self)._wrap(new_impl, space=self.space)`. In the current suite there is exactly one site
+  that needs this, `Bspline.transform` (non-in-place), pinned by
+  `tests/test_transform.py:634`. Every other `is` assertion in the suite is constructor
+  identity, which seeding covers: `tests/test_bspline.py:22,241`,
+  `tests/test_multilevel_extraction.py:103`, `tests/test_quasi_interpolation.py:314`,
+  `tests/test_mpi_collocation.py:188,202`, `tests/test_mpi_qi.py:153`,
+  `tests/test_mpi_l2.py:251`, `tests/test_mpi_thb_qi.py:151`.
+
+There is no reference cycle to worry about under class H: the child holds no Python reference to
+the owner, so the owner's wrapper -> child wrapper -> child handle chain is acyclic and plain
+reference counting collects it. That is a second, quieter advantage over `reference_internal`,
+where the child handle does hold the owner handle.
+
+`__reduce__` reconstructs from the public arrays and the nested wrappers, never from the handle
+-- the rule commit `11f22a7` established for the affine map. Sharing survives a single pickle for
+free, because `pickle` memoises: dumping `(b, b.space)` restores a pair that shares one space.
+Sharing does **not** survive two independent `dumps` calls, which is also true today.
+
+## The failure modes, and the test that catches each
+
+Every one of these is silent. That is the point of the section: the design is cheap to get right
+and its wrong versions do not announce themselves.
+
+| # | mistake | what a user sees | what catches it |
+|---|---|---|---|
+| M1 | class H bound as `const T&` with no policy | a fresh copy per access; `space.spaces[0] is space_1d` **fails**; a memoised derived cache (see the companion note) is cold on every access, so a loop recomputes it every iteration | the identity assertion already in `tests/test_bspline_space.py:89`, and a parity test that the same access twice is the same object |
+| M2 | class H bound as `const T&` with `reference_internal` "because the grid does it" | works today, dangles for the interpreter-free C++ consumer; and for `Bspline`, an escaped `space` silently starts reporting the *new* space after `reverse(in_place=True)` | a C++ unit test that outlives the owner: build the owner in a scope, take the handle out, let the owner die, read. Under `shared_ptr` it passes; under a raw reference ASAN reports the use-after-free. Plus a Python test asserting `sys.getrefcount(owner._impl)` is **unchanged** by the access -- the delta-0 assertion is what pins "no keep-alive was installed", i.e. that nobody quietly reverted to `reference_internal` |
+| M3 | `keep_alive<0, 1>` added to fix a dangle | the dangle stops, the copy stays, the write is still lost (F2) | assert the *aliasing* separately from the *lifetime*: `np.shares_memory(space.spaces[0].knots, space.knots_along(0))`. A copy breaks memory sharing even though the values agree |
+| M4 | `reference_internal` declared on a class-V accessor | nothing; it is a complete no-op. Measured on the pair `copy_at` / `copy_at_refint`: refcount delta 0, no aliasing, owner destroyed, in both | a lint over the bindings: no `rv_policy` on a method whose C++ return type is not a reference or pointer. Cheap to write, and it is the only detector, because the runtime behaviour is identical |
+| M5 | class A bound with a non-`const` scalar | the view comes back **writeable**, so a caller can mutate validated geometry from outside | `assert not arr.flags.writeable`, which `pantr.bezier` already asserts; plus a mutation attempt inside `pytest.raises(ValueError)` |
+| M6 | class A bound with no owner argument | nanobind **copies** silently and the array comes back writeable, so both M5's symptom and a lost aliasing contract | `np.shares_memory(...)` against the owner's storage. `grid_types.cpp:116-121` on `feat/387` already records this exact trap; `tests/test_spanwise_element_extraction.py:1681` is the assertion shape |
+| M7 | the C++ constructor copies its nested spaces instead of sharing | two Python objects that compare identical over two different C++ objects (F6) | a parity assertion that `space.spaces[0]._impl is space_1d._impl` under the C++ backend |
+| M8 | the wrapper builds its `spaces` tuple lazily and forgets to seed from the constructor | `space.spaces[0] is space_1d` fails; values all agree | `tests/test_bspline_space.py:89`, unedited |
+| M9 | a `_ref` accessor gets bound | a dangling reference reachable from Python with no policy anywhere to blame | the bound-surface test: no exported method name ends in `_ref` |
+
+**The one test shape to require per held accessor**, because it is deterministic, needs no C++
+instrumentation, and fails on the design error rather than on the weather:
+
+```python
+def test_space_accessor_shares_rather_than_pins(...):
+    owner = BsplineSpace([s1d_a, s1d_b])
+    impl = owner._impl
+    before = sys.getrefcount(impl)
+    child = owner.spaces[0]
+    assert sys.getrefcount(impl) == before      # no keep-alive: the value is shared, not pinned
+    assert child is s1d_a                       # constructor identity survives
+    del owner
+    gc.collect()
+    assert child.num_basis == expected          # the value outlived its owner
+```
+
+The first assertion is the one that would not be written without this note, and it is the one
+that catches M2. The third one alone is the test F4 shows can pass on a broken design.
+
+## What it costs at the call site
+
+Measured on this machine, 2026-08-31, nanobind 2.14.0, CPython 3.14.6, g++ 14.4 `-O2`; 20000
+accesses per timing, best of 5. The nested object holds `width` doubles.
+
+| accessor shape | width 4 | 64 | 1024 | 16384 |
+|---|---|---|---|---|
+| `.def` + default policy (copies) | 198 ns | 206 ns | 322 ns | 6990 ns |
+| `.def` + `reference_internal` | 213 ns | 205 ns | 216 ns | 212 ns |
+| `def_prop_ro` (property) | 225 ns | 212 ns | 227 ns | 217 ns |
+| by-value accessor (`copy_at`) | 223 ns | 233 ns | 349 ns | 7547 ns |
+| container of 3, default policy | 409 ns | 430 ns | 1082 ns | 109040 ns |
+| container of 3, `reference_internal` | 447 ns | 448 ns | 461 ns | 443 ns |
+| `shared_ptr<const T>` accessor | 224 ns | -- | 233 ns | 229 ns |
+
+Three things to read out of it, and one to read out of the companion note:
+
+- **At the Python boundary the choice is free below about 1000 doubles** -- everything is the
+  ~200 ns call overhead -- and it is a factor of 33 (scalar) to 246 (container of three) above
+  it. So the copy option is not merely unfashionable; on a knot vector of any size it is a
+  measurable per-access cost that no later tuning removes.
+- **`shared_ptr` is indistinguishable from `reference_internal` at the Python boundary.** The
+  atomic pair is 9.1 ns against a 200 ns call. Choosing the safer mechanism costs nothing here.
+- **Inside C++ the atomic pair is 9.1 ns against a 5.8 ns borrow**, which is why `space_ref`
+  exists and is not bound.
+- **The copy option's real cost is not in this table.** A by-value accessor hands back an object
+  with a *cold* derived cache, so `for d in range(dim): space.spaces[d].num_intervals` recomputes
+  the memo on every iteration instead of once per space. That is a shape change, not a constant
+  factor, and it is the argument that kills the copy option outright rather than on price. See
+  `design/bspline_derived_caches.md`.
+
+## What each ticket in the milestone inherits
+
+- **#395 `HierarchicalGrid`.** One held accessor, `root` -> `TensorProductGrid`
+  (`_hierarchical_grid.py:477-484`): store `std::shared_ptr<const TensorProductGrid<double>>`.
+  Its own `cell_tags` / `facet_tags` / `cell_bvh` are **not** class H -- they are the grid mixin's
+  own members and keep `reference_internal` exactly as #386/#387 have them, because a tag
+  registry must alias (it is the accumulating-container exception, `tags.hpp:14-19`). So #395 is
+  the one ticket in the milestone that uses both mechanisms, and the F2 trap is live in it.
+  Also: F1 means its `cell_bvh` binding is the one where the explicit policy is load-bearing, and
+  its two tag properties are the ones where it is documentation.
+- **#396 `BsplineSpace1D` and `BsplineSpace`.** The whole of the H rule, plus F6's two
+  constructors and the seeding rule. `BsplineSpaceRestriction` stays a Python `NamedTuple` whose
+  `space` field holds a freshly built wrapper -- class V, nothing to do. Its `AC` set should
+  include M1, M7 and M8 by name; each is one assertion.
+- **#397 `THBSplineSpace`.** Three held accessors (`grid`, `root_space`, `level_space`), one of
+  which is the `const` exception. `level_space(level)` returns a `shared_ptr` from a
+  `std::vector<std::shared_ptr<const BsplineSpace>>`; the wrapper memoises per level in a
+  `dict[int, BsplineSpace]` memo slot, which is the one place a dict memo is right here because
+  the key is genuinely data. `THBSplineSpaceRestriction.space` is class V.
+- **#398 `Bspline`.** One held accessor (`space`), the reseat semantics of reason 3 above, the
+  one propagation site (`transform`), and **the largest downstream exposure in the milestone**;
+  see the next section. Its `control_points` is class A and its writability is a genuine break --
+  flagged below rather than decided here.
+- **#399 the extraction machinery.** `SpanwiseElementExtraction.space` is the only class-H
+  accessor; `ExtractionStructView` is class A throughout (F5), so what it needs is
+  `bezier_type.cpp`'s view idiom and `tests/test_spanwise_element_extraction.py:1681`'s
+  `shares_memory` assertion, not this note's H rule. Its `compact_ops_1d` arrays are already
+  frozen read-only at `spanwise_element_extraction.py:188-190`, so the `const T` scalar matches
+  today's contract with no behaviour change.
+- **#400 `THBSpline` and `MultiLevelExtraction`.** Two held accessors, both plain. The deferred
+  distribution cluster keeps `LocalSpace` as a Python `NamedTuple` whose `space` field holds a
+  wrapper -- class V by F5, so the deferral costs this note nothing.
+- **#401 scaffolding removal.** The `_adopt` helper
+  (`src/pantr/grid/_grid.py:744-768` on `feat/387`) exists only because the Python oracle exists,
+  and the bspline wrappers will grow their own copies of it. Name them in #401's list on the way
+  in, not on the way out.
+
+## Alternatives rejected
+
+**`rv_policy::reference_internal` throughout, matching the grid.** The cheapest thing to write,
+the most consistent-looking, and it works today. Rejected on reason 1 above: the guarantee lives
+in the binding, and on reason 3, which is a wrong answer rather than a dangling pointer.
+**What would change it:** a ruling that the interpreter-free C++ consumer is hypothetical after
+all. It is not -- it is the premise of the 2026-08-27 amendment.
+
+**Return the nested object by value and accept the copy.** No lifetime question at all, and for a
+`BsplineSpace1D` of a dozen knots the copy is genuinely free (measured: 198 ns against 213 ns at
+width 4). Rejected on three grounds, in increasing order of weight: it is a factor of 33 at
+16384 doubles; it breaks `tests/test_bspline_space.py:89` and `tests/test_transform.py:634`
+outright, because a copy cannot be the object the caller passed in; and it hands back an object
+with a cold derived cache, turning a memo into a per-access recomputation.
+**What would change it:** nothing available. Even dropping both identity assertions leaves the
+cold-cache problem.
+
+**`std::unique_ptr<const T>` plus a raw borrowing accessor.** Expresses single ownership honestly
+and costs no atomics. Rejected because it cannot satisfy `tests/test_transform.py:634` at all: two
+`Bspline`s sharing one space is the contract, and unique ownership forbids it.
+
+**An intern table -- a `WeakKeyDictionary` from handle to wrapper -- so that wrapping the same
+handle twice yields the same wrapper.** This would make F6b automatic and remove the propagation
+rule. Rejected as too much machinery for one site: it needs `nb::is_weak_referenceable()` on
+every bound class, adds a weak-map lookup to every nested access, and introduces a failure mode
+(a wrapper resurrected from the table with a different backend's handle) that the explicit form
+cannot have. **What would change it:** propagation sites multiplying past a handful. There is one
+today.
+
+**`std::enable_shared_from_this` on the nested types, with `reference_internal` on the binding.**
+nanobind supports it -- `nb_type_put_common` checks `has_shared_from_this` and takes out a second
+`shared_ptr` sharing ownership (`nb_type.cpp:2024-2030`) -- so this would give the shared-lifetime
+behaviour *through* a reference-returning accessor. Rejected because it makes the safety depend on
+the owner having created the object through a `shared_ptr` in the first place, which nothing in the
+type enforces: a stack-allocated `BsplineSpace1D` would `throw std::bad_weak_ptr` at the first
+access. Storing the `shared_ptr` is the same guarantee with the failure removed.
+
+## What this design changes for the downstream consumer
+
+`pantr.bspline` is that repository's largest exposure, and pantr's CI cannot see it. Flagged
+explicitly rather than assumed free. Nothing here was checked against that repository; it is not
+this note's to read.
+
+**No signature and no name changes.** Every accessor keeps its name, its arity and its return
+type as Python sees it. `BsplineSpace.spaces` still returns a tuple, `Bspline.space` still returns
+a `BsplineSpace`.
+
+**Four behaviour changes, all of them consequences of the port rather than of this note's choice
+between mechanisms:**
+
+1. **A nested object handed out is no longer the same *C++* object as an independently constructed
+   equal one**, and `__eq__` does not exist on any of these classes to paper over it -- verified:
+   none of `BsplineSpace1D`, `BsplineSpace`, `THBSplineSpace`, `Bspline`, `THBSpline`,
+   `TensorProductGrid`, `HierarchicalGrid` defines `__eq__` or `__hash__`. A consumer comparing
+   spaces with `==` is comparing identity today and will still be comparing identity after. No
+   change, but worth stating because it looks like the kind of thing a port would alter.
+2. **`Bspline(space, cp)` copies `cp`.** The C++ value type copies at construction, so
+   `cp[0] = ...` after construction stops being visible. This is not new policy: the same
+   decision is already shipped for `Bezier` and recorded at
+   `tests/test_bspline_conversion.py:22-32`, which skips `test_copy_false` under the C++ backend
+   with the reason *"the C++ value copies its control points at construction, so `copy=False`
+   shares nothing under that backend"*. #398 inherits both the decision and the skip idiom.
+3. **`Bspline.control_points` becomes a read-only view.** `Bezier`'s precedent
+   (`src/pantr/bezier/_bezier.py:473-484`) is explicit: under the C++ backend it is a read-only
+   view of the object's own storage, writing raises, and it stays valid after the object is
+   dropped. Today `Bspline.control_points` is the live writable array -- verified by execution:
+   `b.control_points is b._control_points` is `True` and `b.control_points[0,0] = 99` changes the
+   object. **This is the one change in the milestone that will break working downstream code
+   silently-turned-loud** (an `IndexError`-free `ValueError: assignment destination is read-only`
+   at the write). It is #398's to schedule and the user's to approve; this note only records that
+   the `Bezier` precedent settles the *shape* and not the *timing*.
+4. **`THBSplineSpace` may stop raising `RuntimeError: THBSplineSpace is stale`.** Once #378 makes
+   refinement return a new grid, the staleness the version counter detects cannot arise from
+   pantr's own API. Whether the check and its exception stay as a guard against a hand-mutated
+   grid is #378's and #397's call; a consumer catching that `RuntimeError` should be told either
+   way.
+
+## Bad practices flagged, for the user's inspection rather than for fixing here
+
+- **`grid_types.cpp`'s and `grid_hierarchy_port.md` W1's `rv_policy` paragraph is right about the
+  mechanism and wrong about the site** (F1). Both name `cell_tags` -- a `def_prop_ro`, where
+  `reference_internal` is already the default -- as the case where the default policy would lose
+  a write. The behaviour of the shipped code is correct; the sentence teaches a rule that is
+  false for half the bindings it will be applied to. **Cost of keeping:** an engineer on #395
+  reads it, concludes "lvalue reference implies name the policy", and either adds noise to
+  properties (harmless) or, believing the converse, omits it from a `.def` (a silent copy). **Cost
+  of fixing:** two comment edits and one sentence in the design note, no behaviour change. Fixing
+  it is a `docs(cpp)` commit that belongs to whoever next opens either file.
+- **`src/pantr/grid/_grid.py`'s `cell_bvh` docstring says concurrent first calls "may each build a
+  valid tree and one write wins, costing redundant construction."** True of the Python
+  implementation. **False of the C++ one**, where two threads writing one `std::optional` is a
+  data race and therefore undefined behaviour, not a lost update. The claim is a Python
+  implementation detail written into the contract of a method both backends implement. Argued and
+  measured in `design/bspline_derived_caches.md`; recorded here because the sentence sits in a
+  file #395 will edit.
+- **`Bspline.control_points` hands out the live writable array with no defensive copy** while
+  `THBSpline.control_points` freezes its at construction
+  (`src/pantr/bspline/_thb_spline.py:84`). Two sibling types, opposite answers, and the mutable
+  one is the type whose `_beziers_cache` and `_locate_cache` are invalidated only by the three
+  sanctioned `in_place=` methods -- so a write through `control_points` desynchronises both caches
+  with nothing raising. That is a defect in today's Python, not something the port introduces, and
+  the port is what will remove it (change 3 above). Worth a ticket so the removal is deliberate
+  rather than a side effect.
+
+## Epistemic status
+
+- **Measured, 2026-08-31, on this machine, nanobind 2.14.0 / CPython 3.14.6 / g++ 14.4 `-O2`:**
+  every row of F1's, F2's, F3's and F4's tables; that `reference_internal` on a by-value return
+  is a no-op, on the pair `copy_at` / `copy_at_refint`; that `sys.getrefcount` on the owner moves
+  by exactly 1 under a keep-alive and 0 without; that a `weakref` on a nanobind instance raises
+  unless the class is annotated; that a bare `rv_policy::reference` escapee read the correct value
+  in the scalar case and garbage in the container case; the seven-row cost table; the 5.83 ns
+  against 14.92 ns `space_ref` / `space` difference. The harness is described under "What was
+  compiled" and is not committed.
+- **Verified by reading nanobind's source at the installed version:** `infer_policy`'s
+  lvalue-reference resolution (`include/nanobind/nb_cast.h:455-473`); `def_prop_ro`'s delegation
+  and `def_prop_rw`'s positional `reference_internal` (`include/nanobind/nb_class.h:693-703`,
+  `732-735`); `def_prop_rw_static`'s `rv_policy::reference` (`:712-729`); the element-wise policy
+  forward (`include/nanobind/stl/detail/nb_list.h:60-67`); `nb_type_put`'s `inst_c2p` lookup and
+  `nb_type_put_common`'s keep-alive, `destruct` flag and `shared_from_this` branch
+  (`src/nb_type.cpp:1963-2050`, `2052-2124`).
+- **Verified by reading the tree at `a45e935`:** the eight held accessors and the roughly
+  thirty-one constructing ones, each at the line cited in F5; that `ExtractionStructView` has no
+  `space` field; that no `__reduce__`, `__getstate__` or `__setstate__` exists anywhere in
+  `src/pantr/bspline/`; that no domain class in `bspline` or `grid` defines `__eq__` or
+  `__hash__`; the shared-`Tag` rationale at `cpp/include/pantr/grid/tags.hpp:14-29`; the array-view
+  rationale at `cpp/bindings/bezier_type.cpp:43-56`; the CI Python matrix.
+- **Verified by reading `feat/387-tensor-product-grid` at `d7b8654` through `git show`:** the
+  wrapper pattern, `_adopt`, the memo slots, the raising `__setattr__`, the `view_of` owner
+  argument, and the four `rv_policy` sites. That worktree was not entered.
+- **Verified by execution in the `pantr` env:** that `b.space` changes identity across
+  `reverse(direction=0, in_place=True)`; that `b.control_points is b._control_points` and the
+  array is writable.
+- **Asserted, not measured:** that a raw-reference version of a class-H accessor is a
+  use-after-free for a C++ consumer. The Python-side analogue was measured (F4); the C++ analogue
+  follows from the object model and was not put under ASAN, because the design does not contain
+  the construct.
+- **Not investigated:** whether the not-yet-public downstream consumer writes through
+  `Bspline.control_points`, or catches `THBSplineSpace`'s staleness `RuntimeError`. Both are owed
+  before #398 and #397 land. Also not investigated: whether `SpanwiseElementExtraction`'s
+  `ops_1d` decompression is on any consumer's hot path, which would change #399's laziness answer
+  rather than its lifetime answer.
+
+## What was compiled, and how to reproduce it
+
+Not committed: it exists to settle the mechanisms, and its home is the bindings and the parity
+tests once the tickets are built.
+
+Three nanobind extensions over a pantr-free stand-in pair -- `Inner` (a nested domain type
+holding one `std::vector<double>`) and `Outer` (a holder with one `Inner` member and a
+`std::vector<Inner>`) -- plus a `SharedOuter` holding `std::vector<std::shared_ptr<const Inner>>`.
+`Inner` counts its own copy constructions and destructions and `Outer` its destructions, which is
+what makes the copy and lifetime columns measurements rather than inferences. Eleven accessors
+were bound over the same two C++ functions, differing only in `.def` versus `def_prop_ro` and in
+the policy or `keep_alive` annotation, so that every row of every table above differs in exactly
+one thing.
+
+```bash
+NBROOT=$(python -c "import nanobind,os;print(os.path.dirname(nanobind.__file__))")
+PYINC=$(python -c "import sysconfig;print(sysconfig.get_paths()['platinclude'])")
+g++ -O2 -std=c++20 -fPIC -fvisibility=hidden -shared -DNDEBUG \
+    -I$NBROOT/include -I$NBROOT/ext/robin_map/include -I$PYINC \
+    life.cpp $NBROOT/src/nb_combined.cpp -o life.so
+```
+
+The C++ accessor benchmark is a separate two-translation-unit build so the accessor bodies cannot
+inline into the loop -- the same precaution `design/grid_hierarchy_port.md` records getting wrong
+first time, for the same reason. `-O2`, no LTO, `taskset` to one core, best of seven over 1e8
+iterations, the direction index varying so the branch is not constant-folded.
+
+One thing to check before believing a small ratio here, by analogy with that note's
+devirtualisation trap: if `space` and `space_ref` time the same, the `shared_ptr` copy was
+elided. Both accessors must be defined in a translation unit the benchmark does not include, and
+the object must be `const` so that neither body can be specialised on the loop.

--- a/design/bspline_ownership_lifetime.md
+++ b/design/bspline_ownership_lifetime.md
@@ -380,6 +380,16 @@ where the child handle does hold the owner handle.
 free, because `pickle` memoises: dumping `(b, b.space)` restores a pair that shares one space.
 Sharing does **not** survive two independent `dumps` calls, which is also true today.
 
+**`__reduce__` is an addition here, not a change, and every one of the nine tickets owes one.**
+Verified: `grep -rn "__reduce__\|__getstate__\|__setstate__" src/pantr/bspline/` at `a45e935`
+returns nothing -- not one class in the module defines any of them, so every type pickles today
+through the default protocol over its `__dict__` or its `__slots__`. The moment a slot holds a
+nanobind handle that default fails, and it fails at `dumps` time with a `TypeError` about the
+handle rather than anywhere near the design decision that caused it. The milestone's cross-cutting
+requirement already asks for a round-trip per type under both backends; what this note adds is
+*what the reduction must contain*: the public arrays and the nested **wrappers**, so that the
+identity contracts of F6 survive the round trip through the seeding rule rather than by accident.
+
 ## The failure modes, and the test that catches each
 
 Every one of these is silent. That is the point of the section: the design is cheap to get right


### PR DESCRIPTION
Closes the two design tickets of milestone 2, #393 and #394. Pure design: two documents, no
source change, no parity claim.

## #393 — how a wrapper holding another domain type keeps its owner alive

**Classify the accessor, not the type.** Three classes:

- *constructs* (about 31 accessors) return by value;
- *holds-a-subobject* (8 sites) — C++ stores `shared_ptr<const T>` and returns a handle copy;
- *array-view* — `nb::ndarray` with the owner as keep-alive.

No `pantr.bspline` accessor uses `reference_internal`, deliberately: that puts the guarantee in
the *binding*, and the end state of this port deletes the binding. `shared_ptr<const T>` puts it
in the *type*. Measured 14.92 ns owning against 5.83 ns borrowing.

The detector for a violation is `sys.getrefcount(owner._impl)`. The obvious test passes on a
broken design, which is why the document specifies the detector rather than the assertion.

## #394 — where derived caches live once the spaces are C++-owned

**Derived quantities live in C++; the wrapper memoises presentation only.** Fourteen sites
collapse to one memo.

Mechanism is double-checked locking over `std::atomic<bool>`. A bare `mutable std::optional`
gave 4 races under a thread sanitizer *and* 60 of 60 correct answers, which is the signature of
undefined behaviour that happens to work. The GIL is not available as the synchroniser: there
are already 19 release sites, and the method filling the largest memo measures 16.9 us. Numba
is not the hazard here, since a nopython kernel never re-enters the extension.

## Why this merges as documents

Both documents were written against the code and their measurements were re-run on this
machine. They are the input to #395 through #400, which are implementation tickets: landing them
on the trunk is what lets those branches cut from `proto/cpp` instead of stacking on this one.

`Closes #393` and `Closes #394` do not fire on a base that is not `main`; both issues are closed
by hand with this PR referenced.