### PR TITLE
refactor(bspline): retire the process-global unique-knot cache

### DIFF
--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -37,45 +37,6 @@ from ._bspline_knots import (
 )
 
 
-@functools.lru_cache(maxsize=128)
-def _cached_unique_knots_and_multiplicity(
-    knots_repr: tuple[bytes, str, int],
-    degree: int,
-    tol: float,
-    in_domain: bool = False,
-) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
-    """Compute unique knots and multiplicities with memoization.
-
-    The cache is bounded to prevent unbounded memory growth in long-running
-    applications that construct many distinct spline spaces.  128 entries is
-    generous for real-world use (an adaptive simulation rarely needs more than
-    a few dozen distinct knot vectors) while still eliminating the risk of a
-    memory leak.
-
-    Args:
-        knots_repr (tuple[bytes, str, int]): Serialized knot vector bytes, dtype string, and size.
-        degree (int): B-spline degree.
-        tol (float): Tolerance value.
-        in_domain (bool): Whether to restrict to the spline domain.
-
-    Returns:
-        tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
-            Unique knots and corresponding multiplicities.
-    """
-    knots_bytes, dtype_str, size = knots_repr
-    dtype = np.dtype(dtype_str)
-    knots = np.frombuffer(knots_bytes, dtype=dtype, count=size).copy()
-    # ``tol`` goes in unrounded, exactly as ``BsplineSpace1D._snap_knots`` passes it, so
-    # the space and its own accessor apply one predicate rather than two that differ in
-    # the last bits of the threshold.
-    unique, mults = _get_unique_knots_and_multiplicity_impl(knots, degree, tol, in_domain)
-    # The same arrays are returned to every caller; freeze them so a caller
-    # mutation cannot poison the cache.
-    unique.flags.writeable = False
-    mults.flags.writeable = False
-    return unique, mults
-
-
 class BsplineSpace1D:
     """A class representing a 1D B-spline with configurable degree and knot vector.
 
@@ -315,12 +276,22 @@ class BsplineSpace1D:
         Returns:
             tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[numpy.intp]]: Tuple of
             (unique_knots, multiplicities) where unique_knots contains the distinct knot values
-            and multiplicities contains the corresponding multiplicity counts.
+            and multiplicities contains the corresponding multiplicity counts. Both arrays are
+            read-only, and a fresh pair is returned by each call.
         """
-        knots_repr = (self._knots.tobytes(), self._knots.dtype.str, int(self._knots.size))
-        degree = int(self._degree)
-        tol = float(self._tol)
-        return _cached_unique_knots_and_multiplicity(knots_repr, degree, tol, in_domain)
+        # ``tol`` goes in unrounded, exactly as :meth:`_snap_knots` passes it, so the
+        # space and its own accessor apply one predicate rather than two that differ
+        # in the last bits of the threshold.
+        unique, mults = _get_unique_knots_and_multiplicity_impl(
+            self._knots, self._degree, self._tol, in_domain
+        )
+        # Frozen because callers treat the result as the space's own report of its
+        # knot classes: :meth:`_first_basis_per_interval_cached` derives a cached
+        # array from it, and the C++ owner this port introduces will hand out a
+        # ``const`` view of storage it owns rather than a copy.
+        unique.flags.writeable = False
+        mults.flags.writeable = False
+        return unique, mults
 
     @functools.cached_property
     def num_intervals(self) -> int:

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -49,7 +49,6 @@ from pantr.bspline._bspline_knots import (
     _get_unique_knots_and_multiplicity_impl,
     _is_in_domain_impl,
 )
-from pantr.bspline._bspline_space_1d import _cached_unique_knots_and_multiplicity
 from pantr.change_basis import compute_lagrange_to_bernstein_1d
 from pantr.tolerance import get_strict
 
@@ -157,20 +156,51 @@ class TestBsplineSpace1DProperties:
         with pytest.raises(ValueError):
             spline.knots[0] = 99.0
 
-    def test_unique_knots_cache_is_bounded(self) -> None:
-        """Test that the knot-multiplicity cache has a finite maxsize.
+    def test_no_process_global_knot_cache(self) -> None:
+        """No process-global cache stands between a space and its knot scan.
 
-        An unbounded cache (functools.cache) would leak memory in long-running
-        applications that construct many distinct spline spaces.  Switching to
-        lru_cache(maxsize=N) ensures old entries are evicted when the cache is
-        full.
+        A process-global ``lru_cache`` stood here until this port. It was bounded,
+        so it did not leak, but its key omitted the backend -- the exact omission
+        ``pantr._backend.backend_keyed_cache`` was introduced to repair for a
+        sibling, where the first backend to fill an entry served every later caller
+        and a parity test compared one result against itself. The knot scan is about
+        to acquire a second implementation, which is when that becomes live, so the
+        cache goes before the dispatch does rather than after.
+
+        The replacement is ownership, not a better key: the derived knot classes
+        belong to the space, are computed once per space, and need no key at all.
         """
-        info = _cached_unique_knots_and_multiplicity.cache_info()
-        assert info.maxsize is not None, (
-            "_cached_unique_knots_and_multiplicity must use lru_cache with a "
-            "finite maxsize, not functools.cache, to avoid unbounded memory growth."
+        from pantr.bspline import _bspline_space_1d  # noqa: PLC0415
+
+        # ``cache_info`` is the public surface every ``functools`` memoizer exposes,
+        # so this catches ``cache`` and ``lru_cache`` alike without naming the
+        # private wrapper type the check would otherwise be pinned to.
+        cached = [
+            name
+            for name, value in vars(_bspline_space_1d).items()
+            if callable(value) and hasattr(value, "cache_info")
+        ]
+        assert not cached, (
+            f"{cached} are process-global caches in _bspline_space_1d. A cache with no "
+            "owner has no bound tied to anything and its key cannot see the active "
+            "backend; memoize on the space instead."
         )
-        assert info.maxsize > 0
+
+    def test_unique_knots_and_multiplicity_are_read_only(self) -> None:
+        """Both returned arrays are frozen, so a caller cannot rewrite a space's report.
+
+        ``_first_basis_per_interval_cached`` derives a cached array from the
+        multiplicities, and the C++ owner hands out a ``const`` view of storage it
+        owns; a writable result would make those two disagree about one space.
+        """
+        spline = BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0], 2)
+        unique, mults = spline.get_unique_knots_and_multiplicity()
+        assert not unique.flags.writeable
+        assert not mults.flags.writeable
+        with pytest.raises(ValueError):
+            unique[0] = 99.0
+        with pytest.raises(ValueError):
+            mults[0] = 99
 
     def test_periodic_property(self) -> None:
         """Test periodic property."""


### PR DESCRIPTION
## What this is

Slice 1 of 4 for #396 (`feat(bspline): own BsplineSpace1D and BsplineSpace in C++`).
Python only: no C++, no binding, no behaviour change a caller can see. It lands first
because `BsplineSpace1D` is named in **53 of the 112 top-level test files** (re-counted on
this tree, `grep -rln BsplineSpace1D tests/*.py | wc -l`), so the front wants a small,
reversible first step through that blast radius before any of it moves.

## The change

`_cached_unique_knots_and_multiplicity` was a module-level `lru_cache(128)` over the
knot-class scan, keyed on `(knots.tobytes(), dtype.str, size)`. It is deleted and the
accessor scans directly, freezing both returned arrays.

Two reasons, in the order that decides it.

**It carries the omission `pantr._backend.backend_keyed_cache` already exists to repair.**
That helper's docstring records the measured failure for a sibling cache: the key omitted
the backend, so the first backend to fill an entry served every later caller, and a parity
test was handed the same object twice and reported agreement it never measured. This key has
the same shape and the same omission. It is *not* live today, because
`_get_unique_knots_and_multiplicity_impl` has exactly one implementation. It becomes live
the moment that scan acquires a C++ one, which is this ticket's whole point — so the cache
goes **ahead of** the dispatch rather than after it. The other order gives a parity test
that cannot fail.

**What it bought was a constant factor, not an order.** A cache *hit* builds an O(n)
`tobytes` key, hashes a never-before-seen `bytes`, and compares it against the stored key,
so it cannot be much cheaper than the scan it replaces. `design/bspline_derived_caches.md`
F5 measures 1.4x to 3.2x across four sizes, against a kernel whose cost at eleven knots is
numba dispatch rather than work. The replacement is ownership rather than a better key: the
derived knot classes belong to the space, are computed once per space, and need no key.

## Verification

Everything below was run in the `pantr` env on this branch.

| check | result |
|---|---|
| `ruff check .` / `ruff format --check .` | clean, whole repo |
| `mypy --config-file mypy.ini src tests scripts` | no issues in 300 source files |
| `lint-imports` | 2 contracts kept, 0 broken |
| `make doctest` | 82 passed, 7 skipped |
| `pytest -n 4` (full suite) | **6327 passed, 2182 skipped, 3 xfailed** |
| `bash scripts/ci_local.sh` (full, every leg) | every line PASS except the two `g++-10` floor legs |

The two `g++-10` floor legs fail on `std::to_chars(..., double, std::chars_format)`, which
libstdc++ 10 does not provide. That is #376, it is pre-existing, and `clang++-10` passes on
the same tree, which is what identifies it as #376 rather than as this branch.

### Mutation check

Both new tests were checked to fail against the behaviour they pin, not merely to pass:

- re-adding an `lru_cache`-wrapped function to `_bspline_space_1d` →
  `test_no_process_global_knot_cache` **FAILED** at the assertion;
- deleting the two `flags.writeable = False` lines →
  `test_unique_knots_and_multiplicity_are_read_only` **FAILED** at the assertion.

Both pass with the change as committed.

### A flake to be aware of, not caused here

`tests/test_sweep_regressions.py::test_reduce_degree_terminates_on_a_periodic_linear_spline`
budgets 2 s of wall clock for a call that should raise immediately. It failed once on a
**cold numba cache** under load from the other agents on this box, and passed in isolation
and on every warm run. Matched warm runs of the same four files: 8.68 s on this branch
against 13.20 s on the merge base, so the removal is not what pressed it. Recorded rather
than filed.

## Proposed decomposition of #396

Written here rather than filed: filing is the owner's call. Four slices, within the
ticket's 3-to-5 estimate.

1. **this PR** — retire the process-global unique-knot cache. Python only.
2. **`feat(bspline): own BsplineSpace1D in C++`** — the header, its free functions over a
   knot span, and the C++ unit tests. No binding and no Python. Carries the `LazySlot`
   double-checked-locking memo `design/bspline_derived_caches.md` asks this ticket to
   establish, and the thread-sanitizer leg that is the only gate able to see a race in it.
3. **`feat(bspline): bind BsplineSpace1D and wrap it from Python`** — the binding at both
   widths, the wrapper/oracle split, `__reduce__`, and the parity and binding-contract
   tests.
4. **`feat(bspline): own, bind and wrap BsplineSpace in C++`** — the aggregate, the
   `shared_ptr<const BsplineSpace1D>` held accessor and the seeding rule from
   `design/bspline_ownership_lifetime.md`, plus `BsplineSpaceRestriction`.

## The downstream-consumer check this slice owes

`_cached_unique_knots_and_multiplicity` was **private and module-level**, and the only
in-tree importer was one test, which this PR rewrites. `pantr.bspline` is the not-yet-public
consumer's largest exposure and pantr's CI cannot see it, so **the census is owed on that
one name before this merges**. Nothing public changes: `get_unique_knots_and_multiplicity`
keeps its signature, its return shape and its read-only arrays.

Two related questions that slice 3 will need answered and that are cheaper to ask once:

- does that consumer call `BsplineSpace1D.get_unique_knots_and_multiplicity` in a loop over
  one space? That is the single place this removal could be felt as a regression rather
  than as a cleanup, and `design/bspline_derived_caches.md` records it as not investigated.
- does it read any of `_knots`, `_degree`, `_tol`, `_periodic` or `_spaces`? In this tree
  every one of those is read only inside the two modules that define them, so the wrapper
  split in slices 3 and 4 is free in-tree; outside it is not checkable from here.

## Not in this PR, and flagged rather than done

`CLAUDE.md`'s Performance notes say "change-of-basis matrices and unique knots are cached to
avoid recomputation across calls". After this PR that is no longer how unique knots work.
The file is the owner's and one of its lines is already under review, so the sentence is
left alone and named here.

Advances #396. `Closes` is deliberately absent: this PR bases on `proto/cpp`, where it would
not fire.
