### PR TITLE
refactor(grid): close the seams the type port opened

### DIFF
--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -102,8 +102,12 @@ class is a wrapper around it. The nine, by the module that exports them:
   :class:`~pantr.grid.BVH`, :class:`~pantr.grid.CellTags`,
   :class:`~pantr.grid.FacetTags` and :class:`~pantr.grid.Partition`.
 
-:class:`pantr.grid.HierarchicalGrid` is the one domain type in those modules that has
-not moved: it is the Python implementation under either backend.
+Two domain types in those modules have **not** moved, and both are deliberate rather
+than pending: :class:`pantr.grid.HierarchicalGrid`, which is the Python implementation
+under either backend until its own ticket, and :class:`pantr.quad.PointsLattice`, which
+``design/cross_backend_types.md`` rules out of the port with four recorded reasons. The
+rest of what these modules export is not a candidate either way -- ``Grid`` is a
+:class:`typing.Protocol` and ``GridRestriction`` is a result record.
 
 **This list was wrong for two releases and that is worth a sentence.** It said three
 modules and named neither half of ``bezier`` while both were merged and dispatching.

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -80,14 +80,8 @@ in which those kernels are C++ and everything else is unchanged.
 * :mod:`pantr.change_basis` -- all eight builders.
 * :mod:`pantr.bezier` -- the arithmetic and the root finding, through two
   catalogues rather than one because they are two ports with two parity claims;
-  and, since FELIGN/pantr#385, the :class:`~pantr.bezier.Bezier` **value type**.
-  That last one is a different kind of entry from every other line here. A
-  catalogue decides which code computes; a ported type decides which object holds
-  the state, so under ``PANTR_BACKEND=cpp`` a Bézier's control points live in C++
-  and the Python class is a wrapper around them. Two types moved that way before
-  it -- :class:`pantr.geometry.AABB` and :class:`pantr.transform.AffineTransform`
-  -- and this list still does not name them, which is the drift the paragraph
-  below is about, caught again.
+  and the :class:`~pantr.bezier.Bezier` **value type**, which is a different kind
+  of entry and is listed with the other ported types below.
   **Interpolation is deliberately not ported**, and
   ``design/bezier_interpolation_port.md`` is where that ruling and its measurements
   live; it is worth reading before proposing any further port, because it is the
@@ -95,10 +89,28 @@ in which those kernels are C++ and everything else is unchanged.
 * :mod:`pantr.grid` -- all nine kernels: tensor-product point location, the BVH's
   build and its two query passes, and the five hierarchical addressing kernels.
 
+**Nine types have moved as well, and that is a different kind of entry.** A
+catalogue decides which code computes; a ported type decides which object holds the
+state, so under ``PANTR_BACKEND=cpp`` the object's data lives in C++ and the Python
+class is a wrapper around it. The nine, by the module that exports them:
+
+* :mod:`pantr.geometry` -- :class:`~pantr.geometry.AABB`.
+* :mod:`pantr.transform` -- :class:`~pantr.transform.AffineTransform`.
+* :mod:`pantr.quad` -- :class:`~pantr.quad.QuadratureRule`.
+* :mod:`pantr.bezier` -- :class:`~pantr.bezier.Bezier`.
+* :mod:`pantr.grid` -- :class:`~pantr.grid.TensorProductGrid`,
+  :class:`~pantr.grid.BVH`, :class:`~pantr.grid.CellTags`,
+  :class:`~pantr.grid.FacetTags` and :class:`~pantr.grid.Partition`.
+
+:class:`pantr.grid.HierarchicalGrid` is the one domain type in those modules that has
+not moved: it is the Python implementation under either backend.
+
 **This list was wrong for two releases and that is worth a sentence.** It said three
 modules and named neither half of ``bezier`` while both were merged and dispatching.
-Nothing checks a prose list, so it drifts silently; if you port a module, the change
-is not finished until this paragraph names it.
+It was then wrong again through the type epic, naming one of the nine types above and
+saying so in the entry for it rather than fixing itself. Nothing checks a prose list,
+so it drifts silently; if you port a module or a type, the change is not finished
+until this paragraph names it.
 
 **Reading a change_basis result needs one more fact than the others.** Its
 builders take their nodes from :mod:`pantr.quad`, so a call under

--- a/src/pantr/grid/__init__.py
+++ b/src/pantr/grid/__init__.py
@@ -12,13 +12,22 @@ neighbours, and ids on demand. The only ``O(num_cells)`` structure -- a
 :meth:`~Grid.query_aabb`, so a grid used purely as a B-spline's knot grid stays
 proportional to its breakpoints, not its cell count.
 
+Five of the types here are owned by the C++ core since the 2026-08-27 amendment to
+``design/cross_backend_types.md``, and the classes below are wrappers holding one:
+:class:`TensorProductGrid`, :class:`BVH`, :class:`CellTags`, :class:`FacetTags` and
+:class:`Partition`. Under ``PANTR_BACKEND=python`` each holds the pre-port Python
+class instead, which is the port's oracle and is temporary.
+:class:`HierarchicalGrid` has not moved: it is the Python implementation under
+either backend.
+
 Main exports:
 
 - :class:`Grid`: the grid contract, as a :class:`typing.Protocol` -- satisfied
   structurally, and carrying axis-aligned box defaults for facets, neighbours,
   reference maps, batch point location, and spatial queries. A consumer
-  annotates ``grid: Grid``; an implementer derives from the private
-  ``_GridPython``, which is where the five primitives are enforced.
+  annotates ``grid: Grid``; an implementer in Python derives from the private
+  ``_GridPython``, which is where the five primitives are enforced, and an
+  implementer in C++ satisfies the matching concept.
 - :class:`GridRestriction`: result of :meth:`Grid.restrict` -- a windowed
   sub-grid plus local-to-global cell index maps.
 - :class:`TensorProductGrid`: concrete tensor-product grid of axis-aligned boxes

--- a/src/pantr/grid/_cell_quadrature.py
+++ b/src/pantr/grid/_cell_quadrature.py
@@ -12,6 +12,26 @@ to that cell's volume and ``sum_i w_i f(x_i)`` approximates the integral of
 This is the uncut/background-cell quadrature bridge: a downstream consumer takes
 this rule for interior cells and substitutes its own cut-cell rule on cells
 flagged as cut.
+
+No C++ counterpart, and why
+---------------------------
+
+Both operands are owned by the C++ core since the 2026-08-27 amendment to
+``design/cross_backend_types.md``: under ``PANTR_BACKEND=cpp`` the cell bounds come
+from ``pantr::grid::TensorProductGrid`` and the reference points and weights from
+``pantr::quad::QuadratureRule``. So this function already *runs on* the port; what
+is still written here is the push-forward itself, one broadcast ``lo + span * u``
+and one product of the span.
+
+Moving those two lines is a port and not a re-pointing, which is why it is not done
+here. C++ is licensed to contract ``lo + span * u`` into a fused multiply-add where
+the target ISA has one and numpy is not, so the two backends would stop agreeing
+bitwise and the gap would have to be bounded rather than asserted away -- a parity
+claim of its own, on a quantity the whole immersed-quadrature path is built on.
+
+It should eventually move, and that is recorded so this is not mistaken for a
+ruling that it never should: a C++ program links pantr with no interpreter present,
+and such a consumer holding a grid and a rule has nothing to call.
 """
 
 from __future__ import annotations

--- a/src/pantr/grid/_cell_quadrature.py
+++ b/src/pantr/grid/_cell_quadrature.py
@@ -16,12 +16,16 @@ flagged as cut.
 No C++ counterpart, and why
 ---------------------------
 
-Both operands are owned by the C++ core since the 2026-08-27 amendment to
-``design/cross_backend_types.md``: under ``PANTR_BACKEND=cpp`` the cell bounds come
-from ``pantr::grid::TensorProductGrid`` and the reference points and weights from
-``pantr::quad::QuadratureRule``. So this function already *runs on* the port; what
-is still written here is the push-forward itself, one broadcast ``lo + span * u``
-and one product of the span.
+This function already *runs on* the port under ``PANTR_BACKEND=cpp``, and what
+reaches it from C++ depends on the grid, because ``grid`` is the
+:class:`~pantr.grid.Grid` protocol rather than one class. The reference points and
+weights always come from ``pantr::quad::QuadratureRule``, a ported type. The cell
+bounds come from ``pantr::grid::TensorProductGrid``'s own ``collect_cell_bounds``
+for a tensor-product grid, and from the ``pantr::grid::hier_collect_cell_bounds``
+*kernel* for a :class:`~pantr.grid.HierarchicalGrid`, which is not a ported type and
+reaches C++ through the kernel catalogue instead. Either way, what is still written
+here is the push-forward itself, one broadcast ``lo + span * u`` and one product of
+the span.
 
 Moving those two lines is a port and not a re-pointing, which is why it is not done
 here. C++ is licensed to contract ``lo + span * u`` into a fused multiply-add where

--- a/tests/test_grid_cell_quadrature.py
+++ b/tests/test_grid_cell_quadrature.py
@@ -240,6 +240,12 @@ class TestCppOwnedOperands:
         would pass just as well on the Python oracle -- and that the composition over them
         is still exact where it has to be. Gauss-Legendre with three points per direction
         is exact to degree five, so the integral is an oracle independent of the grid.
+
+        ``rtol=1e-12`` is this file's existing constant rather than a new one, and what
+        it has to cover is round-off alone: the rule is exact for this integrand in
+        exact arithmetic, so the residual is the summation error over
+        ``num_cells * num_points`` terms, bounded by roughly ``n * eps`` -- of order
+        ``1e-14`` here. The constant leaves about two orders of margin over that.
         """
         del cpp_backend
         from pantr import _pantr_cpp  # noqa: PLC0415  (absent without the compiled extension)

--- a/tests/test_grid_cell_quadrature.py
+++ b/tests/test_grid_cell_quadrature.py
@@ -234,8 +234,8 @@ class TestCppOwnedOperands:
 
         ``cell_quadrature`` has no backend branch of its own: it reads
         ``grid.collect_cell_bounds()`` and the rule's ``points`` and ``weights``, and each
-        of those is forwarded to whichever implementation the wrapper holds. So the thing
-        worth pinning is that under the C++ backend the operands really are the C++ ones
+        of those is answered by whatever the grid and the rule resolve to. So the thing
+        worth pinning is that under the C++ backend those operands really are the C++ ones
         -- asserted on the implementation classes, because every value assertion below
         would pass just as well on the Python oracle -- and that the composition over them
         is still exact where it has to be. Gauss-Legendre with three points per direction

--- a/tests/test_grid_cell_quadrature.py
+++ b/tests/test_grid_cell_quadrature.py
@@ -7,6 +7,7 @@ import numpy.testing as nptest
 import numpy.typing as npt
 import pytest
 
+from pantr._backend import Backend, use_backend
 from pantr.grid import (
     Grid,
     TensorProductGrid,
@@ -15,6 +16,18 @@ from pantr.grid import (
     uniform_grid,
 )
 from pantr.quad import QuadratureRule, gauss_legendre_quadrature
+from tests._parity_harness import demand_cpp_backend
+
+
+@pytest.fixture
+def cpp_backend() -> None:
+    """Require the compiled extension for the test that switches to the C++ backend.
+
+    Routed through the parity harness rather than a bare ``skipif``: a bare skip is
+    silent, and a suite that skips its way to green has let real failures through in
+    this repository.
+    """
+    demand_cpp_backend()
 
 
 def _grid_2d() -> TensorProductGrid:
@@ -211,3 +224,35 @@ class TestRuleConstruction:
         pts, w = cell_quadrature(grid, rule)
         nptest.assert_allclose(pts[0, 0], [1.0, 1.0])
         nptest.assert_allclose(w[0, 0], 4.0)
+
+
+class TestCppOwnedOperands:
+    """The composition runs on a C++-owned grid and a C++-owned rule."""
+
+    def test_maps_a_cpp_rule_onto_a_cpp_grid(self, cpp_backend: None) -> None:
+        """Both operands are the C++ implementations, and the mapped rule still integrates.
+
+        ``cell_quadrature`` has no backend branch of its own: it reads
+        ``grid.collect_cell_bounds()`` and the rule's ``points`` and ``weights``, and each
+        of those is forwarded to whichever implementation the wrapper holds. So the thing
+        worth pinning is that under the C++ backend the operands really are the C++ ones
+        -- asserted on the implementation classes, because every value assertion below
+        would pass just as well on the Python oracle -- and that the composition over them
+        is still exact where it has to be. Gauss-Legendre with three points per direction
+        is exact to degree five, so the integral is an oracle independent of the grid.
+        """
+        del cpp_backend
+        from pantr import _pantr_cpp  # noqa: PLC0415  (absent without the compiled extension)
+
+        with use_backend(Backend.CPP):
+            grid = TensorProductGrid([[0.0, 1.0, 3.0], [0.0, 0.5, 2.5]])
+            rule = gauss_legendre_quadrature(2, 3)
+            assert type(grid._impl) is _pantr_cpp.TensorProductGrid
+            assert type(rule._impl) is _pantr_cpp.QuadratureRule
+
+            pts, w = cell_quadrature(grid, rule)
+
+        # int over [0, 3] x [0, 2.5] of x^2 y^3 = (3^3 / 3) * (2.5^4 / 4).
+        f = pts[..., 0] ** 2 * pts[..., 1] ** 3
+        nptest.assert_allclose(float((w * f).sum()), 9.0 * 2.5**4 / 4.0, rtol=1e-12)
+        nptest.assert_allclose(w.sum(axis=1), _cell_volumes(grid), rtol=1e-12)

--- a/tests/test_grid_overlay.py
+++ b/tests/test_grid_overlay.py
@@ -6,7 +6,20 @@ import numpy as np
 import numpy.testing as nptest
 import pytest
 
+from pantr._backend import Backend, use_backend
 from pantr.grid import TensorProductGrid, overlay, uniform_grid
+from tests._parity_harness import demand_cpp_backend
+
+
+@pytest.fixture
+def cpp_backend() -> None:
+    """Require the compiled extension for the test that switches to the C++ backend.
+
+    Routed through the parity harness rather than a bare ``skipif``: a bare skip is
+    silent, and a suite that skips its way to green has let real failures through in
+    this repository.
+    """
+    demand_cpp_backend()
 
 
 def test_overlay_union_1d() -> None:
@@ -172,3 +185,29 @@ def test_overlay_non_grid_input_raises() -> None:
     grid = uniform_grid([[0.0, 1.0]], 2)
     with pytest.raises(TypeError, match="TensorProductGrid"):
         overlay(grid, object())  # type: ignore[arg-type]
+
+
+def test_overlay_runs_on_cpp_backed_grids(cpp_backend: None) -> None:
+    """Overlay's ``isinstance`` gate admits a grid whose implementation is the C++ one.
+
+    ``overlay`` opens with ``isinstance(grid, TensorProductGrid)`` on both arguments and
+    refuses anything else, so under the C++ backend that gate is the whole of the port's
+    exposure here. Asserting the call returned is not enough on its own: a grid that had
+    quietly stayed on the Python oracle would pass the same gate and say nothing about
+    the port, which is why the implementation class is asserted on the inputs *and* on
+    the result. ``test_overlay_non_grid_input_raises`` is the other half -- it pins that
+    the gate still rejects, so this one cannot pass by the gate having been deleted.
+    """
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (absent without the compiled extension)
+
+    with use_backend(Backend.CPP):
+        grid_a = uniform_grid([[0.0, 1.0]], 2)
+        grid_b = uniform_grid([[0.0, 1.0]], 3)
+        assert type(grid_a._impl) is _pantr_cpp.TensorProductGrid
+        assert type(grid_b._impl) is _pantr_cpp.TensorProductGrid
+
+        result = overlay(grid_a, grid_b)
+
+        assert type(result._impl) is _pantr_cpp.TensorProductGrid
+        nptest.assert_allclose(result.breakpoints[0], [0.0, 1.0 / 3.0, 0.5, 2.0 / 3.0, 1.0])

--- a/tests/test_partition_grid.py
+++ b/tests/test_partition_grid.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._backend import Backend, use_backend
 from pantr.grid import (
     Partition,
     hierarchical_grid,
@@ -16,6 +17,18 @@ from pantr.grid import (
     uniform_grid,
 )
 from pantr.grid._partition_grid import _divisors, _factor_blocks
+from tests._parity_harness import demand_cpp_backend
+
+
+@pytest.fixture
+def cpp_backend() -> None:
+    """Require the compiled extension for the tests that switch to the C++ backend.
+
+    Routed through the parity harness rather than a bare ``skipif``: a bare skip is
+    silent, and a suite that skips its way to green has let real failures through in
+    this repository.
+    """
+    demand_cpp_backend()
 
 
 def _cell_multi_indices(cells_per_axis: tuple[int, ...]) -> npt.NDArray[np.intp]:
@@ -278,9 +291,24 @@ def test_rcb_n_parts_exceeds_active_with_mask_raises() -> None:
 
 
 def test_auto_uses_block_for_tp_feasible() -> None:
+    """``auto`` returns the ``block`` answer on a feasible tensor-product grid.
+
+    Two parts rather than four, and the reason is that four could not show this. On a
+    4x4 grid split four ways, ``block`` and ``rcb`` return the *same* owner array, so
+    the comparison passed whichever branch ``auto`` took -- including the fall-through
+    that runs when ``isinstance(grid, TensorProductGrid)`` fails. Two parts make the two
+    disagree, and the disagreement is asserted first so the case cannot go quietly
+    vacuous again. The 2x2 factorization four parts exercised is pinned against a
+    hand-computed array by ``test_block_2d_four_parts``.
+    """
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
-    auto = partition_grid(grid, 4).cell_owner
-    block = partition_grid(grid, 4, backend="block").cell_owner
+    block = partition_grid(grid, 2, backend="block").cell_owner
+    rcb = partition_grid(grid, 2, backend="rcb").cell_owner
+    assert not np.array_equal(block, rcb), (
+        "block and rcb agree here, so comparing auto against block cannot tell which "
+        "branch auto took; pick a grid and part count where they differ"
+    )
+    auto = partition_grid(grid, 2).cell_owner
     np.testing.assert_array_equal(auto, block)
 
 
@@ -429,3 +457,55 @@ def test_factor_blocks_tie_only_contract() -> None:
 def test_factor_blocks_infeasible_raises() -> None:
     with pytest.raises(ValueError, match="cannot factor"):
         _factor_blocks((4, 4), 7)
+
+
+# --------------------------------------------------------------------------- #
+# The C++ backend reaches both TensorProductGrid dispatch sites
+# --------------------------------------------------------------------------- #
+
+
+def test_auto_takes_the_block_branch_on_a_cpp_backed_grid(cpp_backend: None) -> None:
+    """``auto`` dispatches to ``block`` when the grid's implementation is the C++ one.
+
+    This is the dispatch site that fails silently. ``auto`` tests
+    ``isinstance(grid, TensorProductGrid)`` and falls through to ``rcb`` when it fails,
+    and ``rcb`` returns a perfectly valid partition of the same grid -- so a wrapper the
+    check missed still produces an answer, and a test that only called the function
+    would pass. The branch is pinned by making the two backends disagree first and then
+    asserting which of the two answers came back.
+    """
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (absent without the compiled extension)
+
+    with use_backend(Backend.CPP):
+        grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
+        assert type(grid._impl) is _pantr_cpp.TensorProductGrid
+
+        block = partition_grid(grid, 2, backend="block").cell_owner
+        rcb = partition_grid(grid, 2, backend="rcb").cell_owner
+        assert not np.array_equal(block, rcb), (
+            "block and rcb agree here, so this test cannot tell which branch auto took"
+        )
+
+        np.testing.assert_array_equal(partition_grid(grid, 2).cell_owner, block)
+
+
+def test_block_backend_accepts_a_cpp_backed_grid(cpp_backend: None) -> None:
+    """The ``block`` backend's own guard admits a grid implemented in C++.
+
+    The second dispatch site: ``_block_backend`` refuses anything that is not a
+    :class:`TensorProductGrid`, so under the C++ backend a wrapper it failed to
+    recognize would turn an ordinary call into a ``ValueError``.
+    ``test_block_on_non_tensor_product_grid_raises`` pins that the guard still rejects,
+    so the pair says the guard is live *and* lets the wrapper through.
+    """
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (absent without the compiled extension)
+
+    with use_backend(Backend.CPP):
+        grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
+        assert type(grid._impl) is _pantr_cpp.TensorProductGrid
+        owner = partition_grid(grid, 4, backend="block").cell_owner
+
+    i0, i1 = np.unravel_index(np.arange(16), (4, 4))
+    np.testing.assert_array_equal(owner, (i0 // 2) * 2 + (i1 // 2))


### PR DESCRIPTION
Closes FELIGN/pantr#388. Closed by hand: a closing keyword fires only for a pull
request merged into the default branch, and this one targets `proto/cpp`.

## What this closes, and the surprise in it

The three functions the ticket names -- `cell_quadrature`, `overlay` and
`partition_grid` -- **already run on the C++ pair**. They consume the public
`TensorProductGrid` and `QuadratureRule` classes, and since #383 and #387 those
*are* the wrappers: under `PANTR_BACKEND=cpp` the cell bounds come from
`pantr::grid::TensorProductGrid` and the reference points and weights from
`pantr::quad::QuadratureRule`. There was no adapter in these three files to delete,
because they were never backend-aware and never needed to be -- `isinstance(grid,
TensorProductGrid)` names the wrapper, and the wrapper is the only class a caller
ever holds.

So the seam was not in the code. **It was that nothing said so.** Every test in
these three files ran under the default Python backend, and the one test that
looked like it checked the dispatch could not:

`test_auto_uses_block_for_tp_feasible` compared `partition_grid(grid, 4)` against
`partition_grid(grid, 4, backend="block")` on a 4x4 grid. On that grid and that
part count **`block` and `rcb` return the same owner array**, so the comparison
passed whichever branch `auto` took -- including the fall-through that runs when
the `isinstance` check fails. That is exactly the failure `AC5` was written to
catch, sitting in the suite.

Six commits: the dispatch tests, the recorded answer to the `cell_quadrature.hpp`
conditional, a documentation correction, and three `self-review:` commits fixing
what a review round found in my own work. Nothing else under `src/pantr` changed.

**Two files here are outside the ticket's `Files & modules` list** and are called
out rather than slipped in: `src/pantr/_backend.py` and `src/pantr/grid/__init__.py`.
Both edits are prose only. The case for them is in the seam table below -- in short,
`_backend.py` states its own completion rule ("if you port a module, the change is
not finished until this paragraph names it") and the type epic left it unmet for
nine types, and `pantr.grid`'s package docstring was the only one of the two ported
packages that never said its types had moved. Back them out if you would rather they
went to #404.

## `AC5` -- the dispatch, asserted rather than assumed

Four tests, all gated on the compiled extension through `demand_cpp_backend` rather
than a bare `skipif`:

| test | site pinned |
|---|---|
| `test_grid_overlay.py::test_overlay_runs_on_cpp_backed_grids` | `_overlay.py:69` |
| `test_partition_grid.py::test_auto_takes_the_block_branch_on_a_cpp_backed_grid` | `_partition_grid.py:110` |
| `test_partition_grid.py::test_block_backend_accepts_a_cpp_backed_grid` | `_partition_grid.py:200` |
| `test_grid_cell_quadrature.py::TestCppOwnedOperands::test_maps_a_cpp_rule_onto_a_cpp_grid` | both operands' implementation class |

Each asserts the *implementation class* of every operand, because every value
assertion in them would pass just as well on the Python oracle.

For `_partition_grid.py:110` -- the only site with a silent fall-through -- the
branch is pinned by making `block` and `rcb` **disagree first** (4x4 grid, two
parts) and asserting the disagreement, then asserting which of the two answers came
back. `auto`'s only two outcomes are `_block_partition` and `_rcb_partition`, so a
result equal to one and unequal to the other identifies the branch, and the case
cannot go quietly vacuous again. `test_auto_uses_block_for_tp_feasible` is moved
onto the same footing.

The two guards that *raise* rather than fall through (`_overlay.py:69`,
`_partition_grid.py:200`) are pinned in both directions: these tests say the guard
admits a C++-backed wrapper, and the pre-existing `test_overlay_non_grid_input_raises`
and `test_block_on_non_tensor_product_grid_raises` say it still rejects, so neither
can pass by the guard having been deleted.

**A fourth site exists, and it is deliberately not pinned here.**
`grep -rn "isinstance(.*TensorProductGrid" src/pantr --include=*.py` returns four
sites: the three `AC5` names, plus `HierarchicalGrid.__init__`
(`_hierarchical_grid.py:394`). That one is a type guard that *raises*, not a silent
fall-through, and it is already exercised on a C++-backed root -- confirmed by
construction, `hierarchical_grid(uniform_grid(...), 2)` under `PANTR_BACKEND=cpp`
admits a root whose `_impl` is `pantr._pantr_cpp.TensorProductGrid`, and
`tests/test_grid_cell_quadrature.py::TestGenericGrid` does exactly that in the
suite. A dedicated pin belongs in `tests/test_grid_hierarchical.py`, which #395 is
rewriting; adding one here would collide with that branch for no coverage gained.

**Mutation check.**

*Mutant A -- the `auto` dispatch made blind to the wrapper (`elif False and ...`):*

| test | result |
|---|---|
| the **old** form of `test_auto_uses_block_for_tp_feasible`, on `pytest` | **passed** |
| the same, on `PANTR_BACKEND=cpp pytest` | **passed** |
| its new form | failed |
| `test_auto_takes_the_block_branch_on_a_cpp_backed_grid` | failed |

*Mutant B -- all three guards made to reject a C++-backed wrapper
(`not _python_backend_selected() or not isinstance(...)`):* a **default,
Python-backend** run of `tests/test_grid_overlay.py tests/test_partition_grid.py`
gives `3 failed, 106 passed`, and the three are exactly the three new dispatch
tests. Before this PR nothing in a default run would have noticed.

**Extension-skip check.** With `src/pantr/*.so` moved aside, the four tests **SKIP**
rather than pass: `128 passed, 4 skipped`, each naming `demand_cpp_backend`'s
message.

## `AC3` -- no conversion function

Command, run at this branch's head:

```
grep -rn '_AABBPython\|_AffineTransformPython\|_PartitionPython\|_CellTagsPython\|_FacetTagsPython\|_BVHPython\|_GridPython\|_TensorProductGridPython\|_QuadratureRulePython\|_BezierPython' src/pantr --include=*.py
```

**193 hits over 11 files.** Split by tokenizing each file, so that string and
comment tokens are separated from code rather than judged by eye:

| category | hits |
|---|---:|
| inside a docstring, comment or `TypeAlias` string | 95 |
| an annotation, or a body line of an oracle class returning another of itself | 61 |
| a `class _XPython:` header, or an import of one | 13 |
| inside an `_impl_class()` / `_cell_impl_class()` / `_facet_impl_class()` selector | 11 |
| a runtime `if`/`isinstance` branch | 13 |
| **total** | **193** |

Seven of the thirteen runtime branches are "which implementation am I building"
(`if cls is _XPython:` at `_bezier.py:296`, `geometry.py:564`, `geometry.py:955`,
`_bvh.py:724`, `_bvh.py:850`, `_partition.py:219`, and `if _impl_class() is
_TensorProductGridPython:` at `_tensor_product_grid.py:917`). The remaining six were
read in full:

| site | what it is |
|---|---|
| `geometry.py:229` | `_AABBPython.__eq__`'s own same-type guard |
| `transform.py:436` | `_AffineTransformPython.__matmul__`'s own same-type guard |
| `geometry.py:900` | `AABB.transform` picks a **call shape** on the implementation it already holds: the oracle takes the `_AffineMap` protocol, the C++ type takes matrix and offset arrays (the kernel-seam contract). Wraps the result of the same implementation. |
| `transform.py:729` | `inverse` is a property on the oracle and a method on the handle. |
| `transform.py:772` | `__call__`: the oracle takes array-likes; the C++ path needs its rank check before `ascontiguousarray`, for the reason the comment there records. |
| `_bezier.py:426` | inside `Bezier._mutate`, which **refuses** first (`TypeError` if the active implementation is not this Bézier's) and then rebuilds a handle of the **same** implementation from raw arrays. |

None takes an instance of one implementation and returns the other.

Every `__reduce__` in the ported types pickles **by value** -- raw arrays -- and
every `_rebuild_*` helper goes back through the public constructor, which
re-consults `_impl_class()` for whatever backend is active on read. That is
pickle-by-value, not conversion; it is also what lets a pickle written under one
backend load under the other, which several of these tickets asserted explicitly.

Three *refuse-rather-than-convert* guards exist and raise `TypeError` when objects
of two implementations meet, which is the shape the design asks for in place of a
conversion: `AABB._peer` (`src/pantr/geometry.py:638`), `AffineTransform._peer`
(`src/pantr/transform.py:663`) and `Bezier._mutate`'s guard
(`src/pantr/bezier/_bezier.py:419`).

**One honest qualifier on the criterion's own wording.** "returns only each
wrapper's own `_impl_class()` and `__init__` sites" undercounts the legitimate
categories: the grep also returns 95 docstring and annotation lines, the
`_wrap`/`_take`/`_rebuild_*` factory family, and the oracle classes' own method
bodies -- which cannot be otherwise while the Python backend exists. The operative
half -- *never a function that takes one implementation and returns the other* --
holds exactly, and that is what `design/cross_backend_types.md` forbids.

**And a dynamic check, because a grep cannot see a call path.** Under
`PANTR_BACKEND=cpp`, with `__new__` on all nine oracle classes replaced by a raise,
the three re-pointed entry points and the neighbours they reach through
(`collect_cell_bounds`, `cell_aabb`, `reference_map`, `cell_tags.set`,
`facet_tags.set`, `cell_bvh`, `restrict`, `query_aabb`) all complete with **no
oracle constructed**. The same script under `PANTR_BACKEND=python` fails on its
first call, so the probe is live rather than vacuous.

## `AC2` -- every seam this milestone introduced

Read from the twelve merged tickets' bodies and closing comments, then re-checked
against this tree by running the check named in the right-hand column.

**Removed before this PR** (each verified here, not taken on trust):

| seam | from | verified gone by |
|---|---|---|
| 11 placeholder ctest executables | #380 | `ctest --test-dir build/gcc -L placeholder -N` -> `Total Tests: 0` |
| 6 empty `register_*` binding stubs | #380 | all six are substantive (107-435 lines) |
| `pantr::CapacityError`, "registered but not yet thrown" | #380 | thrown at `cpp/include/pantr/quad/rule.hpp:344` and documented as thrown at `cpp/include/pantr/grid/bvh_tree.hpp:107` |
| the grid does not hold `CellTags`/`FacetTags` yet | #382 | `cpp/include/pantr/grid/grid.hpp` holds both |

**Closed by this PR:**

| seam | from (verbatim) |
|---|---|
| `partition_grid` re-pointing | #381: "`partition_grid` (the factory in `_partition_grid.py`) is not re-pointed here; that is the seam-close ticket." |
| the three functions | #387: "`cell_quadrature`, `overlay` and `partition_grid` are re-pointed by the seam-close ticket." |

No code change was needed for either -- the wrapper is already the class the
`isinstance` names. What closes them is the branch assertion that proves it, plus
the removal of the vacuous test that stood in for one.

**Surviving, with why and the ticket that removes it:**

| seam | from | why it survives | removed by |
|---|---|---|---|
| `_TensorProductGridPython`, the oracle grid | #387 | it *is* the Python backend, still the default | #402 |
| `_impl_class()` and the per-type selectors | #381-#387 | there is a choice to make while two backends exist | #402 |
| the `_adopt` / `_wrap` / `_take` family | #386, #387 | reconciles *presentation*, not implementations: the oracle returns public types, the binding returns handles | #402 |
| `_GridPython` | #386: "`HierarchicalGrid` stays on `_GridPython` and is untouched." | `HierarchicalGrid` still derives from it | #395, then #402 |
| `BVH.__init__`'s `CapacityError` -> `ValueError` translation | #384 | `PANTR_BACKEND` must not decide which exception a caller catches | #402 |
| `cpp/include/pantr/bezier/bezier.hpp`, the forwarding include | #380: "removed by a deliberate decision to break the installed header set" | `cpp/consumer/main.cpp` includes it on purpose, so it is an out-of-tree check as well as a promise | a major-version break; tracked by #402 |
| the adversarial sweep grades the Python backend only | #380 ("Not deciding is the failure mode") | **decided, not fixed** -- `tools/adversarial_sweep/README.md` now says so in its own section; the set it sweeps shrinks as types move | not named |
| `_PYTHON_BACKEND_ONLY` on `test_inplace_no_extra_alloc` | #385: "The Python aliasing defect is not fixed here." | it records the Python `Bezier`'s aliasing defect, not a contract | #375, open |
| the `g++-10` floor legs of `scripts/ci_local.sh` | #380 recorded its own `AC3` as "**not met**" | our own headers do not meet the declared floor | #376, open |
| `reverse`, `permute_directions` and `transform` bound but never routed | #391 (its `Files & modules` list omits `src/pantr/bezier/_bezier.py`) | see below | **no ticket exists** |
| the two 1-D Bernstein products are not unified | #392: "Unifying the two 1-D Bernstein products is **not** in scope." | deliberately left open | not named |
| `restrict`'s default throws `std::logic_error`, which nanobind maps to `RuntimeError`, not `NotImplementedError` | #386 (`cpp/include/pantr/grid/grid.hpp:363`: "A binding owes the Python side the translation") | dormant: both concrete grids override `restrict`, so the throwing base default is unreachable from Python -- I confirmed `HierarchicalGrid` implements it too | #395 reaches it first if a C++ hierarchical grid declines `restrict`; otherwise #402 |
| the numpy-`repr` message formatting survives at two more sites, in the hierarchical grid and the cell index | #387's closing comment, handed forward | they will produce the same backend divergence #387 fixed for the tensor-product grid | #395, named there by #387 |

**One correction to the bookkeeping.** #387's closing comment lists "the tag replay
in the rebuild path" among the scaffolding carried to #388 and #395. It is not
scaffolding. `TensorProductGrid.__reduce__` pickles a grid by its breakpoints *and*
its tags precisely so a pickle written under one backend loads under the other, and
`CellTags` is a separate object in C++ too, so the replay survives the Python
backend rather than dying with it. It should come off #402's list. The other three
items on that line -- the oracle grid, the selector, the adopt/wrap pair -- are in
the surviving table above.

## The conditional the spec poses: `cpp/include/pantr/grid/cell_quadrature.hpp`

**Not added, and the reason is recorded in the module**
(`src/pantr/grid/_cell_quadrature.py`), following the precedent of "say why
`minimize_degree` has no C++ counterpart".

What still runs in Python is the push-forward itself, one broadcast `lo + span * u`
and one product of the span; everything it consumes is answered by C++ under
`PANTR_BACKEND=cpp`. Moving those two lines is a **port**, not a re-pointing: C++ is licensed to contract
`lo + span * u` into a fused multiply-add where the target ISA has one and numpy is
not, so the two backends would stop agreeing bitwise and the gap would need a bound
-- a parity claim of its own, on the quantity the whole immersed-quadrature path
rests on. This ticket's non-goals forbid exactly that ("no numerical change of any
kind"). The note also records that it *should* eventually move, since a C++ program
links pantr with no interpreter and such a consumer has nothing to call, so the
absence is not read as a ruling against the port.

## The Bézier routing gap: handed on, with a measurement

`Bezier.reverse`, `.permute_directions` and `.transform` have working C++
implementations and nanobind bindings -- `reverse_bezier`,
`permute_bezier_directions` and `transform_bezier` are all present in the built
extension -- and nothing routes to them. Confirmed here two ways:
`src/pantr/bezier/_bezier_backend.py`, which holds the dispatch catalogue, contains
**zero** occurrences of `reverse`, `permute` or `transform`; and `_bezier.py` reaches
`_reverse_control_points` (`:982`, `:989`), `_permute_control_points` (`:1036`,
`:1041`) and `_apply_affine_to_control_points` (`:1093`, `:1098`) directly. The cause
is structural: #391's `Files & modules` list does not include `_bezier.py`.

Not landed here, for three reasons:

1. It is in `pantr.bezier`. This ticket's Context scopes it to "the ones inside
   `pantr.grid` and `pantr.quad`".
2. Routing them is new dispatch machinery -- catalogue entries in
   `_bezier_backend.py` and a backend-aware `_bezier.py` -- which the non-goal "No
   new functionality. This ticket only removes scaffolding and re-points callers"
   forbids.
3. For `transform` it is a **numerical change**. Measured on this branch, on a
   random degree-(3,4) rank-3 Bézier under a 3-D rotation: the numpy result and
   `transform_bezier`'s are **not bitwise equal**, the worst relative element
   difference being a few ulp in float64. So routing it owes a parity claim with a
   derived bound, which is a port ticket's work. `reverse` and `permute_directions`
   are pure data movement and were measured **bitwise identical** on the same
   Bézier, so those two are free; the follow-up splits cleanly along that line.

Proposed rather than filed, since filing is the repository owner's call.

## What a review round found in this PR's own work

Three findings, all in the commits above, all fixed here in their own `self-review:`
commits. Two are the class this milestone kept producing -- a locally-plausible
claim that is false, which no passing suite can surface.

- **The corrected type list had an incomplete exception.** It said `HierarchicalGrid`
  was "the one domain type in those modules that has not moved". Enumerating every
  class in the five modules' `__all__` and checking which hold a C++ implementation
  gives thirteen: nine wrappers, `HierarchicalGrid`, `PointsLattice`, `Grid` (a
  Protocol) and `GridRestriction` (a result record). **`PointsLattice` has not moved
  either**, and unlike `HierarchicalGrid` it is not pending -- it is ruled out of the
  port outright. Both are now named, with the two reasons distinguished.
- **The `cell_quadrature` note over-generalised its own subject.** It said flatly
  that under the C++ backend "the cell bounds come from
  `pantr::grid::TensorProductGrid`". False for a path the suite exercises: `grid` is
  the `Grid` protocol, `tests/_thb_assembly.py:63` and `:143` pass a
  `HierarchicalGrid`, and that type is not ported -- it has no wrapper and no
  `_impl`, and reaches C++ through the kernel catalogue, where
  `hier_collect_cell_bounds_kernel()` resolves to `_cpp_hier_collect_cell_bounds`.
  The counterexample was in the same test file, in `TestGenericGrid`. Both paths are
  now named; the argument the note makes is unaffected, since the push-forward is
  Python either way.
- **The new test's tolerance had no derivation.** Two bare `rtol=1e-12`, copied from
  this file's existing pattern. The value stays -- it is the file's constant, not a
  new one -- but the docstring now says what it bounds: the rule is exact for the
  integrand in exact arithmetic, so the comparison is round-off limited at roughly
  `n * eps` over `num_cells * num_points` terms, and `1e-12` leaves about two orders
  of margin. The five older bare `1e-12`s in the same file are left alone; changing
  one would be a numerical change to the suite, which this ticket forbids.

## Verification

Rebased onto `proto/cpp` at `4f79426` and re-run in full on the rebased tree. The
trunk moved twice during this work; neither move changed any C++ or build file
(`git diff --stat fc66ea1 4f79426 -- cpp/ CMakeLists.txt cmake/ CMakePresets.json`
is empty), and the two lines #423 touched in `tests/test_grid_cell_quadrature.py`
rebased without conflict.

| check | result |
|---|---|
| `pytest -q` | 8498 passed, 45 skipped, 7 xfailed |
| `PANTR_BACKEND=cpp pytest -q` | 8495 passed, 48 skipped, 7 xfailed |
| `ruff check .` | All checks passed |
| `ruff format --check .` | 326 files already formatted |
| `mypy --config-file mypy.ini src tests scripts` | Success: no issues found in 301 source files |
| `PYTHONPATH=$(pwd)/src lint-imports` | Contracts: 2 kept, 0 broken |
| `make doctest` | 82 passed, 7 skipped |
| `bash scripts/ci_local.sh` | 49 PASS, 1 INFO, 2 FAIL -- both the `g++-10` floor legs |
| `make docs SPHINXOPTS="-W --keep-going"` | **fails, and it is #417.** A cold build (`rm -rf docs/_build` first, which matters) gives **32 warnings** -- the same count #417's own reproduction reports. Not one names any of the six files here: they are `duplicate object description` and unresolved `_*Python` / `_Impl` / `_impl_class` references in `geometry.py`, `transform.py`, `_bvh.py`, `_tags.py` and `_partition.py`, from earlier tickets of this milestone. This PR adds zero. |

**The two `ci_local.sh` failures are #376 and pre-existing.** `floor: g++-10 build
(-Werror)` and `floor: g++-10 ctest`; every other one of the 52 checks passes,
including `floor: clang++-10 build` and `floor: clang++-10 ctest` on the same tree,
which is what distinguishes a floor defect from one of this branch's. Reproduced
directly: libstdc++ 10 has no floating-point `std::to_chars`, and the two errors are
at `cpp/include/pantr/geometry/aabb.hpp:116` and `:136` -- a file this PR does not
touch. #380 already recorded its own `AC3` as "**not met**" for the same reason.

## Left for someone else, deliberately

- **The `cpp_backend` fixture is now duplicated six times across the grid tests.**
  Three copies predate this PR (`test_grid_bvh.py`, `test_grid_tags.py`, and
  `test_grid_partition.py`'s `both_backends`); this PR adds three more, following
  the established local-fixture pattern rather than inventing a shared one.
  `tests/parity/conftest.py` has a session-scoped fixture of the same name, but it
  covers only `tests/parity/`. Hoisting one into `tests/conftest.py` is the right
  fix and belongs to **#403**, which owns consolidating the test suite the port
  grew: doing it here would touch six files across three live branches for no
  behaviour change.
- **`tests/test_grid_cell_quadrature.py` carries five older bare `rtol=1e-12`.**
  Only the two this PR introduced are given a stated bound. The rest are older than
  this branch, and a tolerance-hunter pass over the file is the cheap way to settle
  whether the constant is derived anywhere or merely habitual.

## Non-goals, honoured

No new functionality, no API change, and **no numerical change**: nothing under
`src/pantr` changed except one module docstring and two package docstrings. Nothing
under `tests/parity/` was touched.
