### PR TITLE
refactor(bspline): make the extraction target an enum instead of a string

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,8 +212,8 @@ release = pantr.__version__
 nitpicky = True
 
 # Private NumPy typing internals are not exposed in the public inventory.
-# CellIndex, Target, and QIKind are Literal/Union type aliases; Sphinx resolves
-# them as py:class but they have no class inventory entry.
+# CellIndex, Target, TargetLike, and QIKind are Literal/Union type aliases; Sphinx
+# resolves them as py:class but they have no class inventory entry.
 nitpick_ignore = [
     ("py:class", "numpy._typing._array_like._Buffer"),
     ("py:class", "numpy._typing._array_like._SupportsArray"),
@@ -247,6 +247,7 @@ nitpick_ignore = [
     ("py:class", "CellIndex"),
     ("py:class", "CellIndicesBatch"),
     ("py:class", "Target"),
+    ("py:class", "TargetLike"),
     ("py:class", "QIKind"),
 ]
 

--- a/docs/guide/spaces-knots.md
+++ b/docs/guide/spaces-knots.md
@@ -120,18 +120,22 @@ forming the full tensor product in memory.
 ### Construction and targets
 
 ```python
-from pantr.bspline import SpanwiseElementExtraction
+from pantr.bspline import ExtractionTarget, SpanwiseElementExtraction
 
-ext = SpanwiseElementExtraction(space, "bezier")     # Bernstein/Bézier basis per element
-ext = SpanwiseElementExtraction(space, "lagrange")   # Lagrange basis at chosen nodes
-ext = SpanwiseElementExtraction(space, "cardinal")   # cardinal B-spline basis
+ext = SpanwiseElementExtraction(space, ExtractionTarget.BEZIER)    # Bernstein/Bézier per element
+ext = SpanwiseElementExtraction(space, ExtractionTarget.LAGRANGE)  # Lagrange at chosen nodes
+ext = SpanwiseElementExtraction(space, ExtractionTarget.CARDINAL)  # cardinal B-spline basis
 ```
 
-| Target | Element-local basis |
+| {class}`~pantr.bspline.ExtractionTarget` | Element-local basis |
 |---|---|
-| ``"bezier"`` | Bernstein / Bézier on each element |
-| ``"lagrange"`` | Lagrange at a {class}`~pantr.basis.LagrangeVariant` node set (``lagrange_variant=…``) |
-| ``"cardinal"`` | cardinal (uniform) B-spline |
+| ``BEZIER`` | Bernstein / Bézier on each element |
+| ``LAGRANGE`` | Lagrange at a {class}`~pantr.basis.LagrangeVariant` node set (``lagrange_variant=…``) |
+| ``CARDINAL`` | cardinal (uniform) B-spline |
+
+The legacy string spellings (``"bezier"``, ``"lagrange"``, ``"cardinal"``) are still
+accepted, but {attr}`~pantr.bspline.SpanwiseElementExtraction.target` always reports the
+enum member.
 
 Construction is ``O(n_elements · p²)`` per direction and happens once; all later applies
 reuse the cached operators.

--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -78,6 +78,7 @@ from ._thb_spline_space import THBSplineSpace, THBSplineSpaceRestriction, create
 from .multilevel_extraction import MultiLevelExtraction
 from .spanwise_element_extraction import (
     ExtractionStructView,
+    ExtractionTarget,
     SpanwiseElementExtraction,
     make_struct_view,
 )
@@ -89,6 +90,7 @@ __all__ = [
     "BsplineSpaceRestriction",
     "CouplingGraph",
     "ExtractionStructView",
+    "ExtractionTarget",
     "LocalSpace",
     "MultiLevelExtraction",
     "SpanwiseElementExtraction",

--- a/src/pantr/bspline/_bspline_to_beziers.py
+++ b/src/pantr/bspline/_bspline_to_beziers.py
@@ -23,7 +23,7 @@ import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from .._numba_compat import nb_jit, nb_prange
-from .spanwise_element_extraction import SpanwiseElementExtraction
+from .spanwise_element_extraction import ExtractionTarget, SpanwiseElementExtraction
 
 if TYPE_CHECKING:
     from . import Bspline, BsplineSpace1D
@@ -110,7 +110,7 @@ def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
     """Decompose a B-spline into Bezier patches via extraction operators.
 
     Converts periodic directions to open form, then delegates operator
-    construction to :class:`SpanwiseElementExtraction` (target ``"bezier"``).
+    construction to :class:`SpanwiseElementExtraction` (target :attr:`ExtractionTarget.BEZIER`).
     Extraction operators are applied direction by direction using the standard
     moveaxis pattern. The resulting control point array is reshaped and split
     into individual :class:`~pantr.bezier.Bezier` objects.
@@ -133,7 +133,7 @@ def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
 
     # is_identity_mask_1d is also built but unused here; its overhead is minor
     # relative to the Numba kernel and accepted for the sake of consolidation.
-    extraction = SpanwiseElementExtraction(bspline.space, target="bezier")
+    extraction = SpanwiseElementExtraction(bspline.space, target=ExtractionTarget.BEZIER)
 
     ctrl = bspline.control_points
     num_intervals = bspline.space.num_intervals

--- a/src/pantr/bspline/multilevel_extraction.py
+++ b/src/pantr/bspline/multilevel_extraction.py
@@ -33,14 +33,19 @@ Main exports:
 
 from __future__ import annotations
 
-from typing import cast, get_args
+from typing import cast
 
 import numpy as np
 import numpy.typing as npt
 
 from ..basis._basis_utils import _allocate_or_validate_out
 from ._thb_spline_space import THBSplineSpace
-from .spanwise_element_extraction import SpanwiseElementExtraction, Target
+from .spanwise_element_extraction import (
+    ExtractionTarget,
+    SpanwiseElementExtraction,
+    TargetLike,
+    _coerce_target,
+)
 
 
 class MultiLevelExtraction:
@@ -71,7 +76,7 @@ class MultiLevelExtraction:
 
     Attributes:
         _space (THBSplineSpace): The hierarchical space being extracted.
-        _target (Target): The single-level reference basis tag.
+        _target (ExtractionTarget): The single-level reference basis.
         _oslo (tuple[tuple[npt.NDArray[np.float64], ...], ...]): Cached per-level,
             per-direction two-scale (Oslo) matrices; ``_oslo[m][k]`` maps level ``m``
             to level ``m+1`` in direction ``k``.
@@ -88,13 +93,14 @@ class MultiLevelExtraction:
 
     __slots__ = ("_coeffs_cache", "_ext", "_oslo", "_space", "_target")
 
-    def __init__(self, space: THBSplineSpace, target: Target = "bezier") -> None:
+    def __init__(self, space: THBSplineSpace, target: TargetLike = ExtractionTarget.BEZIER) -> None:
         """Create a multi-level extraction for a hierarchical space.
 
         Args:
             space (THBSplineSpace): The truncated (or non-truncated) hierarchical space.
-            target (Target): Single-level reference basis, one of ``"bezier"``,
-                ``"lagrange"``, ``"cardinal"``.  Defaults to ``"bezier"``.
+            target (TargetLike): Single-level reference basis: an
+                :class:`ExtractionTarget` or its legacy string spelling.  Defaults to
+                :attr:`ExtractionTarget.BEZIER`.
 
         Raises:
             TypeError: If ``space`` is not a :class:`THBSplineSpace`.
@@ -102,11 +108,9 @@ class MultiLevelExtraction:
         """
         if not isinstance(space, THBSplineSpace):
             raise TypeError(f"space must be a THBSplineSpace; got {type(space).__name__!r}.")
-        if target not in get_args(Target):
-            valid = ", ".join(repr(v) for v in get_args(Target))
-            raise ValueError(f"Unknown target {target!r}; expected one of {valid}.")
+        resolved_target = _coerce_target(target)
         self._space = space
-        self._target = target
+        self._target = resolved_target
         self._oslo = space._build_oslo_matrices()
         self._ext: dict[int, SpanwiseElementExtraction] = {}
         self._coeffs_cache: dict[
@@ -128,11 +132,13 @@ class MultiLevelExtraction:
         return self._space
 
     @property
-    def target(self) -> Target:
-        """Get the single-level reference basis tag.
+    def target(self) -> ExtractionTarget:
+        """Get the single-level reference basis.
 
         Returns:
-            Target: One of ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
+            ExtractionTarget: The element-local basis each level's extraction maps
+                onto.  A string passed at construction is resolved to its enum
+                member, so this never returns a string.
         """
         return self._target
 
@@ -274,7 +280,7 @@ class MultiLevelExtraction:
 
         :math:`C^\epsilon = M^\epsilon E^\epsilon` (shape ``(K, n)``) maps the ``target``
         reference basis on the cell to the active hierarchical functions
-        (``H^\epsilon = C^\epsilon B``).  For ``target="bezier"``, ``B`` is the Bernstein
+        (``H^\epsilon = C^\epsilon B``).  For the Bézier target, ``B`` is the Bernstein
         basis on :math:`[0, 1]^d`.  Rows follow :meth:`active_basis`.
 
         Args:
@@ -390,6 +396,7 @@ class MultiLevelExtraction:
             str: Shows dimension, target, and element count.
         """
         return (
-            f"MultiLevelExtraction(dim={self.dim}, target={self._target!r}, "
+            f"MultiLevelExtraction(dim={self.dim}, "
+            f"target=ExtractionTarget.{self._target.name}, "
             f"num_elements={self.num_elements})"
         )

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -6,25 +6,26 @@ operators once at construction time and, on demand, dispatches to the Layer-3
 Kronecker kernels in ``pantr.bspline._extraction_kernels`` to apply the
 d-dimensional operator for a single element.
 
-Three targets are supported (the source basis is always the B-spline basis):
+Three targets are supported, named by :class:`ExtractionTarget` (the source basis
+is always the B-spline basis):
 
-- ``"bezier"``:   Bernstein (Bézier) basis on each element.
-- ``"lagrange"``: Lagrange basis on each element, at the chosen point
+- ``BEZIER``:   Bernstein (Bézier) basis on each element.
+- ``LAGRANGE``: Lagrange basis on each element, at the chosen point
   distribution (see :class:`pantr.basis.LagrangeVariant`).
-- ``"cardinal"``: cardinal B-spline basis on each element.
+- ``CARDINAL``: cardinal B-spline basis on each element.
 
 Identity short-circuit is used wherever possible. All three targets use
 structural (multiplicity-based) identity predicates:
 
-- ``"bezier"``: element ``e`` is identity iff both its boundary unique knots
+- ``BEZIER``: element ``e`` is identity iff both its boundary unique knots
   have multiplicity ``>= degree + 1``, i.e. the element is already a Bézier
   patch. Knot multiplicities are computed using ``space.tolerance``.
-- ``"lagrange"``: for ``degree == 0`` every element is trivially identity.
+- ``LAGRANGE``: for ``degree == 0`` every element is trivially identity.
   For ``degree > 0`` an element is identity iff its Bézier extraction is
   identity and the Lagrange-to-Bernstein matrix equals ``I`` (which holds when
   the Lagrange nodes coincide with the Bernstein abscissae, e.g. ``degree == 1``
   with equispaced, GLL, or Chebyshev-2nd nodes).
-- ``"cardinal"``: structural mask from
+- ``CARDINAL``: structural mask from
   :meth:`BsplineSpace1D.get_cardinal_intervals` labels uniform-span intervals,
   on which the cardinal extraction operator is exactly the identity.
 """
@@ -33,7 +34,8 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Literal, NamedTuple, get_args
+from enum import IntEnum
+from typing import TYPE_CHECKING, Final, Literal, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
@@ -54,8 +56,75 @@ if TYPE_CHECKING:
     from ._bspline_space_nd import BsplineSpace
 
 
+class ExtractionTarget(IntEnum):
+    """The element-local basis a spanwise extraction maps the B-spline basis onto.
+
+    An :class:`~enum.IntEnum` rather than a string, per the project's convention
+    that a closed set of choices is never stringly typed (``pantr._backend``'s
+    ``Backend`` states the same rule). Two properties
+    follow from the choice and neither is available to a string: an integer member
+    is what crosses the backend seam (``design/cross_backend_types.md``), and it is
+    what a ``nopython`` Numba kernel can hold.
+
+    Attributes:
+        BEZIER: Bernstein (Bézier) basis on each element.
+        LAGRANGE: Lagrange basis on each element, at the point distribution named
+            by :class:`pantr.basis.LagrangeVariant`.
+        CARDINAL: Cardinal B-spline basis on each element.
+    """
+
+    BEZIER = 0
+    LAGRANGE = 1
+    CARDINAL = 2
+
+
 Target = Literal["bezier", "lagrange", "cardinal"]
-"""Supported target bases for spanwise element extraction."""
+"""Legacy string spelling of :class:`ExtractionTarget`, still accepted on input.
+
+Kept so that ``SpanwiseElementExtraction(space, "bezier")`` keeps working. Pass an
+:class:`ExtractionTarget` in new code: the string form cannot cross the backend
+seam and is not what the ``target`` property hands back.
+"""
+
+
+TargetLike = ExtractionTarget | Target
+"""What the public constructors accept for a target: the enum or its legacy string."""
+
+
+_TARGET_BY_NAME: Final[dict[str, ExtractionTarget]] = {
+    "bezier": ExtractionTarget.BEZIER,
+    "lagrange": ExtractionTarget.LAGRANGE,
+    "cardinal": ExtractionTarget.CARDINAL,
+}
+"""The legacy string spellings, mapped onto the enum they name."""
+
+
+def _coerce_target(target: TargetLike) -> ExtractionTarget:
+    """Resolve a target argument to an :class:`ExtractionTarget`.
+
+    The string branch is the compatibility boundary and the only place the legacy
+    spelling is understood; everything downstream of it sees the enum.
+
+    Args:
+        target (TargetLike): An :class:`ExtractionTarget`, or one of the legacy
+            strings ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
+
+    Returns:
+        ExtractionTarget: The resolved target.
+
+    Raises:
+        ValueError: If ``target`` is neither an :class:`ExtractionTarget` nor a
+            recognized string spelling.
+    """
+    if isinstance(target, ExtractionTarget):
+        return target
+    resolved = _TARGET_BY_NAME.get(target) if isinstance(target, str) else None
+    if resolved is None:
+        valid = ", ".join(repr(name) for name in _TARGET_BY_NAME)
+        raise ValueError(
+            f"Unknown target {target!r}; expected an ExtractionTarget or one of {valid}"
+        )
+    return resolved
 
 
 CellIndex = int | tuple[int, ...] | list[int] | npt.NDArray[np.int_]
@@ -104,9 +173,9 @@ class SpanwiseElementExtraction:
 
     Attributes:
         _space (BsplineSpace): Underlying multi-dimensional B-spline space.
-        _target (Target): Target basis tag.
+        _target (ExtractionTarget): Target basis.
         _lagrange_variant (LagrangeVariant): Point distribution used when
-            ``target == "lagrange"``; ignored otherwise.
+            the target is :attr:`ExtractionTarget.LAGRANGE`; ignored otherwise.
         _compact_ops_1d (tuple[npt.NDArray[np.float32 | np.float64], ...]):
             Per-direction compact 3D operator arrays of shape
             ``(n_compact_k, n_out_k, n_in_k)``; only non-identity rows are
@@ -120,7 +189,7 @@ class SpanwiseElementExtraction:
     """
 
     _space: BsplineSpace
-    _target: Target
+    _target: ExtractionTarget
     _lagrange_variant: LagrangeVariant
     _compact_ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...]
     _idx_maps_1d: tuple[npt.NDArray[np.intp], ...]
@@ -129,7 +198,7 @@ class SpanwiseElementExtraction:
     def __init__(
         self,
         space: BsplineSpace,
-        target: Target,
+        target: TargetLike,
         *,
         lagrange_variant: LagrangeVariant = LagrangeVariant.EQUISPACES,
     ) -> None:
@@ -137,9 +206,10 @@ class SpanwiseElementExtraction:
 
         Args:
             space (BsplineSpace): Multi-dimensional B-spline space.
-            target (Target): One of ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
+            target (TargetLike): An :class:`ExtractionTarget`, or its legacy string
+                spelling ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
             lagrange_variant (LagrangeVariant): Point distribution used when
-                ``target == "lagrange"``. Defaults to
+                ``target`` is :attr:`ExtractionTarget.LAGRANGE`. Defaults to
                 :attr:`pantr.basis.LagrangeVariant.EQUISPACES`.
 
         Raises:
@@ -147,9 +217,7 @@ class SpanwiseElementExtraction:
             NotImplementedError: If any direction of ``space`` is periodic;
                 periodic support is deferred to a later version.
         """
-        if target not in get_args(Target):
-            valid = ", ".join(repr(v) for v in get_args(Target))
-            raise ValueError(f"Unknown target {target!r}; expected one of {valid}")
+        resolved_target = _coerce_target(target)
 
         if any(s.periodic for s in space.spaces):
             raise NotImplementedError(
@@ -158,22 +226,22 @@ class SpanwiseElementExtraction:
             )
 
         self._space = space
-        self._target = target
+        self._target = resolved_target
         self._lagrange_variant = lagrange_variant
 
         compact_ops_1d: list[npt.NDArray[np.float32 | np.float64]] = []
         idx_maps_1d: list[npt.NDArray[np.intp]] = []
         masks_1d: list[npt.NDArray[np.bool_]] = []
         for space_1d in space.spaces:
-            if target == "bezier":
+            if resolved_target is ExtractionTarget.BEZIER:
                 ops = space_1d.tabulate_Bezier_extraction_operators()
                 mask = _bezier_structural_identity_mask(space_1d)
-            elif target == "lagrange":
+            elif resolved_target is ExtractionTarget.LAGRANGE:
                 ops = space_1d.tabulate_Lagrange_extraction_operators(
                     lagrange_variant=lagrange_variant
                 )
                 mask = _lagrange_structural_identity_mask(space_1d, lagrange_variant)
-            else:  # target == "cardinal"
+            else:  # resolved_target is ExtractionTarget.CARDINAL
                 ops = space_1d.tabulate_cardinal_extraction_operators()
                 mask = space_1d.get_cardinal_intervals()
             non_id_idx = np.where(~mask)[0]
@@ -217,17 +285,19 @@ class SpanwiseElementExtraction:
         return self._space
 
     @property
-    def target(self) -> Target:
-        """Get the target basis tag.
+    def target(self) -> ExtractionTarget:
+        """Get the target basis.
 
         Returns:
-            Target: One of ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
+            ExtractionTarget: The element-local basis this extraction maps onto.
+                A string passed at construction is resolved to its enum member,
+                so this never returns a string.
         """
         return self._target
 
     @property
     def lagrange_variant(self) -> LagrangeVariant:
-        """Get the Lagrange point distribution used for ``"lagrange"`` target.
+        """Get the Lagrange point distribution used for the Lagrange target.
 
         Returns:
             LagrangeVariant: The point distribution. Meaningless for other targets.
@@ -1200,8 +1270,10 @@ __all__ = [
     "CellIndex",
     "CellIndicesBatch",
     "ExtractionStructView",
+    "ExtractionTarget",
     "SpanwiseElementExtraction",
     "Target",
+    "TargetLike",
     "make_struct_view",
     "normalize_cell_indices",
     "operand_shape",

--- a/src/pantr/viz/_vtk_cells.py
+++ b/src/pantr/viz/_vtk_cells.py
@@ -259,9 +259,9 @@ def _thb_bezier_patches(
         *n_per* is a ``tuple`` of length ``dim`` whose entry ``d`` is
         ``degree[d] + 1``.
     """
-    from ..bspline import MultiLevelExtraction  # noqa: PLC0415
+    from ..bspline import ExtractionTarget, MultiLevelExtraction  # noqa: PLC0415
 
-    mle = MultiLevelExtraction(thb.space, target="bezier")
+    mle = MultiLevelExtraction(thb.space, target=ExtractionTarget.BEZIER)
     cp = np.asarray(thb.control_points, dtype=np.float64)
     coeff = cp.reshape(cp.shape[0], -1)  # (n_dofs, rank)
     n_per = tuple(d + 1 for d in thb.degree)

--- a/tests/test_multilevel_extraction.py
+++ b/tests/test_multilevel_extraction.py
@@ -10,6 +10,7 @@ from pantr.basis import tabulate_bernstein
 from pantr.bspline import (
     BsplineSpace,
     BsplineSpace1D,
+    ExtractionTarget,
     MultiLevelExtraction,
     SpanwiseElementExtraction,
     THBSplineSpace,
@@ -101,7 +102,7 @@ class TestConstruction:
         thb = THBSplineSpace(_root_2d(), _grid_2d())
         mle = MultiLevelExtraction(thb)
         assert mle.space is thb
-        assert mle.target == "bezier"
+        assert mle.target is ExtractionTarget.BEZIER
         assert mle.dim == 2
         assert mle.dtype == np.float64
         assert mle.num_elements == thb.grid.num_cells
@@ -314,7 +315,7 @@ class TestOperatorApi:
     def test_cardinal_target(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         mle = MultiLevelExtraction(thb, "cardinal")
-        assert mle.target == "cardinal"
+        assert mle.target is ExtractionTarget.CARDINAL
         for cid in range(thb.grid.num_cells):
             mle.operator(cid)
             mle.multilevel_operator(cid)
@@ -337,7 +338,7 @@ class TestOperatorApi:
         thb = THBSplineSpace(_root_1d(), grid)
         bezier = MultiLevelExtraction(thb, "bezier")
         lagrange = MultiLevelExtraction(thb, "lagrange")
-        assert lagrange.target == "lagrange"
+        assert lagrange.target is ExtractionTarget.LAGRANGE
         for cid in range(thb.grid.num_cells):
             np.testing.assert_allclose(
                 lagrange.multilevel_operator(cid), bezier.multilevel_operator(cid), atol=1e-12

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -2,8 +2,9 @@
 
 Covers:
 
-- Target dispatch (``bezier``, ``lagrange``, ``cardinal``) and construction
-  errors (unknown target, periodic directions).
+- Target dispatch (:class:`ExtractionTarget`) and construction errors (unknown
+  target, periodic directions), plus the legacy string spelling still resolving
+  to the same enum member and the same operators.
 - Shape/dtype and identity-mask properties.
 - Per-cell :meth:`apply` / :meth:`apply_transpose` / :meth:`apply_MT_K_M` /
   :meth:`apply_M_K_MT` against a dense reference ``kron(M_0, M_1, …)``.
@@ -28,7 +29,7 @@ Covers:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, get_args
 
 import numpy as np
 import numpy.typing as npt
@@ -40,6 +41,7 @@ from pantr.bspline import (
     BsplineSpace,
     BsplineSpace1D,
     ExtractionStructView,
+    ExtractionTarget,
     SpanwiseElementExtraction,
     make_struct_view,
 )
@@ -54,13 +56,26 @@ from pantr.bspline._extraction_kernels import (
     apply_kron_apply_many_3d,
 )
 from pantr.bspline.spanwise_element_extraction import (
+    _TARGET_BY_NAME,
+    Target,
     _bezier_structural_identity_mask,
+    _coerce_target,
     _lagrange_structural_identity_mask,
     normalize_cell_indices,
     operand_shape,
 )
 
 RNG = np.random.default_rng(20260421)
+
+_TARGET_SPELLINGS: list[tuple[Target, ExtractionTarget]] = [
+    ("bezier", ExtractionTarget.BEZIER),
+    ("lagrange", ExtractionTarget.LAGRANGE),
+    ("cardinal", ExtractionTarget.CARDINAL),
+]
+"""The legacy string spellings and the members they name, written out by hand.
+
+Independent of ``_TARGET_BY_NAME`` so that a wrong entry there is refutable.
+"""
 
 
 def _space_2d() -> BsplineSpace:
@@ -94,6 +109,95 @@ def test_unknown_target_rejected() -> None:
     sp = _space_2d()
     with pytest.raises(ValueError, match="Unknown target"):
         SpanwiseElementExtraction(sp, "spline")  # type: ignore[arg-type]
+
+
+def test_unknown_target_type_rejected() -> None:
+    """A target that is neither the enum nor a legacy string raises ValueError.
+
+    ``ExtractionTarget`` is an ``IntEnum``, so a bare ``0`` compares equal to
+    ``ExtractionTarget.BEZIER``.  It is still refused: accepting a raw integer
+    would make the caller's arithmetic silently selectable as a basis.
+    """
+    sp = _space_2d()
+    for bad in (0, None, ("bezier",)):
+        with pytest.raises(ValueError, match="Unknown target"):
+            SpanwiseElementExtraction(sp, bad)  # type: ignore[arg-type]
+
+
+def test_target_spellings_agree_by_construction() -> None:
+    """The legacy strings and the enum members name the same closed set.
+
+    Guards the one drift this compatibility layer can suffer: a member added to
+    ``ExtractionTarget`` with no string spelling, or a string with no member.
+    Neither would fail any other test, because each spelling is exercised alone.
+    ``_TARGET_SPELLINGS`` is written out here rather than read off
+    ``_TARGET_BY_NAME`` on purpose -- a table that supplies both the input and
+    the expectation cannot refute a wrong entry in itself.
+    """
+    assert dict(_TARGET_SPELLINGS) == _TARGET_BY_NAME
+    assert {name for name, _ in _TARGET_SPELLINGS} == set(get_args(Target))
+    assert {member for _, member in _TARGET_SPELLINGS} == set(ExtractionTarget)
+
+
+@pytest.mark.parametrize(("name", "member"), _TARGET_SPELLINGS)
+def test_coerce_target_resolves_both_spellings(name: Target, member: ExtractionTarget) -> None:
+    """``_coerce_target`` maps each legacy string to its member and passes members through."""
+    assert _coerce_target(name) is member
+    assert _coerce_target(member) is member
+
+
+@pytest.mark.parametrize(("name", "member"), _TARGET_SPELLINGS)
+def test_string_and_enum_targets_build_the_same_extraction(
+    name: Target, member: ExtractionTarget
+) -> None:
+    """The two spellings are the same request: same reported target, same operators.
+
+    The operator comparison is what makes this more than a type check -- a
+    coercion wired to the wrong member would keep ``target`` self-consistent and
+    change the operators, which only this comparison sees.  The final assertion
+    pins that the three targets are actually distinguishable on this space, so
+    the comparison above cannot pass by every target agreeing.
+    """
+    sp = _space_2d()
+    from_string = SpanwiseElementExtraction(sp, name)
+    from_enum = SpanwiseElementExtraction(sp, member)
+
+    assert from_string.target is member
+    assert from_enum.target is member
+    assert type(from_string.target) is ExtractionTarget  # never hands a string back
+    for a, b in zip(from_string.ops_1d, from_enum.ops_1d, strict=True):
+        np.testing.assert_array_equal(a, b)
+
+    bezier = SpanwiseElementExtraction(sp, ExtractionTarget.BEZIER)
+    same_as_bezier = all(
+        np.array_equal(a, b) for a, b in zip(from_enum.ops_1d, bezier.ops_1d, strict=True)
+    )
+    assert same_as_bezier == (member is ExtractionTarget.BEZIER)
+
+
+def test_target_members_are_numba_holdable() -> None:
+    """A ``nopython`` kernel can hold and compare an ``ExtractionTarget``.
+
+    This is the property the enum was chosen for -- ``ExtractionTarget``'s
+    docstring claims it, and a ``StrEnum`` (which ``LagrangeVariant`` is) would
+    not have it -- so it is asserted rather than assumed.  A closed-over member
+    A member crosses as an argument and compares against another member inside the
+    compiled function, which is the whole of what the port needs from it.
+    ``int(member)`` is *not* supported in ``nopython`` mode -- measured, it fails
+    typing -- so the kernel-side spelling is the comparison, not a cast.
+    """
+
+    @nb_jit(nopython=True, cache=False)
+    def _dispatch(target: ExtractionTarget) -> int:
+        if target == ExtractionTarget.LAGRANGE:
+            return 1
+        if target == ExtractionTarget.CARDINAL:
+            return 2
+        return 0
+
+    assert _dispatch(ExtractionTarget.BEZIER) == 0
+    assert _dispatch(ExtractionTarget.LAGRANGE) == 1
+    assert _dispatch(ExtractionTarget.CARDINAL) == 2
 
 
 def test_periodic_rejected() -> None:


### PR DESCRIPTION
Advances #399 (the extraction machinery in C++). Base is `proto/cpp`, so `Closes` would
not fire; #399 stays open and this is the first of its slices.

## What this does

`Target` was a bare `Literal["bezier", "lagrange", "cardinal"]`, validated with `get_args`
in two separate places and dispatched on with `==`. This replaces it with
`ExtractionTarget`, an `IntEnum`.

Three reasons, in the order they decide it:

1. The project's rule is that a closed set of choices is never stringly typed;
   `pantr._backend.Backend` states it in those words.
2. `design/cross_backend_types.md`'s kernel-seam table admits **an `IntEnum` value, as an
   integer**, and explicitly refuses **enums as strings**. The target has to cross that seam
   in the later slices of #399.
3. A member is what a `nopython` Numba kernel can hold. `LagrangeVariant` is a `StrEnum` and
   gives neither 2 nor 3; that asymmetry sits inside one constructor signature today.

`SpanwiseElementExtraction` and `MultiLevelExtraction` still accept the legacy strings,
resolved once by `_coerce_target`, which also removes the duplicated validation. Both
`target` properties now return the member.

Measured while writing the test, and it corrected the docstring: **`int(member)` is not
supported inside `nopython` mode** (it fails type inference: *no implementation of function
`int` for `IntEnum<int64>(ExtractionTarget)`*). Holding a member and comparing it against
another member both work, so the kernel-side spelling is the comparison, and the test
asserts that form rather than a cast.

## The one behaviour change, and it needs the downstream census

`ext.target` and `mle.target` used to return `"bezier"`; they now return
`ExtractionTarget.BEZIER`. An `IntEnum` member never compares equal to a string, so a
consumer writing `if ext.target == "bezier":` **silently takes the other branch** rather
than raising. Three assertions in this repo's own suite were exactly that shape and are
updated here.

**Please run the downstream-consumer census before this merges** (`pantr.bspline` is that
repository's largest exposure). The specific questions:

- does it read `SpanwiseElementExtraction.target` or `MultiLevelExtraction.target` and
  compare the result against a string?
- does it import `Target` from `pantr.bspline.spanwise_element_extraction`? (`Target` is
  **not** exported from `pantr.bspline`, so the exposure is the fully qualified path only.)
- does it import `OpKind` or anything else from `pantr.bspline._extraction_helpers`?

Input is unaffected either way: `SpanwiseElementExtraction(space, "bezier")` still works and
is documented as the legacy spelling. If the census says the property is read against a
string, reverting just the two property return types is a two-line change and the enum
survives for the seam.

No deprecation warning is emitted on the string form. Deliberate: pytest treats warnings as
errors here, so a warning would turn ~20 parametrized cases red in the same change, and the
deprecation timeline is not this slice's to pick.

## Mutation check

Each mutation was applied to `src/pantr/bspline/spanwise_element_extraction.py`, the target
tests run, and the tree restored (verified byte-identical afterwards).

| mutation | result |
|---|---|
| `_TARGET_BY_NAME["lagrange"] -> ExtractionTarget.BEZIER` | 3 failed (`test_target_spellings_agree_by_construction`, and both parametrized `lagrange` cases) |
| a non-string, non-enum target falls back to `BEZIER` instead of raising | 1 failed (`test_unknown_target_type_rejected`) |
| store the raw constructor argument instead of the resolved member | 3 failed (both parametrized `lagrange`/`cardinal` cases) |

The first mutation is why the spelling table in the test is **written out by hand** rather
than read off `_TARGET_BY_NAME`. Parametrized off the production table, the "same operators"
test used the mutated table for *both* the input and the expectation, and passed with the
mapping wrong. That is the mirror-test trap, and only the mutation surfaced it.

`test_string_and_enum_targets_build_the_same_extraction` also asserts that the three targets
are actually distinguishable on the test space, so the equality it checks cannot hold
vacuously by every target agreeing.

## Verification

- `pytest -n 4`: **8468 passed, 45 skipped, 7 xfailed**.
- `ruff check .`, `ruff format --check .`, `mypy src tests scripts` (300 files), `lint-imports`
  (2 contracts kept): all clean.
- `make doctest` over the two touched modules: 2 passed.
- `scripts/ci_local.sh`: see the comment below.

**The docs build is red on `proto/cpp` already, and this change does not add to it.** Built
`proto/cpp` at `c65a3f9` in a detached worktree and this branch, both under
`-W --keep-going`: **32 warnings each, and the two warning sets are identical**. All 32 are
`:class:` roles pointing at private port-scaffolding names (`_AABBPython`, `_BVHPython`,
`_CellTagsPython`, `_PartitionPython`, `_QuadratureRulePython`, `_AffineTransformPython`,
`_Impl`, `_impl_class`) plus `pantr.quad._rule_nd` and `CellTags.__iter__`. Reported rather
than fixed: the root cause is understood but it spans eight files this slice does not touch,
and the fix is a `nitpick_ignore` policy call. One warning this change *did* add
(`:class:pantr._backend.Backend`, private) is fixed here, using the double-backtick form
`docs/conf.py` already prescribes for a private class.

## Proposed decomposition of #399

Written here rather than filed, per instruction. #399 is coarse by design; this is how it
splits given what the tree actually contains.

- **S1 (this PR) — the target enum.** No C++. Unblocked, and every later slice needs the
  integer.
- **S2 — the 1D extraction operators in C++.** `_bspline_extraction.py`'s Bézier operator
  (Boehm knot insertion), the Lagrange and cardinal operators built on it, and the two
  structural identity-mask predicates. These take *arrays* (knots, degree, tolerance), not a
  space object, so they sit on the kernel seam and are **not blocked on #396**.
- **S3 — the Kronecker apply kernels in C++.** `_extraction_kernels.py`: 4 op kinds x
  {1,2,3}d x {single, batch}. Also pure arrays, also unblocked. Large; may want to split by
  op kind.
- **S4 — the `SpanwiseElementExtraction` type itself.** **Blocked on #396**, hard: the type
  holds a `BsplineSpace`, and `cpp/include/pantr/` has no `bspline/` directory at all today.
  This is the slice that carries the class-H `shared_ptr<const BsplineSpace>` accessor, the
  two memos from `design/bspline_derived_caches.md` (`ops_1d` DCLP-lazy returning a view of
  the memo, `num_identity_elements` eager), the wrapper, and `__reduce__`.

That is four, not the ticket's "roughly 2 to 3". S2 and S3 could be one PR if the kernel
half is wanted as a unit.

## A question the design notes do not settle: should `ExtractionStructView` be a C++ type at all?

Raising rather than deciding, because it changes public API shape.

`design/bspline_ownership_lifetime.md` F5 classifies `ExtractionStructView` as **class A**
(array views) and says it "needs nothing from the aggregation rule". That settles its
*lifetime*. It does not settle whether the type should move to C++, and I think it should
not:

- Its only purpose is to be **unboxed by Numba**. Its docstring says so, `docs/guide/`
  says so, and `tests/test_spanwise_element_extraction.py:1450-1543` passes it into `@njit`
  functions. A nanobind-bound class cannot be unboxed by Numba, so binding it breaks that
  outright.
- `design/cross_backend_types.md` puts exactly this kind of type on the Python side: "a type
  that exists only to implement the Python binding or its dispatch stays in Python, because
  it could not move even in principle" (the `DegreeKernels` case).
- In the end state there is no interpreter and no Numba, so the `NamedTuple` dies with the
  binding layer, as it should.

**Proposal:** `ExtractionStructView` stays a Python `NamedTuple` with its seven fields and
its field order unchanged. What changes is where its arrays come from: under the C++ backend
`make_struct_view` bundles the class-A `nb::ndarray` views that `SpanwiseElementExtraction`'s
accessors hand out, each with the C++ owner as keep-alive. Numba unboxes those exactly as it
unboxes today's arrays (they are real read-only `numpy.ndarray`s, which is already the status
quo), the storage becomes C++-owned, and
`tests/test_spanwise_element_extraction.py:1681`'s `np.shares_memory` assertion is what pins
it. The C++ side gets its own non-owning view struct of spans as the kernel argument, which
is a genuinely different object with a genuinely different job.

If that reading is wrong, S4 is where it has to be settled, so an answer before S4 is worth
more than one after.


---

# The `.target` return type: what was checked, and what the output side does not guarantee

Answering the question directly, because this is the one thing in the change that can fail
silently.

## Does any read of `.target` compare against a string?

**Inside pantr: no, and this is exhaustive rather than a spot check.** There are seven reads
of `.target` in the whole repository after this change, and none of them is a string
comparison:

| site | what it does |
|---|---|
| `tests/test_spanwise_element_extraction.py:165,166` | `is ExtractionTarget.<MEMBER>` |
| `tests/test_spanwise_element_extraction.py:167` | `type(...) is ExtractionTarget` |
| `tests/test_multilevel_extraction.py:105,318,341` | `is ExtractionTarget.<MEMBER>` (the three assertions this PR changed) |
| `docs/guide/spaces-knots.md:137` | prose |

What was run, over `src/`, `tests/`, `docs/` and `scripts/`, including `pantr/mpi/` and
`pantr/viz/`:

```
grep -rn "\.target\b" src/ tests/ docs/ scripts/ --include=*.py --include=*.md | grep -v target_level
grep -rn '== *"bezier"\|== *"lagrange"\|== *"cardinal"\|"bezier" *==\|in ("bezier"\|in \["bezier"' src/ tests/ docs/ scripts/
```

The second returns six lines, all in `tests/test_bspline_space_1D.py:1738-1770`. **They are
not affected**: `extraction_type` there is a test-local `parametrize` string that selects
which `BsplineSpace1D.tabulate_*_extraction_operators` method to call
(`tests/test_bspline_space_1D.py:1737-1743`). It never touches
`SpanwiseElementExtraction`, and this PR does not change those methods.

**Outside pantr: I cannot establish it, and nothing in this repository can.** The
not-yet-public consumer is where `pantr.bspline` has its largest exposure and pantr's CI
cannot see it. The census that settles it is these three greps in that repository:

```
grep -rn "\.target\b"                                   # any read at all
grep -rn "SpanwiseElementExtraction\|MultiLevelExtraction"
grep -rn "from pantr.bspline.spanwise_element_extraction import\|_extraction_helpers\|_extraction_kernels"
```

A read that goes into an `f`-string, a `repr`, a dict key, or a `==` against a string is the
breaking set. A read passed straight back into a constructor, compared with `is`, or ignored
is unaffected. **This slice should not merge until that has been run**; if it comes back with
a string comparison, reverting the two property return types is a two-line change and the
enum survives for the seam, which is what it is actually for.

## Does the input compatibility have a matching guarantee on the output?

**No, deliberately, and there is no mechanism that would provide one without a worse
defect.** The input side is free -- `_coerce_target` accepts either spelling and resolves
once -- because a coercion at a boundary costs nothing. The output side is not symmetric,
and here is why each candidate fails. All three verdicts are measured, not argued.

**1. An enum deriving from `str` as well as `int` does not exist.** CPython refuses the
declaration outright:

```
class Both(str, int, Enum): ...
TypeError: too many data types for 'Both': {<class 'str'>, <class 'int'>}
```

So the shape that would give both properties at once is not available to choose.

**2. `StrEnum` -- the spelling `LagrangeVariant` already uses -- forfeits the property the
enum exists for, and does it silently.** Measured (numba **0.65.1**, CPython 3.14.6), with a
two-member `StrEnum` `SE`:

| expression inside `@nb_jit(nopython=True)` | `SE.A` | `SE.B` | `"a"` | `"b"` |
|---|---|---|---|---|
| `x == SE.B` (compare against the captured member) | False | **False** | False | False |
| `x == "b"` (compare against a literal) | False | True | False | True |

`numba.typeof(SE.B)` is `unicode_type`, and a member round-trips as its bare string. So the
natural spelling -- capture the member, compare against it -- **compiles cleanly and is dead
in every branch**, with nothing raised. Not "Numba refuses a `StrEnum`", which is what I
expected before measuring: it accepts it and answers wrongly. A kernel written that way could
not be caught by any test of that kernel. `design/cross_backend_types.md`'s seam table
independently refuses "enums as strings", so `StrEnum` loses on both of the enum's two
reasons.

**3. Keeping the `IntEnum` and bolting string equality onto it breaks equality itself.**
Measured, with `__eq__` extended to accept the legacy spelling:

```
T.BEZIER == 0          True
T.BEZIER == "bezier"   True
0 == "bezier"          False          <- equality is no longer transitive
hash(T.BEZIER) == hash("bezier")   False
d = {"bezier": 1}; d[T.BEZIER]     KeyError   <- equal to the key, unusable as the key
```

An `IntEnum` member is *already* equal to its integer, so adding string equality makes it
equal to two things that are not equal to each other. And the hash cannot follow both. That
does not remove the silent failure, it relocates it into a place with no `__eq__` left to
blame -- a dict keyed by the legacy string quietly missing.

**So the asymmetry is the honest position.** Input accepts both spellings because it can;
output returns the member because every mechanism for returning something string-equal is
either impossible, silently wrong inside a kernel, or silently wrong in a dict. What the
change owes instead is that the break be **loud in review rather than at runtime** -- which
is the census above, and the reason the two property return types are the smallest possible
revert if it comes back badly.

One consequence worth recording separately: **`LagrangeVariant` is a `StrEnum`**
(`src/pantr/basis/_basis_tabulate.py:30`). Verified by reading, it reaches no `nopython`
function today -- the only module holding both it and a kernel is `_bspline_extraction.py`,
where it appears at `:252` and `:261-262`, inside the Layer-2 helper and not inside either
jitted function (`:33`, `:133`). So there is no bug. But nothing *stops* it, and by the table
above the first author to branch on a variant inside a kernel gets a dead branch and no
diagnostic. That wants its own ticket rather than a fix here; it is argued in
`design/extraction_port.md`'s flagged-practices section.

---

# Scope note

This branch is `proto/cpp` at `43453c0` plus **this one commit**. The design note and the C++
extraction kernels that were briefly pushed here have been moved to **#426**, which is based on
`proto/cpp` directly and is independent of this one — so the review of this slice is against the
same commit it always was (`1d2682c`), and the two can merge in either order.

Rebased onto `43453c0` (which brought #422's two design notes and #423/#378) and the extension
rebuilt afterwards. Re-verified on the rebased tree: `pytest -n 4` **8502 passed, 45 skipped,
7 xfailed**; `ruff check`, `ruff format --check`, `mypy src tests scripts` (300 files),
`lint-imports` (2 contracts kept) all clean.

`scripts/ci_local.sh`, every leg: all PASS except the two `g++-10` floor legs, which fail in
`<charconv>` on `std::chars_format` — the pre-existing #376 failure. `clang++-10` configures,
builds under `-Werror` and passes ctest on the same tree, which is what identifies the floor
failure as #376 rather than this branch.

**The docs build is red on `proto/cpp` already and this change does not add to it.** Built
`proto/cpp` and this branch in separate worktrees, both under `-W --keep-going`: **32 warnings
each, and the two warning sets are identical**. All 32 are `:class:` roles pointing at private
port-scaffolding names (`_AABBPython`, `_BVHPython`, `_CellTagsPython`, `_PartitionPython`,
`_QuadratureRulePython`, `_AffineTransformPython`, `_Impl`, `_impl_class`) plus
`pantr.quad._rule_nd` and `CellTags.__iter__`. Reported rather than fixed: the root cause is
understood but it spans eight files this slice does not touch, and the fix is a `nitpick_ignore`
policy call. The one warning this change *did* add (a `:class:` role on the private
`pantr._backend.Backend`) is fixed here, using the double-backtick form `docs/conf.py` already
prescribes for a private class.
