### PR TITLE
refactor(grid): make HierarchicalGrid refinement return a new grid instead of mutating

### DIFF
--- a/design/adaptive_thb_approximation.md
+++ b/design/adaptive_thb_approximation.md
@@ -159,11 +159,11 @@ that is very attractive, at the cost of accuracy relative to a true L2 fit. It i
 natural thing to try **first**, precisely because it is the cheapest, and to measure the
 accuracy gap against a fit before deciding the loop needs one.
 
-## What blocks this today: refinement mutates
+## What blocked this: refinement mutated (resolved by #378)
 
-`HierarchicalGrid.refine_cells(self, cell_ids: Sequence[int]) -> None`
-(`src/pantr/grid/_hierarchical_grid.py:1402`) returns `None`, so it refines **in place**.
-`:453` confirms it: refinement recomputes `_level_base` and `_num_cells` and resets the BVH
+In v0.7.0, `HierarchicalGrid.refine_cells(self, cell_ids: Sequence[int]) -> None`
+(`src/pantr/grid/_hierarchical_grid.py:1402`) returned `None`, so it refined **in place**.
+`:453` confirmed it: refinement recomputed `_level_base` and `_num_cells` and reset the BVH
 and tags on the existing object.
 
 The level-wise scheme above needs **all levels alive simultaneously**, because the final
@@ -179,11 +179,26 @@ Two secondary benefits, once refinement is value-returning:
 - The loop becomes restartable and inspectable. Keeping the sequence of spaces means a
   refinement step can be reverted when the stopping criterion decides it went too far,
   which a noise-driven criterion will sometimes want to do.
-- Structural sharing makes it cheap. A refined grid differs from its parent by one level's
-  active set, so the new object can share the parent's immutable data rather than copying
-  it, and the cost of returning a value instead of mutating is close to zero.
+- It is cheap, because the grid stores no per-cell data. The cost of a refinement is the
+  cost of rebuilding the block lists and the packed kernel descriptor, which is what the
+  mutating version already paid on every call.
 
-`refine` (`:1304`) should be checked for the same problem; only `refine_cells` was read.
+**Resolved on `proto/cpp` by #378.** All four entry points -- `refine`, `refine_cells`,
+`coarsen`, `coarsen_cells` -- now return a new grid and leave the receiver untouched, so the
+level-wise scheme above can keep every level's space alive. What the new grid actually shares
+with the one it came from is worth stating exactly, because the paragraph above guessed at it:
+
+- the root `TensorProductGrid` object, shared by reference, as the mutating version and
+  `restrict` already did;
+- the `(lo, hi)` block tuples, which are immutable;
+- **nothing else.** The per-level block *lists*, `_level_base`, `_num_cells` and the four
+  packed `int64` kernel arrays are rebuilt, and the BVH and the two tag registries start
+  empty. So the two grids cannot observe each other through the cell decomposition.
+
+Measured on the branch, refinement's cost per call is flat in the cell count (a single-block
+region refined on grids from 64 to 4096 cells) and superlinear in the *block* count, which is
+what the mutating version measured too: the cost was always the block-list normalization, not
+the copy. Neither the old nor the new call is O(cells).
 
 ## Memory across iterations
 
@@ -202,8 +217,9 @@ Two secondary benefits, once refinement is value-returning:
 
 ## Epistemic status
 
-- **Verified by reading the code:** that `refine_cells` returns `None` and therefore mutates
-  (`_hierarchical_grid.py:1402`), and that refinement resets cached state in place (`:453`);
+- **Verified by reading the code, against v0.7.0:** that `refine_cells` returned `None` and
+  therefore mutated (`_hierarchical_grid.py:1402`), and that refinement reset cached state in
+  place (`:453`). Both were fixed by #378 on `proto/cpp`, after this note was written;
   that `_solve_kronecker` is the tensor-product solve path
   (`_bspline_interpolate.py:154`); that THB quasi-interpolation already exists
   (`_thb_quasi_interpolation.py:49`).
@@ -237,5 +253,10 @@ Two secondary benefits, once refinement is value-returning:
 5. Marking strategy: fixed fraction (refine the worst `θ` of cells, Dörfler-style), fixed
    threshold, or equidistribution? Not discussed here at all, and it changes the number of
    iterations to reach a given accuracy.
-6. Does `refine` (`:1304`) have the same mutation problem as `refine_cells`? Only the latter
-   was read.
+6. **Answered, and the problem is gone.** `refine` had the same problem, and so did
+   `coarsen` and `coarsen_cells`: all four returned `None` and mutated the receiver. Issue #378
+   changed all four to return a new grid on the `proto/cpp` branch, together with deleting the
+   staleness apparatus that existed only to cope with the mutation
+   (`HierarchicalGrid.version`, `THBSplineSpace._grid_snapshot`, `_check_not_stale`, and the
+   *"THBSplineSpace is stale"* `RuntimeError`). See the section above for what that costs and
+   what is actually shared between a grid and the grid it was refined from.

--- a/design/adaptive_thb_approximation.md
+++ b/design/adaptive_thb_approximation.md
@@ -193,12 +193,23 @@ with the one it came from is worth stating exactly, because the paragraph above 
 - the `(lo, hi)` block tuples, which are immutable;
 - **nothing else.** The per-level block *lists*, `_level_base`, `_num_cells` and the four
   packed `int64` kernel arrays are rebuilt, and the BVH and the two tag registries start
-  empty. So the two grids cannot observe each other through the cell decomposition.
+  empty. So the two grids cannot observe each other at all: not through the cell
+  decomposition, and not through the tags, which is the sharper of the two claims because a
+  grid's tags *are* mutable.
 
-Measured on the branch, refinement's cost per call is flat in the cell count (a single-block
-region refined on grids from 64 to 4096 cells) and superlinear in the *block* count, which is
-what the mutating version measured too: the cost was always the block-list normalization, not
-the copy. Neither the old nor the new call is O(cells).
+The same holds one level up, and it does not come for free. `THBSplineSpace.refine`,
+`refine_region` and `coarsen` build the new space over the grid they end up with, which on a
+path that refines or coarsens nothing is the receiver's own grid. They copy it there, so no
+two spaces ever share a grid object. Dropping that copy is the mistake the shape of this
+change invites: the decomposition being immutable makes sharing look safe, and the tag
+registries make it not.
+
+Refinement's cost per call is flat in the cell count and superlinear in the *block* count,
+which is what the mutating version measured too: the cost was always the block-list
+normalization, not the copy. Neither the old nor the new call is O(cells).
+`scripts/bench_grid_refine.py` is the sweep that shows it, including the one case where the
+value-returning form could plausibly have regressed (blocks left on levels a refine does not
+touch, which it now normalizes and the mutating version did not).
 
 ## Memory across iterations
 

--- a/design/adaptive_thb_approximation.md
+++ b/design/adaptive_thb_approximation.md
@@ -185,7 +185,10 @@ Two secondary benefits, once refinement is value-returning:
 
 **Resolved on `proto/cpp` by #378.** All four entry points -- `refine`, `refine_cells`,
 `coarsen`, `coarsen_cells` -- now return a new grid and leave the receiver untouched, so the
-level-wise scheme above can keep every level's space alive. What the new grid actually shares
+level-wise scheme above can keep every level's space alive. The names are unchanged, so the
+break is silent; the ticket's one-cycle deprecation warning was **waived by the owner** on the
+ground that there is no separate mutating spelling left to warn from, and `docs/changelog.md`
+records both the break and the waiver. What the new grid actually shares
 with the one it came from is worth stating exactly, because the paragraph above guessed at it:
 
 - the root `TensorProductGrid` object, shared by reference, as the mutating version and

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -156,13 +156,19 @@ user-facing, and the ports change what it affects.
   the mutating call produced -- checked against the previous implementation over a sweep of
   1D, 2D and 3D grids with isotropic and anisotropic factors, overlapping refinements, both
   coarsening entry points, and `restrict`. Refinement's cost is unchanged in order and dominated
-  by the block-list normalization it always was: measured flat in the cell count (a
-  single-block region refined on a 64 to 4096 cell grid) and superlinear in the *block* count,
-  as before. Nothing copies per-cell data, because the grid stores none.
+  by the block-list normalization it always was: flat in the cell count and superlinear in the
+  *block* count, as before. Nothing copies per-cell data, because the grid stores none.
+  `scripts/bench_grid_refine.py` reports the scalings and says how to run it against the
+  mutating implementation for a side-by-side comparison; read it rather than quoting a figure
+  from here.
 
   `THBSplineSpace.refine`, `refine_region` and `coarsen`, and `THBSpline.refine` and
-  `refine_region`, already returned a new object and are unchanged. Internally they no longer
-  `copy.deepcopy` the grid before refining it, which is why they are now faster.
+  `refine_region`, already returned a new object and their contract is unchanged, down to the
+  returned space's grid never being the receiver's own object. Internally they no longer
+  `copy.deepcopy` the grid before refining it, which is why they are faster; on the paths that
+  refine or coarsen nothing they copy the grid's block lists instead, because a grid's cell
+  decomposition is immutable but its two tag registries are not, and they belong to whoever
+  holds the grid.
 
 - `pantr.change_basis` is a package rather than a single module, so that its dispatch catalogue
   and its Python kernels have somewhere to live. **Every pantr name importable from

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -146,6 +146,11 @@ user-facing, and the ports change what it affects.
   `.refine(`, `.refine_cells(`, `.coarsen(` and `.coarsen_cells(` on a grid receiver; an
   `hasattr`-style smoke test cannot see this change.
 
+  **The one-cycle deprecation warning was waived deliberately, not overlooked.** The ticket
+  asked for the mutating spellings to warn for a cycle before removal; the owner ruled instead
+  that the four methods keep their names, which leaves no separate mutating spelling to attach a
+  warning to, and accepted the silent break on that basis.
+
   The reason is the project's construct-then-freeze rule, and here it is not a style question.
   A `THBSplineSpace` held a reference to its grid, so refining that grid behind the space's back
   left the space describing cells that no longer existed. That was detected at runtime by a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -160,12 +160,16 @@ user-facing, and the ports change what it affects.
   The cell decomposition of the returned grid is identical, cell for cell and id for id, to what
   the mutating call produced -- checked against the previous implementation over a sweep of
   1D, 2D and 3D grids with isotropic and anisotropic factors, overlapping refinements, both
-  coarsening entry points, and `restrict`. Refinement's cost is unchanged in order and dominated
-  by the block-list normalization it always was: flat in the cell count and superlinear in the
-  *block* count, as before. Nothing copies per-cell data, because the grid stores none.
-  `scripts/bench_grid_refine.py` reports the scalings and says how to run it against the
-  mutating implementation for a side-by-side comparison; read it rather than quoting a figure
-  from here.
+  coarsening entry points, and `restrict`. Refinement's cost is unchanged in order: flat in the
+  cell count, superlinear in the block count *of the one or two levels the call rebinds*, and
+  linear in the total block count for the rebuild, exactly as the mutating version was. In
+  particular a refinement sweep does not pay for the levels it never touches -- those are passed
+  through, which is sound because the block-list normalization is a fixed point, and which
+  matters because re-merging them would make each step cost the sum of squared per-level block
+  counts. Nothing copies per-cell data, because the grid stores none.
+  `scripts/bench_grid_refine.py` reports the scalings, including the `untouched` sweep that
+  pins that last point, and says how to run it against the mutating implementation for a
+  side-by-side comparison; read it rather than quoting a figure from here.
 
   `THBSplineSpace.refine`, `refine_region` and `coarsen`, and `THBSpline.refine` and
   `refine_region`, already returned a new object and their contract is unchanged, down to the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -137,6 +137,33 @@ user-facing, and the ports change what it affects.
   points, so there is nothing to reuse between calls.
 
 ### Changed
+- **Breaking. `HierarchicalGrid` refinement returns a new grid instead of mutating.**
+  `refine`, `refine_cells`, `coarsen` and `coarsen_cells` all used to return `None` and change
+  the receiver; each now leaves the receiver untouched and returns a new
+  `HierarchicalGrid`. Write `grid = grid.refine(...)`. **The break is
+  silent**: the methods still exist under the same names and still accept the same arguments, so
+  a call made for its side effect raises nothing and simply discards the refinement. Grep for
+  `.refine(`, `.refine_cells(`, `.coarsen(` and `.coarsen_cells(` on a grid receiver; an
+  `hasattr`-style smoke test cannot see this change.
+
+  The reason is the project's construct-then-freeze rule, and here it is not a style question.
+  A `THBSplineSpace` held a reference to its grid, so refining that grid behind the space's back
+  left the space describing cells that no longer existed. That was detected at runtime by a
+  mutation counter and a staleness guard whose gaps were documented in its own docstrings; with
+  an immutable grid the state is unrepresentable and the whole apparatus is gone.
+
+  The cell decomposition of the returned grid is identical, cell for cell and id for id, to what
+  the mutating call produced -- checked against the previous implementation over a sweep of
+  1D, 2D and 3D grids with isotropic and anisotropic factors, overlapping refinements, both
+  coarsening entry points, and `restrict`. Refinement's cost is unchanged in order and dominated
+  by the block-list normalization it always was: measured flat in the cell count (a
+  single-block region refined on a 64 to 4096 cell grid) and superlinear in the *block* count,
+  as before. Nothing copies per-cell data, because the grid stores none.
+
+  `THBSplineSpace.refine`, `refine_region` and `coarsen`, and `THBSpline.refine` and
+  `refine_region`, already returned a new object and are unchanged. Internally they no longer
+  `copy.deepcopy` the grid before refining it, which is why they are now faster.
+
 - `pantr.change_basis` is a package rather than a single module, so that its dispatch catalogue
   and its Python kernels have somewhere to live. **Every pantr name importable from
   `pantr.change_basis` before still is**, public and private alike, and a test now pins that
@@ -157,6 +184,18 @@ user-facing, and the ports change what it affects.
   own rounding rather than to the root finder and is irreducible without transliterating NumPy
   verbatim. The tanh-sinh rule is unchanged.
 
+
+### Removed
+- `HierarchicalGrid.version`. It existed so that a consumer could detect a mutation the other
+  metadata could not distinguish (a compensating refine/coarsen pair). There is no mutation to
+  detect. Track cells across a refinement by `(level, multi_index)` and resolve them with
+  `cell_id` on the new grid, as `cell_id`'s docstring describes.
+- The `RuntimeError("THBSplineSpace is stale: ...")` and the machinery behind it
+  (`_grid_snapshot`, `_check_not_stale`). Every entry point that could raise it -- on
+  `THBSplineSpace`, on `MultiLevelExtraction`, on `THBSpline`, and
+  `quasi_interpolate_thb_spline` -- no longer can, and their `Raises:` sections no longer
+  promise it. Two accessors, `level_space` and `active_function_indices`, documented that they
+  performed *no* stale check; that hole is closed by there being nothing to check.
 
 ## 0.7.0 (2026-08-19)
 

--- a/scripts/bench_grid_refine.py
+++ b/scripts/bench_grid_refine.py
@@ -26,10 +26,17 @@ script measures the two scalings that settle it rather than reporting a timing:
 
 ``deep``
     One ``refine`` at level 0 on a staircase that leaves blocks on *every* level.
-    This is the case the value-returning implementation could plausibly regress:
-    it hands its whole per-level block list to ``_from_blocks``, which normalizes
-    every level, including the ones the call never touched, where the mutating
-    version normalized only the one or two it did.
+    A cheap check that depth alone costs nothing; its untouched levels hold only a
+    handful of blocks each, so it does **not** reach the worst case.
+
+``untouched``
+    The case ``deep`` misses, and the one the ticket's invariant is about: a broad
+    shallow refinement carrying most of the block mass, then a local sweep drilling
+    at the deepest level, where the touched levels hold two blocks and every other
+    level holds many.  ``refine`` normalizes only the two levels it rebinds, so this
+    sweep must not grow with the shallow block count.  Were the untouched levels
+    re-merged as well, the per-step cost would be the sum of squared per-level block
+    counts -- quadratic in the size of a grid the step does not read.
 
 ``sweep``
     A whole adaptive loop, N successive local ``refine_cells`` steps: what an
@@ -45,12 +52,19 @@ minimum is reported rather than the mean because the fastest run is the one leas
 interfered with. A figure that breaks the trend should be read as noise until more
 repeats say otherwise.
 
-**The cost is the block-list normalization, and it always was.** The grid stores no
-per-cell data at all -- only ``(lo, hi)`` rectangles per level -- so neither the
-mutating nor the value-returning call can be ``O(cells)``. What both pay is the
-greedy merge in ``_normalize_blocks``, which is superlinear in the number of
-blocks at a level. Expect the ``cells`` sweep to be flat and the ``blocks`` sweep
-to rise steeply; that shape, not any individual number, is the result.
+**The cost is the block-list normalization plus the rebuild, and it always was.**
+The grid stores no per-cell data at all -- only ``(lo, hi)`` rectangles per level --
+so neither the mutating nor the value-returning call can be ``O(cells)``. Both pay
+the greedy merge in ``_normalize_blocks``, which is superlinear in the number of
+blocks at the level it is given, and both pay ``_rebuild``, which is linear in the
+total block count. Expect the ``cells`` sweep to be flat, the ``blocks`` sweep to
+rise steeply, and the ``untouched`` sweep to rise only as fast as ``_rebuild``
+does; those shapes, not any individual number, are the result.
+
+**Read the shapes, not the timings.** On a shared host these are contended, so the
+table also prints what each configuration is timing in block counts. A sweep whose
+per-step cost tracked the *untouched* block count would be the regression this file
+exists to catch, and that is visible in the shape even when the clock is noisy.
 
 **To compare against the mutating implementation**, check out the commit before
 #378 into a second tree and run this same script against it with ``PYTHONPATH``
@@ -195,8 +209,9 @@ def _checkerboard(cells_per_axis: int) -> HierarchicalGrid:
 def _staircase(levels: int) -> HierarchicalGrid:
     """Return a 2D grid leaving blocks behind on every level from 0 to ``levels``.
 
-    The case where normalizing every level rather than only the touched ones could
-    cost more than the mutating implementation did.
+    Depth without mass: the levels a refine does not touch hold a handful of blocks
+    each, so this shows that depth alone is free.  ``_shallow_heavy`` is the fixture
+    that puts real block mass on the untouched levels.
 
     Args:
         levels (int): Number of refinement rounds, one per level.
@@ -210,6 +225,58 @@ def _staircase(levels: int) -> HierarchicalGrid:
         for i in range(0, min(width, 12), 2):
             grid = _apply(grid, "refine", (level, (i, 0), (i + 1, 1)))
     return grid
+
+
+def _shallow_heavy(checker: int) -> HierarchicalGrid:
+    """Return a grid whose block mass sits on levels a deep refinement never touches.
+
+    A checkerboard over the whole root drives levels 0 and 1 to many non-mergeable
+    blocks; drilling one corner down four levels then leaves the deep levels holding
+    two blocks each. A sweep at the deepest level therefore touches almost none of
+    the grid's blocks, which is what makes it the fixture that separates
+    "normalize the touched levels" from "normalize every level".
+
+    Args:
+        checker (int): Root cells per axis, and the width of the checkerboard.
+
+    Returns:
+        HierarchicalGrid: The shallow-heavy grid.
+    """
+    grid = _plain(checker)
+    for i in range(0, checker, 2):
+        for j in range(0, checker, 2):
+            grid = _apply(grid, "refine", (0, (i, j), (i + 1, j + 1)))
+    for level in range(1, 5):
+        block_lo, _ = grid.active_blocks(level)[0]
+        grid = _apply(grid, "refine", (level, block_lo, tuple(a + 1 for a in block_lo)))
+    return grid
+
+
+def _deep_sweep_micros(grid_of: Callable[[], HierarchicalGrid], steps: int, repeats: int) -> float:
+    """Time a sweep of ``steps`` refinements, each at the grid's deepest level.
+
+    Args:
+        grid_of (Callable[[], HierarchicalGrid]): Builds a fresh fixture per repeat.
+        steps (int): Refinements in the sweep.
+        repeats (int): Number of repeats.
+
+    Returns:
+        float: Minimum CPU microseconds for the whole sweep.
+    """
+    best = float("inf")
+    for _ in range(repeats):
+        grid = grid_of()
+        gc.collect()
+        start = time.process_time()
+        for _step in range(steps):
+            deepest = grid.max_level
+            blocks = grid.active_blocks(deepest)
+            if not blocks:
+                break
+            block_lo, _ = blocks[len(blocks) // 2]
+            grid = _apply(grid, "refine", (deepest, block_lo, tuple(a + 1 for a in block_lo)))
+        best = min(best, time.process_time() - start)
+    return best * 1e6
 
 
 def _sweep_micros(steps: int, repeats: int) -> tuple[float, HierarchicalGrid]:
@@ -340,7 +407,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     _print_table(
         "deep -- one refine at level 0, with blocks on every level",
-        "the untouched-level normalization the value-returning form adds",
+        "flat: depth alone is free, since the untouched levels are not re-merged",
+        rows,
+    )
+
+    rows = []
+    for checker in (8, 16, 24, 32):
+        grid = _shallow_heavy(checker)
+        per_level = [len(grid.active_blocks(lv)) for lv in range(grid.max_level + 1)]
+        rows.append(
+            Row(
+                f"checker {checker}",
+                grid.num_cells,
+                sum(per_level),
+                sum(per_level[:-2]),
+                _deep_sweep_micros(
+                    lambda checker=checker: _shallow_heavy(checker),  # type: ignore[misc]
+                    20,
+                    max(args.repeats // 3, 3),
+                ),
+            )
+        )
+    _print_table(
+        "untouched -- a 20-step deep sweep over a block-heavy shallow grid",
+        "must not track the untouched column; that column is what a refine skips",
         rows,
     )
 

--- a/scripts/bench_grid_refine.py
+++ b/scripts/bench_grid_refine.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python
+"""Measure what a hierarchical refinement costs, and what it does *not* scale with.
+
+Run it as::
+
+    python scripts/bench_grid_refine.py
+    python scripts/bench_grid_refine.py --repeats 40
+
+Why this script exists
+----------------------
+
+Issue #378 changed :meth:`~pantr.grid.HierarchicalGrid.refine` and its three
+siblings from mutating the receiver to returning a new grid, and the ticket's
+binding invariant was that no refinement sweep may end up copying the whole grid
+per step. That is a claim about *scaling*, not about a single number, so this
+script measures the two scalings that settle it rather than reporting a timing:
+
+``cells``
+    One ``refine`` promoting a single-block region, on grids from 64 to 4096
+    cells. The block count is held at 1 while the cell count grows 64-fold. A cost
+    that tracked the cell count would show up here as a 64-fold rise.
+
+``blocks``
+    One ``refine`` on a grid whose block count has been driven up by a checkerboard
+    of prior refinements. Here the block count is what grows.
+
+``deep``
+    One ``refine`` at level 0 on a staircase that leaves blocks on *every* level.
+    This is the case the value-returning implementation could plausibly regress:
+    it hands its whole per-level block list to ``_from_blocks``, which normalizes
+    every level, including the ones the call never touched, where the mutating
+    version normalized only the one or two it did.
+
+``sweep``
+    A whole adaptive loop, N successive local ``refine_cells`` steps: what an
+    adaptive algorithm actually pays.
+
+Reading the numbers
+-------------------
+
+**CPU time, and the minimum over repeats.** These are sub-millisecond,
+single-threaded, pure-Python-plus-small-NumPy measurements. On a shared machine
+wall time measures the scheduler, so ``time.process_time`` is used, and the
+minimum is reported rather than the mean because the fastest run is the one least
+interfered with. A figure that breaks the trend should be read as noise until more
+repeats say otherwise.
+
+**The cost is the block-list normalization, and it always was.** The grid stores no
+per-cell data at all -- only ``(lo, hi)`` rectangles per level -- so neither the
+mutating nor the value-returning call can be ``O(cells)``. What both pay is the
+greedy merge in ``_normalize_blocks``, which is superlinear in the number of
+blocks at a level. Expect the ``cells`` sweep to be flat and the ``blocks`` sweep
+to rise steeply; that shape, not any individual number, is the result.
+
+**To compare against the mutating implementation**, check out the commit before
+#378 into a second tree and run this same script against it with ``PYTHONPATH``
+pointing there. The script adapts to either API, so the two runs measure the same
+work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import time
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
+
+from pantr.grid import hierarchical_grid, uniform_grid
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from pantr.grid import HierarchicalGrid
+
+_DEFAULT_REPEATS: Final[int] = 25
+"""
+Repeats per configuration, for the minimum to be a stable estimator.
+
+Each repeat rebuilds the fixture, so the cost is a few seconds in total. Twenty-five
+is enough for the minimum to stop moving between runs on a loaded 20-CPU host, which
+is the regime this was written in; it is not a tuned number.
+"""
+
+
+class Row(NamedTuple):
+    """One measured configuration.
+
+    Attributes:
+        label (str): What was varied, for the printed table.
+        num_cells (int): Active cells in the fixture the operation was applied to.
+        total_blocks (int): Active blocks summed over every level of that fixture.
+        untouched_blocks (int): Blocks on levels the timed operation does not touch.
+        micros (float): Minimum CPU time for one operation, in microseconds.
+    """
+
+    label: str
+    num_cells: int
+    total_blocks: int
+    untouched_blocks: int
+    micros: float
+
+
+def _apply(grid: HierarchicalGrid, name: str, args: Sequence[Any]) -> HierarchicalGrid:
+    """Apply one hierarchy operation, tolerating either the old or the new API.
+
+    The pre-#378 methods returned ``None`` and mutated the receiver; the current ones
+    return a new grid. Accepting both is what lets one script measure the same work in
+    a checkout on either side of that change.
+
+    Args:
+        grid (HierarchicalGrid): The grid to operate on.
+        name (str): Method name: ``refine``, ``refine_cells``, ``coarsen`` or
+            ``coarsen_cells``.
+        args (Sequence[Any]): Positional arguments for the method.
+
+    Returns:
+        HierarchicalGrid: The operation's result, or ``grid`` itself if the method
+        mutated it and returned ``None``.
+    """
+    result = getattr(grid, name)(*args)
+    return grid if result is None else result
+
+
+def _total_blocks(grid: HierarchicalGrid) -> int:
+    """Return the number of active blocks summed over every level.
+
+    Args:
+        grid (HierarchicalGrid): The grid to count.
+
+    Returns:
+        int: Total block count.
+    """
+    return sum(len(grid.active_blocks(level)) for level in range(grid.max_level + 1))
+
+
+def _min_micros(
+    build: Callable[[], HierarchicalGrid],
+    name: str,
+    args: Sequence[Any],
+    repeats: int,
+) -> float:
+    """Return the minimum CPU time of one operation, in microseconds.
+
+    Args:
+        build (Callable[[], HierarchicalGrid]): Builds a fresh fixture per repeat, so
+            no repeat inherits the previous one's caches.
+        name (str): Method name to time.
+        args (Sequence[Any]): Positional arguments for the method.
+        repeats (int): Number of repeats.
+
+    Returns:
+        float: Minimum CPU microseconds over the repeats.
+    """
+    best = float("inf")
+    for _ in range(repeats):
+        grid = build()
+        gc.collect()
+        start = time.process_time()
+        _apply(grid, name, args)
+        best = min(best, time.process_time() - start)
+    return best * 1e6
+
+
+def _plain(cells_per_axis: int) -> HierarchicalGrid:
+    """Return an unrefined 2D grid: one block, ``cells_per_axis ** 2`` cells.
+
+    Args:
+        cells_per_axis (int): Root cells per axis.
+
+    Returns:
+        HierarchicalGrid: The unrefined grid.
+    """
+    return hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], cells_per_axis), 2)
+
+
+def _checkerboard(cells_per_axis: int) -> HierarchicalGrid:
+    """Return a 2D grid whose block count has been driven up by isolated refinements.
+
+    Refining every other cell forces the peeled remainder into many non-mergeable
+    blocks, which is what makes the block count grow with the root size.
+
+    Args:
+        cells_per_axis (int): Root cells per axis.
+
+    Returns:
+        HierarchicalGrid: The block-rich grid.
+    """
+    grid = _plain(cells_per_axis)
+    for i in range(0, cells_per_axis, 2):
+        for j in range(0, cells_per_axis, 2):
+            grid = _apply(grid, "refine", (0, (i, j), (i + 1, j + 1)))
+    return grid
+
+
+def _staircase(levels: int) -> HierarchicalGrid:
+    """Return a 2D grid leaving blocks behind on every level from 0 to ``levels``.
+
+    The case where normalizing every level rather than only the touched ones could
+    cost more than the mutating implementation did.
+
+    Args:
+        levels (int): Number of refinement rounds, one per level.
+
+    Returns:
+        HierarchicalGrid: The deep grid.
+    """
+    grid = _plain(8)
+    for level in range(levels):
+        width = 8 * 2**level
+        for i in range(0, min(width, 12), 2):
+            grid = _apply(grid, "refine", (level, (i, 0), (i + 1, 1)))
+    return grid
+
+
+def _sweep_micros(steps: int, repeats: int) -> tuple[float, HierarchicalGrid]:
+    """Time a whole adaptive loop of ``steps`` local refinements.
+
+    Args:
+        steps (int): Number of ``refine_cells`` steps.
+        repeats (int): Number of repeats.
+
+    Returns:
+        tuple[float, HierarchicalGrid]: Minimum CPU microseconds for the whole loop,
+        and the final grid of the last repeat, so the caller can report what was built.
+    """
+    best = float("inf")
+    final = _plain(16)
+    for _ in range(repeats):
+        gc.collect()
+        start = time.process_time()
+        grid = _plain(16)
+        for _step in range(steps):
+            deepest = grid.max_level
+            ids = [c for c in range(grid.num_cells) if grid.cell_level(c) == deepest][:4]
+            if not ids:
+                break
+            grid = _apply(grid, "refine_cells", (ids,))
+        best = min(best, time.process_time() - start)
+        final = grid
+    return best * 1e6, final
+
+
+def _print_table(title: str, note: str, rows: Sequence[Row]) -> None:
+    """Print one measured sweep.
+
+    Args:
+        title (str): Sweep name.
+        note (str): What the reader should conclude from the shape.
+        rows (Sequence[Row]): The measured rows.
+    """
+    print(f"\n{title}")
+    print(f"  {note}")
+    print(f"  {'fixture':>16} {'cells':>8} {'blocks':>8} {'untouched':>10} {'us/call':>10}")
+    for row in rows:
+        print(
+            f"  {row.label:>16} {row.num_cells:>8} {row.total_blocks:>8} "
+            f"{row.untouched_blocks:>10} {row.micros:>10.1f}"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the four sweeps and print them.
+
+    Args:
+        argv (Sequence[str] | None): Command-line arguments; ``None`` uses ``sys.argv``.
+
+    Returns:
+        int: Process exit status, always ``0``.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=_DEFAULT_REPEATS,
+        help=f"repeats per configuration (default {_DEFAULT_REPEATS})",
+    )
+    parser.add_argument(
+        "--sweep-steps", type=int, default=24, help="refinement steps in the adaptive loop"
+    )
+    args = parser.parse_args(argv)
+
+    rows = []
+    for n in (8, 16, 32, 64):
+        grid = _plain(n)
+        rows.append(
+            Row(
+                f"root {n}x{n}",
+                grid.num_cells,
+                _total_blocks(grid),
+                0,
+                _min_micros(lambda n=n: _plain(n), "refine", (0, (0, 0), (n, n)), args.repeats),  # type: ignore[misc]
+            )
+        )
+    _print_table(
+        "cells -- one refine of a single-block region",
+        "flat means the cost does not track the cell count",
+        rows,
+    )
+
+    rows = []
+    for n in (8, 12, 16, 20):
+        grid = _checkerboard(n)
+        rows.append(
+            Row(
+                f"root {n}x{n}",
+                grid.num_cells,
+                _total_blocks(grid),
+                0,
+                _min_micros(
+                    lambda n=n: _checkerboard(n),  # type: ignore[misc]
+                    "refine",
+                    (0, (1, 1), (2, 2)),
+                    args.repeats,
+                ),
+            )
+        )
+    _print_table(
+        "blocks -- one refine on a block-rich grid",
+        "rises steeply: the greedy merge in _normalize_blocks is what a refine pays",
+        rows,
+    )
+
+    rows = []
+    for levels in (3, 5, 7):
+        grid = _staircase(levels)
+        per_level = [len(grid.active_blocks(lv)) for lv in range(grid.max_level + 1)]
+        rows.append(
+            Row(
+                f"{levels} levels",
+                grid.num_cells,
+                sum(per_level),
+                sum(per_level[2:]),
+                _min_micros(
+                    lambda levels=levels: _staircase(levels),  # type: ignore[misc]
+                    "refine",
+                    (0, (7, 7), (8, 8)),
+                    args.repeats,
+                ),
+            )
+        )
+    _print_table(
+        "deep -- one refine at level 0, with blocks on every level",
+        "the untouched-level normalization the value-returning form adds",
+        rows,
+    )
+
+    micros, final = _sweep_micros(args.sweep_steps, max(args.repeats // 2, 3))
+    print(f"\nsweep -- {args.sweep_steps} successive refine_cells steps")
+    print(
+        f"  {micros / 1e3:.2f} ms for the whole loop; final grid: "
+        f"{final.num_cells} cells, max_level {final.max_level}, "
+        f"{_total_blocks(final)} blocks"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pantr/bspline/_thb_quasi_interpolation.py
+++ b/src/pantr/bspline/_thb_quasi_interpolation.py
@@ -75,8 +75,8 @@ def quasi_interpolate_thb_spline(
         TypeError: If ``space`` is not a :class:`~pantr.bspline.THBSplineSpace`.
         ValueError: If ``kind`` is not recognized, or if ``func`` returns an output
             with an invalid shape (0-D, more than 2-D, or wrong leading dimension).
-        RuntimeError: If the grid has been modified since ``space`` was constructed,
-            or an active dof has no leaf cell at its level (inconsistent space).
+        RuntimeError: If an active dof has no leaf cell at its level (inconsistent
+            space).
 
     References:
         Hierarchical quasi-interpolation in truncated hierarchical spaces
@@ -87,7 +87,6 @@ def quasi_interpolate_thb_spline(
     if kind not in get_args(QIKind):
         valid = ", ".join(repr(v) for v in get_args(QIKind))
         raise ValueError(f"Unknown kind {kind!r}; expected one of {valid}.")
-    space._check_not_stale()
 
     grid = space.grid
     dim = space.dim

--- a/src/pantr/bspline/_thb_spline.py
+++ b/src/pantr/bspline/_thb_spline.py
@@ -169,8 +169,7 @@ class THBSpline:
             ValueError: If ``pts`` does not have trailing dimension ``dim``, any point
                 lies outside the grid domain, or ``out`` has the wrong shape/dtype or
                 is not writeable.
-            RuntimeError: If the grid has been modified since construction, or a cell
-                has no active basis functions (inconsistent space).
+            RuntimeError: If a cell has no active basis functions (inconsistent space).
         """
         return self._evaluate_orders(pts, (0,) * self.dim, out)
 
@@ -203,8 +202,7 @@ class THBSpline:
                 ``pts`` does not have trailing dimension ``dim``, any point lies
                 outside the grid domain, or ``out`` has the wrong shape/dtype or is
                 not writeable.
-            RuntimeError: If the grid has been modified since construction, or a cell
-                has no active basis functions (inconsistent space).
+            RuntimeError: If a cell has no active basis functions (inconsistent space).
         """
         return self._evaluate_orders(pts, orders, out)
 
@@ -229,9 +227,8 @@ class THBSpline:
         Raises:
             ValueError: If ``pts``/``orders``/``out`` are invalid (see the public
                 methods).
-            RuntimeError: If the grid is stale or a cell has no active functions.
+            RuntimeError: If a cell has no active functions.
         """
-        self._space._check_not_stale()
         arr = np.asarray(pts, dtype=np.float64)
         if arr.ndim == 0 or arr.shape[-1] != self.dim:
             raise ValueError(
@@ -306,7 +303,6 @@ class THBSpline:
         Raises:
             IndexError: If any id is outside ``[0, grid.num_cells)``.
             ValueError: If ``admissible_class`` is an integer ``< 2``.
-            RuntimeError: If the grid has been modified since construction.
         """
         fine = self._space.refine(cell_ids, admissible_class=admissible_class)
         return self._prolong_to(fine)
@@ -345,7 +341,6 @@ class THBSpline:
             ValueError: If ``admissible_class`` is an integer ``< 2``, ``level`` is
                 out of range, ``lo``/``hi`` have the wrong length, any
                 ``lo[k] >= hi[k]``, or ``[lo, hi)`` lies outside the level domain.
-            RuntimeError: If the grid has been modified since construction.
         """
         fine = self._space.refine_region(level, lo, hi, admissible_class=admissible_class)
         return self._prolong_to(fine)

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -15,7 +15,6 @@ Main exports:
 
 from __future__ import annotations
 
-import copy
 import itertools
 import math
 import string
@@ -336,11 +335,11 @@ class THBSplineSpace:
     reaches); untruncated functions remain plain tensor-product B-splines.  With
     ``truncate=False`` the non-truncated hierarchical basis (HB) is built.
 
-    This space is a snapshot of the grid at construction time.  Calling
-    :meth:`~pantr.grid.HierarchicalGrid.refine` on the underlying grid after
-    construction invalidates this space; subsequent calls to :meth:`active_basis` or
-    :meth:`tabulate_basis` will raise :class:`RuntimeError`.  Create a new
-    :class:`THBSplineSpace` from the updated grid instead.
+    A :class:`~pantr.grid.HierarchicalGrid` is immutable, so this space cannot go
+    stale: :meth:`~pantr.grid.HierarchicalGrid.refine` returns a *new* grid and leaves
+    the one held here untouched.  :meth:`refine`, :meth:`refine_region` and
+    :meth:`coarsen` are the same shape one level up -- each returns a new space over a
+    new grid.
 
     Note:
         :meth:`active_basis` lists functions whose *untruncated* support covers a
@@ -357,7 +356,8 @@ class THBSplineSpace:
 
     Attributes:
         _root_space (BsplineSpace): The level-0 tensor-product space.
-        _grid (HierarchicalGrid): The active-cell hierarchy (snapshot reference).
+        _grid (HierarchicalGrid): The active-cell hierarchy.  Immutable, and may be
+            shared with the space this one was refined from when nothing changed.
         _truncate (bool): Whether the truncated (THB) basis is used; ``False`` for
             the plain hierarchical (HB) basis.
         _regularity (tuple[int | None, ...]): Per-direction continuity used when
@@ -373,10 +373,6 @@ class THBSplineSpace:
         _func_offset (npt.NDArray[np.int64]): Per-level global-dof base; length
             ``num_levels + 1`` (cumulative active-function counts).
         _num_active (int): Total number of active hierarchical functions.
-        _grid_snapshot (tuple[int, int, int]): ``(max_level, num_cells, version)``
-            captured at construction; used to detect post-construction grid
-            mutations (the grid's :attr:`~pantr.grid.HierarchicalGrid.version`
-            counter catches mutations the other two cannot distinguish).
         _trunc (dict): Map from global dof (``int``) to ``_TruncCoeffs``;
             only truncated functions appear (empty when ``truncate=False``).
         _max_active_per_cell (int | None): Memoized :meth:`max_active_per_cell`
@@ -388,7 +384,6 @@ class THBSplineSpace:
         "_contrib_cache",
         "_func_offset",
         "_grid",
-        "_grid_snapshot",
         "_level_spaces",
         "_max_active_per_cell",
         "_num_active",
@@ -485,7 +480,6 @@ class THBSplineSpace:
             np.int64
         )
         self._num_active = int(self._func_offset[-1])
-        self._grid_snapshot = (grid.max_level, grid.num_cells, grid.version)
         self._trunc = self._compute_truncated_coeffs() if truncate else {}
         # Lazy per-cell cache of _cell_contributions (populated on first access). The
         # space is an immutable construction-time snapshot, so cached results stay valid.
@@ -742,20 +736,6 @@ class THBSplineSpace:
                     trunc[offset + pos] = _TruncCoeffs(rep, tuple(box_lo), coeffs)
         return trunc
 
-    def _check_not_stale(self) -> None:
-        """Raise if the grid has been modified since this space was constructed.
-
-        Raises:
-            RuntimeError: If the grid's ``max_level``, ``num_cells``, or mutation
-                ``version`` differs from the snapshot taken at construction.
-        """
-        current = (self._grid.max_level, self._grid.num_cells, self._grid.version)
-        if current != self._grid_snapshot:
-            raise RuntimeError(
-                "THBSplineSpace is stale: the underlying HierarchicalGrid has been modified "
-                "after construction. Create a new THBSplineSpace from the updated grid."
-            )
-
     def _cell_contributions(self, cid: int) -> list[tuple[int, int, tuple[int, ...]]]:
         """Return the active functions non-zero on cell ``cid``.
 
@@ -772,7 +752,6 @@ class THBSplineSpace:
             immutable snapshot).  The returned list is the cached object; callers must
             not mutate it.
         """
-        self._check_not_stale()
         cached = self._contrib_cache.get(cid)
         if cached is not None:
             return cached
@@ -917,8 +896,8 @@ class THBSplineSpace:
     def level_space(self, level: int) -> BsplineSpace:
         """Return the tensor-product space at ``level``.
 
-        Returns a construction-time snapshot; not affected by subsequent grid
-        mutations (no stale check is performed).
+        Fixed at construction, and the grid it was built from is immutable, so
+        nothing can change it afterwards.
 
         Args:
             level (int): Hierarchy level in ``[0, num_levels)``.
@@ -936,8 +915,8 @@ class THBSplineSpace:
     def active_function_indices(self, level: int) -> npt.NDArray[np.int64]:
         """Return the flat indices of the active functions at ``level``.
 
-        Returns a construction-time snapshot; not affected by subsequent grid
-        mutations (no stale check is performed).
+        Fixed at construction, and the grid it was built from is immutable, so
+        nothing can change it afterwards.
 
         Args:
             level (int): Hierarchy level in ``[0, num_levels)``.
@@ -966,7 +945,6 @@ class THBSplineSpace:
 
         Raises:
             IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
-            RuntimeError: If the grid has been modified since construction.
         """
         return np.array([dof for dof, _, _ in self._cell_contributions(cid)], dtype=np.int64)
 
@@ -983,9 +961,6 @@ class THBSplineSpace:
         Returns:
             int: Maximum active-function count over all cells (``>= 1``).
 
-        Raises:
-            RuntimeError: If the grid has been modified since construction.
-
         Note:
             Counts exactly what :meth:`active_basis` returns, which selects on
             tensor-product support. Truncation can only annihilate a function on a cell
@@ -997,7 +972,6 @@ class THBSplineSpace:
             cache for the whole grid -- the same cache :meth:`active_basis` fills lazily,
             but warmed in full.
         """
-        self._check_not_stale()
         if self._max_active_per_cell is None:
             self._max_active_per_cell = max(
                 len(self._cell_contributions(cid)) for cid in range(self._grid.num_cells)
@@ -1036,7 +1010,6 @@ class THBSplineSpace:
             TypeError: If ``cell_ids`` is not integer-valued.
             IndexError: If any cell id is out of range ``[0, grid.num_cells)``.
         """
-        self._check_not_stale()
         grid_restr = self._grid.restrict(cell_ids)
         sub_grid = grid_restr.grid
         if not isinstance(sub_grid, HierarchicalGrid):
@@ -1230,9 +1203,8 @@ class THBSplineSpace:
             ValueError: If ``pts`` does not have trailing dimension ``dim``, if any
                 point lies outside cell ``cid``, or if ``out_basis``/``out_dofs`` has
                 the wrong shape, dtype, or is not writeable.
-            RuntimeError: If the grid has been modified since construction.
         """
-        contribs = self._cell_contributions(cid)  # validates cid; raises if stale
+        contribs = self._cell_contributions(cid)  # validates cid
         n_active = len(contribs)
         dofs = np.array([gdof for gdof, _, _ in contribs], dtype=np.int64)
 
@@ -1340,7 +1312,6 @@ class THBSplineSpace:
             ValueError: If ``pts`` does not have trailing dimension ``dim``, if any
                 point lies outside the bounds of cell ``cid``, or if ``out_basis`` /
                 ``out_dofs`` has the wrong shape, dtype, or is not writeable.
-            RuntimeError: If the grid has been modified since construction.
         """
         return self._tabulate_orders(cid, pts, (0,) * self.dim, out_basis, out_dofs)
 
@@ -1387,7 +1358,6 @@ class THBSplineSpace:
                 ``pts`` does not have trailing dimension ``dim``, if any point lies
                 outside cell ``cid``, or if ``out_basis`` / ``out_dofs`` has the wrong
                 shape, dtype, or is not writeable.
-            RuntimeError: If the grid has been modified since construction.
         """
         if isinstance(orders, int):
             orders_t = (orders,) * self.dim
@@ -1437,9 +1407,7 @@ class THBSplineSpace:
         Raises:
             IndexError: If any id is outside ``[0, grid.num_cells)``.
             ValueError: If ``admissible_class`` is an integer ``< 2``.
-            RuntimeError: If the grid has been modified since construction.
         """
-        self._check_not_stale()
         self._check_admissible_class(admissible_class)
         ids = np.unique(np.asarray(cell_ids, dtype=np.int64).ravel())
         bad = [int(x) for x in ids if int(x) < 0 or int(x) >= self._grid.num_cells]
@@ -1495,9 +1463,7 @@ class THBSplineSpace:
                 out of range, ``lo``/``hi`` have the wrong length, any
                 ``lo[k] >= hi[k]``, or any part of ``[lo, hi)`` lies outside the
                 level domain.
-            RuntimeError: If the grid has been modified since construction.
         """
-        self._check_not_stale()
         self._check_admissible_class(admissible_class)
         lo_t, hi_t = self._validate_region(level, lo, hi)
         # Enumerate the active leaves in the box on the original grid (flat ids are
@@ -1575,11 +1541,16 @@ class THBSplineSpace:
         marked: list[tuple[int, tuple[int, ...]]],
         admissible_class: int | None,
     ) -> THBSplineSpace:
-        """Refine the marked ``(level, midx)`` cells on a fresh grid copy.
+        """Return a new space over this space's grid with the marked cells refined.
 
-        Shared by :meth:`refine` and :meth:`refine_region`.  Does not mutate
-        ``self``.  Callers are responsible for capturing ``marked`` against the
-        original grid before any refinement (flat ids reassign on every refine).
+        Shared by :meth:`refine` and :meth:`refine_region`.  Mutates nothing: the
+        grid is refined by rebinding, so ``self`` and its grid are untouched.
+        Callers are responsible for capturing ``marked`` against the original grid
+        before any refinement (flat ids are reassigned by every refine).
+
+        When ``marked`` refines nothing, the returned space shares this space's grid
+        object.  That is safe -- the grid is immutable -- and it shares the grid's
+        lazy BVH and tag caches, which describe the same cells either way.
 
         Args:
             marked (list[tuple[int, tuple[int, ...]]]): ``(level, midx)`` pairs of
@@ -1591,16 +1562,16 @@ class THBSplineSpace:
             THBSplineSpace: A new space on the refined grid (same ``root_space``,
             ``truncate``, and ``regularity``).
         """
-        grid_copy = copy.deepcopy(self._grid)
+        grid = self._grid
         for level, midx in marked:
             if admissible_class is None:
-                if grid_copy.is_active_leaf(level, midx):
-                    grid_copy.refine(level, list(midx), [i + 1 for i in midx])
+                if grid.is_active_leaf(level, midx):
+                    grid = grid.refine(level, list(midx), [i + 1 for i in midx])
             else:
-                self._refine_recursive(grid_copy, level, midx, admissible_class)
+                grid = self._refine_recursive(grid, level, midx, admissible_class)
         return THBSplineSpace(
             self._root_space,
-            grid_copy,
+            grid,
             truncate=self._truncate,
             regularity=self._regularity,
         )
@@ -1611,18 +1582,23 @@ class THBSplineSpace:
         level: int,
         midx: tuple[int, ...],
         m: int,
-    ) -> None:
-        """Refine cell ``(level, midx)`` on ``grid``, grading for class-``m`` admissibility.
+    ) -> HierarchicalGrid:
+        """Return ``grid`` with cell ``(level, midx)`` refined, graded for class ``m``.
 
         Refines every cell in the refinement neighborhood (recursively, at the coarser
         level ``level - m + 1``) before subdividing ``(level, midx)``, per Algorithm 4
-        of Carraturo et al. (2019).
+        of Carraturo et al. (2019).  Each step queries the grid produced by the
+        previous one, as the in-place version queried the grid it had just mutated.
 
         Args:
-            grid (HierarchicalGrid): The (mutable) grid copy being refined.
+            grid (HierarchicalGrid): The grid to refine.  Not modified.
             level (int): Level of the cell to refine.
             midx (tuple[int, ...]): Per-axis index of the cell at ``level``.
             m (int): Admissibility class (``>= 2``).
+
+        Returns:
+            HierarchicalGrid: The refined grid; ``grid`` itself when the cell is not
+            an active leaf and its neighborhood is empty.
 
         Raises:
             RecursionError: Unreachable in practice — recursion depth is bounded by
@@ -1630,9 +1606,10 @@ class THBSplineSpace:
                 before Python's default recursion limit.
         """
         for nlevel, nmidx in self._refinement_neighborhood(level, midx, m, grid):
-            self._refine_recursive(grid, nlevel, nmidx, m)
+            grid = self._refine_recursive(grid, nlevel, nmidx, m)
         if grid.is_active_leaf(level, midx):
-            grid.refine(level, list(midx), [i + 1 for i in midx])
+            grid = grid.refine(level, list(midx), [i + 1 for i in midx])
+        return grid
 
     def _refinement_neighborhood(
         self,
@@ -1652,7 +1629,7 @@ class THBSplineSpace:
             level (int): Level of the cell.
             midx (tuple[int, ...]): Per-axis index of the cell at ``level``.
             m (int): Admissibility class (``>= 2``, so ``level - m + 2 <= level``).
-            grid (HierarchicalGrid): The grid copy whose active set is queried.
+            grid (HierarchicalGrid): The grid whose active set is queried.
 
         Returns:
             list[tuple[int, tuple[int, ...]]]: ``(level - m + 1, parent_midx)`` cells in
@@ -1704,13 +1681,14 @@ class THBSplineSpace:
         if its coarsening neighborhood (Def. 3.5) is empty, so the resulting mesh stays
         admissible of class ``m``.  With ``admissible_class=None`` that guard is skipped.
 
-        The space is immutable: a fresh grid is coarsened and a new
-        :class:`THBSplineSpace` is built; ``self`` and its grid are unchanged.
-        An empty ``cell_ids`` is valid and returns an unchanged copy of the space.
+        The space is immutable: the grid is coarsened by rebinding, and a new
+        :class:`THBSplineSpace` is built on the result; ``self`` and its grid are
+        unchanged.  An empty ``cell_ids``, and one that coarsens nothing, both return
+        an equivalent new space over this space's own (immutable) grid.
 
         Args:
             cell_ids (npt.ArrayLike): Flat ids of active leaf cells to coarsen away.
-                An empty array is valid and produces an unchanged copy.
+                An empty array is valid and coarsens nothing.
             admissible_class (int | None): Admissibility class ``m >= 2`` to maintain,
                 or ``None`` to skip the admissibility guard.  Defaults to ``2``.
 
@@ -1721,9 +1699,7 @@ class THBSplineSpace:
         Raises:
             IndexError: If any id is outside ``[0, grid.num_cells)``.
             ValueError: If ``admissible_class`` is an integer ``< 2``.
-            RuntimeError: If the grid has been modified since construction.
         """
-        self._check_not_stale()
         if admissible_class is not None and admissible_class < 2:  # noqa: PLR2004
             raise ValueError(
                 f"admissible_class must be an integer >= 2 or None; got {admissible_class!r}."
@@ -1743,7 +1719,7 @@ class THBSplineSpace:
             if level >= 1
         }
         num_children = math.prod(factor)
-        grid_copy = copy.deepcopy(self._grid)
+        grid = self._grid
         # Deepest parent first, so a veto is decided against a mesh whose finer
         # coarsenings have already happened.
         for parent_level, pmidx in sorted(parents, key=lambda pc: -pc[0]):
@@ -1753,7 +1729,7 @@ class THBSplineSpace:
             for child in itertools.product(
                 *(range(pmidx[d] * factor[d], (pmidx[d] + 1) * factor[d]) for d in range(dim))
             ):
-                cid = grid_copy.cell_id(parent_level + 1, child)
+                cid = grid.cell_id(parent_level + 1, child)
                 if cid is not None and (parent_level + 1, child) in marked:
                     child_ids.append(cid)
             # An incomplete family is one `coarsen_cells` would skip anyway, so leaving
@@ -1764,15 +1740,15 @@ class THBSplineSpace:
             if len(child_ids) < num_children:
                 continue
             if admissible_class is not None and not self._coarsening_neighborhood_empty(
-                parent_level, pmidx, admissible_class, grid_copy
+                parent_level, pmidx, admissible_class, grid
             ):
                 continue
             # coarsen_cells applies the rule itself -- it demotes the parent only if all
             # of its children are named active leaves, which is Alg. 5's condition.
-            grid_copy.coarsen_cells(child_ids)
+            grid = grid.coarsen_cells(child_ids)
         return THBSplineSpace(
             self._root_space,
-            grid_copy,
+            grid,
             truncate=self._truncate,
             regularity=self._regularity,
         )
@@ -1795,7 +1771,7 @@ class THBSplineSpace:
             parent_level (int): Level of the parent being considered for coarsening.
             pmidx (tuple[int, ...]): Per-axis index of the parent at ``parent_level``.
             m (int): Admissibility class (``>= 2``).
-            grid (HierarchicalGrid): The grid copy whose active set is queried.
+            grid (HierarchicalGrid): The grid whose active set is queried.
 
         Returns:
             bool: ``True`` iff no active cell at level ``parent_level + m`` lies in the

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -339,7 +339,7 @@ class THBSplineSpace:
     stale: :meth:`~pantr.grid.HierarchicalGrid.refine` returns a *new* grid and leaves
     the one held here untouched.  :meth:`refine`, :meth:`refine_region` and
     :meth:`coarsen` are the same shape one level up -- each returns a new space over a
-    new grid.
+    grid of its own, including when it refines or coarsens nothing.
 
     Note:
         :meth:`active_basis` lists functions whose *untruncated* support covers a
@@ -356,8 +356,9 @@ class THBSplineSpace:
 
     Attributes:
         _root_space (BsplineSpace): The level-0 tensor-product space.
-        _grid (HierarchicalGrid): The active-cell hierarchy.  Immutable, and may be
-            shared with the space this one was refined from when nothing changed.
+        _grid (HierarchicalGrid): The active-cell hierarchy.  Immutable, and never
+            shared with another space's grid: the grid's tag registries and BVH memo
+            are mutable even though its cell decomposition is not.
         _truncate (bool): Whether the truncated (THB) basis is used; ``False`` for
             the plain hierarchical (HB) basis.
         _regularity (tuple[int | None, ...]): Per-direction continuity used when
@@ -1548,9 +1549,11 @@ class THBSplineSpace:
         Callers are responsible for capturing ``marked`` against the original grid
         before any refinement (flat ids are reassigned by every refine).
 
-        When ``marked`` refines nothing, the returned space shares this space's grid
-        object.  That is safe -- the grid is immutable -- and it shares the grid's
-        lazy BVH and tag caches, which describe the same cells either way.
+        When ``marked`` refines nothing the grid is copied instead, so the returned
+        space never holds this space's grid object.  The cell decomposition is
+        immutable, but a grid also carries two tag registries and a BVH memo, which
+        belong to whoever holds the grid, and sharing them across two spaces would
+        make a tag set through one visible through the other.
 
         Args:
             marked (list[tuple[int, tuple[int, ...]]]): ``(level, midx)`` pairs of
@@ -1571,7 +1574,7 @@ class THBSplineSpace:
                 grid = self._refine_recursive(grid, level, midx, admissible_class)
         return THBSplineSpace(
             self._root_space,
-            grid,
+            grid if grid is not self._grid else grid._copy(),
             truncate=self._truncate,
             regularity=self._regularity,
         )
@@ -1684,7 +1687,8 @@ class THBSplineSpace:
         The space is immutable: the grid is coarsened by rebinding, and a new
         :class:`THBSplineSpace` is built on the result; ``self`` and its grid are
         unchanged.  An empty ``cell_ids``, and one that coarsens nothing, both return
-        an equivalent new space over this space's own (immutable) grid.
+        an equivalent new space over a copy of this space's grid -- a copy rather than
+        the same object, so the two spaces never share the grid's tag registries.
 
         Args:
             cell_ids (npt.ArrayLike): Flat ids of active leaf cells to coarsen away.
@@ -1748,7 +1752,7 @@ class THBSplineSpace:
             grid = grid.coarsen_cells(child_ids)
         return THBSplineSpace(
             self._root_space,
-            grid,
+            grid if grid is not self._grid else grid._copy(),
             truncate=self._truncate,
             regularity=self._regularity,
         )

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -1385,8 +1385,9 @@ class THBSplineSpace:
     ) -> THBSplineSpace:
         """Return a new space with the marked cells refined.
 
-        This method does not mutate ``self`` or its grid: a fresh grid is refined
-        and a new :class:`THBSplineSpace` is built; ``self`` and its grid are unchanged.
+        This method does not mutate ``self`` or its grid: the grid is refined by
+        rebinding, and a new :class:`THBSplineSpace` is built on the result; ``self``
+        and its grid are unchanged.
 
         With ``admissible_class=m`` (the default ``m=2``) the refinement is graded so
         the resulting mesh is admissible of class ``m`` (the truncated functions
@@ -1440,9 +1441,9 @@ class THBSplineSpace:
         is the region-based counterpart of :meth:`refine`, which marks individual
         cells by flat id.
 
-        Like :meth:`refine`, this does not mutate ``self`` or its grid: a fresh grid
-        is refined and a new :class:`THBSplineSpace` is returned.  Calls chain, so
-        successive regions refine progressively (graded by default).
+        Like :meth:`refine`, this does not mutate ``self`` or its grid: the grid is
+        refined by rebinding, and a new :class:`THBSplineSpace` is returned.  Calls
+        chain, so successive regions refine progressively (graded by default).
 
         Args:
             level (int): Level at which the box lives.  Must satisfy

--- a/src/pantr/bspline/multilevel_extraction.py
+++ b/src/pantr/bspline/multilevel_extraction.py
@@ -188,7 +188,6 @@ class MultiLevelExtraction:
 
         Raises:
             IndexError: If ``cid`` is out of range.
-            RuntimeError: If the grid has been modified since construction.
         """
         return self._space.active_basis(cid)
 
@@ -217,10 +216,10 @@ class MultiLevelExtraction:
         Raises:
             IndexError: If ``cid`` is out of range.
             ValueError: If ``out`` has the wrong shape, dtype, or is not writeable.
-            RuntimeError: If the grid has been modified since construction.
+            RuntimeError: If a refined coefficient box does not overlap the cell window
+                (a bug in this class).
         """
         space = self._space
-        space._check_not_stale()
         grid = space.grid
         level = grid.cell_level(cid)
         cell_midx = grid.cell_multi_index(cid)
@@ -290,10 +289,8 @@ class MultiLevelExtraction:
         Raises:
             IndexError: If ``cid`` is out of range.
             ValueError: If ``out`` has the wrong shape, dtype, or is not writeable.
-            RuntimeError: If the grid has been modified since construction.
         """
         space = self._space
-        space._check_not_stale()
         level = space.grid.cell_level(cid)
         cell_midx = space.grid.cell_multi_index(cid)
         level_ext = self._level_extraction(level)

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -8,6 +8,15 @@ region into ``m_0 * ... * m_{d-1}`` equal children (the per-direction *factor*).
 Design highlights
 -----------------
 
+*Immutable.*  A grid is frozen once constructed.  :meth:`~HierarchicalGrid.refine`,
+:meth:`~HierarchicalGrid.refine_cells`, :meth:`~HierarchicalGrid.coarsen` and
+:meth:`~HierarchicalGrid.coarsen_cells` **return a new grid** and leave the receiver
+untouched, so a consumer that captured a grid can never be invalidated by a later
+refinement.  Write ``grid = grid.refine(...)``; discarding the return value discards
+the refinement.  Only the three lazy caches a grid inherits from its base (the BVH
+and the two tag registries) are filled in after construction, and filling them
+changes nothing a caller can observe about the cell decomposition.
+
 *No per-cell storage.*  Only **rectangular blocks** are stored — at most one
 small list of ``(lo, hi)`` index pairs per level.  Memory is therefore
 ``O(total_blocks * ndim)``, independent of the total cell count.
@@ -226,8 +235,8 @@ def _normalize_blocks(blocks: list[_Block]) -> list[_Block]:
     """Sort a block list and greedily merge adjacent aligned pairs.
 
     Args:
-        blocks (list[_Block]): List of non-overlapping blocks (modified in
-            place and returned sorted).
+        blocks (list[_Block]): List of non-overlapping blocks.  Not modified; the
+            result is a fresh list.
 
     Returns:
         list[_Block]: Sorted, compacted list of non-overlapping blocks.
@@ -317,6 +326,10 @@ class HierarchicalGrid(_GridPython):
     kept.  A new level is created by :meth:`refine`; the grid starts with all
     root cells active at level 0.
 
+    **The cell decomposition is immutable.**  :meth:`refine`, :meth:`refine_cells`,
+    :meth:`coarsen` and :meth:`coarsen_cells` return a new grid and leave this one
+    unchanged.
+
     Flat cell ids are assigned level-by-level (level 0 first), block-by-block
     within a level (sorted by ``lo`` tuple), and C-order within each block.
 
@@ -329,8 +342,6 @@ class HierarchicalGrid(_GridPython):
         _level_base (list[int]): ``_level_base[l]`` is the flat-id base of
             level ``l``; length ``max_level + 2`` (includes sentinel).
         _num_cells (int): Cached total active cell count.
-        _version (int): Monotonic mutation counter, incremented on every
-            structural change (see :attr:`version`).
         _packed_block_lo (npt.NDArray[np.int64]): Packed block lower bounds for
             the Numba kernels, shape ``(n_blocks_total, ndim)``, concatenated
             level by level in flat-id order (see ``_hier_core``).
@@ -358,7 +369,6 @@ class HierarchicalGrid(_GridPython):
         "_root",
         "_root_knot_starts",
         "_root_knots_flat",
-        "_version",
     )
 
     def __init__(
@@ -404,7 +414,6 @@ class HierarchicalGrid(_GridPython):
         self._blocks: list[list[_Block]] = [[(lo0, hi0)]]
         self._level_base: list[int] = []
         self._num_cells: int = 0
-        self._version: int = 0
         self._rebuild()
 
     @classmethod
@@ -448,9 +457,21 @@ class HierarchicalGrid(_GridPython):
         self._blocks = normalized
         self._level_base = []
         self._num_cells = 0
-        self._version = 0
         self._rebuild()
         return self
+
+    def _copy(self) -> Self:
+        """Return an independent grid with the same root, factor and active cells.
+
+        The result compares cell for cell with this grid but is a distinct object
+        with its own empty BVH and tag caches.  Used by the four hierarchy
+        operations on the paths where they change nothing, so that every one of
+        them returns a grid that never aliases its receiver.
+
+        Returns:
+            Self: A fresh grid over the same active-leaf decomposition.
+        """
+        return self._from_blocks(self._root, self._factor, list(self._blocks))
 
     # ------------------------------------------------------------------
     # Properties
@@ -502,33 +523,18 @@ class HierarchicalGrid(_GridPython):
         """
         return len(self._blocks) - 1
 
-    @property
-    def version(self) -> int:
-        """Get the monotonic mutation counter of this grid.
-
-        Incremented on every structural change (:meth:`refine`, :meth:`coarsen`).
-        Snapshot consumers (e.g. :class:`~pantr.bspline.THBSplineSpace`) compare
-        it to detect *any* post-construction mutation -- ``max_level`` and
-        ``num_cells`` alone cannot distinguish compensating refine/coarsen pairs.
-
-        Returns:
-            int: The current mutation count (``>= 1``).
-        """
-        return self._version
-
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
     def _rebuild(self) -> None:
-        """Recompute ``_level_base``, ``_num_cells``, and reset the BVH/tags.
+        """Derive ``_level_base``, ``_num_cells`` and the packed kernel arrays from ``_blocks``.
 
-        Called after every structural change (construction or refinement).
-        Bumps :attr:`version` so snapshot consumers can detect any mutation,
-        including compensating refine/coarsen pairs that leave ``max_level``
-        and ``num_cells`` unchanged.  Also repacks the block lists into the
-        flat ``int64`` arrays consumed by the ``_hier_core``
-        kernels (``O(total_blocks)`` work).
+        The last step of every construction path, and the only place the derived
+        state is written: a grid is frozen once this returns, so there is nothing to
+        invalidate afterwards and the three inherited caches are left as
+        ``_GridPython.__init__`` set them.  Packing the block lists into the flat
+        ``int64`` arrays the ``_hier_core`` kernels consume is ``O(total_blocks)``.
         """
         base = 0
         level_base: list[int] = []
@@ -538,10 +544,6 @@ class HierarchicalGrid(_GridPython):
         level_base.append(base)  # sentinel for bisect_right
         self._level_base = level_base
         self._num_cells = base
-        self._version += 1
-        self._bvh = None
-        self._cell_tags = None
-        self._facet_tags = None
 
         # Pack the per-level block lists for the Numba kernels, in the same
         # order flat ids are assigned (level by level, block by block, C-order
@@ -1165,9 +1167,10 @@ class HierarchicalGrid(_GridPython):
         """Return the flat id of the active leaf ``(level, midx)``, or ``None``.
 
         The inverse of :meth:`cell_level` and :meth:`cell_multi_index` taken together.
-        Because :meth:`refine` and :meth:`coarsen` reassign every flat id, a caller that
-        must track cells across a mutation keeps them as ``(level, midx)`` pairs -- which
-        are stable -- and resolves them back to ids here, once per mutation.
+        Because :meth:`refine` and :meth:`coarsen` assign the flat ids of the grid they
+        return from scratch, a caller that must track cells across a refinement keeps
+        them as ``(level, midx)`` pairs -- which are stable -- and resolves them back to
+        ids on the new grid here, once per step.
 
         Args:
             level (int): Hierarchy level.
@@ -1309,14 +1312,16 @@ class HierarchicalGrid(_GridPython):
         level: int,
         lo: Sequence[int],
         hi: Sequence[int],
-    ) -> None:
-        """Refine the rectangular region ``[lo, hi)`` at ``level`` to ``level+1``.
+    ) -> Self:
+        """Return a new grid with the region ``[lo, hi)`` at ``level`` refined to ``level+1``.
+
+        This grid is left unchanged; write ``grid = grid.refine(...)``.
 
         Union semantics: only the currently-active portion of ``[lo, hi)`` is
         refined, leaving cells that are already deeper untouched.  If the
-        intersection with active blocks at ``level`` is empty, the call is a
-        silent no-op.  Overlapping calls therefore safely extend the refined
-        region.
+        intersection with active blocks at ``level`` is empty, the returned grid is
+        an unrefined copy of this one.  Overlapping calls therefore safely extend
+        the refined region.
 
         That convenience costs invertibility.  Promoting only part of a box sends
         several distinct grids to the same result, so :meth:`refine` is **not
@@ -1333,8 +1338,9 @@ class HierarchicalGrid(_GridPython):
         the bounding box of the ids given at each level, so it can promote a cell the
         caller did not mark; that costs nothing, since refining removes no cell.)
 
-        After the call all flat cell ids are **reassigned** (the BVH, cell tags,
-        and facet tags are also invalidated).
+        The returned grid assigns flat cell ids afresh, so an id read from this
+        grid does not name the same cell there.  Its BVH and its cell and facet
+        tags start empty; this grid keeps its own.
 
         Args:
             level (int): Refinement level at which the region lives.  Must
@@ -1343,6 +1349,9 @@ class HierarchicalGrid(_GridPython):
                 level-``level`` coordinates.
             hi (Sequence[int]): Per-direction end index (exclusive), in
                 level-``level`` coordinates.
+
+        Returns:
+            Self: A new grid with the active portion of ``[lo, hi)`` refined.
 
         Raises:
             ValueError: If ``level`` is out of range, ``lo``/``hi`` have the
@@ -1391,33 +1400,37 @@ class HierarchicalGrid(_GridPython):
             new_children.append((child_lo, child_hi))
 
         if not new_children:
-            return  # no active cells in the requested region — no-op
+            return self._copy()  # no active cells in the requested region
 
-        self._blocks[level] = _normalize_blocks(new_blocks_at_level)
+        # A fresh outer list; the per-level lists below are rebound, never mutated,
+        # so this grid's own block lists are untouched.  `_from_blocks` sorts and
+        # merges every level, so no normalization is needed here.
+        new_levels: list[list[_Block]] = list(self._blocks)
+        new_levels[level] = new_blocks_at_level
+        while len(new_levels) <= level + 1:
+            new_levels.append([])
+        new_levels[level + 1] = [*new_levels[level + 1], *new_children]
+        return self._from_blocks(self._root, self._factor, new_levels)
 
-        # Extend _blocks if needed and add children at level+1.
-        while len(self._blocks) <= level + 1:
-            self._blocks.append([])
-        self._blocks[level + 1] = _normalize_blocks(self._blocks[level + 1] + new_children)
-
-        self._rebuild()
-
-    def refine_cells(self, cell_ids: Sequence[int]) -> None:
-        """Refine a set of active cells using per-level bounding-box aggregation.
+    def refine_cells(self, cell_ids: Sequence[int]) -> Self:
+        """Return a new grid with a set of active cells refined, by per-level bounding box.
 
         Groups ``cell_ids`` by their level, computes the bounding box of all
         cells at each level (the smallest axis-aligned rectangle containing
-        them), and calls :meth:`refine` once per level.
+        them), and applies :meth:`refine` once per level, coarsest first.  This
+        grid is left unchanged; write ``grid = grid.refine_cells(...)``.
 
         Args:
             cell_ids (Sequence[int]): Flat cell ids to refine.  Cells from
                 multiple levels are handled; repeated ids are silently ignored.
+                An empty sequence yields an unrefined copy.
+
+        Returns:
+            Self: A new grid with the marked cells refined.
 
         Raises:
             IndexError: If any id in ``cell_ids`` is out of range.
         """
-        if not cell_ids:
-            return
         # Group by level.
         level_lo: dict[int, list[int]] = {}
         level_hi: dict[int, list[int]] = {}
@@ -1431,16 +1444,20 @@ class HierarchicalGrid(_GridPython):
                 for k, m in enumerate(midx):
                     level_lo[lv][k] = min(level_lo[lv][k], m)
                     level_hi[lv][k] = max(level_hi[lv][k], m + 1)
+        grid = self
         for lv in sorted(level_lo):
-            self.refine(lv, level_lo[lv], level_hi[lv])
+            grid = grid.refine(lv, level_lo[lv], level_hi[lv])
+        return grid if grid is not self else self._copy()
 
     def coarsen(
         self,
         level: int,
         lo: Sequence[int],
         hi: Sequence[int],
-    ) -> None:
-        """Demote the rectangular region ``[lo, hi)`` from ``level+1`` back to ``level``.
+    ) -> Self:
+        """Return a new grid with ``[lo, hi)`` demoted from ``level+1`` back to ``level``.
+
+        This grid is left unchanged; write ``grid = grid.coarsen(...)``.
 
         Reactivates the level-``level`` cells in ``[lo, hi)`` and removes their
         level-``(level+1)`` children.  The region must be **fully refined to exactly
@@ -1467,8 +1484,9 @@ class HierarchicalGrid(_GridPython):
         active at ``level``, so ``refine(level, lo, hi)`` always undoes
         ``coarsen(level, lo, hi)``.
 
-        After the call all flat cell ids are **reassigned** (the BVH, cell tags, and
-        facet tags are invalidated).
+        The returned grid assigns flat cell ids afresh, so an id read from this grid
+        does not name the same cell there.  Its BVH and its cell and facet tags start
+        empty; this grid keeps its own.
 
         Args:
             level (int): Level whose cells are reactivated.  Must satisfy
@@ -1477,6 +1495,9 @@ class HierarchicalGrid(_GridPython):
                 coordinates.
             hi (Sequence[int]): Per-direction end index (exclusive), in level-``level``
                 coordinates.
+
+        Returns:
+            Self: A new grid with ``[lo, hi)`` active at ``level``.
 
         Raises:
             ValueError: If ``level`` is out of range, ``lo``/``hi`` have the wrong
@@ -1535,14 +1556,20 @@ class HierarchicalGrid(_GridPython):
                 f"fully refined to exactly level {level + 1}.{detail}"
             )
 
-        self._blocks[level + 1] = _normalize_blocks(new_finer)
-        self._blocks[level] = _normalize_blocks([*self._blocks[level], (lo_t, hi_t)])
-        while len(self._blocks) > 1 and not self._blocks[-1]:
-            self._blocks.pop()
-        self._rebuild()
+        # A fresh outer list; the per-level lists are rebound, never mutated, so this
+        # grid's own block lists are untouched.  `_from_blocks` sorts and merges every
+        # level and drops the trailing empty ones, so neither is needed here -- but the
+        # order the demoted box is appended in is observable through the greedy merge,
+        # and is preserved.
+        new_levels: list[list[_Block]] = list(self._blocks)
+        new_levels[level + 1] = new_finer
+        new_levels[level] = [*new_levels[level], (lo_t, hi_t)]
+        return self._from_blocks(self._root, self._factor, new_levels)
 
-    def coarsen_cells(self, cell_ids: Sequence[int]) -> None:
-        """Demote every parent whose children are all named in ``cell_ids``.
+    def coarsen_cells(self, cell_ids: Sequence[int]) -> Self:
+        """Return a new grid with every parent demoted whose children are all named.
+
+        This grid is left unchanged; write ``grid = grid.coarsen_cells(...)``.
 
         The route that destroys only what the caller named.  ``cell_ids`` are grouped
         by parent cell, and a parent is reactivated -- its children removed -- only when
@@ -1576,8 +1603,11 @@ class HierarchicalGrid(_GridPython):
 
         Args:
             cell_ids (Sequence[int]): Flat ids of active leaf cells to coarsen away.
-                Repeated ids and ids at level 0 are ignored.  An empty sequence is a
-                no-op.
+                Repeated ids and ids at level 0 are ignored.  An empty sequence, and
+                one that demotes nothing, both yield an uncoarsened copy.
+
+        Returns:
+            Self: A new grid with the complete named families demoted.
 
         Raises:
             IndexError: If any id in ``cell_ids`` is out of range.
@@ -1592,6 +1622,9 @@ class HierarchicalGrid(_GridPython):
             if level >= 1
         }
         # Deepest first, then lexicographic, so the outcome does not depend on set order.
+        # `grid` carries the demotions already applied, so the active-leaf test below sees
+        # the same state the in-place version saw at that point in the loop.
+        grid = self
         for parent_level, pmidx in sorted(parents, key=lambda parent: (-parent[0], parent[1])):
             children = itertools.product(
                 *(range(p * f, (p + 1) * f) for p, f in zip(pmidx, self._factor, strict=True))
@@ -1601,10 +1634,11 @@ class HierarchicalGrid(_GridPython):
             # parent's own.  It is kept because that is an argument about the caller, not a
             # property of this loop, and it is what the documented rule actually says.
             if all(
-                (parent_level + 1, child) in marked and self.is_active_leaf(parent_level + 1, child)
+                (parent_level + 1, child) in marked and grid.is_active_leaf(parent_level + 1, child)
                 for child in children
             ):
-                self.coarsen(parent_level, pmidx, tuple(p + 1 for p in pmidx))
+                grid = grid.coarsen(parent_level, pmidx, tuple(p + 1 for p in pmidx))
+        return grid if grid is not self else self._copy()
 
     def _coarsen_obstacles(
         self,

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -422,6 +422,8 @@ class HierarchicalGrid(_GridPython):
         root: TensorProductGrid,
         factor: tuple[int, ...],
         blocks: list[list[_Block]],
+        *,
+        unnormalized_levels: frozenset[int] | None = None,
     ) -> Self:
         """Build a grid directly from per-level block lists (internal constructor).
 
@@ -432,20 +434,40 @@ class HierarchicalGrid(_GridPython):
 
         **Every grid not built by ``__init__`` is built here**: :meth:`restrict`'s
         windowed sub-grid, :meth:`refine` and :meth:`coarsen`'s result, and
-        :meth:`_copy`. Two consequences for anyone changing it. Normalizing *every*
-        level, rather than only the ones an operation touched, is what makes the
-        result independent of which levels the caller rebuilt -- and it is only
-        harmless because normalization is a fixed point
-        (``test_normalize_blocks_is_idempotent``); were it not, every flat cell id
-        would move. And the greedy merge is order-dependent, so the order blocks
-        arrive in is observable through the flat ids
-        (``test_normalize_blocks_depends_on_the_order_it_is_given``).
+        :meth:`_copy`. Three consequences for anyone changing it, including whoever
+        mirrors this in another backend.
+
+        The greedy merge is order-dependent, so the order blocks arrive in is
+        observable through the flat ids
+        (``test_normalize_blocks_depends_on_the_order_it_is_given``). Nothing here
+        may reorder a level's blocks.
+
+        ``unnormalized_levels`` is a pure cost switch and never a behavioural one.
+        Normalization is a fixed point -- its output is sorted and pairwise
+        non-mergeable, so re-running it is the identity
+        (``test_normalize_blocks_is_idempotent``) -- so a level already holding a
+        previous call's output normalizes to itself, and skipping that re-run
+        returns the same blocks in the same order. Declaring a level clean when it
+        is not, on the other hand, moves every flat cell id, so the default assumes
+        nothing.
+
+        A level is clean exactly when it holds another grid's ``_blocks[l]``
+        verbatim. That covers :meth:`refine` and :meth:`coarsen`, which rebind only
+        the two levels they touch and share the rest, and :meth:`_copy`, which
+        shares all of them. It does **not** cover :meth:`restrict`: clipping a
+        normalized partition to a window can make two blocks mergeable that were
+        not, so those lists must be normalized again.
 
         Args:
             root (TensorProductGrid): The level-0 root grid of the sub-hierarchy.
             factor (tuple[int, ...]): Per-direction subdivision factor.
             blocks (list[list[_Block]]): ``blocks[l]`` lists the active-leaf
                 ``(lo, hi)`` rectangles at level ``l`` in level-``l`` coordinates.
+            unnormalized_levels (frozenset[int] | None): Levels whose block lists the
+                caller may have altered and which must therefore be normalized here.
+                Every other level is taken verbatim, so a caller that names too few
+                gets a different -- wrong -- cell numbering. ``None``, the default,
+                normalizes every level and is always safe.
 
         Returns:
             Self: A grid whose active leaves span the same cells as
@@ -461,7 +483,15 @@ class HierarchicalGrid(_GridPython):
         _GridPython.__init__(self)
         self._root = root
         self._factor = factor
-        normalized = [_normalize_blocks(list(level_blocks)) for level_blocks in blocks]
+        # `list(...)` on the skipped levels keeps the no-aliasing property the
+        # normalizing path gets for free: `_blocks` is never mutated in place, but a
+        # new grid sharing list objects with its receiver would make that load-bearing.
+        normalized = [
+            list(level_blocks)
+            if unnormalized_levels is not None and level not in unnormalized_levels
+            else _normalize_blocks(list(level_blocks))
+            for level, level_blocks in enumerate(blocks)
+        ]
         while len(normalized) > 1 and not normalized[-1]:
             normalized.pop()
         self._blocks = normalized
@@ -484,7 +514,9 @@ class HierarchicalGrid(_GridPython):
         Returns:
             Self: A fresh grid over the same active-leaf decomposition.
         """
-        return self._from_blocks(self._root, self._factor, list(self._blocks))
+        return self._from_blocks(
+            self._root, self._factor, list(self._blocks), unnormalized_levels=frozenset()
+        )
 
     # ------------------------------------------------------------------
     # Properties
@@ -1415,14 +1447,22 @@ class HierarchicalGrid(_GridPython):
         if not new_children:
             return self._copy()  # no active cells in the requested region
 
-        # A fresh outer list; the per-level lists below are rebound, never mutated,
-        # so this grid's own block lists are untouched (`_from_blocks` normalizes).
+        # A fresh outer list; the per-level lists below are rebound, never mutated, so
+        # this grid's own block lists are untouched.  Every other level is this grid's
+        # own already-normalized list, so only these two are handed to the merge --
+        # which is what keeps a refinement sweep from paying for the whole hierarchy at
+        # every step (`scripts/bench_grid_refine.py`).
         new_levels: list[list[_Block]] = list(self._blocks)
         new_levels[level] = new_blocks_at_level
         while len(new_levels) <= level + 1:
             new_levels.append([])
         new_levels[level + 1] = [*new_levels[level + 1], *new_children]
-        return self._from_blocks(self._root, self._factor, new_levels)
+        return self._from_blocks(
+            self._root,
+            self._factor,
+            new_levels,
+            unnormalized_levels=frozenset({level, level + 1}),
+        )
 
     def refine_cells(self, cell_ids: Sequence[int]) -> Self:
         """Return a new grid with a set of active cells refined, by per-level bounding box.
@@ -1572,13 +1612,19 @@ class HierarchicalGrid(_GridPython):
             )
 
         # A fresh outer list; the per-level lists are rebound, never mutated, so this
-        # grid's own block lists are untouched (`_from_blocks` normalizes and drops
-        # trailing empty levels).  The order the demoted box is appended in is
-        # observable through the greedy merge, though, and is preserved.
+        # grid's own block lists are untouched (`_from_blocks` drops trailing empty
+        # levels).  The order the demoted box is appended in is observable through the
+        # greedy merge, though, and is preserved.  As in `refine`, only the two levels
+        # rebound here are re-normalized; the rest are this grid's own normalized lists.
         new_levels: list[list[_Block]] = list(self._blocks)
         new_levels[level + 1] = new_finer
         new_levels[level] = [*new_levels[level], (lo_t, hi_t)]
-        return self._from_blocks(self._root, self._factor, new_levels)
+        return self._from_blocks(
+            self._root,
+            self._factor,
+            new_levels,
+            unnormalized_levels=frozenset({level, level + 1}),
+        )
 
     def coarsen_cells(self, cell_ids: Sequence[int]) -> Self:
         """Return a new grid with every parent demoted whose children are all named.

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -427,9 +427,19 @@ class HierarchicalGrid(_GridPython):
 
         Bypasses the public ``__init__`` (which starts with a single level-0 block
         spanning the whole root) to assemble an arbitrary, already-consistent
-        active-leaf decomposition. Used by :meth:`restrict` to produce a windowed
-        sub-grid. The per-level block lists are normalized (sorted and merged) and
-        empty trailing levels are dropped.
+        active-leaf decomposition. The per-level block lists are normalized (sorted
+        and merged) and empty trailing levels are dropped.
+
+        **Every grid not built by ``__init__`` is built here**: :meth:`restrict`'s
+        windowed sub-grid, :meth:`refine` and :meth:`coarsen`'s result, and
+        :meth:`_copy`. Two consequences for anyone changing it. Normalizing *every*
+        level, rather than only the ones an operation touched, is what makes the
+        result independent of which levels the caller rebuilt -- and it is only
+        harmless because normalization is a fixed point
+        (``test_normalize_blocks_is_idempotent``); were it not, every flat cell id
+        would move. And the greedy merge is order-dependent, so the order blocks
+        arrive in is observable through the flat ids
+        (``test_normalize_blocks_depends_on_the_order_it_is_given``).
 
         Args:
             root (TensorProductGrid): The level-0 root grid of the sub-hierarchy.
@@ -464,9 +474,12 @@ class HierarchicalGrid(_GridPython):
         """Return an independent grid with the same root, factor and active cells.
 
         The result compares cell for cell with this grid but is a distinct object
-        with its own empty BVH and tag caches.  Used by the four hierarchy
-        operations on the paths where they change nothing, so that every one of
-        them returns a grid that never aliases its receiver.
+        with its own empty BVH and tag caches.  Used on the paths where an operation
+        changes nothing -- :meth:`refine` over a region with no active cells,
+        :meth:`refine_cells` with no ids, :meth:`coarsen_cells` demoting no complete
+        family -- so that every operation returns a grid that never aliases its
+        receiver.  :meth:`coarsen` needs it nowhere: a validated box always demotes
+        something, or the call raises.
 
         Returns:
             Self: A fresh grid over the same active-leaf decomposition.
@@ -1420,6 +1433,9 @@ class HierarchicalGrid(_GridPython):
         them), and applies :meth:`refine` once per level, coarsest first.  This
         grid is left unchanged; write ``grid = grid.refine_cells(...)``.
 
+        As with :meth:`refine`, the returned grid assigns flat cell ids afresh and its
+        BVH and tag caches start empty; this grid keeps its own.
+
         Args:
             cell_ids (Sequence[int]): Flat cell ids to refine.  Cells from
                 multiple levels are handled; repeated ids are silently ignored.
@@ -1569,7 +1585,9 @@ class HierarchicalGrid(_GridPython):
     def coarsen_cells(self, cell_ids: Sequence[int]) -> Self:
         """Return a new grid with every parent demoted whose children are all named.
 
-        This grid is left unchanged; write ``grid = grid.coarsen_cells(...)``.
+        This grid is left unchanged; write ``grid = grid.coarsen_cells(...)``.  As
+        with :meth:`coarsen`, the returned grid assigns flat cell ids afresh and its
+        BVH and tag caches start empty; this grid keeps its own.
 
         The route that destroys only what the caller named.  ``cell_ids`` are grouped
         by parent cell, and a parent is reactivated -- its children removed -- only when

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -1416,8 +1416,7 @@ class HierarchicalGrid(_GridPython):
             return self._copy()  # no active cells in the requested region
 
         # A fresh outer list; the per-level lists below are rebound, never mutated,
-        # so this grid's own block lists are untouched.  `_from_blocks` sorts and
-        # merges every level, so no normalization is needed here.
+        # so this grid's own block lists are untouched (`_from_blocks` normalizes).
         new_levels: list[list[_Block]] = list(self._blocks)
         new_levels[level] = new_blocks_at_level
         while len(new_levels) <= level + 1:
@@ -1573,10 +1572,9 @@ class HierarchicalGrid(_GridPython):
             )
 
         # A fresh outer list; the per-level lists are rebound, never mutated, so this
-        # grid's own block lists are untouched.  `_from_blocks` sorts and merges every
-        # level and drops the trailing empty ones, so neither is needed here -- but the
-        # order the demoted box is appended in is observable through the greedy merge,
-        # and is preserved.
+        # grid's own block lists are untouched (`_from_blocks` normalizes and drops
+        # trailing empty levels).  The order the demoted box is appended in is
+        # observable through the greedy merge, though, and is preserved.
         new_levels: list[list[_Block]] = list(self._blocks)
         new_levels[level + 1] = new_finer
         new_levels[level] = [*new_levels[level], (lo_t, hi_t)]

--- a/tests/parity/test_grid.py
+++ b/tests/parity/test_grid.py
@@ -376,7 +376,7 @@ def _two_level_grid() -> HierarchicalGrid:
     """
     root = uniform_grid(np.tile([0.0, 4.0], (2, 1)), 4)
     grid = hierarchical_grid(root, 2)
-    grid.refine_cells([0, 1, 4])
+    grid = grid.refine_cells([0, 1, 4])
     return grid
 
 
@@ -496,8 +496,8 @@ def _non_dyadic_grid() -> HierarchicalGrid:
     """
     root = uniform_grid(np.array([[-1.0, 2.0 / 3.0], [-0.1, 0.3]]), 3)
     grid = hierarchical_grid(root, 3)
-    grid.refine_cells([0, 4, 8])
-    grid.refine_cells([9, 15])
+    grid = grid.refine_cells([0, 4, 8])
+    grid = grid.refine_cells([9, 15])
     return grid
 
 
@@ -597,10 +597,10 @@ def test_the_descent_counterexample_runs_through_the_real_kernels(cpp_backend: N
     del cpp_backend
     root = TensorProductGrid([np.array([1.0, 2.0])])
     grid = hierarchical_grid(root, 10)
-    grid.refine_cells([0])
+    grid = grid.refine_cells([0])
     point = np.array([[1.71]])
     first = grid.locate_many(point)
-    grid.refine_cells([int(first[0])])
+    grid = grid.refine_cells([int(first[0])])
 
     reference, actual = _both(lambda: grid.locate_many(point))
 

--- a/tests/test_coupling_graph.py
+++ b/tests/test_coupling_graph.py
@@ -30,7 +30,7 @@ def _thb_two_level(*, truncate: bool = True) -> THBSplineSpace:
     """A 1D two-level THB space: degree-2, 4 root cells, left half refined once."""
     root = create_uniform_space(2, 4)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-    grid.refine(0, [0], [2])
+    grid = grid.refine(0, [0], [2])
     return THBSplineSpace(root, grid, truncate=truncate)
 
 
@@ -38,7 +38,7 @@ def _thb_two_level_2d() -> THBSplineSpace:
     """A 2D two-level THB space: degree-(2,2), 4x4 root cells, lower-left quadrant refined."""
     root = create_uniform_space([2, 2], [4, 4])
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
-    grid.refine(0, [0, 0], [2, 2])
+    grid = grid.refine(0, [0, 0], [2, 2])
     return THBSplineSpace(root, grid)
 
 
@@ -46,8 +46,8 @@ def _thb_three_level() -> THBSplineSpace:
     """A 1D three-level THB space: degree-2, 4 root cells, iterated left-half refinement."""
     root = create_uniform_space(2, 4)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-    grid.refine(0, [0], [2])
-    grid.refine(1, [0], [2])
+    grid = grid.refine(0, [0], [2])
+    grid = grid.refine(1, [0], [2])
     return THBSplineSpace(root, grid)
 
 

--- a/tests/test_distributed_space.py
+++ b/tests/test_distributed_space.py
@@ -72,7 +72,7 @@ def _tp_space_and_partition(n_parts: int) -> tuple[BsplineSpace, Partition]:
 def _thb_space_and_partition(n_parts: int) -> tuple[THBSplineSpace, Partition]:
     root = create_uniform_space(2, 4)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-    grid.refine(0, [0], [2])
+    grid = grid.refine(0, [0], [2])
     thb = THBSplineSpace(root, grid)
     part = partition_grid(thb.grid, n_parts)
     return thb, part
@@ -246,7 +246,7 @@ class TestCreateDistributedSpace:
     def test_grid_method_matches_explicit_thb(self) -> None:
         root = create_uniform_space(2, 4)
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(root, grid)
         part = partition_grid(thb.grid, 2)
         for rank in range(2):

--- a/tests/test_grid_cell_quadrature.py
+++ b/tests/test_grid_cell_quadrature.py
@@ -191,7 +191,7 @@ class TestGenericGrid:
     def test_hierarchical_grid_constant_and_volume(self) -> None:
         root = uniform_grid([[0.0, 4.0], [0.0, 4.0]], [4, 4])
         hg = hierarchical_grid(root, 2)
-        hg.refine(0, [0, 0], [2, 2])  # refine the lower-left quadrant
+        hg = hg.refine(0, [0, 0], [2, 2])  # refine the lower-left quadrant
         rule = gauss_legendre_quadrature(2, 2)
         pts, w = cell_quadrature(hg, rule)
         assert pts.shape == (hg.num_cells, rule.num_points, 2)

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -2099,3 +2099,75 @@ def test_normalize_blocks_is_idempotent() -> None:
         assert _normalize_blocks(list(once)) == once
         assert once == blocks  # the stored lists are already in normal form
     assert g.max_level >= 2  # more than one level was checked
+
+
+def _random_decomposition(
+    rng: np.random.Generator,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    """Return a random non-overlapping set of unit blocks in a small lattice.
+
+    Unit blocks, so the set is automatically non-overlapping and covers a valid
+    active-leaf configuration for one level, and shuffled, so the caller can compare
+    two orders of the same set.
+    """
+    ndim = int(rng.integers(1, 4))
+    n = int(rng.integers(2, 6))
+    cells = [c for c in itertools.product(*(range(n),) * ndim) if rng.random() < 0.55]
+    blocks = [(c, tuple(x + 1 for x in c)) for c in cells]
+    rng.shuffle(blocks)
+    return blocks
+
+
+def test_normalize_blocks_is_idempotent_over_random_decompositions() -> None:
+    """Normalization is a fixed point, over decompositions no fixture would reach.
+
+    This is the property the value-returning refinement rests on and the reason the
+    returned grid's flat cell ids match what the mutating implementation produced:
+    every operation hands its *whole* per-level block list to ``_from_blocks``, which
+    normalizes each level including the ones the operation never touched.  Were
+    normalization not a fixed point, those levels would be re-partitioned and every
+    flat id would move.
+    """
+    rng = np.random.default_rng(20260831)
+    merged_something = 0
+    checked = 0
+    for _ in range(400):
+        blocks = _random_decomposition(rng)
+        if not blocks:
+            continue
+        once = _normalize_blocks(list(blocks))
+        assert _normalize_blocks(list(once)) == once
+        checked += 1
+        merged_something += len(once) < len(blocks)
+    # Without merges this would only be testing `sorted`, which is idempotent trivially.
+    assert checked > 300
+    assert merged_something > checked // 2
+
+
+def test_normalize_blocks_depends_on_the_order_it_is_given() -> None:
+    """The greedy merge's normal form is order-dependent, and that is load-bearing.
+
+    Which adjacent pairs merge depends on the order the blocks arrive in, so the same
+    cell set has several valid rectangle partitions and normalization picks the one its
+    input order leads to.  Flat cell ids are handed out block by block, so the
+    partition is observable -- which is why :meth:`~pantr.grid.HierarchicalGrid.coarsen`
+    appends the demoted box *last*, exactly where the in-place implementation appended
+    it, and why :meth:`~pantr.grid.HierarchicalGrid.coarsen_cells` documents its
+    deepest-first parent order as fixed.
+
+    Pinned as a test because the tempting "improvement" -- making normalization
+    canonical, independent of input order -- would move every flat cell id in a
+    coarsened grid, and a reimplementation that merges in a different order (the C++
+    port) would silently disagree with this one.
+    """
+    rng = np.random.default_rng(20260831)
+    differing = 0
+    for _ in range(400):
+        blocks = _random_decomposition(rng)
+        if len(blocks) < 2:
+            continue
+        other = list(blocks)
+        rng.shuffle(other)
+        if _normalize_blocks(list(blocks)) != _normalize_blocks(other):
+            differing += 1
+    assert differing > 0, "normalization has become order-independent; see this docstring"

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -689,7 +689,7 @@ class TestActiveSetAccessors:
         assert g.cell_id(5, (0,)) is None  # nonexistent level
         assert g.cell_id(-1, (0,)) is None  # negative level
 
-    def test_cell_id_is_resolved_afresh_after_a_mutation(self) -> None:
+    def test_cell_id_is_resolved_afresh_on_the_refined_grid(self) -> None:
         """Ids move under refinement; the `(level, midx)` pair does not."""
         g = _grid_1d(4, 2)
         g = g.refine(0, [3], [4])  # refine the last root cell
@@ -1625,7 +1625,7 @@ class TestHierKernelEquivalence:
         with pytest.raises(IndexError, match="out of range"):
             g._decode_flat_id(-1)
 
-    def test_kernel_state_tracks_mutation(self) -> None:
+    def test_kernel_state_tracks_each_returned_grid(self) -> None:
         """Packed kernel arrays are rebuilt by refine/coarsen (results stay exact)."""
         g = _grid_2d(8)
         rng = np.random.default_rng(17)
@@ -1890,7 +1890,7 @@ class TestExportCells:
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def _mutated_2d() -> HierarchicalGrid:
+def _refined_2d() -> HierarchicalGrid:
     """A 2D grid with three levels, several blocks per level, and warm caches."""
     g = _grid_2d(4, 2)
     g = g.refine(0, (1, 1), (3, 3))
@@ -1902,13 +1902,13 @@ def _mutated_2d() -> HierarchicalGrid:
     return g
 
 
-#: Each of the four hierarchy operations, as ``(name, args)`` applied to ``_mutated_2d()``.
 _OPERATIONS = (
     ("refine", (0, (3, 3), (4, 4))),
     ("refine_cells", ([0, 1],)),
     ("coarsen", (1, (2, 2), (5, 5))),
     ("coarsen_cells", (None,)),  # filled in per test: every level-2 leaf
 )
+"""Each of the four hierarchy operations, as ``(name, args)`` applied to ``_refined_2d()``."""
 
 
 def _operation_args(g: HierarchicalGrid, name: str, args: tuple[object, ...]) -> tuple[object, ...]:
@@ -1929,7 +1929,7 @@ class TestRefinementReturnsANewGrid:
 
     @pytest.mark.parametrize(("name", "args"), _OPERATIONS)
     def test_receiver_is_unchanged(self, name: str, args: tuple[object, ...]) -> None:
-        g = _mutated_2d()
+        g = _refined_2d()
         before = _grid_snapshot(g)
         before_cells = _active_cells(g)
         result = getattr(g, name)(*_operation_args(g, name, args))
@@ -1942,7 +1942,7 @@ class TestRefinementReturnsANewGrid:
     def test_result_is_a_distinct_grid_of_the_same_type(
         self, name: str, args: tuple[object, ...]
     ) -> None:
-        g = _mutated_2d()
+        g = _refined_2d()
         result = getattr(g, name)(*_operation_args(g, name, args))
         assert result is not g
         assert type(result) is type(g)
@@ -1953,7 +1953,7 @@ class TestRefinementReturnsANewGrid:
     def test_result_starts_with_empty_caches_and_the_receiver_keeps_its_own(
         self, name: str, args: tuple[object, ...]
     ) -> None:
-        g = _mutated_2d()
+        g = _refined_2d()
         assert _caches_live(g) == (True, True)
         result = getattr(g, name)(*_operation_args(g, name, args))
         assert _caches_live(result) == (False, False)
@@ -1990,7 +1990,7 @@ class TestRefinementNoOpsStillReturnANewGrid:
         assert _caches_live(result) == (False, False)
 
     def test_refine_cells_of_nothing(self) -> None:
-        g = _mutated_2d()
+        g = _refined_2d()
         result = g.refine_cells([])
         assert result is not g
         assert _active_cells(result) == _active_cells(g)
@@ -2006,7 +2006,7 @@ class TestRefinementNoOpsStillReturnANewGrid:
         assert _active_cells(result) == _active_cells(g)
 
     def test_coarsen_cells_of_nothing(self) -> None:
-        g = _mutated_2d()
+        g = _refined_2d()
         result = g.coarsen_cells([])
         assert result is not g
         assert _active_cells(result) == _active_cells(g)
@@ -2016,7 +2016,7 @@ class TestRefinementIsRepeatable:
     """The chained entry points agree with the single-step ones, cell for cell."""
 
     def test_refine_cells_equals_a_hand_written_chain(self) -> None:
-        g = _mutated_2d()
+        g = _refined_2d()
         ids = [0, 1, g.num_cells - 1]
         boxes: dict[int, tuple[list[int], list[int]]] = {}
         for cid in ids:
@@ -2035,6 +2035,29 @@ class TestRefinementIsRepeatable:
             chained = chained.refine(lv, *boxes[lv])
         assert _active_cells(g.refine_cells(ids)) == _active_cells(chained)
         assert len(boxes) > 1  # the chain has more than one link, or this proves little
+
+    def test_refine_cells_spanning_three_levels(self) -> None:
+        """Ids from three distinct levels, so the per-level chain has three links.
+
+        ``test_refine_cells_equals_a_hand_written_chain`` only guarantees two, which
+        cannot distinguish a chain that stops after the first deeper level.
+        """
+        g = _refined_2d()
+        by_level: dict[int, int] = {}
+        for cid in range(g.num_cells):
+            by_level.setdefault(g.cell_level(cid), cid)
+        assert sorted(by_level) == [0, 1, 2]
+        ids = [by_level[lv] for lv in (0, 1, 2)]
+
+        chained = g
+        for lv in (0, 1, 2):
+            midx = g.cell_multi_index(by_level[lv])
+            chained = chained.refine(lv, list(midx), [m + 1 for m in midx])
+
+        assert _active_cells(g.refine_cells(ids)) == _active_cells(chained)
+        # Each level really did gain something, or two of the three links are no-ops.
+        assert g.refine_cells(ids).max_level == g.max_level + 1
+        assert _active_cells(g.refine_cells(ids)) != _active_cells(g)
 
     def test_refining_the_same_grid_twice_gives_the_same_result(self) -> None:
         """Two operations on one receiver are independent, which mutation made false."""
@@ -2061,7 +2084,7 @@ class TestDeepcopy:
     """``copy.deepcopy`` of a grid still works and reconstructs its contents."""
 
     def test_deepcopy_round_trip(self) -> None:
-        g = _mutated_2d()
+        g = _refined_2d()
         clone = copy.deepcopy(g)
         assert clone is not g
         assert _grid_snapshot(clone) == _grid_snapshot(g)
@@ -2076,7 +2099,7 @@ class TestDeepcopy:
             np_testing.assert_array_equal(hi_c, hi_g)
 
     def test_deepcopy_is_independent_of_the_original(self) -> None:
-        g = _mutated_2d()
+        g = _refined_2d()
         clone = copy.deepcopy(g)
         refined = clone.refine(0, (3, 3), (4, 4))
         assert _active_cells(clone) == _active_cells(g)
@@ -2092,7 +2115,7 @@ def test_normalize_blocks_is_idempotent() -> None:
     re-partitioned and every flat cell id would move, so the returned grid would
     stop matching what the mutating implementation produced.
     """
-    g = _mutated_2d()
+    g = _refined_2d()
     for level in range(g.max_level + 1):
         blocks = list(g.active_blocks(level))
         once = _normalize_blocks(blocks)

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -1883,3 +1883,219 @@ class TestExportCells:
 
         assert points.shape == ((n + 1) ** 3, 3)
         assert conn.shape == (n**3, 8)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Value-returning refinement (#378): the receiver is never touched
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _mutated_2d() -> HierarchicalGrid:
+    """A 2D grid with three levels, several blocks per level, and warm caches."""
+    g = _grid_2d(4, 2)
+    g = g.refine(0, (1, 1), (3, 3))
+    g = g.refine(1, (2, 2), (5, 5))
+    g = g.refine(0, (0, 0), (1, 1))
+    _ = g.cell_bvh()
+    g.cell_tags.set("mark", [0, 1, 2], [7, 7, 7])
+    _ = g.facet_tags
+    return g
+
+
+#: Each of the four hierarchy operations, as ``(name, args)`` applied to ``_mutated_2d()``.
+_OPERATIONS = (
+    ("refine", (0, (3, 3), (4, 4))),
+    ("refine_cells", ([0, 1],)),
+    ("coarsen", (1, (2, 2), (5, 5))),
+    ("coarsen_cells", (None,)),  # filled in per test: every level-2 leaf
+)
+
+
+def _operation_args(g: HierarchicalGrid, name: str, args: tuple[object, ...]) -> tuple[object, ...]:
+    """Resolve the placeholder argument of ``coarsen_cells`` against ``g``."""
+    if name != "coarsen_cells":
+        return args
+    return ([cid for cid in range(g.num_cells) if g.cell_level(cid) == 2],)
+
+
+class TestRefinementReturnsANewGrid:
+    """All four hierarchy operations return a new grid and leave the receiver alone.
+
+    The mutating spellings are gone, and with them ``HierarchicalGrid.version`` and
+    the ``THBSplineSpace`` staleness guard: a space built on a grid can no longer be
+    invalidated by a later refinement, so that failure mode is unrepresentable rather
+    than detected.
+    """
+
+    @pytest.mark.parametrize(("name", "args"), _OPERATIONS)
+    def test_receiver_is_unchanged(self, name: str, args: tuple[object, ...]) -> None:
+        g = _mutated_2d()
+        before = _grid_snapshot(g)
+        before_cells = _active_cells(g)
+        result = getattr(g, name)(*_operation_args(g, name, args))
+        assert _grid_snapshot(g) == before
+        assert _active_cells(g) == before_cells
+        # The operation did something, or this test would pass vacuously.
+        assert _active_cells(result) != before_cells
+
+    @pytest.mark.parametrize(("name", "args"), _OPERATIONS)
+    def test_result_is_a_distinct_grid_of_the_same_type(
+        self, name: str, args: tuple[object, ...]
+    ) -> None:
+        g = _mutated_2d()
+        result = getattr(g, name)(*_operation_args(g, name, args))
+        assert result is not g
+        assert type(result) is type(g)
+        assert result.root is g.root  # the root is shared by reference, as `restrict` does
+        assert result.factor == g.factor
+
+    @pytest.mark.parametrize(("name", "args"), _OPERATIONS)
+    def test_result_starts_with_empty_caches_and_the_receiver_keeps_its_own(
+        self, name: str, args: tuple[object, ...]
+    ) -> None:
+        g = _mutated_2d()
+        assert _caches_live(g) == (True, True)
+        result = getattr(g, name)(*_operation_args(g, name, args))
+        assert _caches_live(result) == (False, False)
+        assert result._facet_tags is None
+        # The receiver's caches survive, and its tags still read back.
+        assert _caches_live(g) == (True, True)
+        ids, values = g.cell_tags["mark"]
+        assert ids.tolist() == [0, 1, 2]
+        assert values.tolist() == [7, 7, 7]
+
+    def test_version_attribute_is_gone(self) -> None:
+        """The mutation counter went with the mutation it counted."""
+        g = _grid_2d(2, 2)
+        assert not hasattr(g, "version")
+        assert not hasattr(HierarchicalGrid, "version")
+        assert "_version" not in HierarchicalGrid.__slots__
+
+
+class TestRefinementNoOpsStillReturnANewGrid:
+    """A call that changes nothing still hands back an independent grid.
+
+    Returning ``self`` would be cheaper and, for the cell decomposition, correct --
+    but the three inherited caches are mutable, so the result would then share the
+    receiver's tag registries on exactly the inputs where nothing changed and not on
+    the others.  One rule is worth one rebuild of the block lists.
+    """
+
+    def test_refine_of_a_region_with_no_active_cells(self) -> None:
+        g = _grid_1d(4, 2).refine(0, [0], [2])
+        # [0, 2) at level 0 is entirely refined away, so this promotes nothing.
+        result = g.refine(0, [0], [2])
+        assert result is not g
+        assert _active_cells(result) == _active_cells(g)
+        assert _caches_live(result) == (False, False)
+
+    def test_refine_cells_of_nothing(self) -> None:
+        g = _mutated_2d()
+        result = g.refine_cells([])
+        assert result is not g
+        assert _active_cells(result) == _active_cells(g)
+        assert _caches_live(result) == (False, False)
+        assert _caches_live(g) == (True, True)
+
+    def test_coarsen_cells_that_demotes_nothing(self) -> None:
+        g = _grid_2d(4, 2).refine(0, (1, 1), (3, 3))
+        # One child of a family of four: not a complete family, so nothing is demoted.
+        one_child = next(cid for cid in range(g.num_cells) if g.cell_level(cid) == 1)
+        result = g.coarsen_cells([one_child])
+        assert result is not g
+        assert _active_cells(result) == _active_cells(g)
+
+    def test_coarsen_cells_of_nothing(self) -> None:
+        g = _mutated_2d()
+        result = g.coarsen_cells([])
+        assert result is not g
+        assert _active_cells(result) == _active_cells(g)
+
+
+class TestRefinementIsRepeatable:
+    """The chained entry points agree with the single-step ones, cell for cell."""
+
+    def test_refine_cells_equals_a_hand_written_chain(self) -> None:
+        g = _mutated_2d()
+        ids = [0, 1, g.num_cells - 1]
+        boxes: dict[int, tuple[list[int], list[int]]] = {}
+        for cid in ids:
+            lv = g.cell_level(cid)
+            midx = g.cell_multi_index(cid)
+            if lv in boxes:
+                lo, hi = boxes[lv]
+                boxes[lv] = (
+                    [min(a, m) for a, m in zip(lo, midx, strict=True)],
+                    [max(b, m + 1) for b, m in zip(hi, midx, strict=True)],
+                )
+            else:
+                boxes[lv] = (list(midx), [m + 1 for m in midx])
+        chained = g
+        for lv in sorted(boxes):
+            chained = chained.refine(lv, *boxes[lv])
+        assert _active_cells(g.refine_cells(ids)) == _active_cells(chained)
+        assert len(boxes) > 1  # the chain has more than one link, or this proves little
+
+    def test_refining_the_same_grid_twice_gives_the_same_result(self) -> None:
+        """Two operations on one receiver are independent, which mutation made false."""
+        g = _grid_2d(4, 2)
+        a = g.refine(0, (0, 0), (2, 2))
+        b = g.refine(0, (0, 0), (2, 2))
+        assert a is not b
+        assert _active_cells(a) == _active_cells(b)
+        assert _grid_snapshot(a) == _grid_snapshot(b)
+
+    def test_two_different_operations_do_not_interfere(self) -> None:
+        g = _grid_2d(4, 2).refine(0, (1, 1), (3, 3))
+        before = _active_cells(g)
+        refined = g.refine(0, (0, 0), (1, 1))
+        coarsened = g.coarsen(0, (1, 1), (3, 3))
+        assert (0, (0, 0)) not in _active_cells(refined)
+        assert (1, (2, 2)) not in _active_cells(coarsened)
+        assert _active_cells(refined) != before
+        assert _active_cells(coarsened) != before
+        assert _active_cells(g) == before
+
+
+class TestDeepcopy:
+    """``copy.deepcopy`` of a grid still works and reconstructs its contents."""
+
+    def test_deepcopy_round_trip(self) -> None:
+        g = _mutated_2d()
+        clone = copy.deepcopy(g)
+        assert clone is not g
+        assert _grid_snapshot(clone) == _grid_snapshot(g)
+        assert _active_cells(clone) == _active_cells(g)
+        assert clone.factor == g.factor
+        assert clone.root is not g.root
+        np_testing.assert_array_equal(clone.root.cells_per_axis, g.root.cells_per_axis)
+        for cid in range(g.num_cells):
+            lo_c, hi_c = clone.cell_bounds(cid)
+            lo_g, hi_g = g.cell_bounds(cid)
+            np_testing.assert_array_equal(lo_c, lo_g)
+            np_testing.assert_array_equal(hi_c, hi_g)
+
+    def test_deepcopy_is_independent_of_the_original(self) -> None:
+        g = _mutated_2d()
+        clone = copy.deepcopy(g)
+        refined = clone.refine(0, (3, 3), (4, 4))
+        assert _active_cells(clone) == _active_cells(g)
+        assert _active_cells(refined) != _active_cells(g)
+
+
+def test_normalize_blocks_is_idempotent() -> None:
+    """Re-normalizing an already-normalized level list is the identity.
+
+    Load-bearing: every operation hands its whole per-level block list to
+    ``_from_blocks``, which normalizes each level, including the levels it did not
+    touch.  If normalization were not a fixed point, the untouched levels would be
+    re-partitioned and every flat cell id would move, so the returned grid would
+    stop matching what the mutating implementation produced.
+    """
+    g = _mutated_2d()
+    for level in range(g.max_level + 1):
+        blocks = list(g.active_blocks(level))
+        once = _normalize_blocks(blocks)
+        assert _normalize_blocks(list(once)) == once
+        assert once == blocks  # the stored lists are already in normal form
+    assert g.max_level >= 2  # more than one level was checked

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -248,19 +248,19 @@ class TestHierarchicalGridRefine:
 
     def test_refine_1d_num_cells(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         assert g.num_cells == 4 - 2 + 2 * 2  # 6
 
     def test_refine_2d_num_cells(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         assert g.num_cells == 16 - 4 + 4 * 4  # 28
 
     def test_refine_children_tile_parent(self) -> None:
         """Children of a refined cell exactly tile the parent's bounds."""
         root = uniform_grid([[0.0, 1.0], [0.0, 1.0]], 2)
         g = hierarchical_grid(root, 3)
-        g.refine(0, [0, 0], [1, 1])  # refine root cell (0,0) only
+        g = g.refine(0, [0, 0], [1, 1])  # refine root cell (0,0) only
         parent_lo = np.array([0.0, 0.0])
         parent_hi = np.array([0.5, 0.5])
         fine_los = []
@@ -279,7 +279,7 @@ class TestHierarchicalGridRefine:
 
     def test_refine_cell_levels(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         # Cells [0] and [3] at level 0; refined children at level 1.
         for cid in range(g.num_cells):
             lv = g.cell_level(cid)
@@ -292,71 +292,73 @@ class TestHierarchicalGridRefine:
     def test_sequential_refinement(self) -> None:
         """Refine level 0, then refine a sub-region of the level-1 block."""
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])  # 6 cells
-        g.refine(1, [2], [4])  # refine 2 of the 4 level-1 cells
+        g = g.refine(0, [1], [3])  # 6 cells
+        g = g.refine(1, [2], [4])  # refine 2 of the 4 level-1 cells
         assert g.max_level == 2
         assert g.num_cells == 6 - 2 + 2 * 2  # 8
 
     def test_refine_full_domain(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [4])
+        g = g.refine(0, [0], [4])
         assert g.max_level == 1
         assert g.num_cells == 8  # 4 * 2
 
     def test_refine_overlapping_noop_for_already_refined(self) -> None:
         """A second overlapping refine is a union — already-refined cells skipped."""
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         n1 = g.num_cells
-        g.refine(0, [1], [2])  # fully within already-refined region
+        g = g.refine(0, [1], [2])  # fully within already-refined region
         assert g.num_cells == n1  # no change
 
     def test_two_disjoint_refines_same_level(self) -> None:
         g = _grid_2d(6, 2)
-        g.refine(0, [0, 0], [2, 2])
-        g.refine(0, [4, 4], [6, 6])
+        g = g.refine(0, [0, 0], [2, 2])
+        g = g.refine(0, [4, 4], [6, 6])
         assert g.max_level == 1
         assert len(g._blocks[1]) == 2  # two separate level-1 blocks
 
     def test_refine_invalid_level_raises(self) -> None:
         g = _grid_1d(4, 2)
         with pytest.raises(ValueError, match="level"):
-            g.refine(1, [0], [2])  # level 1 doesn't exist yet
+            g = g.refine(1, [0], [2])  # level 1 doesn't exist yet
 
     def test_refine_lo_ge_hi_raises(self) -> None:
         g = _grid_1d(4, 2)
         with pytest.raises(ValueError, match="lo must be strictly less"):
-            g.refine(0, [2], [2])
+            g = g.refine(0, [2], [2])
 
     def test_refine_out_of_bounds_raises(self) -> None:
         g = _grid_1d(4, 2)
         with pytest.raises(ValueError, match="out of bounds"):
-            g.refine(0, [0], [5])
+            g = g.refine(0, [0], [5])
 
     def test_refine_cells_bounding_box(self) -> None:
         """refine_cells uses bounding box of the given cell ids."""
         g = _grid_1d(6, 2)
         # Cells 1 and 3 are at indices 1 and 3 (level 0, midx 1 and 3).
-        g.refine_cells([1, 3])
+        g = g.refine_cells([1, 3])
         # Bounding box = [1, 4) → 3 cells refined → 6-3+3*2=9
         assert g.num_cells == 9
 
     def test_refine_cells_empty_noop(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine_cells([])
+        g = g.refine_cells([])
         assert g.num_cells == 4
 
-    def test_refine_invalidates_bvh(self) -> None:
+    def test_refine_gives_the_new_grid_a_fresh_bvh_and_leaves_the_receivers(self) -> None:
         g = _grid_2d(4, 2)
         _ = g.cell_bvh()  # build BVH
-        g.refine(0, [1, 1], [3, 3])
-        assert g._bvh is None  # invalidated
+        new = g.refine(0, [1, 1], [3, 3])
+        assert new._bvh is None  # the returned grid starts fresh
+        assert g._bvh is not None  # the receiver keeps its own
 
-    def test_refine_invalidates_tags(self) -> None:
+    def test_refine_gives_the_new_grid_fresh_tags_and_leaves_the_receivers(self) -> None:
         g = _grid_2d(4, 2)
         g.cell_tags.set("test", [0, 1], 1)
-        g.refine(0, [1, 1], [3, 3])
-        assert g._cell_tags is None
+        new = g.refine(0, [1, 1], [3, 3])
+        assert new._cell_tags is None  # the returned grid starts fresh
+        assert g._cell_tags is not None  # the receiver keeps its own
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -369,14 +371,14 @@ class TestHierarchicalGridLocate:
 
     def test_locate_in_frame_cell(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         cid = g.locate([0.1])
         assert cid is not None
         assert g.cell_level(cid) == 0
 
     def test_locate_in_refined_cell(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         cid = g.locate([0.4])  # inside [0.25, 0.75)
         assert cid is not None
         assert g.cell_level(cid) == 1
@@ -395,8 +397,8 @@ class TestHierarchicalGridLocate:
 
     def test_locate_after_two_levels(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
-        g.refine(1, [2], [4])
+        g = g.refine(0, [1], [3])
+        g = g.refine(1, [2], [4])
         cid = g.locate([0.3])  # in the doubly-refined region [0.25, 0.5)
         assert cid is not None
         assert g.cell_level(cid) == 2
@@ -404,7 +406,7 @@ class TestHierarchicalGridLocate:
     def test_locate_2d_consistent_with_bounds(self) -> None:
         """Every cell's interior point maps back to that cell."""
         g = _grid_2d(3, 2)
-        g.refine(0, [1, 1], [2, 2])
+        g = g.refine(0, [1, 1], [2, 2])
         for cid in range(g.num_cells):
             lo, hi = g.cell_bounds(cid)
             mid = (lo + hi) / 2.0
@@ -439,7 +441,7 @@ class TestHierarchicalGridNeighbors:
     def test_coarse_to_fine_neighbor(self) -> None:
         """Frame cell adjacent to a refined region → first fine neighbour."""
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         # Cell 0 (level 0, [0, 0.25)) has right face (lfid=1).
         # Neighbour at (level 0, midx 1) is not active (was refined).
         # First fine child of (0, 1) touching left face: midx 2.
@@ -451,7 +453,7 @@ class TestHierarchicalGridNeighbors:
     def test_fine_to_coarse_neighbor(self) -> None:
         """Fine cell adjacent to a coarser frame cell → the coarse cell."""
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         # First fine cell (midx 2, level 1) has left face adjacent to level-0 frame.
         first_fine = next(cid for cid in range(g.num_cells) if g.cell_level(cid) == 1)
         nbr = g.neighbor_across_facet(first_fine, 0)
@@ -462,7 +464,7 @@ class TestHierarchicalGridNeighbors:
         """Factor-2 2D grid: coarse face abuts factor^(d-1) = 2 fine cells."""
         root = uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4)
         g = hierarchical_grid(root, 2)
-        g.refine(0, [1, 0], [3, 4])  # refine a band; frame cells on left/right
+        g = g.refine(0, [1, 0], [3, 4])  # refine a band; frame cells on left/right
         # Find a frame cell at level 0 adjacent to the refined band.
         # Cell with level-0 midx (0, k) for any k should have right face touching level-1 cells.
         frame_cid = next(
@@ -501,7 +503,7 @@ class TestHierarchicalGridBVH:
 
     def test_query_aabb_covers_refined_cells(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         # Query the refined sub-region.
         q = AABB(np.array([0.25, 0.25]), np.array([0.75, 0.75]))
         hits = g.query_aabb(q)
@@ -514,7 +516,7 @@ class TestHierarchicalGridBVH:
     def test_bvh_rebuilt_after_refine(self) -> None:
         g = _grid_2d(4, 2)
         _ = g.cell_bvh()
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         # BVH is lazily rebuilt on next query — must not raise.
         bvh = g.cell_bvh()
         assert bvh is not None
@@ -528,25 +530,33 @@ class TestHierarchicalGridBVH:
 class TestHierarchicalGridTags:
     """Tests that tags are correctly invalidated after refinement."""
 
-    def test_cell_tags_reset_after_refine(self) -> None:
+    def test_cell_tags_reset_on_the_returned_grid_not_the_receiver(self) -> None:
         g = _grid_2d(4, 2)
         ct = g.cell_tags  # create
         ct.set("label", [0, 1, 2], 7)
-        g.refine(0, [1, 1], [3, 3])
-        assert g._cell_tags is None
+        new = g.refine(0, [1, 1], [3, 3])
+        assert new._cell_tags is None  # the returned grid starts fresh
+        assert g._cell_tags is not None  # the receiver keeps its own
+        ids, values = g.cell_tags["label"]
+        np_testing.assert_array_equal(ids, [0, 1, 2])
+        np_testing.assert_array_equal(values, [7, 7, 7])  # still readable
 
     def test_cell_tags_usable_after_refine(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         ct = g.cell_tags
         ct.set("cut", list(range(g.num_cells)), 1)
         assert "cut" in ct
 
-    def test_facet_tags_reset_after_refine(self) -> None:
+    def test_facet_tags_reset_on_the_returned_grid_not_the_receiver(self) -> None:
         g = _grid_1d(4, 2)
-        _ = g.facet_tags  # create
-        g.refine(0, [1], [3])
-        assert g._facet_tags is None
+        g.facet_tags.set("cut", [[0, 0]], 1)
+        new = g.refine(0, [1], [3])
+        assert new._facet_tags is None  # the returned grid starts fresh
+        assert g._facet_tags is not None  # the receiver keeps its own
+        keys, values = g.facet_tags["cut"]
+        np_testing.assert_array_equal(keys, [[0, 0]])
+        np_testing.assert_array_equal(values, [1])  # still readable
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -576,7 +586,7 @@ class TestActiveSetAccessors:
 
     def test_active_blocks_after_refine(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])
+        g = g.refine(0, [0], [2])
         assert g.active_blocks(0) == (((2,), (4,)),)
         assert g.active_blocks(1) == (((0,), (4,)),)
 
@@ -586,19 +596,19 @@ class TestActiveSetAccessors:
 
     def test_active_leaf_mask_total_equals_num_cells(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [0, 0], [2, 2])
-        g.refine(1, [0, 0], [2, 2])
+        g = g.refine(0, [0, 0], [2, 2])
+        g = g.refine(1, [0, 0], [2, 2])
         total = sum(int(g.active_leaf_mask(level).sum()) for level in range(g.max_level + 1))
         assert total == g.num_cells
 
     def test_subdomain_mask_level0_all_true(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [0, 0], [2, 2])
+        g = g.refine(0, [0, 0], [2, 2])
         assert g.subdomain_mask(0).all()
 
     def test_mask_consistency_1d(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])
+        g = g.refine(0, [0], [2])
         np.testing.assert_array_equal(g.active_leaf_mask(0), [False, False, True, True])
         np.testing.assert_array_equal(g.subdomain_mask(0), [True, True, True, True])
         np.testing.assert_array_equal(
@@ -610,7 +620,7 @@ class TestActiveSetAccessors:
 
     def test_subdomain_mask_out_of_range_raises(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])
+        g = g.refine(0, [0], [2])
         with pytest.raises(ValueError, match="level"):
             g.subdomain_mask(2)
 
@@ -626,8 +636,8 @@ class TestActiveSetAccessors:
         # Refine the left half at level 0, then refine all level-1 cells.
         # Exercises the two-iteration accumulation path in subdomain_mask.
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])  # level-0 block [(2,), (4,)]; level-1 block [(0,), (4,)]
-        g.refine(1, [0], [4])  # level-1 block emptied; level-2 block [(0,), (8,)]
+        g = g.refine(0, [0], [2])  # level-0 block [(2,), (4,)]; level-1 block [(0,), (4,)]
+        g = g.refine(1, [0], [4])  # level-1 block emptied; level-2 block [(0,), (8,)]
         # Level-2 grid: 4 * 2^2 = 16 cells.
         # Subdomain mask: start all True, clear cells covered by coarser leaves.
         # Level-0 leaf block [(2,), (4,)) → scale 4 → slice [8, 16): cleared.
@@ -638,7 +648,7 @@ class TestActiveSetAccessors:
 
     def test_is_active_leaf(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])  # level-0 leaves at [2, 4); level-1 leaves at [0, 8)
+        g = g.refine(0, [0], [2])  # level-0 leaves at [2, 4); level-1 leaves at [0, 8)
         assert g.is_active_leaf(0, (2,))  # active level-0 leaf
         assert not g.is_active_leaf(0, (0,))  # refined away
         assert g.is_active_leaf(1, (0,))  # active level-1 leaf
@@ -649,7 +659,7 @@ class TestActiveSetAccessors:
     def test_is_active_leaf_2d(self) -> None:
         g = _grid_2d(4, 2)
         # Refine level-0 cell (0, 0) -> children at level 1 in [0,2)x[0,2)
-        g.refine(0, [0, 0], [1, 1])
+        g = g.refine(0, [0, 0], [1, 1])
         assert not g.is_active_leaf(0, (0, 0))  # refined away
         assert g.is_active_leaf(0, (1, 0))  # unrefined level-0 leaf
         assert g.is_active_leaf(0, (0, 1))  # unrefined level-0 leaf
@@ -662,8 +672,8 @@ class TestActiveSetAccessors:
     def test_cell_id_inverts_cell_level_and_multi_index(self) -> None:
         """`cell_id` round-trips every active leaf, at every level, in both directions."""
         g = _grid_2d(4, 2)
-        g.refine(0, [0, 0], [2, 2])
-        g.refine(1, [0, 0], [2, 2])
+        g = g.refine(0, [0, 0], [2, 2])
+        g = g.refine(1, [0, 0], [2, 2])
         assert g.max_level == 2
         for cid in range(g.num_cells):
             assert g.cell_id(g.cell_level(cid), g.cell_multi_index(cid)) == cid
@@ -671,7 +681,7 @@ class TestActiveSetAccessors:
     def test_cell_id_none_for_cells_that_are_not_active_leaves(self) -> None:
         """The `None` cases are exactly `is_active_leaf`'s `False` cases."""
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])  # level-0 leaves at [2, 4); level-1 leaves at [0, 4)
+        g = g.refine(0, [0], [2])  # level-0 leaves at [2, 4); level-1 leaves at [0, 4)
         assert g.cell_id(0, (0,)) is None  # refined away
         assert g.cell_id(0, (-1,)) is None  # negative index
         assert g.cell_id(0, (9,)) is None  # past the level's extent
@@ -682,9 +692,9 @@ class TestActiveSetAccessors:
     def test_cell_id_is_resolved_afresh_after_a_mutation(self) -> None:
         """Ids move under refinement; the `(level, midx)` pair does not."""
         g = _grid_1d(4, 2)
-        g.refine(0, [3], [4])  # refine the last root cell
+        g = g.refine(0, [3], [4])  # refine the last root cell
         before = g.cell_id(0, (0,))
-        g.refine(0, [0], [1])  # ids shift: level-0 loses a cell, level-1 gains two
+        g = g.refine(0, [0], [1])  # ids shift: level-0 loses a cell, level-1 gains two
         assert before == 0
         assert g.cell_id(0, (0,)) is None  # cell (0, 0) is gone, its id belongs elsewhere
         assert g.cell_id(0, (1,)) == 0
@@ -750,61 +760,61 @@ class TestHierarchicalGridCoarsen:
     def test_coarsen_inverts_refine_1d(self) -> None:
         g = _grid_1d(4, 2)
         before = _grid_snapshot(g)
-        g.refine(0, [1], [3])
-        g.coarsen(0, [1], [3])
+        g = g.refine(0, [1], [3])
+        g = g.coarsen(0, [1], [3])
         assert _grid_snapshot(g) == before
 
     def test_coarsen_inverts_refine_2d(self) -> None:
         g = _grid_2d(4, 2)
         before = _grid_snapshot(g)
-        g.refine(0, [1, 1], [3, 3])
-        g.coarsen(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
+        g = g.coarsen(0, [1, 1], [3, 3])
         assert _grid_snapshot(g) == before
 
     def test_coarsen_drops_trailing_level(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [4])
+        g = g.refine(0, [0], [4])
         assert g.max_level == 1
-        g.coarsen(0, [0], [4])
+        g = g.coarsen(0, [0], [4])
         assert g.max_level == 0
         assert g.num_cells == 4
 
     def test_coarsen_one_of_two_levels(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])
+        g = g.refine(0, [0], [2])
         snap_one = _grid_snapshot(g)
-        g.refine(1, [0], [4])  # refine all level-1 cells to level 2
-        g.coarsen(1, [0], [4])  # undo just the level-1 refinement
+        g = g.refine(1, [0], [4])  # refine all level-1 cells to level 2
+        g = g.coarsen(1, [0], [4])  # undo just the level-1 refinement
         assert _grid_snapshot(g) == snap_one
 
     def test_coarsen_partial_region_raises(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [1])  # only cell 0 refined
+        g = g.refine(0, [0], [1])  # only cell 0 refined
         with pytest.raises(ValueError, match="fully refined"):
-            g.coarsen(0, [0], [2])  # cell 1 has no children
+            g = g.coarsen(0, [0], [2])  # cell 1 has no children
 
     def test_coarsen_level_out_of_range_raises(self) -> None:
         g = _grid_1d(4, 2)  # max_level 0, no level 1 to coarsen from
         with pytest.raises(ValueError, match="level"):
-            g.coarsen(0, [0], [1])
+            g = g.coarsen(0, [0], [1])
 
     def test_coarsen_lo_ge_hi_raises(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [4])
+        g = g.refine(0, [0], [4])
         with pytest.raises(ValueError, match="strictly less"):
-            g.coarsen(0, [2], [2])
+            g = g.coarsen(0, [2], [2])
 
     def test_coarsen_out_of_bounds_raises(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [4])
+        g = g.refine(0, [0], [4])
         with pytest.raises(ValueError, match="out of bounds"):
-            g.coarsen(0, [0], [5])  # hi=5 > 4 cells at level 0
+            g = g.coarsen(0, [0], [5])  # hi=5 > 4 cells at level 0
 
     def test_coarsen_wrong_ndim_raises(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [4])
+        g = g.refine(0, [0], [4])
         with pytest.raises(ValueError, match="length"):
-            g.coarsen(0, [0, 0], [4, 4])  # 1D grid, 2D lo/hi
+            g = g.coarsen(0, [0, 0], [4, 4])  # 1D grid, 2D lo/hi
 
 
 class TestCoarsenIsNotAnUnconditionalInverse:
@@ -820,18 +830,18 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         """One refine of an all-active box, then coarsen, restores the grid exactly."""
         g = _grid_1d(6, 2)
         assert g.num_cells == 6
-        g.refine(0, [0], [2])
+        g = g.refine(0, [0], [2])
         assert g.num_cells == 8
-        g.coarsen(0, [0], [2])
+        g = g.coarsen(0, [0], [2])
         assert g.num_cells == 6
 
     def test_coarsen_inverts_refine_disjoint_from_an_earlier_one_1d(self) -> None:
         """Two disjoint refines: coarsening the second is still exact."""
         g = _grid_1d(6, 2)
-        g.refine(0, [0], [2])
-        g.refine(0, [3], [5])
+        g = g.refine(0, [0], [2])
+        g = g.refine(0, [3], [5])
         assert g.num_cells == 10
-        g.coarsen(0, [3], [5])
+        g = g.coarsen(0, [3], [5])
         assert g.num_cells == 8
 
     def test_coarsen_after_overlapping_refines_demotes_the_whole_box_1d(self) -> None:
@@ -847,11 +857,11 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         same reproduction through it and gets the 8 back.
         """
         g = _grid_1d(6, 2)
-        g.refine(0, [0], [2])
+        g = g.refine(0, [0], [2])
         assert g.num_cells == 8
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         assert g.num_cells == 9
-        g.coarsen(0, [1], [3])
+        g = g.coarsen(0, [1], [3])
         assert g.num_cells == 7
         assert g.active_blocks(0) == (((1,), (6,)),)
         assert g.active_blocks(1) == (((0,), (2,)),)
@@ -860,9 +870,9 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         """The 2D control on a non-dyadic factor: single refine, then coarsen, is exact."""
         g = _grid_2d(3, 3)
         assert g.num_cells == 9
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         assert g.num_cells == 41
-        g.coarsen(0, [1, 1], [3, 3])
+        g = g.coarsen(0, [1, 1], [3, 3])
         assert g.num_cells == 9
 
     def test_coarsen_after_overlapping_refines_demotes_the_whole_box_2d_non_dyadic(self) -> None:
@@ -872,11 +882,11 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         regression cannot hide: 41 would mean `coarsen` had inverted the second refine.
         """
         g = _grid_2d(3, 3)
-        g.refine(0, [0, 0], [2, 2])
+        g = g.refine(0, [0, 0], [2, 2])
         assert g.num_cells == 41
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         assert g.num_cells == 65
-        g.coarsen(0, [1, 1], [3, 3])
+        g = g.coarsen(0, [1, 1], [3, 3])
         assert g.num_cells == 33
         # The shape, not only the count: dropping the block merge on reactivation leaves
         # 33 cells in a structurally different partition, which the count alone misses.
@@ -886,19 +896,19 @@ class TestCoarsenIsNotAnUnconditionalInverse:
     def test_refine_undoes_coarsen_unconditionally(self) -> None:
         """The other direction holds with no hypothesis: refine always undoes coarsen."""
         g = _grid_1d(6, 2)
-        g.refine(0, [0], [2])
-        g.refine(0, [1], [3])
+        g = g.refine(0, [0], [2])
+        g = g.refine(0, [1], [3])
         before = _grid_snapshot(g)
-        g.coarsen(0, [1], [3])
-        g.refine(0, [1], [3])
+        g = g.coarsen(0, [1], [3])
+        g = g.refine(0, [1], [3])
         assert _grid_snapshot(g) == before
 
     def test_coarsen_names_cells_that_are_still_leaves(self) -> None:
         """The refusal names the box cells that have no children to remove."""
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [1])  # only cell 0 is refined
+        g = g.refine(0, [0], [1])  # only cell 0 is refined
         with pytest.raises(ValueError, match="still active leaves at level 0") as excinfo:
-            g.coarsen(0, [0], [2])
+            g = g.coarsen(0, [0], [2])
         named = str(excinfo.value).split("still active leaves at level 0")[1]
         assert "(1,)" in named
         assert "refined beyond" not in str(excinfo.value)
@@ -909,10 +919,10 @@ class TestCoarsenIsNotAnUnconditionalInverse:
     def test_coarsen_names_cells_refined_beyond_the_target_level(self) -> None:
         """The refusal names the box cells whose children are themselves refined."""
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])
-        g.refine(1, [0], [2])  # cell 0's children go on to level 2
+        g = g.refine(0, [0], [2])
+        g = g.refine(1, [0], [2])  # cell 0's children go on to level 2
         with pytest.raises(ValueError, match="refined beyond level 1") as excinfo:
-            g.coarsen(0, [0], [2])
+            g = g.coarsen(0, [0], [2])
         named = str(excinfo.value).split("refined beyond level 1")[1]
         assert "(0,)" in named
         assert "still active leaves" not in str(excinfo.value)
@@ -957,11 +967,11 @@ class TestCoarsenIsNotAnUnconditionalInverse:
                 int(rng.integers(a + 1, min(a + 3, n) + 1)) for a, n in zip(lo, extent, strict=True)
             ]
             if not coarsening:
-                g.refine(level, lo, hi)
+                g = g.refine(level, lo, hi)
                 continue
             expected = _obstacles_by_cellwise_walk(g, level, lo, hi)
             try:
-                g.coarsen(level, lo, hi)
+                g = g.coarsen(level, lo, hi)
             except ValueError as exc:
                 assert expected, f"refused a region the oracle finds coarsenable: {exc}"
                 named = _cells_named_in(str(exc))
@@ -985,23 +995,23 @@ class TestCoarsenIsNotAnUnconditionalInverse:
     def test_coarsen_names_exactly_the_cap_without_a_remainder(self) -> None:
         """A listing landing exactly on the cap must not claim a remainder."""
         g = _grid_1d(8, 2)
-        g.refine(0, [0], [1])  # cells 1..6 of the box below are leaves: exactly the cap
+        g = g.refine(0, [0], [1])  # cells 1..6 of the box below are leaves: exactly the cap
         with pytest.raises(ValueError) as excinfo:
-            g.coarsen(0, [0], [1 + _MAX_NAMED_CELLS])
+            g = g.coarsen(0, [0], [1 + _MAX_NAMED_CELLS])
         message = str(excinfo.value)
         assert "more" not in message
         named = message.split("with no children to remove: ")[1]
         assert named.count("), (") == _MAX_NAMED_CELLS - 1
         # One cell further, the remainder is reported rather than dropped.
         with pytest.raises(ValueError, match="and 1 more"):
-            g.coarsen(0, [0], [2 + _MAX_NAMED_CELLS])
+            g = g.coarsen(0, [0], [2 + _MAX_NAMED_CELLS])
 
     def test_coarsen_truncates_a_long_list_of_offending_cells(self) -> None:
         """A large rejected region names a few cells and counts the rest."""
         g = _grid_2d(6, 2)
-        g.refine(0, [0, 0], [1, 1])  # 1 of the 36 level-0 cells is refined
+        g = g.refine(0, [0, 0], [1, 1])  # 1 of the 36 level-0 cells is refined
         with pytest.raises(ValueError) as excinfo:
-            g.coarsen(0, [0, 0], [6, 6])
+            g = g.coarsen(0, [0, 0], [6, 6])
         message = str(excinfo.value)
         named = message.split("with no children to remove: ")[1]
         assert named.count("), (") == _MAX_NAMED_CELLS - 1  # exactly the cap is spelled out
@@ -1017,20 +1027,20 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         """
         g = _grid_1d(2, 2)
         for level in range(21):
-            g.refine(level, [0], [1])  # deepen without growing the grid
+            g = g.refine(level, [0], [1])  # deepen without growing the grid
         region = g.level_cells_per_axis(20)[0]
         assert region > _MAX_DIAGNOSED_CELLS
         with pytest.raises(ValueError, match=f"spans {region} cells, too many to name"):
-            g.coarsen(20, [0], [region])
+            g = g.coarsen(20, [0], [region])
 
     def test_coarsen_names_offending_cells_with_an_anisotropic_factor(self) -> None:
         """The per-axis factor is respected when locating the offending cells."""
         g = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], [2, 2]), (2, 3))
         assert g.factor == (2, 3)
-        g.refine(0, [0, 0], [2, 2])  # every level-0 cell -> level 1
-        g.refine(1, [0, 0], [1, 1])  # level-1 cell (0, 0) -> level 2
+        g = g.refine(0, [0, 0], [2, 2])  # every level-0 cell -> level 1
+        g = g.refine(1, [0, 0], [1, 1])  # level-1 cell (0, 0) -> level 2
         with pytest.raises(ValueError, match="refined beyond level 1") as excinfo:
-            g.coarsen(0, [0, 0], [2, 2])
+            g = g.coarsen(0, [0, 0], [2, 2])
         named = str(excinfo.value).split("refined beyond level 1")[1]
         assert "(0, 0)" in named
         # Only cell (0, 0) owns the level-2 cells, so no other cell may be named.
@@ -1046,11 +1056,11 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         not appear anywhere in the message.
         """
         g = _grid_1d(8, 2)
-        g.refine(0, [0], [4])  # level-1 cells 0..7
-        g.refine(1, [0], [4])  # level-1 cells 0..3 -> level-2 cells 0..7
-        g.refine(2, [0], [2])  # level-2 cells 0, 1 -> level 3
+        g = g.refine(0, [0], [4])  # level-1 cells 0..7
+        g = g.refine(1, [0], [4])  # level-1 cells 0..3 -> level-2 cells 0..7
+        g = g.refine(2, [0], [2])  # level-2 cells 0, 1 -> level 3
         with pytest.raises(ValueError) as excinfo:
-            g.coarsen(1, [0], [12])
+            g = g.coarsen(1, [0], [12])
         message = str(excinfo.value)
         assert "still active leaves at level 1" in message
         assert "refined beyond level 2" in message
@@ -1067,10 +1077,10 @@ class TestCoarsenIsNotAnUnconditionalInverse:
     def test_coarsen_names_cells_absent_at_the_requested_level(self) -> None:
         """The refusal names box cells that a coarser active leaf covers."""
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])
-        g.refine(1, [0], [2])  # max_level 2, so coarsening level 1 is in range
+        g = g.refine(0, [0], [2])
+        g = g.refine(1, [0], [2])  # max_level 2, so coarsening level 1 is in range
         with pytest.raises(ValueError, match="covered by a coarser active leaf") as excinfo:
-            g.coarsen(1, [4], [6])  # level-1 cells 4, 5 sit inside level-0 leaf cell 2
+            g = g.coarsen(1, [4], [6])  # level-1 cells 4, 5 sit inside level-0 leaf cell 2
         named = str(excinfo.value).split("covered by a coarser active leaf")[1]
         assert "(4,)" in named
         assert "(5,)" in named
@@ -1107,9 +1117,9 @@ class TestCoarsenCells:
         g = _grid_1d(4, 2)
         before = _grid_snapshot(g)
         assert before == (4, 0, ((((0,), (4,)),),))
-        g.refine_cells([0])
+        g = g.refine_cells([0])
         assert (g.num_cells, g.max_level) == (5, 1)
-        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 1])
+        g = g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 1])
         assert _grid_snapshot(g) == before
         assert (g.num_cells, g.max_level, g.active_blocks(0)) == (4, 0, (((0,), (4,)),))
 
@@ -1117,38 +1127,38 @@ class TestCoarsenCells:
         """The 2D control on ``factor = 3``: nine children collapse back to one cell."""
         g = _grid_2d(3, 3)
         before = _grid_snapshot(g)
-        g.refine_cells([4])  # the middle root cell
+        g = g.refine_cells([4])  # the middle root cell
         assert (g.num_cells, g.max_level) == (17, 1)
-        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 1])
+        g = g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 1])
         assert _grid_snapshot(g) == before
 
     def test_partial_parent_is_skipped_without_raising(self) -> None:
         """A parent with only some children named is left exactly as it was."""
         g = _grid_1d(4, 2)
-        g.refine_cells([0])
+        g = g.refine_cells([0])
         before = _grid_snapshot(g)
         children = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
         assert len(children) == 2
-        g.coarsen_cells(children[:1])  # one of the two children
+        g = g.coarsen_cells(children[:1])  # one of the two children
         assert _grid_snapshot(g) == before
 
     def test_level_zero_ids_are_ignored(self) -> None:
         """A root cell has no parent, so naming it does nothing (and does not raise)."""
         g = _grid_1d(4, 2)
-        g.refine_cells([0])
+        g = g.refine_cells([0])
         before = _grid_snapshot(g)
-        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 0])
+        g = g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 0])
         assert _grid_snapshot(g) == before
 
     def test_empty_and_repeated_ids(self) -> None:
         """An empty call is a no-op; a repeated id counts once, not twice."""
         g = _grid_1d(4, 2)
-        g.refine_cells([0])
+        g = g.refine_cells([0])
         before = _grid_snapshot(g)
-        g.coarsen_cells([])
+        g = g.coarsen_cells([])
         assert _grid_snapshot(g) == before
         children = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
-        g.coarsen_cells([*children, *children])
+        g = g.coarsen_cells([*children, *children])
         assert (g.num_cells, g.max_level) == (4, 0)
 
     def test_out_of_range_id_raises_before_anything_is_demoted(self) -> None:
@@ -1160,16 +1170,16 @@ class TestCoarsenCells:
         """
         g = _grid_1d(4, 2)
         with pytest.raises(IndexError, match="out of range"):
-            g.coarsen_cells([4])
+            g = g.coarsen_cells([4])
         with pytest.raises(IndexError, match="out of range"):
-            g.coarsen_cells([-1])
+            g = g.coarsen_cells([-1])
         assert _grid_snapshot(g) == (4, 0, ((((0,), (4,)),),))
 
-        g.refine_cells([0])
+        g = g.refine_cells([0])
         before = _grid_snapshot(g)
         children = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
         with pytest.raises(IndexError, match="out of range"):
-            g.coarsen_cells([*children, g.num_cells])
+            g = g.coarsen_cells([*children, g.num_cells])
         assert _grid_snapshot(g) == before
 
     def test_parents_at_two_levels_are_demoted_deepest_first(self) -> None:
@@ -1187,38 +1197,41 @@ class TestCoarsenCells:
         that difference, which is why this pins the blocks themselves.
         """
         g = _grid_2d(3, 2)
-        g.refine(0, [0, 1], [2, 3])
-        g.refine(1, [1, 3], [2, 5])
-        g.refine(1, [1, 4], [3, 5])
+        g = g.refine(0, [0, 1], [2, 3])
+        g = g.refine(1, [1, 3], [2, 5])
+        g = g.refine(1, [1, 4], [3, 5])
         assert (g.num_cells, g.max_level) == (30, 2)
-        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) >= 1])
+        g = g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) >= 1])
         assert (g.num_cells, g.max_level) == (18, 1)
         assert g.active_blocks(0) == (((0, 0), (2, 1)), ((1, 1), (2, 2)), ((2, 0), (3, 3)))
         assert g.active_blocks(1) == (((0, 2), (2, 6)), ((2, 4), (4, 6)))
 
-    def test_coarsen_cells_invalidates_the_bvh_and_the_tags(self) -> None:
-        """Coarsening by id invalidates the same caches the box `coarsen` does.
+    def test_coarsen_cells_returns_a_grid_with_fresh_caches_and_leaves_the_receivers(self) -> None:
+        """Every returned grid starts with empty caches; only the receiver's stay live.
 
-        Both routes reach `_rebuild`, but only through a `coarsen` call that actually
-        fires: a call that demotes nothing must leave the caches alone, since ids did
-        not move.
+        There is no mutation counter left to tell a no-op apart from a real coarsen at
+        the grid level -- `version` counted a mutation, and mutation is unrepresentable
+        now that every call returns a fresh object.  The active-leaf set is the oracle
+        instead: unchanged after a no-op, different after a real one.
         """
         g = _grid_1d(4, 2)
-        g.refine_cells([0])
+        g = g.refine_cells([0])
         g.cell_tags.set("test", [0, 1], 1)
         _ = g.cell_bvh()
         children = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
 
         assert _caches_live(g) == (True, True)
+        before = _active_cells(g)
 
-        version = g.version
-        g.coarsen_cells(children[:1])  # partial parent: nothing is demoted
-        assert g.version == version
-        assert _caches_live(g) == (True, True)
+        partial = g.coarsen_cells(children[:1])  # partial parent: nothing is demoted
+        assert _active_cells(partial) == before
+        assert _caches_live(partial) == (False, False)
+        assert _caches_live(g) == (True, True)  # receiver untouched
 
-        g.coarsen_cells(children)
-        assert g.version > version
-        assert _caches_live(g) == (False, False)
+        full = g.coarsen_cells(children)
+        assert _active_cells(full) != before
+        assert _caches_live(full) == (False, False)
+        assert _caches_live(g) == (True, True)  # receiver still untouched
 
     def test_destroys_only_the_named_children_after_overlapping_refines(self) -> None:
         """The cell-exact counterpart of the box contrast test above.
@@ -1231,10 +1244,10 @@ class TestCoarsenCells:
         caller controls by naming cells.
         """
         g = _grid_1d(6, 2)
-        g.refine(0, [0], [2])
+        g = g.refine(0, [0], [2])
         after_first = _grid_snapshot(g)
         assert g.num_cells == 8
-        g.refine(0, [1], [3])  # only cell 2 is still active, so only cell 2 is promoted
+        g = g.refine(0, [1], [3])  # only cell 2 is still active, so only cell 2 is promoted
         assert g.num_cells == 9
         children_of = {
             parent: [
@@ -1247,12 +1260,12 @@ class TestCoarsenCells:
         assert children_of == {1: [5, 6], 2: [7, 8]}
 
         undo_second = copy.deepcopy(g)
-        undo_second.coarsen_cells(children_of[2])
+        undo_second = undo_second.coarsen_cells(children_of[2])
         assert undo_second.num_cells == 8
         assert _grid_snapshot(undo_second) == after_first
 
         both_parents = copy.deepcopy(g)
-        both_parents.coarsen_cells(children_of[1] + children_of[2])
+        both_parents = both_parents.coarsen_cells(children_of[1] + children_of[2])
         assert both_parents.num_cells == 7
         assert both_parents.active_blocks(0) == (((1,), (6,)),)
         assert both_parents.active_blocks(1) == (((0,), (2,)),)
@@ -1266,10 +1279,10 @@ class TestCoarsenCells:
         cascades past what the caller could name, which is the point of the method.
         """
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])  # level-1 cells 0..3
-        g.refine(1, [0], [2])  # level-2 cells 0..3; level-1 leaves are 2, 3
+        g = g.refine(0, [0], [2])  # level-1 cells 0..3
+        g = g.refine(1, [0], [2])  # level-2 cells 0..3; level-1 leaves are 2, 3
         assert (g.num_cells, g.max_level) == (8, 2)
-        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) >= 1])
+        g = g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) >= 1])
         assert (g.num_cells, g.max_level) == (5, 1)
         assert g.active_blocks(0) == (((1,), (4,)),)  # cell 0 is still refined
         assert g.active_blocks(1) == (((0,), (2,)),)
@@ -1277,8 +1290,8 @@ class TestCoarsenCells:
     def test_a_shallow_parent_still_goes_when_its_children_are_named(self) -> None:
         """The deepest-first order is not a restriction on which levels may be named."""
         g = _grid_1d(4, 2)
-        g.refine(0, [0], [2])  # level-1 cells 0..3
-        g.refine(1, [0], [2])  # level-2 cells 0..3; level-1 leaves are 2, 3
+        g = g.refine(0, [0], [2])  # level-1 cells 0..3
+        g = g.refine(1, [0], [2])  # level-2 cells 0..3; level-1 leaves are 2, 3
         # Name the level-2 children of level-1 cell 0 and the level-1 children of
         # level-0 cell 1: two parents at two different levels, neither nested.
         marked = [
@@ -1287,7 +1300,7 @@ class TestCoarsenCells:
             if (g.cell_level(c) == 2 and g.cell_multi_index(c)[0] < 2)
             or (g.cell_level(c) == 1 and g.cell_multi_index(c)[0] >= 2)
         ]
-        g.coarsen_cells(marked)
+        g = g.coarsen_cells(marked)
         assert g.active_blocks(0) == (((1,), (4,)),)  # level-0 cell 1 reborn
         assert g.active_blocks(1) == (((0,), (1,)),)  # cell 0 reborn; cell 1 still refined
         assert g.active_blocks(2) == (((2,), (4,)),)  # cell 1's children survive untouched
@@ -1328,7 +1341,7 @@ class TestCoarsenCells:
                     int(rng.integers(a + 1, min(a + 3, n) + 1))
                     for a, n in zip(lo, extent, strict=True)
                 ]
-                g.refine(level, lo, hi)
+                g = g.refine(level, lo, hi)
                 continue
             pool = [c for c in range(g.num_cells) if g.cell_level(c) >= 1]
             if not pool:
@@ -1340,7 +1353,7 @@ class TestCoarsenCells:
                 (g.cell_level(pool[int(i)]), g.cell_multi_index(pool[int(i)])) for i in pool_idx
             }
             before = _active_cells(g)
-            g.coarsen_cells([pool[int(i)] for i in pool_idx])
+            g = g.coarsen_cells([pool[int(i)] for i in pool_idx])
             after = _active_cells(g)
             assert before - marked <= after, "removed a cell that was not named"
             for level, midx in after - before:
@@ -1382,7 +1395,7 @@ class TestHierarchicalGridRestrict:
 
     def test_refined_region_matches_global(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         requested = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
         r = g.restrict(requested)
         _check_restrict(g, r, requested)
@@ -1391,7 +1404,7 @@ class TestHierarchicalGridRestrict:
 
     def test_in_subset_flags_fill_cells(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         # Request only the level-0 frame leaves inside root box [0,3)x[0,3).
         requested = [
             c
@@ -1405,7 +1418,7 @@ class TestHierarchicalGridRestrict:
 
     def test_single_deep_cell_returns_root_subtree(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [2, 2])  # refine root cell (1,1) -> 4 level-1 leaves
+        g = g.refine(0, [1, 1], [2, 2])  # refine root cell (1,1) -> 4 level-1 leaves
         fine = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
         r = g.restrict([fine[0]])
         _check_restrict(g, r, [fine[0]])
@@ -1414,7 +1427,7 @@ class TestHierarchicalGridRestrict:
 
     def test_coarse_only_region_trims_levels(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         # Root row 0 is entirely level-0 frame, disjoint from the refined region.
         requested = [
             c for c in range(g.num_cells) if g.cell_level(c) == 0 and g.cell_multi_index(c)[0] == 0
@@ -1428,7 +1441,7 @@ class TestHierarchicalGridRestrict:
 
     def test_full_grid_is_identity(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         r = g.restrict(list(range(g.num_cells)))
         assert r.grid.num_cells == g.num_cells
         assert set(r.local_to_global_cell.tolist()) == set(range(g.num_cells))
@@ -1437,7 +1450,7 @@ class TestHierarchicalGridRestrict:
 
     def test_full_grid_neighbors_match(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         r = g.restrict(list(range(g.num_cells)))
         sub, l2g = r.grid, r.local_to_global_cell
         for k in range(sub.num_cells):
@@ -1448,7 +1461,7 @@ class TestHierarchicalGridRestrict:
 
     def test_window_neighbors_map_to_global(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         requested = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
         r = g.restrict(requested)
         sub, l2g = r.grid, r.local_to_global_cell
@@ -1460,7 +1473,7 @@ class TestHierarchicalGridRestrict:
 
     def test_sub_root_not_reclamped(self) -> None:
         g = _grid_2d(4, 2)  # root breakpoints [0, .25, .5, .75, 1]
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         requested = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
         sub = g.restrict(requested).grid
         assert isinstance(sub, HierarchicalGrid)
@@ -1468,7 +1481,7 @@ class TestHierarchicalGridRestrict:
 
     def test_1d(self) -> None:
         g = _grid_1d(4, 2)
-        g.refine(0, [1], [3])
+        g = g.refine(0, [1], [3])
         requested = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
         r = g.restrict(requested)
         _check_restrict(g, r, requested)
@@ -1476,7 +1489,7 @@ class TestHierarchicalGridRestrict:
 
     def test_returns_grid_restriction(self) -> None:
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])
+        g = g.refine(0, [1, 1], [3, 3])
         r = g.restrict([0, 1, 2])
         assert isinstance(r, GridRestriction)
         assert isinstance(r.grid, HierarchicalGrid)
@@ -1499,12 +1512,12 @@ class TestHierarchicalGridRestrict:
     def test_multilevel_restrict(self) -> None:
         # Two levels of refinement: level 0 → level 1 → level 2.
         g = _grid_2d(4, 2)
-        g.refine(0, [1, 1], [3, 3])  # level-1 leaves in [1,3)x[1,3)
+        g = g.refine(0, [1, 1], [3, 3])  # level-1 leaves in [1,3)x[1,3)
         # Refine one level-1 block to level 2.
         l1_cells = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
         l1_midxs = [g.cell_multi_index(c) for c in l1_cells]
         lo = min(m[0] for m in l1_midxs)
-        g.refine(1, [lo, lo], [lo + 1, lo + 1])
+        g = g.refine(1, [lo, lo], [lo + 1, lo + 1])
         l2_cells = [c for c in range(g.num_cells) if g.cell_level(c) == 2]
         assert len(l2_cells) > 0
         r = g.restrict([l2_cells[0]])
@@ -1541,9 +1554,9 @@ def _irregular_grid(ndim: int, factor: int | tuple[int, ...]) -> HierarchicalGri
     g = hierarchical_grid(TensorProductGrid(bp), factor)
     for lev in range(3):
         n = g.level_cells_per_axis(lev)
-        g.refine(lev, [0] * ndim, [max(1, n[k] // 2) for k in range(ndim)])
+        g = g.refine(lev, [0] * ndim, [max(1, n[k] // 2) for k in range(ndim)])
     n1 = g.level_cells_per_axis(1)
-    g.refine(1, [max(0, n1[k] - 2) for k in range(ndim)], list(n1))
+    g = g.refine(1, [max(0, n1[k] - 2) for k in range(ndim)], list(n1))
     return g
 
 
@@ -1596,7 +1609,7 @@ class TestHierKernelEquivalence:
     def test_encode_midx_inactive_positions(self) -> None:
         """_encode_midx returns None for refined (non-leaf) and never-active positions."""
         g = _grid_2d(4)
-        g.refine(0, [0, 0], [2, 2])
+        g = g.refine(0, [0, 0], [2, 2])
         # (0, (0, 0)) was refined away -> not an active leaf.
         assert g._encode_midx(0, (0, 0)) is None
         # A level beyond the hierarchy.
@@ -1617,11 +1630,11 @@ class TestHierKernelEquivalence:
         g = _grid_2d(8)
         rng = np.random.default_rng(17)
         pts = rng.random((500, 2))
-        g.refine(0, [0, 0], [4, 4])
+        g = g.refine(0, [0, 0], [4, 4])
         after_refine = g.locate_many(pts)
         expected = np.array([-1 if (c := g.locate(p)) is None else c for p in pts])
         np_testing.assert_array_equal(after_refine, expected)
-        g.coarsen(0, [0, 0], [4, 4])
+        g = g.coarsen(0, [0, 0], [4, 4])
         after_coarsen = g.locate_many(pts)
         expected2 = np.array([-1 if (c := g.locate(p)) is None else c for p in pts])
         np_testing.assert_array_equal(after_coarsen, expected2)
@@ -1629,7 +1642,7 @@ class TestHierKernelEquivalence:
     def test_restricted_grid_uses_fresh_packed_arrays(self) -> None:
         """Grids built via restrict() (the _from_blocks path) locate correctly."""
         g = _grid_2d(8)
-        g.refine(0, [0, 0], [4, 4])
+        g = g.refine(0, [0, 0], [4, 4])
         restr = g.restrict(np.arange(min(20, g.num_cells)))
         sub = restr.grid
         rng = np.random.default_rng(23)
@@ -1689,7 +1702,7 @@ def _boundary_facets_bruteforce(grid: HierarchicalGrid) -> list[list[int]]:
 def _refined_corner_grid() -> HierarchicalGrid:
     """2x2 unit grid with the low corner root cell refined once: 3 coarse + 4 fine."""
     g = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 2), 2)
-    g.refine(0, (0, 0), (1, 1))
+    g = g.refine(0, (0, 0), (1, 1))
     return g
 
 
@@ -1808,8 +1821,8 @@ class TestExportCells:
     def test_roundtrip_exact_on_dyadic_grid(self) -> None:
         """With dyadic breakpoints and a dyadic factor every corner agrees bitwise."""
         g = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 2), 2)
-        g.refine(0, (0, 0), (1, 1))
-        g.refine(1, (0, 0), (2, 2))
+        g = g.refine(0, (0, 0), (1, 1))
+        g = g.refine(1, (0, 0), (2, 2))
         points, conn = g.export_cells()
 
         for cid in range(g.num_cells):
@@ -1838,7 +1851,7 @@ class TestExportCells:
     def test_dedup_exact_with_non_uniform_breakpoints(self) -> None:
         """Non-uniform root breakpoints deduplicate exactly as well."""
         g = hierarchical_grid(TensorProductGrid([np.array([0.0, 0.3, 1.0])] * 2), 2)
-        g.refine(0, (0, 0), (1, 1))
+        g = g.refine(0, (0, 0), (1, 1))
         points, _ = g.export_cells()
 
         assert points.shape == (14, 2)

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -2109,11 +2109,11 @@ class TestDeepcopy:
 def test_normalize_blocks_is_idempotent() -> None:
     """Re-normalizing an already-normalized level list is the identity.
 
-    Load-bearing: every operation hands its whole per-level block list to
-    ``_from_blocks``, which normalizes each level, including the levels it did not
-    touch.  If normalization were not a fixed point, the untouched levels would be
-    re-partitioned and every flat cell id would move, so the returned grid would
-    stop matching what the mutating implementation produced.
+    Load-bearing: it is what licenses ``refine`` and ``coarsen`` to hand
+    ``_from_blocks`` the levels they never rebound and declare them already
+    normalized.  Were normalization not a fixed point, those levels would need
+    re-merging, and skipping it would re-partition nothing while a caller that
+    re-merged them anyway would get a different answer from one that did not.
     """
     g = _refined_2d()
     for level in range(g.max_level + 1):
@@ -2144,12 +2144,16 @@ def _random_decomposition(
 def test_normalize_blocks_is_idempotent_over_random_decompositions() -> None:
     """Normalization is a fixed point, over decompositions no fixture would reach.
 
-    This is the property the value-returning refinement rests on and the reason the
-    returned grid's flat cell ids match what the mutating implementation produced:
-    every operation hands its *whole* per-level block list to ``_from_blocks``, which
-    normalizes each level including the ones the operation never touched.  Were
-    normalization not a fixed point, those levels would be re-partitioned and every
-    flat id would move.
+    The property ``_from_blocks``'s ``unnormalized_levels`` argument rests on, and so
+    the reason a refinement sweep does not pay for the levels it never reads: a level
+    holding a previous call's output normalizes to itself, so passing it through
+    unchanged and re-merging it give the same blocks in the same order.  Were that
+    false, the two would disagree and every flat cell id in the result would move.
+
+    The stronger statement behind it is that the output is *pairwise non-mergeable*:
+    the merge loop only exits after a pass that compared every pair and merged none.
+    Idempotence follows, because ``_try_merge`` is symmetric, so non-mergeability is a
+    property of the set rather than of the order it is listed in.
     """
     rng = np.random.default_rng(20260831)
     merged_something = 0
@@ -2194,3 +2198,169 @@ def test_normalize_blocks_depends_on_the_order_it_is_given() -> None:
         if _normalize_blocks(list(blocks)) != _normalize_blocks(other):
             differing += 1
     assert differing > 0, "normalization has become order-independent; see this docstring"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Parity: skipping the untouched levels changes nothing
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _normalize_every_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force ``_from_blocks`` back to normalizing every level, ignoring its argument.
+
+    Lets one test run an operation down both paths and compare, rather than asserting
+    a property the fast path is supposed to have.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture used to install the override.
+    """
+    original = HierarchicalGrid._from_blocks.__func__  # type: ignore[attr-defined]
+
+    def unconditional(
+        cls: type[HierarchicalGrid],
+        root: TensorProductGrid,
+        factor: tuple[int, ...],
+        blocks: list[list[tuple[tuple[int, ...], tuple[int, ...]]]],
+        *,
+        unnormalized_levels: frozenset[int] | None = None,
+    ) -> HierarchicalGrid:
+        return original(cls, root, factor, blocks, unnormalized_levels=None)  # type: ignore[no-any-return]
+
+    monkeypatch.setattr(HierarchicalGrid, "_from_blocks", classmethod(unconditional))
+
+
+def _random_hierarchy(rng: np.random.Generator, ndim: int) -> HierarchicalGrid:
+    """Return a randomly refined hierarchy with blocks left on several levels.
+
+    Refines scattered single cells level by level, which leaves the peeled remainder
+    as many non-mergeable blocks on every level -- the configuration where skipping
+    the untouched levels changes the most work, and so where a parity break would
+    show up first.
+
+    Args:
+        rng (np.random.Generator): Source of randomness.
+        ndim (int): Spatial dimension.
+
+    Returns:
+        HierarchicalGrid: The refined grid.
+    """
+    root = int(rng.integers(3, 6))
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * ndim, root), 2)
+    for level in range(int(rng.integers(2, 5))):
+        blocks = grid.active_blocks(level)
+        if not blocks:
+            break
+        for _ in range(int(rng.integers(1, 5))):
+            blocks = grid.active_blocks(level)
+            if not blocks:
+                break
+            blo, bhi = blocks[int(rng.integers(len(blocks)))]
+            cell = tuple(int(rng.integers(lo, hi)) for lo, hi in zip(blo, bhi, strict=True))
+            grid = grid.refine(level, cell, tuple(c + 1 for c in cell))
+    return grid
+
+
+def _apply_random_operation(grid: HierarchicalGrid, rng: np.random.Generator) -> HierarchicalGrid:
+    """Apply one randomly chosen hierarchy operation.
+
+    Args:
+        grid (HierarchicalGrid): The grid to operate on.
+        rng (np.random.Generator): Source of randomness.
+
+    Returns:
+        HierarchicalGrid: The operation's result.
+    """
+    choice = int(rng.integers(4))
+    if choice == 0:
+        populated = [lv for lv in range(grid.max_level + 1) if grid.active_blocks(lv)]
+        level = populated[int(rng.integers(len(populated)))]
+        blocks = grid.active_blocks(level)
+        blo, bhi = blocks[int(rng.integers(len(blocks)))]
+        cell = tuple(int(rng.integers(lo, hi)) for lo, hi in zip(blo, bhi, strict=True))
+        return grid.refine(level, cell, tuple(c + 1 for c in cell))
+    if choice == 1:
+        ids = [
+            int(c) for c in rng.choice(grid.num_cells, size=min(3, grid.num_cells), replace=False)
+        ]
+        return grid.refine_cells(ids)
+    if choice == 2:
+        return grid.coarsen_cells([int(c) for c in range(grid.num_cells)])
+    return grid._copy()
+
+
+def _levels(grid: HierarchicalGrid) -> list[tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]]:
+    """Return every level's block list, for a block-for-block comparison.
+
+    Args:
+        grid (HierarchicalGrid): The grid to read.
+
+    Returns:
+        list: One entry per level, each the level's blocks in stored order.
+    """
+    return [grid.active_blocks(level) for level in range(grid.max_level + 1)]
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_skipping_untouched_levels_reproduces_normalizing_all_of_them(
+    ndim: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fast path returns the same partition, block for block, as the slow one.
+
+    ``refine``, ``coarsen`` and ``_copy`` hand ``_from_blocks`` the levels they did not
+    rebind, and declare them already normalized rather than re-merging them.  That is
+    only sound because normalization is a fixed point, and the merge is *order
+    dependent*, so a break would not be a slower-but-equal partition -- it would be a
+    different rectangle decomposition of the same cells, moving every flat cell id.
+
+    So this compares the two paths directly, on hierarchies deep and irregular enough
+    that most of the block mass sits on levels the operation never touches.
+    """
+    rng = np.random.default_rng(20260831 + ndim)
+    fast_results = []
+    for _ in range(60):
+        grid = _random_hierarchy(rng, ndim)
+        seed = int(rng.integers(1 << 30))
+        fast = _apply_random_operation(grid, np.random.default_rng(seed))
+        fast_results.append((grid, seed, _levels(fast), fast.num_cells))
+
+    _normalize_every_level(monkeypatch)
+    untouched_mass = 0
+    for grid, seed, fast_levels, fast_cells in fast_results:
+        # Rebuilt under the override, so the receiver itself took the slow path too.
+        slow_grid = grid._copy()
+        slow = _apply_random_operation(slow_grid, np.random.default_rng(seed))
+        assert _levels(slow) == fast_levels
+        assert slow.num_cells == fast_cells
+        untouched_mass += sum(len(b) for b in fast_levels[:-2])
+    # Guard against the comparison being vacuous: the skipped levels must carry blocks.
+    assert untouched_mass > 100
+
+
+def test_restrict_still_normalizes_every_level() -> None:
+    """Clipping to a window can make two blocks mergeable, so ``restrict`` cannot skip.
+
+    ``refine`` and ``coarsen`` may declare their untouched levels already normalized
+    because they pass another grid's stored lists verbatim.  ``restrict`` does not: it
+    intersects each block with the window, and two blocks that differed on two axes can
+    end up differing on one and adjacent there.  The blocks below are exactly that case
+    -- ``[(0,0),(2,1))`` and ``[(0,1),(1,2))`` do not merge, but their clips to
+    ``x < 1`` do -- so a restricted grid whose level is left unmerged would hand out
+    different cell ids from one built the same way by any other route.
+    """
+    left = ((0, 0), (2, 1))
+    right = ((0, 1), (1, 2))
+    assert _try_merge(*left, *right) is None
+    assert _normalize_blocks([left, right]) == [left, right]
+
+    clipped_left = ((0, 0), (1, 1))
+    clipped_right = right
+    assert _normalize_blocks([clipped_left, clipped_right]) == [((0, 0), (1, 2))]
+
+    # And end to end: every level of a restricted grid is in normal form.
+    grid = _refined_2d()
+    restricted = grid.restrict(list(range(grid.num_cells // 2)))
+    sub = restricted.grid
+    assert isinstance(sub, HierarchicalGrid)
+    for level in range(sub.max_level + 1):
+        blocks = list(sub.active_blocks(level))
+        assert _normalize_blocks(list(blocks)) == blocks

--- a/tests/test_local_space.py
+++ b/tests/test_local_space.py
@@ -379,7 +379,7 @@ def _refined_thb(
     knots = [0.0] * 3 + [float(i) for i in range(1, n)] + [float(n)] * 3
     sp = BsplineSpace1D(knots, 2)
     grid = hierarchical_grid(uniform_grid([[0.0, float(n)], [0.0, float(n)]], n), 2)
-    grid.refine(0, list(lo), list(hi))
+    grid = grid.refine(0, list(lo), list(hi))
     return THBSplineSpace(BsplineSpace([sp, sp]), grid)
 
 
@@ -487,7 +487,7 @@ def _corner_refined_thb() -> THBSplineSpace:
     knots = [0.0] * 3 + [float(i) for i in range(1, 6)] + [6.0] * 3
     sp = BsplineSpace1D(knots, 2)
     grid = hierarchical_grid(uniform_grid([[0.0, 6.0], [0.0, 6.0]], 6), 2)
-    grid.refine(0, [0, 0], [3, 3])
+    grid = grid.refine(0, [0, 0], [3, 3])
     return THBSplineSpace(BsplineSpace([sp, sp]), grid)
 
 

--- a/tests/test_multilevel_extraction.py
+++ b/tests/test_multilevel_extraction.py
@@ -121,30 +121,30 @@ class TestReproduction:
 
     def test_1d_two_levels(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         assert _reproduction_error(THBSplineSpace(_root_1d(), grid)) < 1e-12
 
     def test_1d_three_levels(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
-        grid.refine(1, [0], [2])
+        grid = grid.refine(0, [0], [2])
+        grid = grid.refine(1, [0], [2])
         assert _reproduction_error(THBSplineSpace(_root_1d(), grid)) < 1e-12
 
     def test_2d_corner(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         assert _reproduction_error(THBSplineSpace(_root_2d(), grid)) < 1e-12
 
     def test_2d_three_levels(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [1, 1], [3, 3])
-        grid.refine(1, [2, 2], [6, 6])
+        grid = grid.refine(0, [1, 1], [3, 3])
+        grid = grid.refine(1, [2, 2], [6, 6])
         assert _reproduction_error(THBSplineSpace(_root_2d(), grid)) < 1e-12
 
     def test_hb(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
-        grid.refine(1, [0], [2])
+        grid = grid.refine(0, [0], [2])
+        grid = grid.refine(1, [0], [2])
         assert _reproduction_error(THBSplineSpace(_root_1d(), grid, truncate=False)) < 1e-12
 
     def test_unrefined_equals_single_level_bezier(self) -> None:
@@ -171,13 +171,13 @@ class TestPartitionOfUnity:
 
     def test_pou_1d(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
-        grid.refine(1, [0], [2])
+        grid = grid.refine(0, [0], [2])
+        grid = grid.refine(1, [0], [2])
         assert _pou_error(THBSplineSpace(_root_1d(), grid)) < 1e-10
 
     def test_pou_2d(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         assert _pou_error(THBSplineSpace(_root_2d(), grid)) < 1e-10
 
 
@@ -191,8 +191,8 @@ class TestMayerNarrowBand:
 
     def test_narrow_band_1d(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [1], [2])  # single root cell -> level 1
-        grid.refine(1, [2], [3])  # single level-1 cell -> level 2
+        grid = grid.refine(0, [1], [2])  # single root cell -> level 1
+        grid = grid.refine(1, [2], [3])  # single level-1 cell -> level 2
         thb = THBSplineSpace(_root_1d(), grid)
         assert thb.num_levels == 3
         assert _reproduction_error(thb) < 1e-12
@@ -200,8 +200,8 @@ class TestMayerNarrowBand:
 
     def test_narrow_band_2d(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [1, 1], [2, 2])  # single root cell -> level 1
-        grid.refine(1, [2, 2], [3, 3])  # single level-1 cell -> level 2
+        grid = grid.refine(0, [1, 1], [2, 2])  # single root cell -> level 1
+        grid = grid.refine(1, [2, 2], [3, 3])  # single level-1 cell -> level 2
         thb = THBSplineSpace(_root_2d(), grid)
         assert thb.num_levels == 3
         assert _reproduction_error(thb) < 1e-12
@@ -211,8 +211,8 @@ class TestMayerNarrowBand:
         # If the §3.6.1 bug were present, the straddling passive function would be
         # spuriously truncated to zero in Mᵉ.  Guard that no row is all zeros.
         grid = _grid_1d()
-        grid.refine(0, [1], [2])
-        grid.refine(1, [2], [3])
+        grid = grid.refine(0, [1], [2])
+        grid = grid.refine(1, [2], [3])
         thb = THBSplineSpace(_root_1d(), grid)
         mle = MultiLevelExtraction(thb)
         for cid in range(thb.grid.num_cells):
@@ -233,7 +233,7 @@ class TestOperatorApi:
 
     def test_shapes_and_active_basis(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         mle = MultiLevelExtraction(thb)
         n_bernstein = thb.degrees[0] + 1
@@ -289,15 +289,19 @@ class TestOperatorApi:
         assert ret is out
         np.testing.assert_allclose(out, mle.multilevel_operator(0))
 
-    def test_stale_grid_raises(self) -> None:
+    def test_refine_returns_new_grid_and_leaves_extraction_unaffected(self) -> None:
+        """No staleness RuntimeError any more: HierarchicalGrid.refine returns a new grid."""
         grid = _grid_1d()
         thb = THBSplineSpace(_root_1d(), grid)
         mle = MultiLevelExtraction(thb)
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            mle.operator(0)
-        with pytest.raises(RuntimeError, match="stale"):
-            mle.multilevel_operator(0)
+        op0_before = mle.operator(0)
+        mop0_before = mle.multilevel_operator(0)
+        refined = grid.refine(0, [0], [2])
+        assert refined is not grid
+        assert thb.grid is grid
+        assert mle.space is thb
+        np.testing.assert_array_equal(mle.operator(0), op0_before)
+        np.testing.assert_array_equal(mle.multilevel_operator(0), mop0_before)
 
     def test_negative_cid_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
@@ -329,7 +333,7 @@ class TestOperatorApi:
     def test_lagrange_target(self) -> None:
         # Mᵉ is target-independent; only Eᵉ (hence Cᵉ) changes with the target.
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         bezier = MultiLevelExtraction(thb, "bezier")
         lagrange = MultiLevelExtraction(thb, "lagrange")
@@ -356,8 +360,8 @@ class TestElementCoeffsMemoization:
     @staticmethod
     def _thb() -> THBSplineSpace:
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
-        grid.refine(0, [0, 0], [2, 2])
-        grid.refine(1, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(1, [0, 0], [2, 2])
         return THBSplineSpace(_root_2d(), grid)
 
     def test_cache_returns_shared_readonly_entry(self) -> None:

--- a/tests/test_partition_graph.py
+++ b/tests/test_partition_graph.py
@@ -174,7 +174,7 @@ def test_real_space_partition_is_valid() -> None:
 def test_thb_space_partition_is_valid() -> None:
     root = create_uniform_space(2, 4)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-    grid.refine(0, [0], [2])
+    grid = grid.refine(0, [0], [2])
     thb = THBSplineSpace(root, grid)
     part = partition_graph(coupling_graph(thb), 2)
     _assert_full_partition(part.cell_owner, 2, thb.grid.num_cells)
@@ -320,7 +320,7 @@ def test_metis_real_space_is_valid() -> None:
 def test_metis_thb_space_is_valid() -> None:
     root = create_uniform_space(2, 4)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-    grid.refine(0, [0], [2])
+    grid = grid.refine(0, [0], [2])
     thb = THBSplineSpace(root, grid)
     owner = partition_graph(coupling_graph(thb), 2, backend="metis").cell_owner
     # METIS does not guarantee both parts non-empty; check only valid range.

--- a/tests/test_quasi_interpolation.py
+++ b/tests/test_quasi_interpolation.py
@@ -133,46 +133,46 @@ class TestThbReproduction:
 
     def test_1d_two_levels(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         assert _thb_reproduction_error(THBSplineSpace(_root_1d(), grid)) < 1e-10
 
     def test_1d_three_levels(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
-        grid.refine(1, [0], [2])
+        grid = grid.refine(0, [0], [2])
+        grid = grid.refine(1, [0], [2])
         assert _thb_reproduction_error(THBSplineSpace(_root_1d(), grid)) < 1e-10
 
     def test_2d_corner(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         assert _thb_reproduction_error(THBSplineSpace(_root_2d(), grid)) < 1e-10
 
     def test_2d_three_levels(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [1, 1], [3, 3])
-        grid.refine(1, [2, 2], [6, 6])
+        grid = grid.refine(0, [1, 1], [3, 3])
+        grid = grid.refine(1, [2, 2], [6, 6])
         assert _thb_reproduction_error(THBSplineSpace(_root_2d(), grid)) < 1e-10
 
     def test_narrow_band_1d(self) -> None:
         # Single-cell-wide multi-level band: exercises the leaf-cell / truncation path.
         grid = _grid_1d()
-        grid.refine(0, [1], [2])
-        grid.refine(1, [2], [3])
+        grid = grid.refine(0, [1], [2])
+        grid = grid.refine(1, [2], [3])
         thb = THBSplineSpace(_root_1d(), grid)
         assert thb.num_levels == 3
         assert _thb_reproduction_error(thb) < 1e-10
 
     def test_narrow_band_2d(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [1, 1], [2, 2])
-        grid.refine(1, [2, 2], [3, 3])
+        grid = grid.refine(0, [1, 1], [2, 2])
+        grid = grid.refine(1, [2, 2], [3, 3])
         thb = THBSplineSpace(_root_2d(), grid)
         assert thb.num_levels == 3
         assert _thb_reproduction_error(thb) < 1e-10
 
     def test_reproduces_polynomials_1d(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         qi = quasi_interpolate_thb_spline(lambda p: 1.0 - 2.0 * p[:, 0] + 3.0 * p[:, 0] ** 2, thb)
         xs = _sample(1)
@@ -181,7 +181,7 @@ class TestThbReproduction:
 
     def test_reproduces_polynomials_2d(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         thb = THBSplineSpace(_root_2d(), grid)
         qi = quasi_interpolate_thb_spline(lambda p: p[:, 0] ** 2 + p[:, 0] * p[:, 1] + 1.0, thb)
         pts = _sample(2)
@@ -190,7 +190,7 @@ class TestThbReproduction:
 
     def test_vector_valued(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         rng = np.random.default_rng(3)
         coeffs = rng.standard_normal((thb.num_total_basis, 2))
@@ -204,8 +204,8 @@ class TestThbReproduction:
         # refined regions has more than one leaf-cell candidate; exercises the
         # nearest-Greville selection branch.
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
-        grid.refine(0, [3], [4])
+        grid = grid.refine(0, [0], [2])
+        grid = grid.refine(0, [3], [4])
         thb = THBSplineSpace(_root_1d(), grid)
         assert _thb_reproduction_error(thb) < 1e-10
 
@@ -257,7 +257,7 @@ class TestHb:
 
     def test_refined_hb_runs(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid, truncate=False)
         qi = quasi_interpolate_thb_spline(lambda p: np.sin(p[:, 0]), thb)
         assert qi.control_points.shape == (thb.num_total_basis,)
@@ -277,12 +277,16 @@ class TestHb:
         with pytest.raises(ValueError, match="values"):
             quasi_interpolate_thb_spline(lambda p: np.zeros(p.shape[0] + 1), thb)
 
-    def test_stale_grid_raises_on_qi(self) -> None:
+    def test_refine_leaves_qi_on_old_grid_unaffected(self) -> None:
+        """No staleness RuntimeError any more: refine returns a new grid, leaving thb intact."""
         grid = _grid_1d()
         thb = THBSplineSpace(_root_1d(), grid)
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            quasi_interpolate_thb_spline(lambda p: p[:, 0], thb)
+        qi_before = quasi_interpolate_thb_spline(lambda p: p[:, 0], thb)
+        refined = grid.refine(0, [0], [2])
+        assert refined is not grid
+        assert thb.grid is grid
+        qi_after = quasi_interpolate_thb_spline(lambda p: p[:, 0], thb)
+        np.testing.assert_array_equal(qi_after.control_points, qi_before.control_points)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -347,13 +351,18 @@ class TestThbSpline:
         with pytest.raises(ValueError, match="trailing dimension"):
             spline.evaluate(np.array([[0.1]]))
 
-    def test_stale_grid_raises_on_evaluate(self) -> None:
+    def test_refine_leaves_existing_spline_unaffected(self) -> None:
+        """No staleness RuntimeError any more: refine returns a new grid, leaving thb intact."""
         grid = _grid_1d()
         thb = THBSplineSpace(_root_1d(), grid)
-        spline = THBSpline(thb, np.zeros(thb.num_total_basis))
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            spline.evaluate(np.array([[0.5]]))
+        rng = np.random.default_rng(9)
+        spline = THBSpline(thb, rng.standard_normal(thb.num_total_basis))
+        value_before = spline.evaluate(np.array([[0.5]]))
+        refined = grid.refine(0, [0], [2])
+        assert refined is not grid
+        assert thb.grid is grid
+        assert spline.space is thb
+        np.testing.assert_array_equal(spline.evaluate(np.array([[0.5]])), value_before)
 
     def test_bad_coeffs_ndim_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
@@ -381,7 +390,7 @@ class TestThbSpline:
         # Vector-valued evaluate on a refined 2D grid exercises the full
         # multi-level dofs → active_basis → tabulate_basis → matmul path.
         grid = _grid_2d()
-        grid.refine(0, [1, 1], [3, 3])
+        grid = grid.refine(0, [1, 1], [3, 3])
         thb = THBSplineSpace(_root_2d(), grid)
         rng = np.random.default_rng(7)
         coeffs = rng.standard_normal((thb.num_total_basis, 2))
@@ -421,7 +430,7 @@ class TestThbSpline:
     def test_evaluate_derivatives_reproduces_polynomial_derivative(self) -> None:
         # On a refined THB space, QI reproduces x^2 exactly; its derivative is 2x.
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         spline = quasi_interpolate_thb_spline(lambda p: p[:, 0] ** 2, thb)
         xs = _sample(1)

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -145,8 +145,8 @@ def _two_level_jump_grid() -> tuple[HierarchicalGrid, int, int]:
     ([0.25, 0.3125]) that share the facet at x = 0.25.
     """
     grid = HierarchicalGrid(uniform_grid([[0.0, 1.0]], [4]), 2)
-    grid.refine(0, [1], [3])
-    grid.refine(1, [2], [4])
+    grid = grid.refine(0, [1], [3])
+    grid = grid.refine(1, [2], [4])
     cid_coarse = next(
         c
         for c in range(grid.num_cells)
@@ -175,8 +175,8 @@ def test_hierarchical_hanging_neighbors_mixed_level_facet() -> None:
     plane and overlaps the coarse cell's extent.
     """
     grid = HierarchicalGrid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4]), 2)
-    grid.refine(0, [1, 0], [2, 4])  # refine the x-index-1 column to level 1
-    grid.refine(1, [2, 2], [3, 3])  # refine one of its cells to level 2
+    grid = grid.refine(0, [1, 0], [2, 4])  # refine the x-index-1 column to level 1
+    grid = grid.refine(1, [2, 2], [3, 3])  # refine one of its cells to level 2
 
     coarse = next(
         c
@@ -206,24 +206,34 @@ def test_hierarchical_hanging_neighbors_mixed_level_facet() -> None:
         assert grid.neighbor_across_facet(fine, 0) == coarse
 
 
-def test_thb_space_detects_compensating_refine_coarsen() -> None:
+def test_refine_coarsen_leave_existing_thb_space_unaffected() -> None:
+    """No staleness RuntimeError any more: refine/coarsen return new grids, `space.grid` is intact.
+
+    A coarsen then a refine can land on the same (max_level, num_cells) summary as before
+    while describing a different cell layout -- the reason the deleted version counter
+    existed. With HierarchicalGrid immutable, `space`'s own grid is simply never touched by
+    calls on `grid`, so no staleness check is needed at all.
+    """
     root = BsplineSpace([_open_uniform_1d(2, 8)])
     grid = HierarchicalGrid(uniform_grid([[0.0, 1.0]], [8]), 2)
-    grid.refine(0, [0], [2])
-    grid.refine(0, [4], [6])
+    grid = grid.refine(0, [0], [2])
+    grid = grid.refine(0, [4], [6])
     space = THBSplineSpace(root, grid)
     snapshot = (grid.max_level, grid.num_cells)
 
-    grid.coarsen(0, [4], [6])
-    grid.refine(0, [5], [7])
-    assert (grid.max_level, grid.num_cells) == snapshot  # the snapshot cannot tell
-
-    # Cell id 2 now decodes to a different cell; a stale evaluation must raise, not
-    # silently mix the old active set with the new cell layout.
     lo, hi = grid.cell_bounds(2)
     pt = 0.5 * (lo + hi).reshape(1, 1)
-    with pytest.raises(RuntimeError):
-        space.tabulate_basis(2, pt)
+    values_before, dofs_before = space.tabulate_basis(2, pt)
+
+    other = grid.coarsen(0, [4], [6])
+    other = other.refine(0, [5], [7])
+    assert (other.max_level, other.num_cells) == snapshot  # same summary, different layout
+    assert other is not grid
+    assert space.grid is grid
+
+    values_after, dofs_after = space.tabulate_basis(2, pt)
+    np.testing.assert_array_equal(values_after, values_before)
+    np.testing.assert_array_equal(dofs_after, dofs_before)
 
 
 def test_locate_nan_is_a_miss() -> None:

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from collections.abc import Callable, Sequence
 
 import numpy as np
@@ -21,6 +22,7 @@ from pantr.bspline import (
 from pantr.bspline._thb_eval_core import _combine_tp_values
 from pantr.bspline._thb_spline_space import _box_all_true, _func_support_1d
 from pantr.grid import HierarchicalGrid, hierarchical_grid, tensor_product_grid, uniform_grid
+from pantr.tolerance import get_strict
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Helpers
@@ -2655,3 +2657,98 @@ class TestTHBSplineRefine:
         f = self._field(np.random.default_rng(8))
         with pytest.raises(ValueError, match="level must be in"):
             f.refine_region(9, [0, 0], [1, 1])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The staleness apparatus is gone, and deepcopy still works (#378)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+_DEEPCOPY_VALUE_ATOL: float = get_strict(np.float64)
+"""
+Bound on the difference between a deepcopied space's tabulated values and the original's.
+
+Both sides run the same code on the same inputs, so the only difference admissible here is a
+reordering inside the evaluation's own summation (its kernels use ``prange``), not
+approximation error.  The bound is the strict preset -- a dimensionless ``4 * eps`` -- times
+the magnitude of the quantity compared, and that magnitude is ``1``: a THB basis is
+non-negative and sums to one on every cell, the partition-of-unity property this file already
+asserts elsewhere, so every tabulated value lies in ``[0, 1]``.  Measured difference on this
+machine: exactly zero, so the bound is slack by construction rather than fitted.
+"""
+
+
+def _refined_2d_space() -> THBSplineSpace:
+    """A truncated 2D space over a three-level grid with a warm per-cell cache."""
+    grid = _grid_2d()
+    grid = grid.refine(0, (1, 1), (3, 3))
+    grid = grid.refine(1, (2, 2), (5, 5))
+    space = THBSplineSpace(_root_2d(), grid)
+    _ = space.max_active_per_cell()  # warms _contrib_cache and _max_active_per_cell
+    return space
+
+
+class TestStalenessApparatusIsGone:
+    """The names that existed only to detect a grid mutation are deleted, not hidden.
+
+    Keeping any of them would keep the apparatus, which is what #378 set out to
+    remove: with an immutable grid there is nothing to snapshot and nothing to check.
+    """
+
+    def test_grid_snapshot_and_stale_check_are_absent(self) -> None:
+        space = THBSplineSpace(_root_1d(), _grid_1d())
+        assert not hasattr(space, "_grid_snapshot")
+        assert not hasattr(space, "_check_not_stale")
+        assert "_grid_snapshot" not in THBSplineSpace.__slots__
+
+    def test_the_grid_has_no_mutation_counter(self) -> None:
+        assert not hasattr(_grid_1d(), "version")
+
+    def test_no_public_entry_point_promises_a_staleness_error(self) -> None:
+        """No surviving docstring offers the `RuntimeError` a caller can no longer get."""
+        for owner in (THBSplineSpace, THBSpline, MultiLevelExtraction):
+            for name in dir(owner):
+                doc = getattr(getattr(owner, name), "__doc__", None) or ""
+                assert "modified since construction" not in doc, f"{owner.__name__}.{name}"
+                assert "is stale" not in doc, f"{owner.__name__}.{name}"
+
+
+class TestDeepcopy:
+    """``copy.deepcopy`` of a space still works and round-trips its contents."""
+
+    def test_space_round_trip(self) -> None:
+        space = _refined_2d_space()
+        clone = copy.deepcopy(space)
+
+        assert clone is not space
+        assert clone.grid is not space.grid
+        assert clone.dim == space.dim
+        assert clone.degrees == space.degrees
+        assert clone.num_total_basis == space.num_total_basis
+        assert clone.num_basis_per_level == space.num_basis_per_level
+        assert clone.grid.num_cells == space.grid.num_cells
+        assert clone.grid.max_level == space.grid.max_level
+        assert clone.max_active_per_cell() == space.max_active_per_cell()
+        pts = np.array([[0.3, 0.7]])
+        largest = 0.0
+        for cid in range(space.grid.num_cells):
+            np.testing.assert_array_equal(clone.active_basis(cid), space.active_basis(cid))
+            lo, hi = space.grid.cell_bounds(cid)
+            local = np.asarray(lo) + pts * (np.asarray(hi) - np.asarray(lo))
+            vals_c, dofs_c = clone.tabulate_basis(cid, local)
+            vals_s, dofs_s = space.tabulate_basis(cid, local)
+            np.testing.assert_array_equal(dofs_c, dofs_s)
+            np.testing.assert_allclose(vals_c, vals_s, rtol=0.0, atol=_DEEPCOPY_VALUE_ATOL)
+            largest = max(largest, float(np.abs(vals_s).max()))
+        # The values compared are real, not an all-zero array the tolerance would pass anyway.
+        assert largest > 0.25
+        assert space.grid.max_level >= 2  # a single-level space would prove little
+
+    def test_clone_refines_independently(self) -> None:
+        space = _refined_2d_space()
+        clone = copy.deepcopy(space)
+        fine = clone.refine([0])
+
+        assert fine.grid.num_cells > clone.grid.num_cells
+        assert clone.grid.num_cells == space.grid.num_cells
+        assert clone.num_total_basis == space.num_total_basis

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -196,8 +196,8 @@ class TestReproduction:
     def test_reproduce_1d_three_levels(self) -> None:
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
-        grid.refine(1, [0], [2])
+        grid = grid.refine(0, [0], [2])
+        grid = grid.refine(1, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=False)
         assert thb.num_levels == 3
         assert _max_reproduction_residual(thb, lambda p: np.ones(len(p))) < 1e-9
@@ -207,7 +207,7 @@ class TestReproduction:
     def test_reproduce_2d_corner_refinement(self) -> None:
         root = _root_2d()
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         thb = THBSplineSpace(root, grid, truncate=False)
         assert _max_reproduction_residual(thb, lambda p: np.ones(len(p))) < 1e-9
         assert _max_reproduction_residual(thb, lambda p: p[:, 0]) < 1e-9
@@ -217,8 +217,8 @@ class TestReproduction:
     def test_reproduce_2d_two_levels(self) -> None:
         root = _root_2d()
         grid = _grid_2d()
-        grid.refine(0, [1, 1], [3, 3])
-        grid.refine(1, [2, 2], [6, 6])
+        grid = grid.refine(0, [1, 1], [3, 3])
+        grid = grid.refine(1, [2, 2], [6, 6])
         thb = THBSplineSpace(root, grid, truncate=False)
         assert thb.num_levels == 3
         assert _max_reproduction_residual(thb, lambda p: p[:, 0] * p[:, 1]) < 1e-9
@@ -235,7 +235,7 @@ class TestSelection:
     def test_hand_example_1d(self) -> None:
         # Degree 2, 4 cells, refine the left half [0, 2) at level 0.
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid, truncate=False)
         assert thb.num_basis_per_level == (4, 4)
         np.testing.assert_array_equal(thb.active_function_indices(0), [2, 3, 4, 5])
@@ -245,8 +245,8 @@ class TestSelection:
         # Every active function: support ⊆ Ω_l and ⊄ Ω_{l+1}.
         root = _root_2d()
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
-        grid.refine(1, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(1, [0, 0], [2, 2])
         thb = THBSplineSpace(root, grid, truncate=False)
         for level in range(thb.num_levels):
             space = thb.level_space(level)
@@ -279,7 +279,7 @@ class TestSelection:
         # Refining the entire domain at level 0 displaces all level-0 functions.
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [4])
+        grid = grid.refine(0, [0], [4])
         thb = THBSplineSpace(root, grid, truncate=False)
         assert thb.num_basis_per_level[0] == 0
         assert thb.num_basis_per_level[1] > 0
@@ -296,7 +296,7 @@ class TestEvaluation:
     def test_active_basis_matches_nonzeros(self) -> None:
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=False)
         for cid in range(grid.num_cells):
             lo, hi = grid.cell_bounds(cid)
@@ -311,7 +311,7 @@ class TestEvaluation:
     def test_values_nonnegative(self) -> None:
         root = _root_2d()
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         thb = THBSplineSpace(root, grid, truncate=False)
         mat, _ = _collocation(thb)
         assert mat.min() >= 0.0
@@ -386,7 +386,7 @@ class TestEvaluation:
         # HB (non-truncated) is NOT a partition of unity over refined regions.
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=False)
         cid = grid.locate([0.1])
         assert cid is not None
@@ -402,28 +402,103 @@ class TestEvaluation:
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-class TestStaleGrid:
-    """THBSplineSpace raises RuntimeError if the grid is modified after construction."""
+class TestGridCannotGoStale:
+    """A space built on a grid can no longer be invalidated by a later refinement.
 
-    def test_stale_grid_active_basis_raises(self) -> None:
+    ``HierarchicalGrid.refine``/``coarsen`` (and their ``_cells`` variants) leave the
+    receiver untouched and return a new grid, so the "stale" ``RuntimeError`` this
+    class used to guard is gone: the failure mode it caught -- a ``THBSplineSpace``
+    outlived by mutation of the grid it was built on -- is now unrepresentable. Each
+    test below reruns the exact sequence that used to raise and checks instead that
+    the space's own grid is untouched and every read reproduces the value captured
+    before that call.
+    """
+
+    def test_active_basis_matches_before_a_later_grid_refine(self) -> None:
         grid = _grid_1d()
         thb = THBSplineSpace(_root_1d(), grid, truncate=False)
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            thb.active_basis(0)
+        n_cells, max_level = grid.num_cells, grid.max_level
+        before = thb.active_basis(0)
 
-    def test_stale_grid_tabulate_basis_raises(self) -> None:
+        new_grid = grid.refine(0, [0], [2])
+
+        assert new_grid is not grid
+        assert thb.grid is grid
+        assert thb.grid.num_cells == n_cells
+        assert thb.grid.max_level == max_level
+        np.testing.assert_array_equal(thb.active_basis(0), before)
+
+    def test_tabulate_basis_matches_before_a_later_grid_refine(self) -> None:
         grid = _grid_1d()
         thb = THBSplineSpace(_root_1d(), grid, truncate=False)
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            thb.tabulate_basis(0, np.array([[0.1]]))
+        pts = np.array([[0.1]])
+        before_vals, before_dofs = thb.tabulate_basis(0, pts)
 
-    def test_unmodified_grid_does_not_raise(self) -> None:
+        new_grid = grid.refine(0, [0], [2])
+
+        assert new_grid is not grid
+        assert thb.grid is grid
+        vals, dofs = thb.tabulate_basis(0, pts)
+        np.testing.assert_allclose(vals, before_vals)
+        np.testing.assert_array_equal(dofs, before_dofs)
+
+    def test_max_active_per_cell_matches_before_a_later_grid_refine(self) -> None:
+        """Old: raised whether the value had been cached before the grid refine or not.
+
+        Both orderings are exercised here.
+        """
         grid = _grid_1d()
-        thb = THBSplineSpace(_root_1d(), grid, truncate=False)
-        # No refine call — must not raise.
-        _ = thb.active_basis(0)
+        uncached = THBSplineSpace(_root_1d(), grid)
+        cached = THBSplineSpace(_root_1d(), grid)
+        before = cached.max_active_per_cell()  # warm the memoized value before refining
+
+        new_grid = grid.refine(0, [0], [2])
+
+        assert new_grid is not grid
+        assert uncached.grid is grid
+        assert cached.grid is grid
+        assert uncached.max_active_per_cell() == before  # was never cached
+        assert cached.max_active_per_cell() == before  # was already cached
+
+    def test_contrib_cache_matches_before_a_later_grid_refine(self) -> None:
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid)
+        before = thb._cell_contributions(0)  # warm the per-cell cache
+        assert 0 in thb._contrib_cache
+
+        new_grid = grid.refine(0, [0], [2])
+
+        assert new_grid is not grid
+        assert thb.grid is grid
+        assert thb._cell_contributions(0) is before  # cache untouched, same object back
+
+    def test_space_refine_matches_before_a_later_grid_refine(self) -> None:
+        grid = _grid_1d()
+        coarse = THBSplineSpace(_root_1d(), grid)
+        before = coarse.refine([0])
+
+        new_grid = grid.refine(0, [0], [2])
+
+        assert new_grid is not grid
+        assert coarse.grid is grid
+        after = coarse.refine([0])
+        assert after.grid.num_cells == before.grid.num_cells
+        assert after.num_total_basis == before.num_total_basis
+        assert after.num_basis_per_level == before.num_basis_per_level
+
+    def test_space_refine_region_matches_before_a_later_grid_refine(self) -> None:
+        grid = _grid_1d()
+        coarse = THBSplineSpace(_root_1d(), grid)
+        before = coarse.refine_region(0, [0], [1])
+
+        new_grid = grid.refine(0, [0], [2])
+
+        assert new_grid is not grid
+        assert coarse.grid is grid
+        after = coarse.refine_region(0, [0], [1])
+        assert after.grid.num_cells == before.grid.num_cells
+        assert after.num_total_basis == before.num_total_basis
+        assert after.num_basis_per_level == before.num_basis_per_level
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -442,8 +517,8 @@ class TestLevelSpaces:
     def test_levels_are_nested_1d(self) -> None:
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
-        grid.refine(1, [0], [2])
+        grid = grid.refine(0, [0], [2])
+        grid = grid.refine(1, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=False)
         for level in range(thb.num_levels - 1):
             coarse = thb.level_space(level).spaces[0].knots
@@ -455,7 +530,7 @@ class TestLevelSpaces:
         # Anisotropic refinement: factor 1 on the second axis.
         root = _root_2d()
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), (2, 1))
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         thb = THBSplineSpace(root, grid, truncate=False)
         level0 = thb.level_space(0)
         level1 = thb.level_space(1)
@@ -474,15 +549,15 @@ class TestLevelSpaces:
 def _refined_1d_three_levels() -> THBSplineSpace:
     """Degree-2 1D space with the left region refined twice (truncated)."""
     grid = _grid_1d()
-    grid.refine(0, [0], [2])
-    grid.refine(1, [0], [2])
+    grid = grid.refine(0, [0], [2])
+    grid = grid.refine(1, [0], [2])
     return THBSplineSpace(_root_1d(), grid, truncate=True)
 
 
 def _refined_2d_corner() -> THBSplineSpace:
     """Degree-(2, 2) space with the lower-left corner refined once (truncated)."""
     grid = _grid_2d()
-    grid.refine(0, [0, 0], [2, 2])
+    grid = grid.refine(0, [0, 0], [2, 2])
     return THBSplineSpace(_root_2d(), grid, truncate=True)
 
 
@@ -499,8 +574,8 @@ class TestTruncation:
 
     def test_partition_of_unity_2d_three_levels(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [1, 1], [3, 3])
-        grid.refine(1, [2, 2], [6, 6])
+        grid = grid.refine(0, [1, 1], [3, 3])
+        grid = grid.refine(1, [2, 2], [6, 6])
         thb = THBSplineSpace(_root_2d(), grid, truncate=True)
         assert thb.num_levels == 3
         mat, _ = _collocation(thb)
@@ -533,7 +608,7 @@ class TestTruncation:
         # THB and HB values coincide there (same selection, same values).
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])  # refine left half [0, 0.5)
+        grid = grid.refine(0, [0], [2])  # refine left half [0, 0.5)
         thb = THBSplineSpace(root, grid, truncate=True)
         hb = THBSplineSpace(root, grid, truncate=False)
         cid = grid.locate([0.9])  # cell [0.75, 1.0], outside the refinement
@@ -549,7 +624,7 @@ class TestTruncation:
         # Where HB over-sums (> 1), THB sums to exactly 1.
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=True)
         hb = THBSplineSpace(root, grid, truncate=False)
         cid = grid.locate([0.1])  # refined region
@@ -588,7 +663,7 @@ class TestTruncation:
     def test_partition_of_unity_with_regularity_c0(self) -> None:
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=True, regularity=0)
         mat, _ = _collocation(thb)
         np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
@@ -598,7 +673,7 @@ class TestTruncation:
         # less than its HB counterpart (truncation reduced it) and >= 0.
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=True)
         hb = THBSplineSpace(root, grid, truncate=False)
         cid = grid.locate([0.3])
@@ -625,7 +700,7 @@ class TestTruncation:
     def test_partition_of_unity_anisotropic_truncated(self) -> None:
         root = _root_2d()
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), (2, 1))
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         thb = THBSplineSpace(root, grid, truncate=True)
         mat, _ = _collocation(thb)
         np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
@@ -647,7 +722,7 @@ class TestTruncation:
     def test_thb_and_hb_same_active_count(self) -> None:
         # Truncation changes function values but not the active-function selection.
         root, grid = _root_2d(), _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         thb = THBSplineSpace(root, grid, truncate=True)
         hb = THBSplineSpace(root, grid, truncate=False)
         assert thb.num_total_basis == hb.num_total_basis
@@ -666,7 +741,7 @@ class TestTruncation:
         # Verify that factor=3 (non-power-of-2) refinement still gives partition of unity.
         root = _root_1d()
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 3)
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=True)
         mat, _ = _collocation(thb)
         np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
@@ -677,7 +752,7 @@ class TestTruncation:
         sp1d = BsplineSpace1D(knots, 1)
         root = BsplineSpace([sp1d])
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(root, grid, truncate=True)
         mat, _ = _collocation(thb)
         np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
@@ -686,10 +761,10 @@ class TestTruncation:
         # Scalar regularity=0 and equivalent sequence form [0] produce the same space.
         root = _root_1d()
         grid1 = _grid_1d()
-        grid1.refine(0, [0], [2])
+        grid1 = grid1.refine(0, [0], [2])
         thb_scalar = THBSplineSpace(root, grid1, truncate=True, regularity=0)
         grid2 = _grid_1d()
-        grid2.refine(0, [0], [2])
+        grid2 = grid2.refine(0, [0], [2])
         thb_seq = THBSplineSpace(root, grid2, truncate=True, regularity=[0])
         assert thb_scalar.num_total_basis == thb_seq.num_total_basis
         mat, _ = _collocation(thb_seq)
@@ -741,7 +816,7 @@ class TestDerivatives:
     def test_order_zero_equals_values_hb(self) -> None:
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         hb = THBSplineSpace(root, grid, truncate=False)
         cid = grid.locate([0.1])
         assert cid is not None
@@ -832,8 +907,8 @@ class TestDerivatives:
     def test_hb_derivative_reproduction(self) -> None:
         root = _root_1d()
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
-        grid.refine(1, [0], [2])
+        grid = grid.refine(0, [0], [2])
+        grid = grid.refine(1, [0], [2])
         hb = THBSplineSpace(root, grid, truncate=False)
         a_val, pts = _collocation(hb)
         a_dx, _ = _collocation_derivatives(hb, 1)
@@ -956,13 +1031,6 @@ class TestRefine:
         with pytest.raises(ValueError, match="admissible_class"):
             coarse.refine([0], admissible_class=0)
 
-    def test_stale_grid_refine_raises(self) -> None:
-        grid = _grid_1d()
-        coarse = THBSplineSpace(_root_1d(), grid)
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            coarse.refine([0])
-
 
 def _lower_left_level0_ids(thb: THBSplineSpace, threshold: float = 0.5) -> npt.NDArray[np.int64]:
     """Flat ids of the active (level-0) cells whose midpoint is below ``threshold`` per axis."""
@@ -1046,7 +1114,7 @@ class TestRefineRegion:
     def test_matches_grid_refine_ungraded(self) -> None:
         root = _root_2d()
         grid = hierarchical_grid(tensor_product_grid(root), 2)
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         reference = THBSplineSpace(root, grid)
         region = create_thb_space(root).refine_region(0, [0, 0], [2, 2], admissible_class=None)
         assert region.num_basis_per_level == reference.num_basis_per_level
@@ -1109,13 +1177,6 @@ class TestRefineRegion:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
         with pytest.raises(ValueError, match="admissible_class"):
             coarse.refine_region(0, [0], [1], admissible_class=1)
-
-    def test_stale_grid_raises(self) -> None:
-        grid = _grid_1d()
-        coarse = THBSplineSpace(_root_1d(), grid)
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            coarse.refine_region(0, [0], [1])
 
 
 class TestAdmissibility:
@@ -2165,7 +2226,7 @@ class TestContribCache:
 
     def test_second_call_returns_same_object(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         cid = grid.locate([0.1])
         assert cid is not None
@@ -2173,18 +2234,9 @@ class TestContribCache:
         second = thb._cell_contributions(cid)
         assert second is first
 
-    def test_cache_warm_stale_grid_still_raises(self) -> None:
-        grid = _grid_1d()
-        thb = THBSplineSpace(_root_1d(), grid)
-        _ = thb._cell_contributions(0)  # warm cache
-        assert 0 in thb._contrib_cache
-        grid.refine(0, [0], [2])  # mutate grid after cache is warm
-        with pytest.raises(RuntimeError, match="stale"):
-            thb._cell_contributions(0)
-
     def test_different_cells_cached_independently(self) -> None:
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         c0 = grid.locate([0.1])
         c1 = grid.locate([0.8])
@@ -2219,7 +2271,7 @@ class TestMaxActivePerCell:
         """The cached value equals an explicit loop over active_basis, and exceeds the flat one."""
         grid = _grid_2d()
         for level in range(rounds):
-            grid.refine(level, [0, 0], [2 * 2**level, 2 * 2**level])
+            grid = grid.refine(level, [0, 0], [2 * 2**level, 2 * 2**level])
         thb = THBSplineSpace(_root_2d(), grid, truncate=truncate)
 
         loop_max = max(thb.active_basis(cid).size for cid in range(grid.num_cells))
@@ -2230,7 +2282,7 @@ class TestMaxActivePerCell:
     def test_thb_and_hb_agree(self) -> None:
         """Truncation changes coefficients, not the active set, so the count is the same."""
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         root = _root_2d()
 
         thb = THBSplineSpace(root, grid, truncate=True)
@@ -2240,7 +2292,7 @@ class TestMaxActivePerCell:
     def test_cached_across_calls(self) -> None:
         """The result is memoized: a second call recomputes nothing."""
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
 
         first = thb.max_active_per_cell()
@@ -2248,23 +2300,6 @@ class TestMaxActivePerCell:
         thb._contrib_cache.clear()
         assert thb.max_active_per_cell() == first
         assert thb._contrib_cache == {}
-
-    def test_stale_grid_raises(self) -> None:
-        """A grid mutated after construction is rejected, as for active_basis."""
-        grid = _grid_1d()
-        thb = THBSplineSpace(_root_1d(), grid)
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            thb.max_active_per_cell()
-
-    def test_stale_grid_raises_after_caching(self) -> None:
-        """Staleness is detected even once the value has been cached."""
-        grid = _grid_1d()
-        thb = THBSplineSpace(_root_1d(), grid)
-        _ = thb.max_active_per_cell()
-        grid.refine(0, [0], [2])
-        with pytest.raises(RuntimeError, match="stale"):
-            thb.max_active_per_cell()
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -2279,7 +2314,7 @@ def _refined_thb_2d(
     knots = [0.0] * 3 + [float(i) for i in range(1, n)] + [float(n)] * 3
     sp = BsplineSpace1D(knots, 2)
     grid = hierarchical_grid(uniform_grid([[0.0, float(n)], [0.0, float(n)]], n), 2)
-    grid.refine(0, list(lo), list(hi))
+    grid = grid.refine(0, list(lo), list(hi))
     return THBSplineSpace(BsplineSpace([sp, sp]), grid, truncate=truncate)
 
 
@@ -2341,7 +2376,7 @@ def test_restrict_full_grid_2d() -> None:
 def test_restrict_full_grid_1d() -> None:
     knots = [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0, 4.0]  # degree 2, 4 intervals
     grid = hierarchical_grid(uniform_grid([[0.0, 4.0]], 4), 2)
-    grid.refine(0, [1], [3])
+    grid = grid.refine(0, [1], [3])
     g = THBSplineSpace(BsplineSpace([BsplineSpace1D(knots, 2)]), grid)
     n_interior, _ = _check_restrict_interior(g, list(range(g.grid.num_cells)))
     assert n_interior == g.grid.num_cells
@@ -2398,8 +2433,8 @@ class TestTHBSplineEvaluateGrouping:
     @staticmethod
     def _spline(rank: int = 1) -> THBSpline:
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
-        grid.refine(1, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(1, [0, 0], [2, 2])
         thb = THBSplineSpace(_root_2d(), grid)
         rng = np.random.default_rng(31)
         shape = (thb.num_total_basis,) if rank == 1 else (thb.num_total_basis, rank)
@@ -2509,7 +2544,7 @@ class TestTHBSplineEvaluateGrouping:
     def _spline_1d() -> THBSpline:
         """1D THBSpline fixture on [0, 1] with one level of refinement."""
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         rng = np.random.default_rng(53)
         return THBSpline(thb, rng.random(thb.num_total_basis))

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -405,7 +405,7 @@ class TestEvaluation:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stale-grid detection
+# The grid cannot go stale
 # ──────────────────────────────────────────────────────────────────────────────
 
 
@@ -2714,12 +2714,12 @@ _DEEPCOPY_VALUE_ATOL: float = get_strict(np.float64)
 Bound on the difference between a deepcopied space's tabulated values and the original's.
 
 Both sides run the same code on the same inputs, so the only difference admissible here is a
-reordering inside the evaluation's own summation (its kernels use ``prange``), not
-approximation error.  The bound is the strict preset -- a dimensionless ``4 * eps`` -- times
-the magnitude of the quantity compared, and that magnitude is ``1``: a THB basis is
-non-negative and sums to one on every cell, the partition-of-unity property this file already
-asserts elsewhere, so every tabulated value lies in ``[0, 1]``.  Measured difference on this
-machine: exactly zero, so the bound is slack by construction rather than fitted.
+reordering inside one of the reductions the evaluation performs -- NumPy's, for a truncated
+dof's coefficient contraction, or a Numba kernel's -- and never approximation error.  The
+bound is the strict preset, a dimensionless ``4 * eps``, times the magnitude of the quantity
+compared, and that magnitude is ``1``: a THB basis is non-negative and sums to one on every
+cell, the partition-of-unity property this file already asserts elsewhere, so every tabulated
+value lies in ``[0, 1]``.  Slack by construction, not fitted to an observation.
 """
 
 

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -50,6 +50,11 @@ def _grid_2d() -> HierarchicalGrid:
     return hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
 
 
+def _cells_of(grid: HierarchicalGrid) -> set[tuple[int, tuple[int, ...]]]:
+    """Return every active leaf as a ``(level, midx)`` pair, stable across reassignment."""
+    return {(grid.cell_level(cid), grid.cell_multi_index(cid)) for cid in range(grid.num_cells)}
+
+
 def _collocation(
     thb: THBSplineSpace, n_per_axis: int | None = None
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
@@ -992,10 +997,26 @@ class TestRefine:
         assert child is not None
         assert fine.grid.cell_level(child) == 1
 
-    def test_refine_empty_copies_grid(self) -> None:
-        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+    def test_refine_empty_gives_an_independent_grid(self) -> None:
+        """A refine that refines nothing must not hand back the receiver's own grid.
+
+        A grid's cell decomposition is immutable, but the two tag registries and the
+        BVH it carries are not, and they belong to whoever holds the grid.  Sharing the
+        object would let a tag set through one space appear in the other, and in the
+        grid the caller passed to the constructor.
+        """
+        grid = _grid_1d()
+        coarse = THBSplineSpace(_root_1d(), grid)
         fine = coarse.refine([], admissible_class=None)
+
+        assert fine.grid is not coarse.grid
+        assert fine.grid is not grid
         assert fine.grid.num_cells == coarse.grid.num_cells
+        assert _cells_of(fine.grid) == _cells_of(coarse.grid)
+
+        fine.grid.cell_tags.set("only_on_fine", [0], [42])
+        assert "only_on_fine" not in coarse.grid.cell_tags
+        assert "only_on_fine" not in grid.cell_tags
 
     def test_ungraded_refines_exactly_marked_multi_cell(self) -> None:
         # Verifies the is_active_leaf guard: already-coarse cells not in [0, 1] are untouched.
@@ -1142,13 +1163,18 @@ class TestRefineRegion:
         fine = thb.refine_region(0, [0, 0], [4, 4]).refine_region(1, [0, 0], [4, 4])
         assert fine.num_levels == 3
 
-    def test_empty_region_is_noop(self) -> None:
+    def test_empty_region_is_a_structural_noop_over_an_independent_grid(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
         all_refined = coarse.refine_region(0, [0], [4], admissible_class=None)  # all level-0 cells
         # No level-0 leaves remain, so the box maps to an empty marked set: structural no-op.
         again = all_refined.refine_region(0, [0], [4], admissible_class=None)
         assert again.grid.num_cells == all_refined.grid.num_cells
         assert again.num_basis_per_level == all_refined.num_basis_per_level
+        # Structurally a no-op, but still a grid of its own: see
+        # `TestRefine.test_refine_empty_gives_an_independent_grid`.
+        assert again.grid is not all_refined.grid
+        again.grid.cell_tags.set("only_on_again", [0], [1])
+        assert "only_on_again" not in all_refined.grid.cell_tags
 
     def test_level_out_of_range_raises(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
@@ -1794,6 +1820,25 @@ def _active_indices(thb: THBSplineSpace) -> tuple[tuple[int, ...], ...]:
 
 class TestCoarsen:
     """THBSplineSpace.coarsen reverses refinement and grades for admissibility."""
+
+    def test_coarsen_nothing_gives_an_independent_grid(self) -> None:
+        """A coarsen that demotes nothing must not hand back the receiver's own grid.
+
+        Same reason as `TestRefine.test_refine_empty_gives_an_independent_grid`: the
+        decomposition is immutable but the tag registries the grid carries are not.
+        Both routes into `coarsen` that demote nothing are covered -- an empty id list,
+        and an id at level 0, which has no parent.
+        """
+        grid = _grid_1d()
+        coarse = THBSplineSpace(_root_1d(), grid)
+        for label, ids in (("empty", []), ("level 0 only", [0])):
+            same = coarse.coarsen(ids)
+            assert same.grid is not coarse.grid, label
+            assert same.grid is not grid, label
+            assert _cells_of(same.grid) == _cells_of(coarse.grid), label
+            same.grid.cell_tags.set("only_on_result", [0], [7])
+            assert "only_on_result" not in coarse.grid.cell_tags, label
+            assert "only_on_result" not in grid.cell_tags, label
 
     def test_coarsen_inverts_refine_1d(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())

--- a/tests/test_thb_validation_basis.py
+++ b/tests/test_thb_validation_basis.py
@@ -69,7 +69,7 @@ class TestNonnegativityAndPartitionOfUnity:
     @pytest.mark.parametrize("dim", [1, 2])
     def test_nonnegative(self, dim: int) -> None:
         root, grid = (_root_1d(), _grid_1d()) if dim == 1 else (_root_2d(), _grid_2d())
-        grid.refine(0, [0] * dim, [2] * dim)
+        grid = grid.refine(0, [0] * dim, [2] * dim)
         thb = THBSplineSpace(root, grid)
         for cid, pts in _cell_samples(thb):
             assert thb.tabulate_basis(cid, pts)[0].min() >= -1e-13
@@ -77,7 +77,7 @@ class TestNonnegativityAndPartitionOfUnity:
     @pytest.mark.parametrize("dim", [1, 2])
     def test_partition_of_unity(self, dim: int) -> None:
         root, grid = (_root_1d(), _grid_1d()) if dim == 1 else (_root_2d(), _grid_2d())
-        grid.refine(0, [0] * dim, [2] * dim)
+        grid = grid.refine(0, [0] * dim, [2] * dim)
         thb = THBSplineSpace(root, grid)
         for cid, pts in _cell_samples(thb):
             vals, _ = thb.tabulate_basis(cid, pts)
@@ -86,7 +86,7 @@ class TestNonnegativityAndPartitionOfUnity:
     def test_hb_is_not_partition_of_unity(self) -> None:
         # Truncation is what restores PoU; the non-truncated basis over-counts.
         grid = _grid_1d()
-        grid.refine(0, [0], [2])
+        grid = grid.refine(0, [0], [2])
         hb = THBSplineSpace(_root_1d(), grid, truncate=False)
         worst = 0.0
         for cid, pts in _cell_samples(hb):
@@ -101,7 +101,7 @@ class TestLinearIndependenceAndStability:
     @pytest.mark.parametrize("dim", [1, 2])
     def test_gram_is_spd_full_rank(self, dim: int) -> None:
         root, grid = (_root_1d(), _grid_1d()) if dim == 1 else (_root_2d(), _grid_2d())
-        grid.refine(0, [0] * dim, [2] * dim)
+        grid = grid.refine(0, [0] * dim, [2] * dim)
         thb = THBSplineSpace(root, grid)
         mass = gram_matrix(thb)
         np.testing.assert_allclose(mass, mass.T, atol=1e-14)
@@ -126,7 +126,7 @@ class TestLinearIndependenceAndStability:
         for chain in refine_chains:
             grid = _grid_1d()
             for level, lo, hi in chain:
-                grid.refine(level, lo, hi)
+                grid = grid.refine(level, lo, hi)
             mass = gram_matrix(THBSplineSpace(_root_1d(), grid))
             d = np.sqrt(np.diag(mass))
             conds.append(float(np.linalg.cond(mass / np.outer(d, d))))
@@ -146,7 +146,7 @@ class TestPreservationAndReproduction:
     def test_l2_reproduces_polynomials_1d(self, degree: int) -> None:
         root = create_uniform_space([degree], [5])
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 5), 2)
-        grid.refine(0, [1], [3])
+        grid = grid.refine(0, [1], [3])
         thb = THBSplineSpace(root, grid)
         pcoeffs = np.random.default_rng(degree).standard_normal(degree + 1)
 
@@ -159,7 +159,7 @@ class TestPreservationAndReproduction:
 
     def test_qi_reproduces_polynomial_2d(self) -> None:
         grid = _grid_2d()
-        grid.refine(0, [0, 0], [2, 2])
+        grid = grid.refine(0, [0, 0], [2, 2])
         thb = THBSplineSpace(_root_2d(), grid)
 
         def poly(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
@@ -182,7 +182,7 @@ class TestDerivativeReproduction:
     def test_first_derivative_of_polynomial_1d(self, degree: int) -> None:
         root = create_uniform_space([degree], [6])
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 6), 2)
-        grid.refine(0, [1], [4])  # partial refinement => truncated functions present
+        grid = grid.refine(0, [1], [4])  # partial refinement => truncated functions present
         thb = THBSplineSpace(root, grid)
         pcoeffs = np.random.default_rng(degree).standard_normal(degree + 1)
 

--- a/tests/test_thb_validation_identities.py
+++ b/tests/test_thb_validation_identities.py
@@ -52,12 +52,12 @@ class TestRefinementNesting:
 
     def test_prolongation_reproduces_field(self) -> None:
         coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-        coarse_grid.refine(0, [1], [3])
+        coarse_grid = coarse_grid.refine(0, [1], [3])
         coarse = THBSplineSpace(_root_1d(), coarse_grid)
 
         fine_grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-        fine_grid.refine(0, [1], [3])
-        fine_grid.refine(1, [2], [6])
+        fine_grid = fine_grid.refine(0, [1], [3])
+        fine_grid = fine_grid.refine(1, [2], [6])
         fine = THBSplineSpace(_root_1d(), fine_grid)
 
         rng = np.random.default_rng(0)
@@ -75,7 +75,7 @@ class TestRefinementNesting:
         def space(refines: list[tuple[int, list[int], list[int]]]) -> THBSplineSpace:
             grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
             for level, lo, hi in refines:
-                grid.refine(level, lo, hi)
+                grid = grid.refine(level, lo, hi)
             return THBSplineSpace(_root_1d(), grid)
 
         coarse = space([(0, [1], [3])])
@@ -97,12 +97,12 @@ class TestCoarseningExactInverse:
 
     def test_restriction_left_inverse(self) -> None:
         coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
-        coarse_grid.refine(0, [0, 0], [2, 2])
+        coarse_grid = coarse_grid.refine(0, [0, 0], [2, 2])
         coarse = THBSplineSpace(_root_2d(), coarse_grid)
 
         fine_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
-        fine_grid.refine(0, [0, 0], [2, 2])
-        fine_grid.refine(1, [0, 0], [4, 4])
+        fine_grid = fine_grid.refine(0, [0, 0], [2, 2])
+        fine_grid = fine_grid.refine(1, [0, 0], [4, 4])
         fine = THBSplineSpace(_root_2d(), fine_grid)
 
         prolong = coarse.prolongation_to(fine)
@@ -129,24 +129,24 @@ class TestCoarseningProjection:
     @staticmethod
     def _nested_1d() -> tuple[THBSplineSpace, THBSplineSpace]:
         coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-        coarse_grid.refine(0, [1], [3])
+        coarse_grid = coarse_grid.refine(0, [1], [3])
         coarse = THBSplineSpace(_root_1d(), coarse_grid)
 
         fine_grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-        fine_grid.refine(0, [1], [3])
-        fine_grid.refine(1, [2], [6])
+        fine_grid = fine_grid.refine(0, [1], [3])
+        fine_grid = fine_grid.refine(1, [2], [6])
         fine = THBSplineSpace(_root_1d(), fine_grid)
         return coarse, fine
 
     @staticmethod
     def _nested_2d() -> tuple[THBSplineSpace, THBSplineSpace]:
         coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
-        coarse_grid.refine(0, [0, 0], [2, 2])
+        coarse_grid = coarse_grid.refine(0, [0, 0], [2, 2])
         coarse = THBSplineSpace(_root_2d(), coarse_grid)
 
         fine_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
-        fine_grid.refine(0, [0, 0], [2, 2])
-        fine_grid.refine(1, [0, 0], [4, 4])
+        fine_grid = fine_grid.refine(0, [0, 0], [2, 2])
+        fine_grid = fine_grid.refine(1, [0, 0], [4, 4])
         fine = THBSplineSpace(_root_2d(), fine_grid)
         return coarse, fine
 
@@ -211,7 +211,7 @@ class TestBezierReconstruction:
         root = create_uniform_space([degree] * dim, [4] * dim)
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, 4), 2)
         for level, lo_box, hi_box in refines:
-            grid.refine(level, lo_box, hi_box)
+            grid = grid.refine(level, lo_box, hi_box)
         thb = THBSplineSpace(root, grid)
 
         def func(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:

--- a/tests/test_thb_validation_l2.py
+++ b/tests/test_thb_validation_l2.py
@@ -47,7 +47,7 @@ def _uniform_refined(degree: int, n: int, depth: int, dim: int) -> THBSplineSpac
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
     for level in range(depth):
         n_at = n * (2**level)
-        grid.refine(level, [0] * dim, [n_at] * dim)
+        grid = grid.refine(level, [0] * dim, [n_at] * dim)
     return THBSplineSpace(root, grid)
 
 
@@ -62,7 +62,7 @@ def _graded_refined(degree: int, depth: int, dim: int) -> THBSplineSpace:
     n = 4 * 2**depth
     root = create_uniform_space([degree] * dim, [n] * dim)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
-    grid.refine(0, [0] * dim, [n // 2] * dim)
+    grid = grid.refine(0, [0] * dim, [n // 2] * dim)
     return THBSplineSpace(root, grid)
 
 
@@ -78,7 +78,7 @@ class TestL2Reproduction:
         knots = _KNOTS_DEG2_4
         root = BsplineSpace([BsplineSpace1D(knots, 2) for _ in range(dim)])
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, 4), 2)
-        grid.refine(0, [0] * dim, [2] * dim)
+        grid = grid.refine(0, [0] * dim, [2] * dim)
         thb = THBSplineSpace(root, grid)
         coeffs = np.random.default_rng(dim).standard_normal(thb.num_total_basis)
         target = THBSpline(thb, coeffs)
@@ -125,7 +125,7 @@ class TestAdaptiveEfficiency:
         root = create_uniform_space([2], [8])
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 8), 2)
         for level, lo, hi in refines:
-            grid.refine(level, lo, hi)
+            grid = grid.refine(level, lo, hi)
         return THBSplineSpace(root, grid)
 
     def test_adaptive_beats_uniform(self) -> None:

--- a/tests/test_thb_validation_qi.py
+++ b/tests/test_thb_validation_qi.py
@@ -36,7 +36,7 @@ def _uniform_refined(degree: int, n: int, depth: int, dim: int) -> THBSplineSpac
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
     for level in range(depth):
         n_at = n * (2**level)
-        grid.refine(level, [0] * dim, [n_at] * dim)
+        grid = grid.refine(level, [0] * dim, [n_at] * dim)
     return THBSplineSpace(root, grid)
 
 
@@ -51,7 +51,7 @@ def _graded_refined(degree: int, depth: int, dim: int, *, truncate: bool = True)
     n = 4 * 2**depth
     root = create_uniform_space([degree] * dim, [n] * dim)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
-    grid.refine(0, [0] * dim, [n // 2] * dim)
+    grid = grid.refine(0, [0] * dim, [n // 2] * dim)
     return THBSplineSpace(root, grid, truncate=truncate)
 
 
@@ -153,7 +153,7 @@ class TestQIAdaptiveEfficiency:
         root = create_uniform_space([2], [8])
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 8), 2)
         for level, lo, hi in refines:
-            grid.refine(level, lo, hi)
+            grid = grid.refine(level, lo, hi)
         return THBSplineSpace(root, grid)
 
     def test_adaptive_beats_uniform(self) -> None:

--- a/tests/test_viz_thb.py
+++ b/tests/test_viz_thb.py
@@ -50,7 +50,7 @@ def _graded_space(dim: int, degree: int = 2, n: int = 4) -> THBSplineSpace:
     """
     root = create_uniform_space([degree] * dim, [n] * dim)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
-    grid.refine(0, [0] * dim, [n // 2] * dim)
+    grid = grid.refine(0, [0] * dim, [n // 2] * dim)
     return THBSplineSpace(root, grid)
 
 
@@ -65,8 +65,8 @@ def _three_level_space(dim: int, degree: int = 2, n: int = 4) -> THBSplineSpace:
     """A 3-level graded THB space (refine the lower block twice)."""
     root = create_uniform_space([degree] * dim, [n] * dim)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
-    grid.refine(0, [0] * dim, [n // 2] * dim)
-    grid.refine(1, [0] * dim, [n // 2] * dim)
+    grid = grid.refine(0, [0] * dim, [n // 2] * dim)
+    grid = grid.refine(1, [0] * dim, [n // 2] * dim)
     return THBSplineSpace(root, grid)
 
 

--- a/tools/adversarial_sweep/_probes_grid.py
+++ b/tools/adversarial_sweep/_probes_grid.py
@@ -854,7 +854,7 @@ def _tensor_product_from_space_cases(profile: Profile) -> Iterator[Case]:
 # ---------------------------------------------------------------------------
 
 
-def _deep_refine_chain(grid: HierarchicalGrid, target_level: int) -> None:
+def _deep_refine_chain(grid: HierarchicalGrid, target_level: int) -> HierarchicalGrid:
     """Refine a hierarchical grid's origin cell down to ``target_level``.
 
     Repeatedly refines only the single active cell at multi-index ``(0, ..., 0)``,
@@ -862,14 +862,18 @@ def _deep_refine_chain(grid: HierarchicalGrid, target_level: int) -> None:
     exponentially.
 
     Args:
-        grid (HierarchicalGrid): Grid to mutate in place.
+        grid (HierarchicalGrid): Grid whose origin cell is refined; left unchanged.
         target_level (int): Deepest level to reach.
+
+    Returns:
+        HierarchicalGrid: A new grid refined down to ``target_level``.
     """
     ndim = grid.ndim
     origin_lo = tuple(0 for _ in range(ndim))
     origin_hi = tuple(1 for _ in range(ndim))
     for level in range(target_level):
-        grid.refine(level, origin_lo, origin_hi)
+        grid = grid.refine(level, origin_lo, origin_hi)
+    return grid
 
 
 def _hier_construction_cases(profile: Profile) -> Iterator[Case]:
@@ -963,8 +967,7 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
         def build(
             grid: HierarchicalGrid = grid, target_level: int = target_level
         ) -> HierarchicalGrid:
-            _deep_refine_chain(grid, target_level)
-            return grid
+            return _deep_refine_chain(grid, target_level)
 
         yield Case(
             GROUP,
@@ -991,12 +994,14 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
     # Union semantics: refining a region with no active cells there is a no-op.
     root = _tp_grid(2, (0.0, 1.0), 4)
     grid = HierarchicalGrid(root, 2)
-    grid.refine(0, (0, 0), (1, 1))
+    grid = grid.refine(0, (0, 0), (1, 1))
 
     def refine_noop() -> tuple[int, int]:
         before = grid.num_cells
-        grid.refine(0, (0, 0), (1, 1))  # already fully refined away at level 0
-        return before, grid.num_cells
+        # Already fully refined away at level 0: the returned grid is a distinct
+        # object but its cell count must match, which is what this case checks.
+        after = grid.refine(0, (0, 0), (1, 1))
+        return before, after.num_cells
 
     yield Case(
         GROUP,
@@ -1023,9 +1028,8 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
 
     def refine_then_coarsen() -> tuple[int, int]:
         before = grid2.num_cells
-        grid2.refine(0, (1, 1), (2, 2))
-        grid2.coarsen(0, (1, 1), (2, 2))
-        return before, grid2.num_cells
+        after = grid2.refine(0, (1, 1), (2, 2)).coarsen(0, (1, 1), (2, 2))
+        return before, after.num_cells
 
     yield Case(
         GROUP,
@@ -1068,7 +1072,7 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
         GROUP,
         "hier_coarsen_partial_region",
         HierarchicalGrid.coarsen,
-        lambda: (grid3.refine(0, (0, 0), (1, 1)), grid3.coarsen(0, (0, 0), (2, 2)))[-1],
+        lambda: grid3.refine(0, (0, 0), (1, 1)).coarsen(0, (0, 0), (2, 2)),
         {"kind": "partially-refined-region"},
         # "...or the region is not fully refined to exactly level level+1."
         must_reject=True,
@@ -1097,7 +1101,7 @@ def _hier_bounds_cases(profile: Profile) -> Iterator[Case]:
         for target_level in (2,) if profile is not Profile.FULL else (1, 2, 3):
             root = _tp_grid(ndim, (0.0, 1.0), 2)
             grid = HierarchicalGrid(root, 2)
-            _deep_refine_chain(grid, target_level)
+            grid = _deep_refine_chain(grid, target_level)
             tag = f"d{ndim}_l{target_level}"
             params = {"ndim": ndim, "target_level": target_level}
 
@@ -1202,7 +1206,7 @@ def _hier_locate_cases(profile: Profile) -> Iterator[Case]:
         for domain in domains(profile):
             root = _tp_grid(ndim, domain, 2)
             grid = HierarchicalGrid(root, 2)
-            _deep_refine_chain(grid, 2)
+            grid = _deep_refine_chain(grid, 2)
             yield from _locate_roundtrip_case(
                 f"hier_{_grid_tag(ndim, domain)}",
                 grid,
@@ -1222,7 +1226,7 @@ def _hier_mask_cases(profile: Profile) -> Iterator[Case]:
     """
     root = _tp_grid(2, (0.0, 1.0), 2)
     grid = HierarchicalGrid(root, 2)
-    _deep_refine_chain(grid, 3)
+    grid = _deep_refine_chain(grid, 3)
 
     levels = range(grid.max_level + 1) if profile is Profile.FULL else (0, grid.max_level)
     for level in levels:
@@ -1294,7 +1298,7 @@ def _hier_hanging_neighbor_cases(profile: Profile) -> Iterator[Case]:
     """
     root = _tp_grid(2, (0.0, 1.0), 2)
     grid = HierarchicalGrid(root, 2)
-    grid.refine(0, (0, 0), (1, 1))  # refine one root cell; leaves a hanging interface
+    grid = grid.refine(0, (0, 0), (1, 1))  # refine one root cell; leaves a hanging interface
 
     def check_touching(_: object) -> str | None:
         for cid in range(grid.num_cells):
@@ -1345,7 +1349,7 @@ def _hier_restrict_cases(profile: Profile) -> Iterator[Case]:
     """
     root = _tp_grid(2, (0.0, 1.0), 3)
     grid = HierarchicalGrid(root, 2)
-    grid.refine(0, (1, 1), (2, 2))
+    grid = grid.refine(0, (1, 1), (2, 2))
 
     selectors = {
         "single_leaf": np.array([0]),

--- a/tutorials/09_grids_and_quadrature.py
+++ b/tutorials/09_grids_and_quadrature.py
@@ -60,7 +60,8 @@ ug.plot(scalars="cell_id", show_edges=True, cpos="xy")
 # A hierarchical grid
 # -------------------
 # The same export works for a refined hierarchical grid -- the active cells show
-# the multi-level structure directly.
+# the multi-level structure directly.  Refinement returns a *new* grid and leaves
+# the one it was called on alone, so the result has to be captured.
 hgrid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
-hgrid.refine(0, [0, 0], [2, 2])
+hgrid = hgrid.refine(0, [0, 0], [2, 2])
 viz.grid_to_pyvista(hgrid).plot(show_edges=True, cpos="xy")


### PR DESCRIPTION
Implements #378, the gate to all nine tickets of milestone 2.

## What changes

`HierarchicalGrid` refinement no longer mutates the receiver. It builds and returns a new grid,
leaving the receiver untouched. The same change follows through the space-level refinement that
delegates to it, and through the tutorial and the adversarial-sweep probes.

## The names were kept, deliberately

`grid.refine(...)` written as a bare statement now discards the refinement and raises nothing.
Keeping the name is the reversible direction: renaming later is cheap, un-renaming something
already published is not. Ruled on by the repository owner.

The known consequence, recorded so the next reader does not rediscover it: the downstream
consumer's smoke test is a `hasattr` check over `boundary_facets`, `export_cells` and `refine`.
The attribute still exists, so that test stays green while the semantics under the name have
changed. A `hasattr` check cannot see this class of change.

## Measured, not assumed

`_normalize_blocks`'s greedy merge is **order-dependent**: 1852 of 3886 random decompositions
change partition under a reshuffle, while all 3886 are idempotent. Flat cell ids are handed out
block by block, so #395's C++ port must reproduce the merge order exactly or the two backends
will disagree about cell ids with everything else identical. Pinned by a test in this PR rather
than left as a note.

## Acceptance

- Both backends green over the whole suite.
- The value-returning contract is pinned by its own test, including the no-op case, where an
  earlier revision of this branch shared the receiver's grid instead of returning an independent
  one. That was caught in self-review and is fixed with its own test.

`Closes #378` does not fire on a base that is not `main`; the issue is closed by hand once this
merges.