### PR TITLE
feat(bspline): own BsplineSpace1D in C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,17 @@ target_compile_options(pantr_core INTERFACE
 # Eigen under a consumer's different version is outside what was measured.
 target_link_libraries(pantr_core INTERFACE $<BUILD_INTERFACE:Eigen3::Eigen>)
 
+# Threads, and unlike Eigen this one DOES cross the install boundary.
+# `pantr/core/lazy.hpp` puts an `std::mutex` and an `std::atomic<bool>` inside a
+# header, so the thread-safety contract the domain types promise is compiled into
+# every consumer's translation unit rather than into a library they link. On a
+# glibc new enough to have folded the pthread symbols into libc this changes
+# nothing; on anything older it is the difference between linking and not, and a
+# consumer has no way to know they owe it. `find_dependency(Threads)` in
+# cmake/pantrConfig.cmake.in is the other half.
+find_package(Threads REQUIRED)
+target_link_libraries(pantr_core INTERFACE Threads::Threads)
+
 # BUILD_INTERFACE only, deliberately. cpp/include/pantr/core/mdspan.hpp decides
 # for itself from `__cpp_lib_mdspan`, so this definition is redundant in-tree and
 # would be actively wrong once installed: the probe measures the compiler that

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,13 @@ target_link_libraries(pantr_core INTERFACE $<BUILD_INTERFACE:Eigen3::Eigen>)
 # nothing; on anything older it is the difference between linking and not, and a
 # consumer has no way to know they owe it. `find_dependency(Threads)` in
 # cmake/pantrConfig.cmake.in is the other half.
+# `FindThreads` recommends this: without it a platform may be linked with a bare
+# `-lpthread` instead of the `-pthread` compiler flag, and some libc versions need
+# the flag's preprocessor defines for thread-safe behaviour rather than merely the
+# library. Inert on every configuration exercised today -- glibc has folded the
+# pthread symbols into libc, and CMAKE_HAVE_LIBC_PTHREAD comes back true -- which
+# is exactly why it would go unnoticed on the first platform where it is not.
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 target_link_libraries(pantr_core INTERFACE Threads::Threads)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,6 +31,17 @@
       "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++" }
     },
     {
+      "name": "gcc-tsan",
+      "inherits": "gcc",
+      "displayName": "GCC, ThreadSanitizer",
+      "description": "The only gate that can see a race in a lazily-filled memo. A bare `mutable std::optional` memo was measured at 4 TSan reports with 8 threads AND 60 correct answers in 60 unsanitized runs, so no assertion on a value can stand in for this leg. Its own build directory and its own preset because -fsanitize=thread cannot be combined with the address sanitizer the gcc-debug preset carries. -O1 rather than -O0: TSan's own documentation asks for it, and at -O0 the memo accessor does not get inlined into the loop the way the shipped build compiles it.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS_DEBUG": "-g -O1 -fsanitize=thread -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread"
+      }
+    },
+    {
       "name": "gcc-debug",
       "inherits": "gcc",
       "displayName": "GCC, debug with sanitizers",
@@ -57,6 +68,11 @@
       "name": "gcc-debug",
       "configurePreset": "gcc-debug",
       "jobs": 20
+    },
+    {
+      "name": "gcc-tsan",
+      "configurePreset": "gcc-tsan",
+      "jobs": 20
     }
   ],
   "testPresets": [
@@ -75,6 +91,12 @@
     {
       "name": "gcc-debug",
       "configurePreset": "gcc-debug",
+      "output": { "outputOnFailure": true },
+      "execution": { "jobs": 20, "noTestsAction": "error", "stopOnFailure": false }
+    },
+    {
+      "name": "gcc-tsan",
+      "configurePreset": "gcc-tsan",
       "output": { "outputOnFailure": true },
       "execution": { "jobs": 20, "noTestsAction": "error", "stopOnFailure": false }
     }

--- a/cmake/pantrConfig.cmake.in
+++ b/cmake/pantrConfig.cmake.in
@@ -7,6 +7,11 @@ include(CMakeFindDependencyMacro)
 # move would break silently every time a new header adopts it.
 find_dependency(Eigen3)
 
+# Threads is a hard requirement for the same reason Eigen is, and for a sharper
+# one: pantr/core/lazy.hpp's memo is an `std::mutex` and an `std::atomic<bool>` in
+# a header, so it is compiled into the consumer's own translation units.
+find_dependency(Threads)
+
 # Kokkos mdspan is NOT a hard requirement, because whether it is needed depends
 # on the consumer's standard library rather than on ours. pantr/core/mdspan.hpp
 # selects on `__cpp_lib_mdspan`, so a consumer whose libstdc++ ships <mdspan>

--- a/cpp/include/pantr/bspline/knots.hpp
+++ b/cpp/include/pantr/bspline/knots.hpp
@@ -35,27 +35,41 @@
 /// each site. The oracle uses **two** ways of differencing two knots, and they
 /// differ at `float32`:
 ///
-///  - **In `T`, then widened.** The class scan, the boundary multiplicity count
-///    and the cardinal-interval window are numba expressions over a `float32[:]`
-///    array, so the subtraction is `float32` and only the comparison against
-///    `tol` widens. Reproduced here as `value_of(T(a - b))` cast to `double`.
+///  - **In `T`, then widened.** The class scan and the boundary multiplicity count
+///    are numba expressions over a `float32[:]` array, so the subtraction is
+///    `float32` and only the comparison against `tol` widens. Reproduced here as
+///    `value_of(T(a - b))` cast to `double`. Verified rather than assumed, by
+///    reading numba's own typing: `njit(lambda k: k[1] - k[0])` on a `float32`
+///    array reports a `float32` return type, and the comparison against a Python
+///    float takes `(float32[:], float64) -> bool`.
 ///  - **Widened, then in `double`.** `_left_end_open`, `_right_end_open` and
 ///    `_knot_scale` are Python expressions written `float(a) - float(b)`, so both
 ///    operands widen first and the subtraction happens in `double`. Reproduced
 ///    here as `as_double(a) - as_double(b)`.
 ///
-/// **They cannot disagree about a class boundary, and the argument is worth having
-/// rather than trusting.** A verdict flips only if the two differences straddle
-/// `tol`. Two knots whose difference is near `tol = 8 * eps * scale` and whose own
+/// **They disagree about a class boundary only inside a hairline band at the
+/// threshold itself, and the argument is worth having rather than trusting.** An
+/// earlier draft of this comment opened with "cannot disagree", which its own
+/// derivation already contradicted and which a review refuted: fuzzing the two
+/// spellings against each other found real `float32` disagreements, all within the
+/// last ulp of `tol`, at about 0.05% of trials drawn deliberately onto the
+/// threshold and none at `float64`. A verdict flips only if the two differences
+/// straddle `tol`. Two knots whose difference is near `tol = 8 * eps * scale` and whose own
 /// magnitudes are near `scale` are within a relative `8 * eps` of each other, so
 /// Sterbenz makes the storage-width subtraction *exact* and the two agree
 /// identically. Where the operands are small against `scale` -- a pair straddling
 /// zero on a vector whose scale comes from elsewhere -- the subtraction is an
 /// addition and its error is at most half an ulp of the result, so a flip needs the
 /// exact difference to lie within a relative `2^-24` of the threshold. That is
-/// derived, not measured, and it is why this is a faithfulness question rather than
-/// a correctness one: the two are written separately because the code should say
-/// which arithmetic it reproduces, not because a test would catch getting it wrong.
+/// derived, and then measured twice with results that agree. A differential sweep of
+/// 3000 *randomly drawn* knot vectors against the oracle, with the class scan
+/// written both ways, reported 0 mismatches for either spelling -- random draws do
+/// not land in a band of relative width `2^-24`. Fuzzing drawn deliberately onto the
+/// threshold does land in it, and finds the disagreements above.
+///
+/// So the site is a faithfulness question rather than a correctness one, but not a
+/// vacuous one: the arithmetic here is the oracle's, and a test that pinned the
+/// difference would be pinning which of two defensible answers the last ulp gets.
 ///
 /// ## Messages
 ///

--- a/cpp/include/pantr/bspline/knots.hpp
+++ b/cpp/include/pantr/bspline/knots.hpp
@@ -1,0 +1,467 @@
+#pragma once
+
+/// \file
+/// The knot vector: its tolerance, its classes, and the refusals a space owes.
+///
+/// Everything here is a free function over a knot span and a degree, deliberately:
+/// `BsplineSpace1D` calls all of it from its constructor, and a free function
+/// taking the frozen state can be tested without an object and cannot read a
+/// half-initialised `this`. `design/bspline_derived_caches.md` asks for exactly
+/// that shape for the derived block.
+///
+/// ## One tolerance, and where it comes from
+///
+/// `knot_tolerance` is `8 * eps(T) * knot_scale(knots)`, and every parametric
+/// comparison the B-spline layer makes is a comparison of quantities of that
+/// magnitude: are these two knots one knot, is this point inside the domain, are
+/// these two knot intervals the same length. The derivation is the oracle's and is
+/// written out in `src/pantr/bspline/_bspline_knots.py`: two knots reached by
+/// different routes differ by at most `4 * eps * scale` by the triangle
+/// inequality, and the factor is that bound doubled, for a contraction, a
+/// different vector width and one further rounding upstream. The scale carries the
+/// coordinate magnitudes as well as the span, because on a knot vector based at
+/// 1e6 a knot difference is formed from two coordinates of that size.
+///
+/// **The tolerance is a `double` at every width, and that is not an oversight.**
+/// The oracle computes it in Python floats and passes it into a numba kernel typed
+/// `float64` even when the knots are `float32`, so the comparison there widens the
+/// `float32` difference and tests it against a `double` threshold. Storing it as
+/// `T` would round the threshold to `float` and change the predicate in the last
+/// bits, which is a knot-classification verdict rather than a rounding.
+///
+/// ## The two arithmetics, which are not the same arithmetic
+///
+/// This is the trap in porting this module, so it is stated once here and again at
+/// each site. The oracle uses **two** ways of differencing two knots, and they
+/// differ at `float32`:
+///
+///  - **In `T`, then widened.** The class scan, the boundary multiplicity count
+///    and the cardinal-interval window are numba expressions over a `float32[:]`
+///    array, so the subtraction is `float32` and only the comparison against
+///    `tol` widens. Reproduced here as `value_of(T(a - b))` cast to `double`.
+///  - **Widened, then in `double`.** `_left_end_open`, `_right_end_open` and
+///    `_knot_scale` are Python expressions written `float(a) - float(b)`, so both
+///    operands widen first and the subtraction happens in `double`. Reproduced
+///    here as `as_double(a) - as_double(b)`.
+///
+/// **They cannot disagree about a class boundary, and the argument is worth having
+/// rather than trusting.** A verdict flips only if the two differences straddle
+/// `tol`. Two knots whose difference is near `tol = 8 * eps * scale` and whose own
+/// magnitudes are near `scale` are within a relative `8 * eps` of each other, so
+/// Sterbenz makes the storage-width subtraction *exact* and the two agree
+/// identically. Where the operands are small against `scale` -- a pair straddling
+/// zero on a vector whose scale comes from elsewhere -- the subtraction is an
+/// addition and its error is at most half an ulp of the result, so a flip needs the
+/// exact difference to lie within a relative `2^-24` of the threshold. That is
+/// derived, not measured, and it is why this is a faithfulness question rather than
+/// a correctness one: the two are written separately because the code should say
+/// which arithmetic it reproduces, not because a test would catch getting it wrong.
+///
+/// ## Messages
+///
+/// Every refusal below carries the oracle's message character for character, so
+/// that the two backends are indistinguishable to a caller who reads the text and
+/// so that `tests/parity/` can compare them. `pantr/core/format.hpp` carries the
+/// three Python format specifiers they interpolate.
+
+#include <algorithm>
+#include <cmath>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "pantr/core/format.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+namespace detail {
+
+/// The floating-point value of a scalar, as a `double`.
+///
+/// Tier B, so it goes through the two-step `value_of` lookup rather than casting
+/// the scalar. Used wherever the oracle wrote `float(x)`.
+///
+/// \param x The scalar.
+/// \return Its value, widened.
+template <Real T>
+[[nodiscard]] constexpr double as_double(const T& x) noexcept {
+    using pantr::value_of;
+    return static_cast<double>(value_of(x));
+}
+
+/// The numpy name of `T`'s storage format, as the oracle's messages spell it.
+///
+/// Local to this header because exactly one message interpolates it. Promote it
+/// to the core when a second one does.
+///
+/// \return `"float32"` or `"float64"`.
+template <Real T>
+[[nodiscard]] constexpr const char* dtype_name() noexcept {
+    if constexpr (std::same_as<value_type_t<T>, float>) {
+        return "float32";
+    } else {
+        return "float64";
+    }
+}
+
+/// Machine epsilon of `T`'s value component.
+///
+/// \return `eps`, as a `double`.
+template <Real T>
+[[nodiscard]] constexpr double epsilon() noexcept {
+    return static_cast<double>(std::numeric_limits<value_type_t<T>>::epsilon());
+}
+
+/// Machine epsilons a strict parametric comparison allows for.
+///
+/// The oracle's `pantr.tolerance._STRICT_EPS_FACTOR`, times its
+/// `_bspline_knots._KNOT_MERGE_SAFETY`: four for a value reached by one convex
+/// combination and differenced against another such value, doubled for a
+/// contraction, a different vector width and one rounding upstream. Both are
+/// powers of two, so the product is exact and the only rounding in
+/// `knot_tolerance` is its final multiply by the scale -- which is what lets the
+/// two backends agree on the threshold to the last bit rather than merely to
+/// within it.
+inline constexpr double kKnotToleranceEpsilons = 8.0;
+
+}  // namespace detail
+
+/// The magnitude a parametric comparison on a knot vector is relative to.
+///
+/// The span alone is not enough: on a knot vector based at 1e6 a knot difference
+/// is formed from two coordinates of that size, so it carries an absolute error of
+/// `eps * 1e6` however short the span is. The coordinate magnitudes are therefore
+/// taken alongside the span, and the largest wins.
+///
+/// No floor is applied. A floor of 1 would be a physical choice this layer is not
+/// entitled to make, and it would destroy scale covariance on a domain smaller
+/// than one unit -- exactly the case where an absolute tolerance merged every knot
+/// in the vector.
+///
+/// \param knots A non-decreasing, non-empty knot vector.
+/// \return `max(span, |knots[0]|, |knots[n-1]|)`, zero only for a vector that is
+///         identically zero.
+template <Real T>
+[[nodiscard]] double knot_scale(std::span<const T> knots) {
+    // Unqualified, with the using-declaration, per the rule in
+    // `pantr/core/scalar.hpp`; these arguments are already `double`, and the
+    // discipline guard in `scripts/ci_local.sh` is spelling-based by design.
+    using std::abs;
+    // `float(hi) - float(lo)`: the oracle widens both ends before subtracting.
+    const double lo = detail::as_double(knots.front());
+    const double hi = detail::as_double(knots.back());
+    return std::max({hi - lo, abs(lo), abs(hi)});
+}
+
+/// The absolute tolerance for comparing parametric coordinates of a knot vector.
+///
+/// See the file comment for the derivation and for why the result is a `double` at
+/// every width.
+///
+/// \param knots A non-decreasing, non-empty knot vector.
+/// \return `8 * eps(T) * knot_scale(knots)`, in the units of `knots`.
+template <Real T>
+[[nodiscard]] double knot_tolerance(std::span<const T> knots) {
+    return detail::kKnotToleranceEpsilons * detail::epsilon<T>() * knot_scale(knots);
+}
+
+/// Where the knot classes of a vector begin and end, without allocating.
+///
+/// A class is a maximal run of knots no two consecutive members of which differ by
+/// more than the tolerance. The domain range names the classes holding the two
+/// domain ends, whose whole class is reported -- clamped copies outside the domain
+/// included, which is what the multiplicity of a boundary knot means.
+struct KnotClassRange {
+    std::int64_t count = 0;         ///< How many classes the whole vector has.
+    std::int64_t domain_begin = 0;  ///< The class holding `knots[degree]`.
+    std::int64_t domain_end = 0;    ///< One past the class holding `knots[n-degree-1]`.
+
+    /// The number of in-domain knot intervals the range describes.
+    ///
+    /// \return One less than the number of in-domain classes; never negative,
+    ///         because the domain always spans at least one class.
+    [[nodiscard]] constexpr std::int64_t num_intervals() const noexcept {
+        return domain_end - domain_begin - 1;
+    }
+};
+
+/// Locate the knot classes of a non-decreasing knot vector.
+///
+/// Knots are grouped by *gap*: the vector is non-decreasing, so one pass suffices,
+/// and a class ends where the step to the next knot exceeds `tol`. Grouping by gap
+/// rather than by a rounding grid is what makes the answer depend on the knots and
+/// not on where they sit relative to an origin: two values one ulp apart can
+/// straddle a grid line and never merge, for any grid spacing.
+///
+/// The cost of the gap rule is chaining -- `n` knots each within `tol` of the next
+/// collapse into one class however far apart the ends are. That is accepted rather
+/// than capped: a class-width cap would break idempotence, since a class split by
+/// the cap leaves two representatives that may be within `tol` of each other and
+/// would merge on the next pass.
+///
+/// \param knots A non-decreasing knot vector of at least `2 * degree + 2` entries.
+/// \param degree The polynomial degree, which fixes where the domain starts and ends.
+/// \param tol The absolute parametric tolerance, from `knot_tolerance`.
+/// \return The class count and the in-domain class range.
+template <Real T>
+[[nodiscard]] KnotClassRange classify_knots(std::span<const T> knots, std::int64_t degree,
+                                            double tol) {
+    const auto n = static_cast<std::int64_t>(knots.size());
+    const std::int64_t lo_index = degree;
+    const std::int64_t hi_index = n - degree - 1;
+
+    KnotClassRange range;
+    std::int64_t klass = 0;
+    std::int64_t lo_class = 0;
+    std::int64_t hi_class = 0;
+    for (std::int64_t i = 1; i < n; ++i) {
+        // Differenced in `T` and only then widened: the oracle's scan is a numba
+        // expression over the knot array. See the file comment.
+        const T step = knots[static_cast<std::size_t>(i)] - knots[static_cast<std::size_t>(i - 1)];
+        if (detail::as_double(step) > tol) {
+            ++klass;
+        }
+        if (i == lo_index) {
+            lo_class = klass;
+        }
+        if (i == hi_index) {
+            hi_class = klass;
+        }
+    }
+    range.count = klass + 1;
+    range.domain_begin = lo_class;
+    range.domain_end = hi_class + 1;
+    return range;
+}
+
+/// The distinct knots of a vector and their multiplicities.
+///
+/// Every member of a class is represented by the class's **first** knot, chosen
+/// rather than averaged, so the values returned are knots the vector actually
+/// contains and the grouping is idempotent: regrouping the represented vector
+/// reproduces it. An average would be a fresh rounding, and could place two
+/// adjacent classes' representatives a single ulp apart.
+///
+/// The multiplicities sum to `knots.size()`, so repeating each representative by
+/// its multiplicity rebuilds the whole vector with each class collapsed onto it.
+template <Real T>
+struct KnotClasses {
+    std::vector<T> unique;                  ///< One representative per class.
+    std::vector<std::int64_t> multiplicity;  ///< How many knots each class holds.
+    std::size_t domain_begin = 0;           ///< First in-domain class.
+    std::size_t domain_end = 0;             ///< One past the last in-domain class.
+};
+
+/// Build the distinct knots and their multiplicities.
+///
+/// The in-domain form the oracle offers is the contiguous subrange
+/// `[domain_begin, domain_end)` of these arrays rather than a second computation,
+/// which is why there is one memo here and not two.
+///
+/// \param knots A non-decreasing knot vector of at least `2 * degree + 2` entries.
+/// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance, from `knot_tolerance`.
+/// \return The classes, with the in-domain subrange marked.
+template <Real T>
+[[nodiscard]] KnotClasses<T> unique_knots_and_multiplicity(std::span<const T> knots,
+                                                           std::int64_t degree, double tol) {
+    const KnotClassRange range = classify_knots(knots, degree, tol);
+
+    KnotClasses<T> classes;
+    classes.unique.reserve(static_cast<std::size_t>(range.count));
+    classes.multiplicity.assign(static_cast<std::size_t>(range.count), 0);
+    classes.domain_begin = static_cast<std::size_t>(range.domain_begin);
+    classes.domain_end = static_cast<std::size_t>(range.domain_end);
+
+    std::size_t klass = 0;
+    classes.unique.push_back(knots.front());
+    classes.multiplicity[0] = 1;
+    for (std::size_t i = 1; i < knots.size(); ++i) {
+        const T step = knots[i] - knots[i - 1];
+        if (detail::as_double(step) > tol) {
+            ++klass;
+            classes.unique.push_back(knots[i]);
+        }
+        ++classes.multiplicity[klass];
+    }
+    return classes;
+}
+
+/// The number of basis functions a knot vector and degree define.
+///
+/// In the non-periodic case it is the knot count less the degree less one. In the
+/// periodic case that count is reduced by the regularity at the domain's start,
+/// which is the degree less the multiplicity of the first in-domain knot.
+///
+/// \param knots A non-decreasing knot vector of at least `2 * degree + 2` entries.
+/// \param degree The polynomial degree.
+/// \param periodic Whether the space is periodic.
+/// \param tol The absolute parametric tolerance, from `knot_tolerance`.
+/// \return The number of basis functions, which the caller must still check is at
+///         least `degree + 1`.
+template <Real T>
+[[nodiscard]] std::int64_t num_basis(std::span<const T> knots, std::int64_t degree, bool periodic,
+                                     double tol) {
+    auto count = static_cast<std::int64_t>(knots.size()) - degree - 1;
+    if (!periodic) {
+        return count;
+    }
+
+    using std::abs;
+    // The multiplicity of `knots[degree]` among the first `degree + 1` knots.
+    // Differenced in `T`, as the oracle's numba expression is.
+    const T first = knots[static_cast<std::size_t>(degree)];
+    std::int64_t multiplicity = 0;
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        const T offset = knots[static_cast<std::size_t>(i)] - first;
+        if (abs(detail::as_double(offset)) <= tol) {
+            ++multiplicity;
+        }
+    }
+    const std::int64_t regularity = degree - multiplicity;
+    return count - regularity - 1;
+}
+
+/// Collapse each group of knots meant to be one knot onto a single stored value.
+///
+/// The grouping is the one `classify_knots` reports, so a space and its own
+/// accessor cannot disagree about which knots are the same knot -- two
+/// implementations of one idea is how they came to disagree before.
+///
+/// \param knots A non-decreasing knot vector.
+/// \param tol The absolute parametric tolerance, from `knot_tolerance`.
+/// \return A vector of the same length, dtype and ordering, with each class
+///         collapsed onto its first knot.
+template <Real T>
+[[nodiscard]] std::vector<T> snap_knots(std::span<const T> knots, double tol) {
+    std::vector<T> snapped(knots.begin(), knots.end());
+    T representative = knots.front();
+    for (std::size_t i = 1; i < knots.size(); ++i) {
+        // The class boundaries are decided on the ORIGINAL vector, so the step is
+        // taken from `knots` and never from the partly-rewritten `snapped`.
+        const T step = knots[i] - knots[i - 1];
+        if (detail::as_double(step) > tol) {
+            representative = knots[i];
+        }
+        snapped[i] = representative;
+    }
+    return snapped;
+}
+
+/// Refuse a knot vector that snapping collapsed onto a single point.
+///
+/// This refuses one specific cause -- the knots *were* distinct, and the merge rule
+/// found none of them distinguishable at their own magnitude -- so that the caller
+/// is told the thing they could not see coming. A vector that arrived already flat
+/// is not this function's case and passes through untouched; it is refused a step
+/// later by `check_space_has_an_interval`, which owns the *consequence* both causes
+/// share. Keeping the two apart is what lets each message be true.
+///
+/// This is reachable, and the arithmetic that makes it so is not a defect. A mesh
+/// of `n` intervals over a span `s` at offset `x` survives only while
+/// `s / n > 8 * eps * max(s, |x|)`. When `|x|` dominates, that fails once `|x| / s`
+/// reaches `1 / (8 * eps * n)` -- about `5.2e5 / n` at `float32` and `5.6e14 / n` at
+/// `float64`. Past it no threshold satisfies both requirements at once, because an
+/// interior knot is then uncertain by a sizeable fraction of the span.
+///
+/// \param raw The knot vector as supplied, non-decreasing, before snapping.
+/// \param snapped The same vector afterwards.
+/// \param tol The absolute tolerance snapping used, from `knot_tolerance`.
+/// \throws std::invalid_argument If `raw` held more than one distinct knot while
+///         `snapped` holds only one.
+template <Real T>
+void check_snapping_kept_an_interval(std::span<const T> raw, std::span<const T> snapped,
+                                     double tol) {
+    using pantr::value_of;
+    // Both vectors are non-decreasing, so "all knots identical" is exactly "first
+    // equals last", tested bitwise and needing no tolerance of its own.
+    if (value_of(raw.front()) == value_of(raw.back())
+        || value_of(snapped.front()) != value_of(snapped.back())) {
+        return;
+    }
+
+    const double scale = knot_scale(raw);
+    // `np.spacing(raw.dtype.type(scale))`: the scale is rounded INTO the knot
+    // format first, and the ulp is that format's, not the accumulator's.
+    const auto scale_in_storage = static_cast<value_type_t<T>>(scale);
+    const double ulp = static_cast<double>(
+        std::nextafter(scale_in_storage, std::numeric_limits<value_type_t<T>>::infinity())
+        - scale_in_storage);
+
+    // `np.diff(raw.astype(float64))`: widened first, so this difference is the
+    // `double` one and not the storage-width one. A positive gap exists because the
+    // vector is non-decreasing and its ends differ.
+    double closest = std::numeric_limits<double>::infinity();
+    for (std::size_t i = 1; i < raw.size(); ++i) {
+        const double gap = detail::as_double(raw[i]) - detail::as_double(raw[i - 1]);
+        if (gap > 0.0) {
+            closest = std::min(closest, gap);
+        }
+    }
+
+    const std::string name = detail::dtype_name<T>();
+    // Widening the format is only a remedy if there is a wider one to move to.
+    const std::string remedy =
+        std::same_as<value_type_t<T>, float>
+            ? "Use float64, move the domain nearer the origin, or coarsen the mesh."
+            : "Move the domain nearer the origin, or coarsen the mesh.";
+
+    throw std::invalid_argument(
+        "knot snapping collapsed every knot onto "
+        + pantr::detail::format_scalar(snapped.front()) + ": in " + name + " at |coordinate| ~ "
+        + pantr::detail::format_general(scale, 3) + " two knots are the same knot unless they "
+        + "differ by more than " + pantr::detail::format_general(tol, 3) + " ("
+        + pantr::detail::format_fixed(tol / ulp, 0) + " ulp there), and the closest pair in ["
+        + pantr::detail::format_scalar(raw.front()) + ", "
+        + pantr::detail::format_scalar(raw.back()) + "] is "
+        + pantr::detail::format_general(closest, 3) + " apart. This mesh is finer than " + name
+        + " resolves at that magnitude. " + remedy);
+}
+
+/// Refuse a knot vector whose domain is a single point.
+///
+/// A space with no interval has no cell, and every operation defined over its cells
+/// is therefore undefined on it. The rule lives at the one place a space comes into
+/// being rather than at each consumer, because three consumers met the degeneracy
+/// by *returning a value* rather than raising, and a survey of what raised would
+/// not have found them.
+///
+/// The predicate is the interval count, not "every knot is the same value". The
+/// family is wider than it looks: `[0, 1, 1, 1, 2]` at degree 1 holds three
+/// distinct values and still has a domain of one point, because an interior knot of
+/// high enough multiplicity swallows it whole.
+///
+/// \param knots The knot vector, non-decreasing and already snapped if snapping was
+///        requested.
+/// \param degree The polynomial degree, which fixes where the domain starts and ends.
+/// \param num_intervals The space's interval count, from `KnotClassRange`.
+/// \param tol The absolute tolerance the count was taken at.
+/// \throws std::invalid_argument If `num_intervals` is zero.
+template <Real T>
+void check_space_has_an_interval(std::span<const T> knots, std::int64_t degree,
+                                 std::int64_t num_intervals, double tol) {
+    if (num_intervals > 0) {
+        return;
+    }
+
+    const std::int64_t last = static_cast<std::int64_t>(knots.size()) - degree - 1;
+    const std::string tol_text = pantr::detail::format_general(tol, 3);
+    throw std::invalid_argument(
+        "knot vector spans no interval: at degree " + std::to_string(degree)
+        + " the domain runs from knots[" + std::to_string(degree) + "] = "
+        + pantr::detail::format_scalar(knots[static_cast<std::size_t>(degree)]) + " to knots["
+        + std::to_string(last) + "] = "
+        + pantr::detail::format_scalar(knots[static_cast<std::size_t>(last)])
+        + ", and every step between them is at most this vector's tolerance of " + tol_text
+        + ", so its in-domain knots are all one knot, the space has no cell, and nothing can be "
+          "evaluated, tabulated or located on it. The domain needs two consecutive knots more "
+          "than "
+        + tol_text + " apart.");
+}
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/space_1d.hpp
+++ b/cpp/include/pantr/bspline/space_1d.hpp
@@ -52,10 +52,14 @@
 ///  - **The derived arrays are built at most once and shared, not copied.** The
 ///    oracle memoises the same quantities per object with `functools.cached_property`
 ///    and an `lru_cache`; the latter was a process-global cache and is gone.
-///  - **This type does not accept a knot vector it cannot own.** The oracle stores
-///    the caller's array when it is already floating-point and freezes it in place;
-///    this copies. That is the same decision `pantr/bezier/bezier.hpp` records for
-///    a control net, and in the same direction.
+///  - **Both sides copy the knot vector, and there is no divergence here.** An
+///    earlier draft of this comment said the oracle stores a floating-point array
+///    in place and that only this type copies. That is false:
+///    `_bspline_space_1d.py:99-106` copies too, and says why -- it freezes the
+///    vector read-only afterwards, and freezing a caller's array in place would
+///    mutate caller state. Recorded because the claim was written down and
+///    believed, and because `pantr/bezier/bezier.hpp` makes a structurally similar
+///    claim about a control net that is worth the same scrutiny.
 ///
 /// ## Thread safety
 ///
@@ -340,7 +344,12 @@ class BsplineSpace1D {
         if (degree < 0) {
             throw std::invalid_argument("degree must be non-negative");
         }
-        if (static_cast<std::int64_t>(knots.size()) < 2 * degree + 2) {
+        // Divided rather than multiplied: `2 * degree + 2` is signed overflow, and
+        // so undefined, for a degree near the top of the range. Python's integers
+        // are arbitrary-precision, so the oracle's spelling is exact for any degree
+        // and this one has to be too. The size is at least 0, so the division is
+        // well defined.
+        if ((static_cast<std::int64_t>(knots.size()) - 2) / 2 < degree) {
             throw std::invalid_argument("knots must have at least 2*degree+2 elements");
         }
         // `np.all(np.diff(knots) >= 0)`: the difference is formed first and only

--- a/cpp/include/pantr/bspline/space_1d.hpp
+++ b/cpp/include/pantr/bspline/space_1d.hpp
@@ -1,0 +1,410 @@
+#pragma once
+
+/// \file
+/// The 1D B-spline space: a knot vector, a degree, and the quantities they fix.
+///
+/// ## What this type owns, and what it does not
+///
+/// It owns the *value* -- the knot vector, the degree, the periodicity flag and
+/// the parametric tolerance those imply -- plus every quantity that is a function
+/// of them: how many basis functions there are, how many intervals, where the
+/// domain runs, whether the ends are clamped, the distinct knots and their
+/// multiplicities, and the first supported basis index of each interval.
+///
+/// It owns no *operations*. Basis tabulation, the three families of extraction
+/// operator, knot insertion, subdivision and restriction are separate ports over
+/// free functions taking a `const BsplineSpace1D&`, exactly as
+/// `pantr/bezier/bezier.hpp` splits the Bézier value from evaluation, elevation
+/// and the product. That is what lets them proceed independently of one another
+/// once this type exists, and it is why `get_cardinal_intervals` -- a computation
+/// over the knots rather than a property of them -- is not here.
+///
+/// ## Validating rather than asserting
+///
+/// This is not a kernel but the C++ counterpart of Layer 2, so it validates and
+/// throws in a release build as much as a debug one. A caller with no Python
+/// cannot be protected by `cpp/bindings/`. `pantr/core/error.hpp` sets the split
+/// the whole port uses: type-kind checks stay in the Python wrapper, because
+/// nanobind has no path to `TypeError`; value and range checks live here.
+///
+/// ## Parity notes for the Python oracle
+///
+/// `pantr.bspline.BsplineSpace1D` is the oracle. What this type reproduces, and
+/// the two places it deliberately differs:
+///
+///  - **The order of the checks is the oracle's**, and it is load-bearing rather
+///    than incidental: two simultaneously bad arguments must produce the same
+///    message on both sides, and only the order decides which one they get.
+///  - **The messages are the oracle's, character for character**, including the
+///    two that interpolate a formatted float. `pantr/core/format.hpp` carries the
+///    three Python format specifiers involved.
+///  - **The tolerance is derived from the knots as supplied, before snapping**,
+///    and is never recomputed afterwards -- which matters because snapping can
+///    move the last knot onto its class's first one and so change the scale. The
+///    oracle computes it once in `__init__` and stores it; so does this.
+///  - **`num_basis` is computed from the snapped knots and the raw tolerance.**
+///    The oracle's `_validate_input` computes a *different* basis count, from the
+///    raw knots, purely to refuse a vector that cannot support the degree; the
+///    stored count comes from the snapped vector. The two can differ, because
+///    snapping moves knots onto class representatives and so can change the
+///    multiplicity of the first in-domain knot. Both are reproduced, in that
+///    order.
+///  - **The derived arrays are built at most once and shared, not copied.** The
+///    oracle memoises the same quantities per object with `functools.cached_property`
+///    and an `lru_cache`; the latter was a process-global cache and is gone.
+///  - **This type does not accept a knot vector it cannot own.** The oracle stores
+///    the caller's array when it is already floating-point and freezes it in place;
+///    this copies. That is the same decision `pantr/bezier/bezier.hpp` records for
+///    a control net, and in the same direction.
+///
+/// ## Thread safety
+///
+/// Every accessor below is safe to call concurrently on the same object with no
+/// external locking, including the ones that fill the derived block: it is a
+/// `pantr::LazySlot`, whose file comment carries the measurement behind that
+/// choice. In a sweep, hoist `unique_knots()` or `first_basis_per_interval()` into
+/// a local span before the loop rather than calling it per element.
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+#include "pantr/bspline/knots.hpp"
+#include "pantr/core/lazy.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+/// What the constructor does with knots that are the same knot.
+///
+/// A `bool` here would read `BsplineSpace1D(knots, 2, false, true)` at the call
+/// site, where neither flag is recoverable without opening the header.
+enum class KnotSnapping : std::uint8_t {
+    /// Collapse each class of near-duplicate knots onto its first member, and
+    /// refuse a vector that this collapses onto a single point. The oracle's
+    /// `snap_knots=True`, and its default.
+    merge_near_duplicates = 0,
+    /// Store the knots as supplied. The interval requirement still applies; only
+    /// the merging and the snapping diagnosis are skipped. The oracle's
+    /// `snap_knots=False`.
+    as_given = 1,
+};
+
+/// A 1D B-spline space: a knot vector and a polynomial degree.
+///
+/// An instance always has at least one interval. A knot vector whose in-domain
+/// knots all fall in one class is refused at construction, since such a space has
+/// no cell and nothing can be evaluated, tabulated or located on it.
+///
+/// Instances are immutable: no operation changes an existing space, and every
+/// derived one is returned by value. The one mutable member is the derived block,
+/// whose fill no caller can observe -- it yields the same values and the same
+/// spans however many times it runs -- which is the test `CLAUDE.md` sets for a
+/// reasoned exception to construct-then-freeze.
+template <Real T>
+class BsplineSpace1D {
+  public:
+    /// Build a space from a knot vector and a degree.
+    ///
+    /// \param knots The knot vector: non-decreasing, at least `2 * degree + 2`
+    ///        entries. Copied; the caller keeps its own storage.
+    /// \param degree The polynomial degree, non-negative.
+    /// \param periodic Whether the space is periodic.
+    /// \param snapping What to do with knots that are the same knot.
+    /// \throws std::invalid_argument If the degree is negative, the vector is too
+    ///         short or not non-decreasing, the vector cannot support the degree,
+    ///         snapping collapsed a vector that had more than one distinct knot,
+    ///         or the resulting space spans no interval.
+    BsplineSpace1D(std::span<const T> knots, std::int64_t degree, bool periodic,
+                   KnotSnapping snapping)
+        : degree_(degree), periodic_(periodic) {
+        check_arguments(knots, degree, periodic);
+
+        // Derived from the knots as supplied, and never recomputed: snapping can
+        // move the last knot onto its class's first one, which would move the
+        // scale. See the parity note in the file comment.
+        tol_ = knot_tolerance(knots);
+
+        if (snapping == KnotSnapping::merge_near_duplicates) {
+            knots_ = snap_knots(knots, tol_);
+            // Runs first: when snapping is what destroyed the mesh, its diagnosis
+            // is the specific one and names the remedy. The interval check below
+            // owns the same symptom from any other cause.
+            check_snapping_kept_an_interval<T>(knots, std::span<const T>(knots_), tol_);
+        } else {
+            knots_.assign(knots.begin(), knots.end());
+        }
+
+        const KnotClassRange range = classify_knots<T>(knots_, degree_, tol_);
+        num_intervals_ = range.num_intervals();
+        check_space_has_an_interval<T>(knots_, degree_, num_intervals_, tol_);
+        num_basis_ = pantr::bspline::num_basis<T>(knots_, degree_, periodic_, tol_);
+    }
+
+    /// The knot vector, as stored.
+    ///
+    /// \return A view of this space's own storage, valid while it lives.
+    [[nodiscard]] std::span<const T> knots() const noexcept {
+        return std::span<const T>(knots_);
+    }
+
+    /// The polynomial degree.
+    ///
+    /// \return The degree, non-negative.
+    [[nodiscard]] std::int64_t degree() const noexcept { return degree_; }
+
+    /// Whether the space is periodic.
+    ///
+    /// \return `true` for a periodic space.
+    [[nodiscard]] bool periodic() const noexcept { return periodic_; }
+
+    /// The absolute tolerance for parametric comparisons on this space.
+    ///
+    /// In the units of the knot vector, being a dimensionless strict tier scaled by
+    /// the knot vector's own magnitude. Two knots closer than this are the same
+    /// knot, a point within this of an end is inside the domain, and two knot
+    /// intervals differing by less than this are the same length.
+    ///
+    /// Being an absolute *parametric* length, it is not the factor to scale a
+    /// physical coordinate or a spline coefficient by.
+    ///
+    /// \return The tolerance, a `double` at every knot width. See
+    ///         `pantr/bspline/knots.hpp` for why.
+    [[nodiscard]] double tolerance() const noexcept { return tol_; }
+
+    /// The number of basis functions.
+    ///
+    /// \return The knot count less the degree less one, reduced in the periodic
+    ///         case by the regularity at the domain's start.
+    [[nodiscard]] std::int64_t num_basis() const noexcept { return num_basis_; }
+
+    /// The number of intervals in the domain.
+    ///
+    /// \return One less than the number of distinct in-domain knots; at least 1,
+    ///         because the constructor refuses a space with none.
+    [[nodiscard]] std::int64_t num_intervals() const noexcept { return num_intervals_; }
+
+    /// The knot vector's domain.
+    ///
+    /// Two indexed reads rather than a stored pair: an eager field and this are the
+    /// same computation, and not duplicating state is the tiebreak.
+    ///
+    /// \return `{knots[degree], knots[n - degree - 1]}`.
+    [[nodiscard]] std::array<T, 2> domain() const noexcept {
+        const auto first = static_cast<std::size_t>(degree_);
+        const std::size_t last = knots_.size() - first - 1;
+        return {knots_[first], knots_[last]};
+    }
+
+    /// Whether the left end is clamped.
+    ///
+    /// The comparison is **absolute and in `double`**: the oracle writes
+    /// `abs(float(a) - float(b)) <= tol`, so both operands widen before the
+    /// subtraction. A relative comparison would read a gap of up to
+    /// `1e-5 * |knots[degree]|` as clamped -- half the domain, on a knot vector
+    /// based at 1e6.
+    ///
+    /// \return `true` if the first `degree + 1` knots are equal to within the
+    ///         tolerance; always `false` for a periodic space, whatever its knots.
+    [[nodiscard]] bool has_left_end_open() const noexcept {
+        using std::abs;
+        if (periodic_) {
+            return false;
+        }
+        const double gap = detail::as_double(knots_.front())
+                           - detail::as_double(knots_[static_cast<std::size_t>(degree_)]);
+        return abs(gap) <= tol_;
+    }
+
+    /// Whether the right end is clamped.
+    ///
+    /// Absolute and in `double`, as `has_left_end_open` is.
+    ///
+    /// \return `true` if the last `degree + 1` knots are equal to within the
+    ///         tolerance; always `false` for a periodic space.
+    [[nodiscard]] bool has_right_end_open() const noexcept {
+        using std::abs;
+        if (periodic_) {
+            return false;
+        }
+        const std::size_t first = knots_.size() - static_cast<std::size_t>(degree_) - 1;
+        const double gap = detail::as_double(knots_[first]) - detail::as_double(knots_.back());
+        return abs(gap) <= tol_;
+    }
+
+    /// Whether both ends are clamped.
+    ///
+    /// \return `true` if the space is open at both ends.
+    [[nodiscard]] bool has_open_knots() const noexcept {
+        return has_left_end_open() && has_right_end_open();
+    }
+
+    /// Whether the knots describe a single Bézier segment.
+    ///
+    /// \return `true` iff the space is non-periodic, clamped at both ends, and has
+    ///         exactly `degree + 1` basis functions.
+    [[nodiscard]] bool has_bezier_like_knots() const noexcept {
+        return !periodic_ && has_left_end_open() && has_right_end_open()
+               && num_basis_ == degree_ + 1;
+    }
+
+    /// The distinct knots of the whole vector.
+    ///
+    /// \return One representative per class, in order; a view of the derived block.
+    [[nodiscard]] std::span<const T> unique_knots() const {
+        return std::span<const T>(derived().classes.unique);
+    }
+
+    /// The multiplicities of the distinct knots of the whole vector.
+    ///
+    /// \return One count per class, summing to `knots().size()`.
+    [[nodiscard]] std::span<const std::int64_t> multiplicity() const {
+        return std::span<const std::int64_t>(derived().classes.multiplicity);
+    }
+
+    /// The distinct knots inside the domain.
+    ///
+    /// A subrange of `unique_knots()` rather than a second computation, which is
+    /// why there is one memo here and not two.
+    ///
+    /// \return The in-domain representatives, `num_intervals() + 1` of them.
+    [[nodiscard]] std::span<const T> unique_knots_in_domain() const {
+        const KnotClasses<T>& classes = derived().classes;
+        return std::span<const T>(classes.unique)
+            .subspan(classes.domain_begin, classes.domain_end - classes.domain_begin);
+    }
+
+    /// The multiplicities of the distinct knots inside the domain.
+    ///
+    /// The whole class of each boundary knot is reported, clamped copies outside
+    /// the domain included, which is what the multiplicity of a boundary knot
+    /// means.
+    ///
+    /// \return The in-domain counts, `num_intervals() + 1` of them.
+    [[nodiscard]] std::span<const std::int64_t> multiplicity_in_domain() const {
+        const KnotClasses<T>& classes = derived().classes;
+        return std::span<const std::int64_t>(classes.multiplicity)
+            .subspan(classes.domain_begin, classes.domain_end - classes.domain_begin);
+    }
+
+    /// The index of the first basis function supported on each interval.
+    ///
+    /// Entry `j` is the smallest global function index `i` whose function is
+    /// non-zero on the open interval between in-domain unique knots `j` and
+    /// `j + 1`. The functions non-zero there are exactly `i` through `i + degree`,
+    /// so this one index describes the whole support of the interval.
+    ///
+    /// It is exact integer arithmetic and no basis evaluation: the functions
+    /// non-zero on the span starting at knot index `k` are `k - degree` through
+    /// `k`, where `k` is the *last* position at which that unique knot occurs.
+    /// Selecting the unique knots whose last position lies in `[degree, num_basis)`
+    /// picks out exactly the knots that start an in-domain interval, which makes
+    /// the first interval no different from the rest and needs no special case for
+    /// a non-clamped knot vector.
+    ///
+    /// \return A view of `num_intervals()` non-decreasing indices, whose successive
+    ///         differences are the interior knot multiplicities.
+    /// \throws std::invalid_argument If the space is periodic.
+    [[nodiscard]] std::span<const std::int64_t> first_basis_per_interval() const {
+        if (periodic_) {
+            throw std::invalid_argument(
+                "first_basis_per_interval: periodic B-spline spaces are not supported.");
+        }
+        return std::span<const std::int64_t>(derived().first_basis);
+    }
+
+  private:
+    /// Everything derived from the knots that allocates. One struct, one flag, one
+    /// fill: grouping by "computed by the same scan" is what keeps this to a single
+    /// mutex rather than one per quantity.
+    struct Derived {
+        KnotClasses<T> classes;                 ///< The distinct knots and their counts.
+        std::vector<std::int64_t> first_basis;  ///< Empty for a periodic space.
+    };
+
+    /// Refuse the constructor's arguments before anything is stored.
+    ///
+    /// The order is the oracle's `_validate_input`: degree, then length, then
+    /// monotonicity, then whether the vector can support the degree at all. The
+    /// type-kind checks that sit between the first two there belong to the Python
+    /// wrapper, because nanobind has no path to `TypeError`.
+    ///
+    /// \param knots The knot vector as supplied.
+    /// \param degree The requested degree.
+    /// \param periodic Whether the space is periodic, which changes the basis count.
+    /// \throws std::invalid_argument On any of the four refusals.
+    static void check_arguments(std::span<const T> knots, std::int64_t degree, bool periodic) {
+        if (degree < 0) {
+            throw std::invalid_argument("degree must be non-negative");
+        }
+        if (static_cast<std::int64_t>(knots.size()) < 2 * degree + 2) {
+            throw std::invalid_argument("knots must have at least 2*degree+2 elements");
+        }
+        // `np.all(np.diff(knots) >= 0)`: the difference is formed first and only
+        // then compared, which is not the same predicate as `knots[i] >= knots[i-1]`
+        // -- a vector of two infinities differences to NaN and is refused, while the
+        // direct comparison would accept it.
+        for (std::size_t i = 1; i < knots.size(); ++i) {
+            const T step = knots[i] - knots[i - 1];
+            if (!(detail::as_double(step) >= 0.0)) {
+                throw std::invalid_argument("knots must be non-decreasing");
+            }
+        }
+        // Derived only here, after the shape and ordering checks: the tolerance
+        // reads the endpoints, so it needs a vector that has them.
+        const double tol = knot_tolerance(knots);
+        if (pantr::bspline::num_basis<T>(knots, degree, periodic, tol) < degree + 1) {
+            throw std::invalid_argument("Not enough knots for the specified degree");
+        }
+    }
+
+    /// Build the derived block from the frozen state.
+    ///
+    /// A static function over the state rather than a member, so that it can be
+    /// tested without an object and cannot read a half-initialised `this`.
+    ///
+    /// \param knots The stored knot vector.
+    /// \param degree The degree.
+    /// \param periodic Whether the space is periodic.
+    /// \param tol The parametric tolerance.
+    /// \param num_basis The stored basis count.
+    /// \return The classes, and the per-interval first basis index for a
+    ///         non-periodic space.
+    static Derived build_derived(std::span<const T> knots, std::int64_t degree, bool periodic,
+                                 double tol, std::int64_t num_basis) {
+        Derived block{unique_knots_and_multiplicity(knots, degree, tol), {}};
+        if (periodic) {
+            return block;
+        }
+        std::int64_t last_position = -1;
+        for (const std::int64_t multiplicity : block.classes.multiplicity) {
+            last_position += multiplicity;
+            if (last_position >= degree && last_position < num_basis) {
+                block.first_basis.push_back(last_position - degree);
+            }
+        }
+        return block;
+    }
+
+    /// The derived block, building it on first use.
+    ///
+    /// \return The block, valid while this space lives.
+    [[nodiscard]] const Derived& derived() const {
+        return derived_.get([this] {
+            return build_derived(std::span<const T>(knots_), degree_, periodic_, tol_, num_basis_);
+        });
+    }
+
+    std::vector<T> knots_;              ///< The knot vector, snapped if requested.
+    std::int64_t degree_ = 0;           ///< The polynomial degree.
+    bool periodic_ = false;             ///< Whether the space is periodic.
+    double tol_ = 0.0;                  ///< The parametric tolerance, from the raw knots.
+    std::int64_t num_basis_ = 0;        ///< The number of basis functions.
+    std::int64_t num_intervals_ = 0;    ///< The number of in-domain intervals.
+    LazySlot<Derived> derived_;         ///< The derived arrays, built at most once.
+};
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/space_1d.hpp
+++ b/cpp/include/pantr/bspline/space_1d.hpp
@@ -58,8 +58,16 @@
 ///    `_bspline_space_1d.py:99-106` copies too, and says why -- it freezes the
 ///    vector read-only afterwards, and freezing a caller's array in place would
 ///    mutate caller state. Recorded because the claim was written down and
-///    believed, and because `pantr/bezier/bezier.hpp` makes a structurally similar
-///    claim about a control net that is worth the same scrutiny.
+///    believed.
+///
+///    `pantr/bezier/bezier.hpp:60-65` makes the structurally similar claim about a
+///    control net, and **that one is true** -- checked by execution rather than
+///    assumed, because the resemblance is exactly what made this one look safe.
+///    `_BezierPython.__init__` stores what `numpy.asarray` returns, which does not
+///    copy an array that already has the right dtype, and a write through the
+///    caller's array is visible in the Bezier afterwards. The two oracles genuinely
+///    differ: a space copies because it freezes its knots read-only, and a Bezier
+///    does not, which is the defect FELIGN/pantr#375 fixes.
 ///
 /// ## Thread safety
 ///

--- a/cpp/include/pantr/core/format.hpp
+++ b/cpp/include/pantr/core/format.hpp
@@ -31,6 +31,18 @@
 /// notation itself. That difference is the only one this file has to bridge, and
 /// it is bridged in exactly one place.
 ///
+/// ## One deliberate change from the code this replaces
+///
+/// The unreachable formatting-overflow branch used to throw
+/// `std::invalid_argument("AABB: could not format a bound.")`. It now throws
+/// `std::logic_error`, which is the accurate type: nothing about the caller's
+/// argument is wrong, an internal buffer bound was exceeded. It matters at the
+/// binding, where `pantr/core/error.hpp` records that nanobind maps
+/// `std::invalid_argument` to `ValueError` and everything else to `RuntimeError` --
+/// and blaming the caller for this one would be wrong. `aabb.hpp`'s file comment
+/// still says the class throws `std::invalid_argument`; that remains true of every
+/// reachable path and of all of its actual validation.
+///
 /// ## The toolchain floor this file carries
 ///
 /// `format_repr` needs the **floating-point** overload of `std::to_chars`, which
@@ -45,6 +57,7 @@
 #include <charconv>
 #include <cmath>
 #include <cstdio>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <system_error>
@@ -60,6 +73,26 @@ namespace pantr::detail {
 /// about 310 digits before the point. The `errc` and truncation checks below are
 /// what make this a bound rather than an assumption.
 inline constexpr std::size_t kFormatBufferSize = 512;
+
+/// Python's spelling of a value `snprintf` would spell differently, if this is one.
+///
+/// \param v The value to render.
+/// \return The rendering, or nothing at all when `v` is finite.
+[[nodiscard]] inline std::optional<std::string> format_non_finite(double v) {
+    // CPython prints a NaN **without a sign, ever**, at every format specifier, even
+    // for one whose sign bit is set. glibc's `printf` prints `-nan` for that value.
+    // So every spelling below has to intercept the non-finite cases rather than hand
+    // them to `snprintf`, and this is not theoretical: a knot vector holding an
+    // infinity gives `tol / ulp == inf / nan`, whose NaN came out negative on this
+    // platform, and the two backends' messages then differed by one character.
+    if (std::isnan(v)) {
+        return "nan";
+    }
+    if (std::isinf(v)) {
+        return v < 0.0 ? "-inf" : "inf";
+    }
+    return std::nullopt;
+}
 
 /// Render a `double` the way Python's `repr` renders a float.
 ///
@@ -81,11 +114,8 @@ inline constexpr std::size_t kFormatBufferSize = 512;
 /// \throws std::logic_error If the value could not be rendered, which the buffer
 ///         size makes unreachable and which is checked rather than assumed.
 [[nodiscard]] inline std::string format_repr(double v) {
-    if (std::isnan(v)) {
-        return "nan";
-    }
-    if (std::isinf(v)) {
-        return v < 0.0 ? "-inf" : "inf";
+    if (const std::optional<std::string> special = format_non_finite(v)) {
+        return *special;
     }
 
     std::array<char, kFormatBufferSize> buffer{};
@@ -141,6 +171,9 @@ template <class T>
 /// \return The rendered value.
 /// \throws std::logic_error If the value could not be rendered.
 [[nodiscard]] inline std::string format_general(double v, int precision) {
+    if (const std::optional<std::string> special = format_non_finite(v)) {
+        return *special;
+    }
     std::array<char, kFormatBufferSize> buffer{};
     const int written =
         std::snprintf(buffer.data(), buffer.size(), "%.*g", precision, v);  // NOLINT
@@ -157,6 +190,9 @@ template <class T>
 /// \return The rendered value.
 /// \throws std::logic_error If the value could not be rendered.
 [[nodiscard]] inline std::string format_fixed(double v, int precision) {
+    if (const std::optional<std::string> special = format_non_finite(v)) {
+        return *special;
+    }
     std::array<char, kFormatBufferSize> buffer{};
     const int written =
         std::snprintf(buffer.data(), buffer.size(), "%.*f", precision, v);  // NOLINT

--- a/cpp/include/pantr/core/format.hpp
+++ b/cpp/include/pantr/core/format.hpp
@@ -1,0 +1,169 @@
+#pragma once
+
+/// \file
+/// Rendering a floating-point value the way Python renders it, for the port's
+/// exception messages.
+///
+/// ## Why this is core rather than local to one type
+///
+/// The port reproduces its oracle's messages character for character, because a
+/// parity test compares them (`tests/parity/test_bezier_type.py` is the shipped
+/// example) and because the message is part of what a caller is told. Several of
+/// those messages interpolate a floating-point number, and each spelling below is
+/// a distinct Python format specifier, not a matter of taste:
+///
+///  - `format_repr`, and `format_scalar` over a scalar, are `repr(x)` and `f"{x!r}"`,
+///  - `format_general` is `f"{x:.Ng}"`,
+///  - `format_fixed` is `f"{x:.Nf}"`.
+///
+/// `pantr/geometry/aabb.hpp` needed the first of them and grew it in place; it is
+/// here now because `pantr/bspline/knots.hpp` needs all three, and a second copy
+/// of a repr rule is exactly how the first one went wrong. The notation bug the
+/// comment on `format_repr` records was found once and would have had to be found
+/// again.
+///
+/// ## Where the two languages actually agree
+///
+/// The *digits* are correctly rounded on both sides -- CPython formats through
+/// David Gay's `dtoa` and glibc's `printf` is correctly rounded too -- so
+/// `%.3g` and `f"{x:.3g}"` produce the same characters. What does **not** transfer
+/// is `std::to_chars`'s choice of notation, which is why `format_repr` picks the
+/// notation itself. That difference is the only one this file has to bridge, and
+/// it is bridged in exactly one place.
+///
+/// ## The toolchain floor this file carries
+///
+/// `format_repr` needs the **floating-point** overload of `std::to_chars`, which
+/// libstdc++ 10 does not provide -- it defines no `__cpp_lib_to_chars`, and the
+/// facility arrived in libstdc++ 11. That is FELIGN/pantr#376, whose specification
+/// is a configure-time probe saying so rather than a reimplementation, so the call
+/// stays. Collecting the rule here is what turns "some header somewhere needs it"
+/// into one file a probe can name, and `format_general` and `format_fixed`
+/// deliberately go through `snprintf` instead, which the floor does have.
+
+#include <array>
+#include <charconv>
+#include <cmath>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::detail {
+
+/// The widest a rendered `double` can be here, with room to spare.
+///
+/// A shortest-round-trip `double` needs at most 17 significant digits, a sign, a
+/// point and a four-character exponent; `%.Nf` of a value near `DBL_MAX` needs
+/// about 310 digits before the point. The `errc` and truncation checks below are
+/// what make this a bound rather than an assumption.
+inline constexpr std::size_t kFormatBufferSize = 512;
+
+/// Render a `double` the way Python's `repr` renders a float.
+///
+/// Two rules have to agree, and conflating them is how this went wrong once
+/// already. The **digits** are the shortest sequence that round-trips, which is
+/// what `std::to_chars` produces and what Python's `repr` uses. The **notation**
+/// is a separate decision, and the two languages make it differently: bare
+/// `std::to_chars` picks whichever spelling is textually shorter, so `100000.0`
+/// comes out as `1e+05`, while Python decides positionally -- fixed notation when
+/// the decimal exponent lands in `[-4, 16)`, scientific otherwise. Those rules
+/// coincide on typical magnitudes and diverge on round numbers, which is why the
+/// first version passed every value the tests happened to carry.
+///
+/// So the exponent is obtained first, in scientific form, and the notation is then
+/// chosen by Python's rule and rendered explicitly.
+///
+/// \param v The value to render.
+/// \return Its Python-style textual form.
+/// \throws std::logic_error If the value could not be rendered, which the buffer
+///         size makes unreachable and which is checked rather than assumed.
+[[nodiscard]] inline std::string format_repr(double v) {
+    if (std::isnan(v)) {
+        return "nan";
+    }
+    if (std::isinf(v)) {
+        return v < 0.0 ? "-inf" : "inf";
+    }
+
+    std::array<char, kFormatBufferSize> buffer{};
+    auto written = std::to_chars(buffer.data(), buffer.data() + buffer.size(), v,
+                                 std::chars_format::scientific);
+    if (written.ec != std::errc{}) {
+        throw std::logic_error("pantr: could not render a floating-point value.");
+    }
+    const std::string sci(buffer.data(), written.ptr);
+
+    // `to_chars`'s scientific form is always `d[.ddd]e[+-]dd`, so the exponent is
+    // whatever follows the one `e`.
+    const std::size_t e_pos = sci.find('e');
+    const int exponent = std::stoi(sci.substr(e_pos + 1));
+
+    // Python: fixed notation while the decimal point sits inside the digits or just
+    // before them, scientific once it has moved far enough either way.
+    constexpr int kFixedLowerExponent = -5;
+    constexpr int kFixedUpperExponent = 16;
+    if (exponent <= kFixedLowerExponent || exponent >= kFixedUpperExponent) {
+        return sci;
+    }
+
+    written = std::to_chars(buffer.data(), buffer.data() + buffer.size(), v,
+                            std::chars_format::fixed);
+    if (written.ec != std::errc{}) {
+        throw std::logic_error("pantr: could not render a floating-point value.");
+    }
+    std::string text(buffer.data(), written.ptr);
+    if (text.find('.') == std::string::npos) {
+        text += ".0";
+    }
+    return text;
+}
+
+/// Render a scalar the way Python's `repr` renders a float.
+///
+/// Tier B: the rendering is a function of the value, so it goes through
+/// `value_of` rather than touching the scalar directly.
+///
+/// \param x The value to render.
+/// \return Its Python-style textual form.
+template <class T>
+[[nodiscard]] inline std::string format_scalar(const T& x) {
+    using pantr::value_of;
+    return format_repr(static_cast<double>(value_of(x)));
+}
+
+/// Render a `double` the way Python's `f"{v:.Ng}"` renders a float.
+///
+/// \param v The value to render.
+/// \param precision The `N` of the format specifier; at least 1, as Python's is.
+/// \return The rendered value.
+/// \throws std::logic_error If the value could not be rendered.
+[[nodiscard]] inline std::string format_general(double v, int precision) {
+    std::array<char, kFormatBufferSize> buffer{};
+    const int written =
+        std::snprintf(buffer.data(), buffer.size(), "%.*g", precision, v);  // NOLINT
+    if (written < 0 || static_cast<std::size_t>(written) >= buffer.size()) {
+        throw std::logic_error("pantr: could not render a floating-point value.");
+    }
+    return {buffer.data(), static_cast<std::size_t>(written)};
+}
+
+/// Render a `double` the way Python's `f"{v:.Nf}"` renders a float.
+///
+/// \param v The value to render.
+/// \param precision The `N` of the format specifier; may be 0.
+/// \return The rendered value.
+/// \throws std::logic_error If the value could not be rendered.
+[[nodiscard]] inline std::string format_fixed(double v, int precision) {
+    std::array<char, kFormatBufferSize> buffer{};
+    const int written =
+        std::snprintf(buffer.data(), buffer.size(), "%.*f", precision, v);  // NOLINT
+    if (written < 0 || static_cast<std::size_t>(written) >= buffer.size()) {
+        throw std::logic_error("pantr: could not render a floating-point value.");
+    }
+    return {buffer.data(), static_cast<std::size_t>(written)};
+}
+
+}  // namespace pantr::detail

--- a/cpp/include/pantr/core/lazy.hpp
+++ b/cpp/include/pantr/core/lazy.hpp
@@ -81,8 +81,9 @@ class LazySlot {
     LazySlot(const LazySlot& /*other*/) noexcept {}
 
     /// Move the owner, not the memo: the new slot starts cold and the source is
-    /// left exactly as it was, which is legal for a moved-from object and is what
-    /// keeps this `noexcept`.
+    /// left exactly as it was, which is legal for a moved-from object. Leaving it
+    /// alone is the class-level semantics rather than an exception-safety
+    /// necessity -- clearing the source would be `noexcept` too.
     LazySlot(LazySlot&& /*other*/) noexcept {}
 
     /// Clear this slot: the value it held described the state being overwritten.

--- a/cpp/include/pantr/core/lazy.hpp
+++ b/cpp/include/pantr/core/lazy.hpp
@@ -1,0 +1,152 @@
+#pragma once
+
+/// \file
+/// A derived value computed at most once, from any number of threads.
+///
+/// ## The contract this exists to make true
+///
+/// > Every non-mutating public accessor on a C++-owned pantr domain type is safe
+/// > to call concurrently from any number of threads on the same object, with no
+/// > external locking. A lazy memo behind such an accessor is filled at most once
+/// > and published atomically.
+///
+/// That sentence is `design/bspline_derived_caches.md`'s, and it is the reason
+/// this is a type rather than three lines copied into each owner. The port has at
+/// least five of these coming -- a grid's bounding-volume hierarchy, a 1D space's
+/// derived knot arrays, a THB space's contribution table, a multi-level
+/// extraction's per-level spaces -- and the shape that gets copied by hand is the
+/// bare `mutable std::optional`, which is a **data race** rather than a benign
+/// lost update.
+///
+/// ## Why not the two obvious spellings
+///
+/// **A bare `mutable std::optional`, filled on first `const` access.** Measured
+/// under g++ 14.4 `-fsanitize=thread` with 8 threads first-touching one memo: 4
+/// data races, every frame in the unsynchronised accessor -- one on the
+/// `optional`'s engaged flag and the rest on the contained vector's pointer
+/// triple. **And measured without the sanitizer: 60 runs of 8 threads produced
+/// the correct answer 60 times.** That is the finding, not the exoneration: two
+/// threads assigning one `std::optional<std::vector<double>>` can leave a torn
+/// pointer triple, double-free the loser's buffer, or leak it, and no test that
+/// checks a value will ever see it.
+///
+/// **`std::call_once`.** Correct, idiomatic, and measured at one to a few
+/// microseconds on its *first* call, size-independently -- roughly ten times the
+/// entire construction of a small B-spline space. `strace` on a minimal program
+/// shows glibc's `pthread_once` issuing `futex(..., FUTEX_WAKE_PRIVATE, INT_MAX)`
+/// on that first call with zero waiters. Double-checked locking is the same
+/// guarantee without that syscall: measured within noise of computing eagerly on
+/// first use, and 3 to 8 ns per access thereafter.
+///
+/// ## Reading it correctly in a hot loop
+///
+/// The accessor looks free and is not. A sweep over cells or intervals should
+/// hoist the `get` out of the loop into a local reference **once** and take a span
+/// before the loop rather than per element; a few nanoseconds per element over an
+/// `n * (p + 1)` sweep is a measurable tax for no reason, and the fix is a local
+/// rather than a mechanism.
+
+#include <atomic>
+#include <mutex>
+#include <optional>
+#include <utility>
+
+namespace pantr {
+
+/// A `T` built on first use and then never again.
+///
+/// Copy and move leave the target **cold** rather than carrying the source's
+/// value across. That is not laziness about implementing it: the memo is a
+/// function of its owner's state, the owner is what is being copied, and a memo
+/// that travelled would have to be proved still to describe the target. Assignment
+/// clears the target for the same reason, which matters because assignment is what
+/// replaces the owner's state underneath it.
+///
+/// **The slot is not itself thread-safe against assignment.** `get` is safe
+/// against any number of concurrent `get`s; assigning or destroying the slot while
+/// another thread reads it is a data race like any other write to a shared object,
+/// and the owning types here are immutable after construction so it does not
+/// arise. `cpp/include/pantr/grid/tags.hpp` says the same of the one mutable
+/// member the domain layer keeps.
+///
+/// \tparam T The derived value. Must be movable; it is constructed by the builder
+///         and moved into the slot.
+template <class T>
+class LazySlot {
+  public:
+    /// Start cold.
+    LazySlot() noexcept = default;
+
+    /// Copy the owner, not the memo: the new slot starts cold.
+    LazySlot(const LazySlot& /*other*/) noexcept {}
+
+    /// Move the owner, not the memo: the new slot starts cold and the source is
+    /// left exactly as it was, which is legal for a moved-from object and is what
+    /// keeps this `noexcept`.
+    LazySlot(LazySlot&& /*other*/) noexcept {}
+
+    /// Clear this slot: the value it held described the state being overwritten.
+    LazySlot& operator=(const LazySlot& other) noexcept {
+        if (this != &other) {
+            clear();
+        }
+        return *this;
+    }
+
+    /// Clear this slot, for the reason copy assignment does.
+    LazySlot& operator=(LazySlot&& other) noexcept {
+        if (this != &other) {
+            clear();
+        }
+        return *this;
+    }
+
+    ~LazySlot() = default;
+
+    /// The value, building it on the first call.
+    ///
+    /// The `acquire` load and the `release` store are the pair that makes this
+    /// correct: the release store publishes every write the builder made, and the
+    /// acquire load is what a reader synchronises with. Dropping either, or making
+    /// both `relaxed`, restores the race with the ceremony still visible. The
+    /// second load is inside the lock and is `relaxed` because the lock already
+    /// orders it.
+    ///
+    /// A builder that throws leaves the slot cold and the lock released, so the
+    /// next caller retries rather than reading a half-built value.
+    ///
+    /// \param build A callable returning the value; invoked at most once.
+    /// \return The stored value, valid for the lifetime of this slot.
+    template <class F>
+    [[nodiscard]] const T& get(F&& build) const {
+        if (!ready_.load(std::memory_order_acquire)) {
+            const std::lock_guard<std::mutex> guard(mutex_);
+            if (!ready_.load(std::memory_order_relaxed)) {
+                value_.emplace(std::forward<F>(build)());
+                ready_.store(true, std::memory_order_release);
+            }
+        }
+        return *value_;
+    }
+
+    /// Whether the value has been built.
+    ///
+    /// For tests and diagnostics. A caller that branches on this is asking a
+    /// question whose answer can change before it is used.
+    ///
+    /// \return `true` once `get` has returned at least once.
+    [[nodiscard]] bool filled() const noexcept { return ready_.load(std::memory_order_acquire); }
+
+  private:
+    /// Drop the value and mark the slot cold.
+    void clear() noexcept {
+        value_.reset();
+        ready_.store(false, std::memory_order_release);
+    }
+
+    mutable std::mutex mutex_;                ///< Held only while the value is built.
+    mutable std::atomic<bool> ready_{false};  ///< Whether `value_` has been published.
+    mutable std::optional<T> value_;          ///< The value, once built.
+};
+
+}  // namespace pantr

--- a/cpp/include/pantr/geometry/aabb.hpp
+++ b/cpp/include/pantr/geometry/aabb.hpp
@@ -62,9 +62,7 @@
 /// is deliberately not taken here.
 
 #include <algorithm>
-#include <charconv>
 #include <cmath>
-#include <array>
 #include <cstddef>
 #include <functional>
 #include <limits>
@@ -74,6 +72,7 @@
 #include <string>
 #include <vector>
 
+#include "pantr/core/format.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/core/scalar.hpp"
 
@@ -83,66 +82,11 @@ namespace detail {
 
 /// Format a scalar the way Python's `repr` formats a float.
 ///
-/// Two rules have to agree, and conflating them is how this went wrong once
-/// already. The **digits** are the shortest sequence that round-trips, which is
-/// what `std::to_chars` produces and what Python's `repr` uses. The **notation**
-/// is a separate decision, and the two languages make it differently: bare
-/// `std::to_chars` picks whichever spelling is textually shorter, so `100000.0`
-/// comes out as `1e+05`, while Python decides positionally -- fixed notation
-/// when the decimal exponent lands in `[-4, 16)`, scientific otherwise. Those
-/// rules coincide on typical magnitudes and diverge on round numbers, which is
-/// why the first version passed every value the tests happened to carry.
-///
-/// So the exponent is obtained first, in scientific form, and the notation is
-/// then chosen by Python's rule and rendered explicitly.
-///
-/// \param x The value to format.
-/// \return Its Python-style textual form.
-template <class T>
-[[nodiscard]] inline std::string format_scalar(const T& x) {
-    const double v = static_cast<double>(value_of(x));
-    if (std::isnan(v)) {
-        return "nan";
-    }
-    if (std::isinf(v)) {
-        return v < 0.0 ? "-inf" : "inf";
-    }
-
-    // 24 digits and a sign and an exponent fit any shortest-round-trip double
-    // several times over; the `ec` check below is what makes that a check rather
-    // than an assumption.
-    std::array<char, 64> buffer{};
-    auto written = std::to_chars(buffer.data(), buffer.data() + buffer.size(), v,
-                                 std::chars_format::scientific);
-    if (written.ec != std::errc{}) {
-        throw std::invalid_argument("AABB: could not format a bound.");
-    }
-    const std::string sci(buffer.data(), written.ptr);
-
-    // `to_chars`'s scientific form is always `d[.ddd]e[+-]dd`, so the exponent is
-    // whatever follows the one `e`.
-    const std::size_t e_pos = sci.find('e');
-    const int exponent = std::stoi(sci.substr(e_pos + 1));
-
-    // Python: fixed notation while the decimal point sits inside the digits or
-    // just before them, scientific once it has moved far enough either way.
-    constexpr int kFixedLowerExponent = -5;
-    constexpr int kFixedUpperExponent = 16;
-    if (exponent <= kFixedLowerExponent || exponent >= kFixedUpperExponent) {
-        return sci;
-    }
-
-    written = std::to_chars(buffer.data(), buffer.data() + buffer.size(), v,
-                            std::chars_format::fixed);
-    if (written.ec != std::errc{}) {
-        throw std::invalid_argument("AABB: could not format a bound.");
-    }
-    std::string text(buffer.data(), written.ptr);
-    if (text.find('.') == std::string::npos) {
-        text += ".0";
-    }
-    return text;
-}
+/// Moved to `pantr/core/format.hpp` when the B-spline space port needed the same
+/// rule for its own messages, and re-exported here so every call site below keeps
+/// its spelling. The notation rule it implements was got wrong once; a second copy
+/// of it is what this avoids.
+using pantr::detail::format_scalar;
 
 /// Format a corner the way Python formats a list of floats.
 ///

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -29,7 +29,9 @@ set(PANTR_TEST_SOURCES
     test_grid_tensor_product.cpp
     test_bezier_product.cpp
     test_format.cpp
-    test_lazy.cpp)
+    test_lazy.cpp
+    test_bspline_knots.cpp
+    test_bspline_space_1d.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file.

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -28,7 +28,8 @@ set(PANTR_TEST_SOURCES
     test_grid_defaults.cpp
     test_grid_tensor_product.cpp
     test_bezier_product.cpp
-    test_format.cpp)
+    test_format.cpp
+    test_lazy.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file.

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -27,7 +27,8 @@ set(PANTR_TEST_SOURCES
     test_grid_bvh_type.cpp
     test_grid_defaults.cpp
     test_grid_tensor_product.cpp
-    test_bezier_product.cpp)
+    test_bezier_product.cpp
+    test_format.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file.

--- a/cpp/tests/test_bspline_knots.cpp
+++ b/cpp/tests/test_bspline_knots.cpp
@@ -1,0 +1,356 @@
+/// \file
+/// The knot vector's tolerance, its classes, and the refusals a space owes.
+///
+/// ## Where the expected values come from
+///
+/// Three different provenances, kept apart on purpose because they carry
+/// different weight.
+///
+///  - **Derived here.** The tolerance is asserted against `8 * eps * scale`
+///    recomputed in the test from `std::numeric_limits`, not against a literal
+///    copied from a run. A literal would pass if both sides drifted together.
+///  - **Hand-checkable structure.** The class counts, multiplicities and interval
+///    counts are read off the knot vectors by eye; each case says what it is for.
+///  - **The oracle's text, verbatim.** The five messages are what
+///    `pantr.bspline.BsplineSpace1D` prints for the same arguments, captured by
+///    running it. They are asserted character for character because they are also
+///    the messages a Python caller sees under either backend, and a reworded one
+///    here is a parity failure that an assertion on the exception *type* would
+///    not notice.
+///
+/// Nothing here has a numerical tolerance of its own. Every quantity is a count,
+/// an index, a knot value reproduced exactly, or a string.
+///
+/// ## The two cases that would not be written without having got them wrong
+///
+/// **Chaining.** Classes are grouped by gap, so `n` knots each within `tol` of the
+/// next collapse into one class however far apart the ends are. A vector whose
+/// four leading knots step by `0.56 * tol` is one class even though its ends are
+/// `1.7 * tol` apart, and the test says so.
+///
+/// **Snapping decides its boundaries on the original vector.** Rewriting knots in
+/// place while scanning changes the predicate for every later step: the same
+/// four-knot chain splits into two classes if `knots[i-1]` has already been moved
+/// onto its representative. That is a silent wrong answer -- a different interval
+/// count on a legal space -- and `check_snap_reads_the_original_vector` is the only
+/// thing in the suite that distinguishes the two implementations.
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bspline/knots.hpp"
+
+namespace {
+
+using pantr::bspline::check_snapping_kept_an_interval;
+using pantr::bspline::check_space_has_an_interval;
+using pantr::bspline::classify_knots;
+using pantr::bspline::knot_scale;
+using pantr::bspline::knot_tolerance;
+using pantr::bspline::KnotClassRange;
+using pantr::bspline::num_basis;
+using pantr::bspline::snap_knots;
+using pantr::bspline::unique_knots_and_multiplicity;
+
+/// A span over a vector, for brevity below.
+template <class T>
+std::span<const T> view(const std::vector<T>& v) {
+    return std::span<const T>(v);
+}
+
+/// The message of the `std::invalid_argument` that `fn` throws.
+///
+/// Returns a marker rather than asserting, so the caller's own check reports and a
+/// failure names the case it came from.
+template <class F>
+std::string message_of(F&& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument& e) {
+        return e.what();
+    } catch (...) {
+        return "<threw something else>";
+    }
+    return "<did not throw>";
+}
+
+/// Check a string against the oracle's, reporting both on failure.
+void same(const std::string& actual, const std::string& expected, const char* what) {
+    PANTR_CHECK_MSG(actual == expected,
+                    std::string(what) + ":\n  got  '" + actual + "'\n  want '" + expected + "'");
+}
+
+/// The scale is the largest of the span and the two coordinate magnitudes.
+///
+/// The offset cases are the point: on a knot vector based at 1e6 a knot difference
+/// is formed from two coordinates of that size, so the span alone would understate
+/// the magnitude a comparison is relative to by six orders.
+void check_knot_scale() {
+    PANTR_CHECK(knot_scale<double>(view(std::vector<double>{0.0, 1.0})) == 1.0);
+    PANTR_CHECK(knot_scale<double>(view(std::vector<double>{1e6, 1e6 + 1.0})) == 1e6 + 1.0);
+    PANTR_CHECK(knot_scale<double>(view(std::vector<double>{-5.0, -1.0})) == 5.0);
+    PANTR_CHECK(knot_scale<double>(view(std::vector<double>{-2.0, 3.0})) == 5.0);
+    // A domain smaller than one unit keeps its own scale: no floor is applied, so
+    // the tolerance stays covariant under a change of parametric unit.
+    PANTR_CHECK(knot_scale<double>(view(std::vector<double>{0.0, 1e-6})) == 1e-6);
+    PANTR_CHECK(knot_scale<double>(view(std::vector<double>{0.0, 0.0})) == 0.0);
+}
+
+/// The tolerance is `8 * eps(T) * scale`, at both widths.
+///
+/// Recomputed from `numeric_limits` rather than compared against a literal: the
+/// factor is what is being asserted, and a literal would agree with a wrong factor
+/// as readily as with the right one. The exactness claim is separate and is checked
+/// too -- 8 and eps are both powers of two, so the product is exact and the only
+/// rounding is the final multiply, which is what lets the two backends agree on the
+/// threshold to the last bit rather than merely to within it.
+void check_knot_tolerance() {
+    constexpr double eps64 = std::numeric_limits<double>::epsilon();
+    constexpr double eps32 = static_cast<double>(std::numeric_limits<float>::epsilon());
+
+    const std::vector<double> unit{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0};
+    PANTR_CHECK(knot_tolerance(view(unit)) == 8.0 * eps64 * 2.0);
+
+    const std::vector<float> unit32{0.0F, 0.0F, 0.0F, 0.25F, 0.7F, 0.7F, 1.0F, 1.0F, 1.0F};
+    PANTR_CHECK(knot_tolerance(view(unit32)) == 8.0 * eps32 * 1.0);
+
+    // Scale covariance: doubling every knot doubles the tolerance exactly, because
+    // the scale is linear and the multiply by a power of two is exact.
+    const std::vector<double> doubled{0.0, 0.0, 0.0, 2.0, 4.0, 4.0, 4.0};
+    PANTR_CHECK(knot_tolerance(view(doubled)) == 2.0 * knot_tolerance(view(unit)));
+}
+
+/// Classes, multiplicities, and the in-domain range.
+void check_classes() {
+    // Clamped, degree 2, two unit intervals. Read off the vector: three classes
+    // with multiplicities 3, 1, 3, all of them in the domain.
+    const std::vector<double> clamped{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0};
+    const double tol = knot_tolerance(view(clamped));
+    const KnotClassRange range = classify_knots(view(clamped), 2, tol);
+    PANTR_CHECK(range.count == 3);
+    PANTR_CHECK(range.domain_begin == 0);
+    PANTR_CHECK(range.domain_end == 3);
+    PANTR_CHECK(range.num_intervals() == 2);
+
+    const auto classes = unique_knots_and_multiplicity(view(clamped), 2, tol);
+    PANTR_CHECK(classes.unique == std::vector<double>({0.0, 1.0, 2.0}));
+    PANTR_CHECK(classes.multiplicity == std::vector<std::int64_t>({3, 1, 3}));
+    PANTR_CHECK(classes.domain_begin == 0);
+    PANTR_CHECK(classes.domain_end == 3);
+
+    // The multiplicities sum to the whole vector, which is what makes
+    // `repeat(unique, multiplicity)` reproduce it.
+    std::int64_t total = 0;
+    for (const std::int64_t m : classes.multiplicity) {
+        total += m;
+    }
+    PANTR_CHECK(total == static_cast<std::int64_t>(clamped.size()));
+
+    // Unclamped, degree 3: the domain is the interior, so the in-domain range is a
+    // strict subrange and the boundary classes outside it are still counted.
+    const std::vector<double> open{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 10.0};
+    const KnotClassRange interior = classify_knots(view(open), 3, knot_tolerance(view(open)));
+    PANTR_CHECK(interior.count == 9);
+    PANTR_CHECK(interior.domain_begin == 3);
+    PANTR_CHECK(interior.domain_end == 6);
+    PANTR_CHECK(interior.num_intervals() == 2);
+}
+
+/// Knots chain into one class through the steps between them.
+///
+/// Four knots each `0.56 * tol` from the next are one class, although the first and
+/// the last are `1.7 * tol` apart. Grouping by gap is what makes the answer depend
+/// on the knots rather than on where they sit relative to an origin, and chaining
+/// is the accepted cost of it: capping a class's width would break idempotence,
+/// since a class split by the cap leaves two representatives within `tol` of each
+/// other that would merge on the next pass.
+void check_chaining() {
+    const std::vector<double> chained{0.0, 1e-15, 2e-15, 3e-15, 0.5, 1.0};
+    const double tol = knot_tolerance(view(chained));
+    PANTR_CHECK_MSG(1e-15 < tol, "the step must be inside the tolerance for this to be the case");
+    PANTR_CHECK_MSG(3e-15 > tol, "and the ends outside it, or nothing is being shown");
+
+    const auto classes = unique_knots_and_multiplicity(view(chained), 1, tol);
+    PANTR_CHECK(classes.unique == std::vector<double>({0.0, 0.5, 1.0}));
+    PANTR_CHECK(classes.multiplicity == std::vector<std::int64_t>({4, 1, 1}));
+}
+
+/// A step of exactly the tolerance is inside it, not outside.
+///
+/// The predicate is "the same knot unless they differ by MORE than `tol`", so the
+/// boundary is closed on the merging side. Nothing else in this file pins it: every
+/// other case has steps that are orders of magnitude clear of the threshold, so
+/// flipping `>` to `>=` left the whole suite green when it was tried. The case has
+/// to be constructed, because a step lands exactly on the threshold only if it is
+/// built from it.
+///
+/// The oracle agrees: `_get_unique_knots_and_multiplicity_impl` on this vector
+/// reports classes `[0, 0.25, 0.5, 0.75, 1]` with multiplicities `[2, 1, 1, 1, 1]`.
+void check_the_boundary_step_merges() {
+    constexpr double eps = std::numeric_limits<double>::epsilon();
+    const std::vector<double> knots{0.0, 8.0 * eps, 0.25, 0.5, 0.75, 1.0};
+    const double tol = knot_tolerance(view(knots));
+    PANTR_CHECK_MSG(tol == 8.0 * eps, "the vector's scale must be exactly 1 for this to be exact");
+    PANTR_CHECK_MSG(knots[1] - knots[0] == tol, "the step must be exactly the tolerance");
+
+    const auto classes = unique_knots_and_multiplicity(view(knots), 1, tol);
+    PANTR_CHECK_MSG(classes.multiplicity == std::vector<std::int64_t>({2, 1, 1, 1, 1}),
+                    "a step of exactly the tolerance is a merge, not a split");
+    PANTR_CHECK(classes.unique == std::vector<double>({0.0, 0.25, 0.5, 0.75, 1.0}));
+}
+
+/// Snapping takes the class's FIRST knot, and is idempotent.
+///
+/// Chosen rather than averaged, so the values returned are knots the vector
+/// actually contains. An average would be a fresh rounding, and over `degree + 1`
+/// identical copies at large magnitude it is not even the identity, so it moved the
+/// reported domain.
+void check_snap_takes_the_first_knot() {
+    const std::vector<double> raw{0.0, 0.0, 0.0, 0.5, 0.5 + 2e-16, 1.0, 1.0, 1.0};
+    const double tol = knot_tolerance(view(raw));
+    PANTR_CHECK_MSG(raw[3] != raw[4], "the pair must really be distinct before snapping");
+
+    const std::vector<double> snapped = snap_knots(view(raw), tol);
+    PANTR_CHECK(snapped == std::vector<double>({0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0}));
+    PANTR_CHECK_MSG(snapped[4] == raw[3], "the representative is the class's first knot");
+
+    const std::vector<double> again = snap_knots(view(snapped), tol);
+    PANTR_CHECK_MSG(again == snapped, "snapping is idempotent");
+}
+
+/// Snapping reads the original vector, never the one it is writing.
+///
+/// This is the whole content of the test. Rewriting in place would compare
+/// `knots[i]` against a `knots[i-1]` already moved onto its representative, which
+/// splits the chain above into two classes and yields a *legal space with a
+/// different interval count* -- a wrong answer with nothing raising. The two
+/// implementations agree on every vector without a chain, which is why this case
+/// has to be constructed rather than stumbled on.
+void check_snap_reads_the_original_vector() {
+    const std::vector<double> chained{0.0, 1e-15, 2e-15, 3e-15, 0.5, 1.0};
+    const double tol = knot_tolerance(view(chained));
+    const std::vector<double> snapped = snap_knots(view(chained), tol);
+    PANTR_CHECK(snapped == std::vector<double>({0.0, 0.0, 0.0, 0.0, 0.5, 1.0}));
+
+    // What the in-place spelling would produce, computed here so the difference is
+    // visible rather than asserted in the abstract.
+    std::vector<double> in_place(chained);
+    for (std::size_t i = 1; i < in_place.size(); ++i) {
+        if (in_place[i] - in_place[i - 1] > tol) {
+            continue;
+        }
+        in_place[i] = in_place[i - 1];
+    }
+    PANTR_CHECK_MSG(in_place != snapped,
+                    "the in-place spelling must differ here, or this case proves nothing");
+}
+
+/// The basis count, non-periodic and periodic.
+void check_num_basis() {
+    const std::vector<double> clamped{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0};
+    // Seven knots, degree 2: `7 - 2 - 1`.
+    PANTR_CHECK(num_basis(view(clamped), 2, false, knot_tolerance(view(clamped))) == 4);
+
+    // Ten uniform knots, degree 2, periodic. The first in-domain knot has
+    // multiplicity 1, so the regularity is `2 - 1 = 1` and the count is
+    // `(10 - 2 - 1) - 1 - 1 = 5`.
+    const std::vector<double> uniform{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+    const double tol = knot_tolerance(view(uniform));
+    PANTR_CHECK(num_basis(view(uniform), 2, false, tol) == 7);
+    PANTR_CHECK(num_basis(view(uniform), 2, true, tol) == 5);
+}
+
+/// The snapping refusal, at both widths, with the oracle's text.
+///
+/// Both cases are reachable rather than contrived: a mesh of `n` intervals over a
+/// span `s` at offset `x` survives only while `s / n > 8 * eps * max(s, |x|)`, so
+/// four unit-quarter intervals stop being resolvable past `|x| / s` of about
+/// `5.2e5 / n` at `float32` and `5.6e14 / n` at `float64`. The two widths differ in
+/// their remedy line, which is why both are here: widening the format is only a
+/// remedy when there is a wider one to move to.
+void check_snapping_refusal() {
+    const std::vector<float> raw32{1000000.0F,      1000000.0F,      1000000.0F,
+                                   1000000.25F,     1000000.5F,      1000000.75F,
+                                   1000001.0F,      1000001.0F,      1000001.0F};
+    const double tol32 = knot_tolerance(view(raw32));
+    const std::vector<float> snapped32 = snap_knots(view(raw32), tol32);
+    same(message_of([&] { check_snapping_kept_an_interval<float>(raw32, snapped32, tol32); }),
+         "knot snapping collapsed every knot onto 1000000.0: in float32 at |coordinate| ~ 1e+06 "
+         "two knots are the same knot unless they differ by more than 0.954 (15 ulp there), and "
+         "the closest pair in [1000000.0, 1000001.0] is 0.25 apart. This mesh is finer than "
+         "float32 resolves at that magnitude. Use float64, move the domain nearer the origin, or "
+         "coarsen the mesh.",
+         "snapping refusal at float32");
+
+    const std::vector<double> raw64{2e14,        2e14,        2e14,        2e14 + 0.25,
+                                    2e14 + 0.5,  2e14 + 0.75, 2e14 + 1.0,  2e14 + 1.0,
+                                    2e14 + 1.0};
+    const double tol64 = knot_tolerance(view(raw64));
+    const std::vector<double> snapped64 = snap_knots(view(raw64), tol64);
+    same(message_of([&] { check_snapping_kept_an_interval<double>(raw64, snapped64, tol64); }),
+         "knot snapping collapsed every knot onto 200000000000000.0: in float64 at |coordinate| ~ "
+         "2e+14 two knots are the same knot unless they differ by more than 0.355 (11 ulp there), "
+         "and the closest pair in [200000000000000.0, 200000000000001.0] is 0.25 apart. This mesh "
+         "is finer than float64 resolves at that magnitude. Move the domain nearer the origin, or "
+         "coarsen the mesh.",
+         "snapping refusal at float64");
+
+    // A vector that arrived flat is NOT this refusal's case, and passes through it
+    // untouched so that the interval check downstream owns the consequence and can
+    // give the message that is true of it.
+    const std::vector<double> flat{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    const double flat_tol = knot_tolerance(view(flat));
+    same(message_of([&] {
+             check_snapping_kept_an_interval<double>(flat, snap_knots(view(flat), flat_tol),
+                                                     flat_tol);
+         }),
+         "<did not throw>", "an already-flat vector is not the snapping case");
+}
+
+/// The no-interval refusal, with the oracle's text.
+///
+/// The vector holds three distinct values and still has a one-point domain, because
+/// the domain runs from `knots[degree]` to `knots[n - degree - 1]` and an interior
+/// knot of high enough multiplicity swallows it whole. Counting intervals catches
+/// that and the flat case together, and introduces no threshold of its own.
+void check_no_interval_refusal() {
+    const std::vector<double> swallowed{0.0, 1.0, 1.0, 1.0, 2.0};
+    const double tol = knot_tolerance(view(swallowed));
+    const KnotClassRange range = classify_knots(view(swallowed), 1, tol);
+    PANTR_CHECK_MSG(range.num_intervals() == 0, "this vector must really span no interval");
+
+    same(message_of([&] {
+             check_space_has_an_interval<double>(swallowed, 1, range.num_intervals(), tol);
+         }),
+         "knot vector spans no interval: at degree 1 the domain runs from knots[1] = 1.0 to "
+         "knots[3] = 1.0, and every step between them is at most this vector's tolerance of "
+         "3.55e-15, so its in-domain knots are all one knot, the space has no cell, and nothing "
+         "can be evaluated, tabulated or located on it. The domain needs two consecutive knots "
+         "more than 3.55e-15 apart.",
+         "no-interval refusal");
+
+    same(message_of([&] { check_space_has_an_interval<double>(swallowed, 1, 1, tol); }),
+         "<did not throw>", "a space with an interval passes");
+}
+
+}  // namespace
+
+int main() {
+    check_knot_scale();
+    check_knot_tolerance();
+    check_classes();
+    check_chaining();
+    check_the_boundary_step_merges();
+    check_snap_takes_the_first_knot();
+    check_snap_reads_the_original_vector();
+    check_num_basis();
+    check_snapping_refusal();
+    check_no_interval_refusal();
+    return pantr::test::summary("test_bspline_knots");
+}

--- a/cpp/tests/test_bspline_space_1d.cpp
+++ b/cpp/tests/test_bspline_space_1d.cpp
@@ -400,6 +400,30 @@ void check_knot_refusals() {
                     "a domain swallowed by an interior knot: got '" + no_interval + "'");
 }
 
+/// The knot vector that made the two backends' messages differ by one character.
+///
+/// An infinite knot gives a scale of infinity, so the tolerance is infinite and the
+/// ulp at that scale is a NaN -- and `tol / ulp` is then `inf / nan`, whose NaN came
+/// out with its sign bit set on this platform. **CPython prints a NaN without a
+/// sign at every format specifier; glibc's `printf` prints `-nan`.** So the C++
+/// message read `(-nan ulp there)` where the oracle's read `(nan ulp there)`, and
+/// nothing but a byte-for-byte comparison on this input would have shown it.
+///
+/// The whole message is asserted rather than its prefix, because the divergence was
+/// one character in the middle of it. `pantr/core/format.hpp` is what was changed;
+/// the direction is argued there and in the pull request, and it is the C++ side
+/// that moved because a port reproduces its oracle rather than editing it.
+void check_the_non_finite_message() {
+    constexpr float infinity = std::numeric_limits<float>::infinity();
+    const std::vector<float> unbounded{-infinity, 0.0F, 0.0F, infinity};
+    same(message_of([&] { (void)space(unbounded, 1); }),
+         "knot snapping collapsed every knot onto -inf: in float32 at |coordinate| ~ inf two "
+         "knots are the same knot unless they differ by more than inf (nan ulp there), and the "
+         "closest pair in [-inf, inf] is inf apart. This mesh is finer than float32 resolves at "
+         "that magnitude. Use float64, move the domain nearer the origin, or coarsen the mesh.",
+         "the message an infinite knot produces");
+}
+
 /// Eight threads first-touching one space's derived block. The sanitizer's target.
 ///
 /// It asserts what it can -- one buffer, the right values from every thread -- but
@@ -463,6 +487,7 @@ int main() {
     check_float_storage();
     check_argument_refusals();
     check_knot_refusals();
+    check_the_non_finite_message();
     check_concurrent_first_touch();
     return pantr::test::summary("test_bspline_space_1d");
 }

--- a/cpp/tests/test_bspline_space_1d.cpp
+++ b/cpp/tests/test_bspline_space_1d.cpp
@@ -349,13 +349,24 @@ void check_argument_refusals() {
     same(message_of([&] { (void)space(uniform, 2, true); }),
          "Not enough knots for the specified degree", "a periodic space with too few functions");
 
-    // Degree first: a vector that fails both the degree check and the length check
-    // must report the degree, because that is the order the oracle checks in.
+    // Each adjacent pair of checks, exercised by an input that fails BOTH, so that
+    // only the order decides the message. Without these, swapping two checks that
+    // are each individually correct leaves the whole suite green -- which is what a
+    // review found, with only the first of the three transitions covered. Every
+    // expected message here is the one the oracle produces for the same input.
     same(message_of([&] {
              (void)BsplineSpace1D<double>(std::span<const double>(tooshort), -1, false,
                                           KnotSnapping::merge_near_duplicates);
          }),
-         "degree must be non-negative", "the degree check runs before the length check");
+         "degree must be non-negative", "degree before length");
+
+    const std::vector<double> short_and_descending{1.0, 0.0, 1.0};
+    same(message_of([&] { (void)space(short_and_descending, 2); }),
+         "knots must have at least 2*degree+2 elements", "length before monotonicity");
+
+    const std::vector<double> descending_and_too_few{0.0, 1.0, 2.0, 3.0, 2.0, 5.0, 6.0};
+    same(message_of([&] { (void)space(descending_and_too_few, 2, true); }),
+         "knots must be non-decreasing", "monotonicity before the basis count");
 }
 
 /// The two constructor refusals that are properties of the knots, not the arguments.

--- a/cpp/tests/test_bspline_space_1d.cpp
+++ b/cpp/tests/test_bspline_space_1d.cpp
@@ -1,0 +1,457 @@
+/// \file
+/// The 1D B-spline space: what it stores, what it derives, and what it refuses.
+///
+/// ## What is asserted, and against what
+///
+/// The structural quantities -- basis counts, interval counts, class
+/// multiplicities, per-interval first-basis indices -- are read off each knot
+/// vector by hand, and every case below says which feature of the vector it is
+/// there for. Three of them are the shipped docstring examples of
+/// `pantr.bspline.BsplineSpace1D`, so they are checkable against the library's own
+/// published contract rather than against a run of it.
+///
+/// Nothing here carries a numerical tolerance. A space stores knots and answers
+/// counting questions about them; every assertion is an integer, a knot value
+/// reproduced bit for bit from the input, a boolean, or a string.
+///
+/// ## The three cases that exist because getting them wrong is silent
+///
+/// **`check_stored_basis_count_comes_from_the_snapped_vector`.** The oracle
+/// computes the basis count *twice* from different vectors: once from the knots as
+/// supplied, purely to refuse a vector that cannot support the degree, and once
+/// from the snapped vector, which is what it stores. Snapping can change the
+/// multiplicity of the first in-domain knot, so for a periodic space the two
+/// genuinely differ -- 3 against 4 on the vector used here. A port that stored the
+/// validation count would be wrong by one basis function with nothing raising.
+///
+/// **`check_the_derived_block_is_shared_not_rebuilt`.** The derived arrays are
+/// handed out as views of storage the space owns. If an accessor rebuilt or copied
+/// them, every value assertion in this file would still pass, a caller's span would
+/// dangle, and a loop over intervals would recompute an `O(n)` scan per iteration.
+/// Comparing addresses is what distinguishes the two.
+///
+/// **`check_end_openness_is_absolute`.** Clampedness is an absolute comparison
+/// against the space's own tolerance, in `double`. A relative one -- `np.isclose`'s
+/// default `rtol` is `1e-5` -- would read a gap of `1e-5 * |knots[degree]|` as
+/// clamped, which on a knot vector based at 1e6 is half the domain.
+
+#include <atomic>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bspline/space_1d.hpp"
+
+namespace {
+
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::KnotSnapping;
+
+/// Build a space from a knot list, snapping, for brevity below.
+template <class T>
+BsplineSpace1D<T> space(const std::vector<T>& knots, std::int64_t degree, bool periodic = false) {
+    return BsplineSpace1D<T>(std::span<const T>(knots), degree, periodic,
+                             KnotSnapping::merge_near_duplicates);
+}
+
+/// The message of the `std::invalid_argument` that `fn` throws.
+template <class F>
+std::string message_of(F&& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument& e) {
+        return e.what();
+    } catch (...) {
+        return "<threw something else>";
+    }
+    return "<did not throw>";
+}
+
+/// Check a string against the oracle's, reporting both on failure.
+void same(const std::string& actual, const std::string& expected, const char* what) {
+    PANTR_CHECK_MSG(actual == expected,
+                    std::string(what) + ":\n  got  '" + actual + "'\n  want '" + expected + "'");
+}
+
+/// A span compared against a vector, elementwise.
+template <class T>
+bool equals(std::span<const T> actual, const std::vector<T>& expected) {
+    return std::vector<T>(actual.begin(), actual.end()) == expected;
+}
+
+/// A clamped quadratic over two unit intervals: the docstring's own example.
+void check_clamped_quadratic() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0};
+    const auto s = space(knots, 2);
+
+    PANTR_CHECK(equals(s.knots(), knots));
+    PANTR_CHECK(s.degree() == 2);
+    PANTR_CHECK(!s.periodic());
+    // Seven knots, degree 2, so `7 - 2 - 1` functions over two distinct interior
+    // steps. `space.num_intervals` is 2 in the shipped docstring.
+    PANTR_CHECK(s.num_basis() == 4);
+    PANTR_CHECK(s.num_intervals() == 2);
+    PANTR_CHECK(s.domain()[0] == 0.0);
+    PANTR_CHECK(s.domain()[1] == 2.0);
+    PANTR_CHECK(s.has_left_end_open());
+    PANTR_CHECK(s.has_right_end_open());
+    PANTR_CHECK(s.has_open_knots());
+    // Not Bézier-like: four basis functions against `degree + 1 == 3`, so there is
+    // more than one non-zero span.
+    PANTR_CHECK(!s.has_bezier_like_knots());
+
+    PANTR_CHECK(equals(s.unique_knots(), std::vector<double>{0.0, 1.0, 2.0}));
+    PANTR_CHECK(equals(s.multiplicity(), std::vector<std::int64_t>{3, 1, 3}));
+    PANTR_CHECK(equals(s.unique_knots_in_domain(), std::vector<double>{0.0, 1.0, 2.0}));
+    PANTR_CHECK(equals(s.multiplicity_in_domain(), std::vector<std::int64_t>{3, 1, 3}));
+    PANTR_CHECK(equals(s.first_basis_per_interval(), std::vector<std::int64_t>{0, 1}));
+}
+
+/// An interior knot of multiplicity 2: the docstring's `[0, 1, 3]` example.
+///
+/// The successive differences of the result are the interior multiplicities, which
+/// is what the jump from 1 to 3 shows and what a per-interval loop that assumed
+/// consecutive indices would get wrong.
+void check_repeated_interior_knot() {
+    const auto s = space(std::vector<double>{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0}, 2);
+    PANTR_CHECK(s.num_basis() == 6);
+    PANTR_CHECK(s.num_intervals() == 3);
+    PANTR_CHECK(equals(s.multiplicity(), std::vector<std::int64_t>{3, 1, 2, 3}));
+    PANTR_CHECK(equals(s.first_basis_per_interval(), std::vector<std::int64_t>{0, 1, 3}));
+}
+
+/// A single Bézier segment, and degree zero.
+void check_bezier_like_and_degree_zero() {
+    // `[1, 1, 1, 3, 3, 3]` at degree 2: clamped, one span, `degree + 1` functions.
+    const auto bez = space(std::vector<double>{1.0, 1.0, 1.0, 3.0, 3.0, 3.0}, 2);
+    PANTR_CHECK(bez.num_basis() == 3);
+    PANTR_CHECK(bez.num_intervals() == 1);
+    PANTR_CHECK(bez.has_bezier_like_knots());
+    PANTR_CHECK(equals(bez.first_basis_per_interval(), std::vector<std::int64_t>{0}));
+
+    // Degree 0: one function per interval, and the ends are trivially "clamped"
+    // because the first and last `degree + 1 == 1` knots are one knot.
+    const auto flat = space(std::vector<double>{0.0, 1.0, 2.0, 3.0}, 0);
+    PANTR_CHECK(flat.num_basis() == 3);
+    PANTR_CHECK(flat.num_intervals() == 3);
+    PANTR_CHECK(flat.has_open_knots());
+    PANTR_CHECK(!flat.has_bezier_like_knots());
+    PANTR_CHECK(equals(flat.first_basis_per_interval(), std::vector<std::int64_t>{0, 1, 2}));
+}
+
+/// An unclamped vector, where the domain is a strict interior.
+void check_unclamped() {
+    const auto s = space(std::vector<double>{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 10.0}, 3);
+    PANTR_CHECK(s.num_basis() == 5);
+    PANTR_CHECK(s.num_intervals() == 2);
+    PANTR_CHECK(s.domain()[0] == 3.0);
+    PANTR_CHECK(s.domain()[1] == 5.0);
+    PANTR_CHECK(!s.has_left_end_open());
+    PANTR_CHECK(!s.has_right_end_open());
+    PANTR_CHECK(equals(s.unique_knots_in_domain(), std::vector<double>{3.0, 4.0, 5.0}));
+    // The first interval is no different from the rest: selecting the classes whose
+    // last position lies in `[degree, num_basis)` needs no special case for a
+    // non-clamped vector.
+    PANTR_CHECK(equals(s.first_basis_per_interval(), std::vector<std::int64_t>{0, 1}));
+}
+
+/// A periodic space: no clamped end whatever the knots, and no per-interval index.
+void check_periodic() {
+    const auto s = space(
+        std::vector<double>{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}, 2, true);
+    PANTR_CHECK(s.periodic());
+    // `(10 - 2 - 1)` less the regularity `2 - 1` less one.
+    PANTR_CHECK(s.num_basis() == 5);
+    PANTR_CHECK(s.num_intervals() == 5);
+    PANTR_CHECK(s.domain()[0] == 2.0);
+    PANTR_CHECK(s.domain()[1] == 7.0);
+    PANTR_CHECK_MSG(!s.has_left_end_open(), "a periodic space has no clamped end by definition");
+    PANTR_CHECK(!s.has_right_end_open());
+    PANTR_CHECK(!s.has_bezier_like_knots());
+    PANTR_CHECK(equals(s.unique_knots_in_domain(),
+                       std::vector<double>{2.0, 3.0, 4.0, 5.0, 6.0, 7.0}));
+
+    same(message_of([&] { (void)s.first_basis_per_interval(); }),
+         "first_basis_per_interval: periodic B-spline spaces are not supported.",
+         "first_basis_per_interval on a periodic space");
+}
+
+/// The stored basis count comes from the snapped vector, not the validated one.
+///
+/// See the file comment. `knots[0..2]` step by `0.6 * tol` each, so they chain into
+/// one class although the outer two are `1.2 * tol` apart: the multiplicity of the
+/// first in-domain knot is 2 before snapping and 3 after, which moves the periodic
+/// regularity and so the count. The oracle reports 4.
+void check_stored_basis_count_comes_from_the_snapped_vector() {
+    constexpr double tol = 8.0 * 2.220446049250313e-16;  // the tolerance of a unit domain
+    const std::vector<double> knots{0.0, 0.6 * tol, 1.2 * tol, 0.25, 0.5, 0.75, 1.0};
+    const auto s = space(knots, 2, true);
+
+    PANTR_CHECK(equals(s.knots(), std::vector<double>{0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0}));
+    PANTR_CHECK_MSG(s.num_basis() == 4,
+                    "the count is 3 from the vector as supplied and 4 from the snapped one");
+    PANTR_CHECK(s.num_intervals() == 2);
+}
+
+/// `KnotSnapping::as_given` stores the vector untouched.
+///
+/// The interval requirement still applies; only the merging and the snapping
+/// diagnosis are skipped. The class scan then reports the same classes either way,
+/// because grouping is by gap and the gaps are unchanged -- what differs is the
+/// values stored, which is what a caller asking for `as_given` wants.
+void check_as_given() {
+    const std::vector<double> raw{0.0, 0.0, 0.0, 0.5, 0.5 + 2e-16, 1.0, 1.0, 1.0};
+    const BsplineSpace1D<double> kept(std::span<const double>(raw), 2, false,
+                                      KnotSnapping::as_given);
+    PANTR_CHECK(equals(kept.knots(), raw));
+    PANTR_CHECK(kept.num_intervals() == 2);
+    PANTR_CHECK(equals(kept.unique_knots(), std::vector<double>{0.0, 0.5, 1.0}));
+    PANTR_CHECK(equals(kept.multiplicity(), std::vector<std::int64_t>{3, 2, 3}));
+
+    const auto merged = space(raw, 2);
+    PANTR_CHECK(merged.knots()[4] == 0.5);
+    PANTR_CHECK_MSG(kept.knots()[4] != merged.knots()[4],
+                    "the two spellings must really store different knots here");
+}
+
+/// Clampedness is absolute, and in `double`.
+///
+/// A relative comparison at `numpy`'s default `rtol` of `1e-5` would admit a gap of
+/// `1e-5 * 1e6 == 10` at the left end of this vector, which is ten times its whole
+/// domain. The gap here is 1, so an absolute test rejects it and a relative one
+/// would not.
+void check_end_openness_is_absolute() {
+    const auto s = space(std::vector<double>{1000000.0, 1000000.0, 1000001.0, 1000002.0,
+                                             1000003.0, 1000003.0},
+                         2);
+    PANTR_CHECK_MSG(s.tolerance() < 1.0, "the tolerance must be far below the gap being tested");
+    PANTR_CHECK_MSG(!s.has_left_end_open(),
+                    "knots[0] and knots[degree] differ by 1, far more than the tolerance");
+    PANTR_CHECK(!s.has_right_end_open());
+}
+
+/// A clamping gap of exactly the tolerance counts as clamped.
+///
+/// The comparison is `<= tol`, so the boundary is closed on the clamped side, and
+/// nothing else here pins that: every other case is orders clear of the threshold.
+/// Snapping is off, because with it on the two knots would merge first -- for the
+/// same reason, the boundary being closed -- and the gap under test would be zero.
+///
+/// The oracle agrees: the same vector reports a clamped left end and an unclamped
+/// right one.
+void check_the_boundary_clamping_gap_is_open() {
+    constexpr double eps = std::numeric_limits<double>::epsilon();
+    const std::vector<double> knots{0.0, 8.0 * eps, 0.5, 1.0};
+    const BsplineSpace1D<double> s(std::span<const double>(knots), 1, false,
+                                   KnotSnapping::as_given);
+    PANTR_CHECK_MSG(s.tolerance() == 8.0 * eps, "the scale must be exactly 1 here");
+    PANTR_CHECK_MSG(knots[1] - knots[0] == s.tolerance(),
+                    "the gap must be exactly the tolerance");
+    PANTR_CHECK_MSG(s.has_left_end_open(), "a gap of exactly the tolerance is clamped");
+    PANTR_CHECK_MSG(!s.has_right_end_open(), "and the far end is not, which keeps this honest");
+}
+
+/// The derived arrays are the space's own storage, shared rather than rebuilt.
+///
+/// Addresses, because values would agree under a copying implementation. The
+/// in-domain forms are asserted to be *subspans of the same buffer*, which is what
+/// makes them one memo rather than two.
+void check_the_derived_block_is_shared_not_rebuilt() {
+    const auto s = space(std::vector<double>{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0}, 2);
+
+    PANTR_CHECK(s.unique_knots().data() == s.unique_knots().data());
+    const auto* first = s.unique_knots().data();
+    const auto* again = s.unique_knots().data();
+    PANTR_CHECK_MSG(first == again, "two reads must return the same storage");
+    PANTR_CHECK_MSG(s.multiplicity().data() == s.multiplicity().data(),
+                    "and so must the multiplicities");
+    PANTR_CHECK_MSG(s.first_basis_per_interval().data() == s.first_basis_per_interval().data(),
+                    "and so must the per-interval indices");
+
+    const auto whole = s.unique_knots();
+    const auto in_domain = s.unique_knots_in_domain();
+    PANTR_CHECK_MSG(in_domain.data() >= whole.data()
+                        && in_domain.data() + in_domain.size() <= whole.data() + whole.size(),
+                    "the in-domain form is a subspan of the whole, not a second array");
+}
+
+/// A copy carries the value and not the memo; a move leaves the target usable.
+///
+/// Copying the memo would be correct here and buys nothing; what must not happen is
+/// the opposite error, a copy that keeps a memo describing the source. The values
+/// are asserted after the copy so that "cold" does not mean "wrong".
+void check_copy_and_move() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0};
+    auto original = space(knots, 2);
+    PANTR_CHECK(equals(original.unique_knots(), std::vector<double>{0.0, 1.0, 2.0}));
+
+    const BsplineSpace1D<double> copied(original);
+    PANTR_CHECK(copied.num_basis() == 4);
+    PANTR_CHECK(copied.num_intervals() == 2);
+    PANTR_CHECK(copied.tolerance() == original.tolerance());
+    PANTR_CHECK(equals(copied.unique_knots(), std::vector<double>{0.0, 1.0, 2.0}));
+    PANTR_CHECK_MSG(copied.unique_knots().data() != original.unique_knots().data(),
+                    "the copy owns its own derived block");
+
+    const BsplineSpace1D<double> moved(std::move(original));
+    PANTR_CHECK(moved.num_basis() == 4);
+    PANTR_CHECK(equals(moved.first_basis_per_interval(), std::vector<std::int64_t>{0, 1}));
+}
+
+/// The same space at `float`, where the stored knots are the rounded ones.
+///
+/// `float32` is a supported storage format for a pantr space, so the type is
+/// exercised at both widths. `0.7F` is not 0.7, and the space stores and reports
+/// the `float` value; the tolerance is `8 * eps32` rather than `8 * eps64`, which is
+/// four orders wider and is why a `float32` mesh stops resolving so much sooner.
+void check_float_storage() {
+    const std::vector<float> knots{0.0F, 0.0F, 0.0F, 0.25F, 0.7F, 0.7F, 1.0F, 1.0F, 1.0F};
+    const auto s = space(knots, 2);
+    PANTR_CHECK(s.num_basis() == 6);
+    PANTR_CHECK(s.num_intervals() == 3);
+    PANTR_CHECK(s.domain()[0] == 0.0F);
+    PANTR_CHECK(s.domain()[1] == 1.0F);
+    PANTR_CHECK(equals(s.unique_knots(), std::vector<float>{0.0F, 0.25F, 0.7F, 1.0F}));
+    PANTR_CHECK(equals(s.multiplicity(), std::vector<std::int64_t>{3, 1, 2, 3}));
+    PANTR_CHECK(equals(s.first_basis_per_interval(), std::vector<std::int64_t>{0, 1, 3}));
+    PANTR_CHECK(s.tolerance() == 8.0 * static_cast<double>(1.1920928955078125e-07));
+}
+
+/// The four argument refusals, in the oracle's order and with its text.
+///
+/// The order is load-bearing rather than incidental: two simultaneously bad
+/// arguments must produce the same message on both sides, and only the order
+/// decides which one they get. The last case has a legal length and a legal
+/// ordering and still cannot support its degree.
+void check_argument_refusals() {
+    const std::vector<double> fine{0.0, 0.0, 1.0, 1.0};
+    same(message_of([&] {
+             (void)BsplineSpace1D<double>(std::span<const double>(fine), -1, false,
+                                          KnotSnapping::merge_near_duplicates);
+         }),
+         "degree must be non-negative", "negative degree");
+
+    const std::vector<double> tooshort{0.0, 0.0, 1.0};
+    same(message_of([&] { (void)space(tooshort, 2); }),
+         "knots must have at least 2*degree+2 elements", "too few knots");
+
+    const std::vector<double> unsorted{0.0, 0.0, 1.0, 0.5, 1.0, 1.0};
+    same(message_of([&] { (void)space(unsorted, 2); }), "knots must be non-decreasing",
+         "a descending step");
+
+    const std::vector<double> uniform{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    same(message_of([&] { (void)space(uniform, 2, true); }),
+         "Not enough knots for the specified degree", "a periodic space with too few functions");
+
+    // Degree first: a vector that fails both the degree check and the length check
+    // must report the degree, because that is the order the oracle checks in.
+    same(message_of([&] {
+             (void)BsplineSpace1D<double>(std::span<const double>(tooshort), -1, false,
+                                          KnotSnapping::merge_near_duplicates);
+         }),
+         "degree must be non-negative", "the degree check runs before the length check");
+}
+
+/// The two constructor refusals that are properties of the knots, not the arguments.
+///
+/// Snapping is diagnosed before the interval requirement, and that ordering is what
+/// lets each message be true: "this mesh is finer than float32 resolves here" names
+/// a remedy and is false of a vector the caller supplied flat, which the second
+/// check owns instead.
+void check_knot_refusals() {
+    const std::vector<float> unresolvable{1000000.0F,  1000000.0F,  1000000.0F,
+                                          1000000.25F, 1000000.5F,  1000000.75F,
+                                          1000001.0F,  1000001.0F,  1000001.0F};
+    const std::string collapsed = message_of([&] { (void)space(unresolvable, 2); });
+    PANTR_CHECK_MSG(collapsed.rfind("knot snapping collapsed every knot onto 1000000.0:", 0) == 0,
+                    "an unresolvable mesh is diagnosed as snapping, not as a flat domain: got '"
+                        + collapsed + "'");
+
+    // The same vector with snapping off reaches the *other* refusal, which is what
+    // shows the two are separate rules rather than one with two spellings.
+    const std::string as_given = message_of([&] {
+        (void)BsplineSpace1D<float>(std::span<const float>(unresolvable), 2, false,
+                                    KnotSnapping::as_given);
+    });
+    PANTR_CHECK_MSG(as_given.rfind("knot vector spans no interval:", 0) == 0,
+                    "with snapping off the interval rule owns the same symptom: got '" + as_given
+                        + "'");
+
+    const std::vector<double> swallowed{0.0, 1.0, 1.0, 1.0, 2.0};
+    const std::string no_interval = message_of([&] { (void)space(swallowed, 1); });
+    PANTR_CHECK_MSG(no_interval.rfind("knot vector spans no interval: at degree 1", 0) == 0,
+                    "a domain swallowed by an interior knot: got '" + no_interval + "'");
+}
+
+/// Eight threads first-touching one space's derived block. The sanitizer's target.
+///
+/// It asserts what it can -- one buffer, the right values from every thread -- but
+/// its real job is to put concurrent first touches through the memo so that a
+/// thread-sanitizer build has something to look at. A value assertion cannot see
+/// the failure this guards: the unsynchronised spelling of the same memo produced
+/// 60 correct answers in 60 runs and 4 sanitizer reports.
+void check_concurrent_first_touch() {
+    constexpr int num_threads = 8;
+    const auto s = space(std::vector<double>{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0}, 2);
+
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    std::vector<const double*> seen(num_threads, nullptr);
+    std::vector<std::int64_t> sums(num_threads, -1);
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([&, t] {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!go.load(std::memory_order_acquire)) {
+            }
+            const auto index = static_cast<std::size_t>(t);
+            seen[index] = s.unique_knots().data();
+            std::int64_t total = 0;
+            for (const std::int64_t m : s.multiplicity()) {
+                total += m;
+            }
+            sums[index] = total;
+        });
+    }
+    while (ready.load(std::memory_order_acquire) < num_threads) {
+    }
+    go.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+
+    for (int t = 0; t < num_threads; ++t) {
+        const auto index = static_cast<std::size_t>(t);
+        PANTR_CHECK_MSG(seen[index] == seen[0], "every thread must see one buffer");
+        PANTR_CHECK_MSG(sums[index] == 9, "the multiplicities sum to the knot count");
+    }
+}
+
+}  // namespace
+
+int main() {
+    check_clamped_quadratic();
+    check_repeated_interior_knot();
+    check_bezier_like_and_degree_zero();
+    check_unclamped();
+    check_periodic();
+    check_stored_basis_count_comes_from_the_snapped_vector();
+    check_as_given();
+    check_end_openness_is_absolute();
+    check_the_boundary_clamping_gap_is_open();
+    check_the_derived_block_is_shared_not_rebuilt();
+    check_copy_and_move();
+    check_float_storage();
+    check_argument_refusals();
+    check_knot_refusals();
+    check_concurrent_first_touch();
+    return pantr::test::summary("test_bspline_space_1d");
+}

--- a/cpp/tests/test_format.cpp
+++ b/cpp/tests/test_format.cpp
@@ -1,0 +1,127 @@
+/// \file
+/// The three Python format specifiers `pantr/core/format.hpp` reproduces.
+///
+/// ## Why this file exists separately from `test_aabb.cpp`
+///
+/// `format_repr` was checked until now only through the AABB messages that use
+/// it, which meant it was checked on the values those messages happened to carry.
+/// That is exactly how its notation bug survived: fixed and scientific notation
+/// coincide on typical magnitudes and diverge on round numbers, so a sweep over
+/// realistic box corners never reached the divergence. Now that a second type
+/// depends on the same rule, the rule gets its own cases, chosen for where the two
+/// languages *could* part company rather than for where they are exercised.
+///
+/// ## Where each expectation comes from
+///
+/// Every string below is what CPython prints, and each was obtained by running the
+/// corresponding expression rather than by reasoning about it. The three that
+/// matter most are the round numbers -- `1e5`, `1e16`, `1e-5` -- because those are
+/// the ones where `std::to_chars`'s "shortest text" rule and Python's positional
+/// rule give different answers, and where a formatter that merely round-trips
+/// would still be wrong.
+///
+/// Nothing here has a tolerance. A rendering is a string: it is right or it is not.
+
+#include <limits>
+#include <string>
+
+#include "check.hpp"
+#include "pantr/core/format.hpp"
+
+namespace {
+
+using pantr::detail::format_fixed;
+using pantr::detail::format_general;
+using pantr::detail::format_repr;
+using pantr::detail::format_scalar;
+
+/// Check one rendering against the text Python produces.
+///
+/// \param actual What the header produced.
+/// \param expected What CPython prints.
+/// \param what The expression, for the failure line.
+void same(const std::string& actual, const std::string& expected, const char* what) {
+    PANTR_CHECK_MSG(actual == expected,
+                    std::string(what) + ": got '" + actual + "', want '" + expected + "'");
+}
+
+/// `repr`, on the values where the notation rule decides the answer.
+void check_repr() {
+    // Ordinary magnitudes, where the two rules agree and a wrong formatter still
+    // looks right.
+    same(format_repr(0.5), "0.5", "repr(0.5)");
+    same(format_repr(-0.5), "-0.5", "repr(-0.5)");
+    same(format_repr(0.1), "0.1", "repr(0.1)");
+    same(format_repr(2.0), "2.0", "repr(2.0)");
+    same(format_repr(0.0), "0.0", "repr(0.0)");
+    same(format_repr(-0.0), "-0.0", "repr(-0.0)");
+
+    // The round numbers. `to_chars` alone renders these as `1e+05` and `1e-05`,
+    // because the scientific spelling is shorter; Python decides on the decimal
+    // exponent and keeps fixed notation until it leaves `[-4, 16)`.
+    same(format_repr(100000.0), "100000.0", "repr(1e5)");
+    same(format_repr(1e15), "1000000000000000.0", "repr(1e15)");
+    same(format_repr(1e16), "1e+16", "repr(1e16)");
+    same(format_repr(1e-4), "0.0001", "repr(1e-4)");
+    same(format_repr(1e-5), "1e-05", "repr(1e-5)");
+
+    // Shortest round-trip, where a fixed 17-digit rendering would differ.
+    same(format_repr(0.30000000000000004), "0.30000000000000004", "repr(0.1 + 0.2)");
+    same(format_repr(1000000.25), "1000000.25", "repr(1000000.25)");
+    same(format_repr(200000000000000.0), "200000000000000.0", "repr(2e14)");
+
+    // The non-finite values, which Python spells without a sign on nan.
+    constexpr double infinity = std::numeric_limits<double>::infinity();
+    same(format_repr(infinity), "inf", "repr(inf)");
+    same(format_repr(-infinity), "-inf", "repr(-inf)");
+    same(format_repr(std::numeric_limits<double>::quiet_NaN()), "nan", "repr(nan)");
+}
+
+/// `repr` reached through a scalar, at both storage widths.
+///
+/// The widening is the point: `repr(float(np.float32(0.7)))` is the `double`
+/// rendering of the `float32` value, not `0.7`, and a formatter that rendered the
+/// `float` directly would print `0.7` and be wrong by the same rule the oracle
+/// follows.
+void check_scalar() {
+    same(format_scalar(0.7), "0.7", "repr(0.7) as double");
+    same(format_scalar(0.7F), "0.699999988079071", "repr(float(np.float32(0.7)))");
+    same(format_scalar(1000000.0F), "1000000.0", "repr(float(np.float32(1e6)))");
+}
+
+/// `f"{v:.Ng}"`, including the two exponent forms and the trailing-zero rule.
+void check_general() {
+    same(format_general(1000000.0, 3), "1e+06", "f'{1e6:.3g}'");
+    same(format_general(0.9536743, 3), "0.954", "f'{0.9536743:.3g}'");
+    // The tolerance of a unit-domain float64 space, which is what the "spans no
+    // interval" message interpolates.
+    same(format_general(3.552713678800501e-15, 3), "3.55e-15", "f'{3.55e-15:.3g}'");
+    same(format_general(0.25, 3), "0.25", "f'{0.25:.3g}'");
+    same(format_general(2e14, 3), "2e+14", "f'{2e14:.3g}'");
+    same(format_general(1.0, 3), "1", "f'{1.0:.3g}'");
+    same(format_general(1234.0, 3), "1.23e+03", "f'{1234.0:.3g}'");
+}
+
+/// `f"{v:.Nf}"`, at the precision the snapping message uses.
+///
+/// The half-way case is the one worth pinning: both CPython and glibc round to
+/// even, so 0.5 renders as `0` and 1.5 as `2`. A formatter rounding half away from
+/// zero would print `1` and `2`.
+void check_fixed() {
+    same(format_fixed(15.4, 0), "15", "f'{15.4:.0f}'");
+    same(format_fixed(11.2, 0), "11", "f'{11.2:.0f}'");
+    same(format_fixed(0.5, 0), "0", "f'{0.5:.0f}'");
+    same(format_fixed(1.5, 0), "2", "f'{1.5:.0f}'");
+    same(format_fixed(2.5, 0), "2", "f'{2.5:.0f}'");
+    same(format_fixed(0.125, 2), "0.12", "f'{0.125:.2f}'");
+}
+
+}  // namespace
+
+int main() {
+    check_repr();
+    check_scalar();
+    check_general();
+    check_fixed();
+    return pantr::test::summary("test_format");
+}

--- a/cpp/tests/test_format.cpp
+++ b/cpp/tests/test_format.cpp
@@ -22,6 +22,7 @@
 ///
 /// Nothing here has a tolerance. A rendering is a string: it is right or it is not.
 
+#include <cmath>
 #include <limits>
 #include <string>
 
@@ -100,6 +101,35 @@ void check_general() {
     same(format_general(2e14, 3), "2e+14", "f'{2e14:.3g}'");
     same(format_general(1.0, 3), "1", "f'{1.0:.3g}'");
     same(format_general(1234.0, 3), "1.23e+03", "f'{1234.0:.3g}'");
+    // Negative values, which no case here reached until a review said so.
+    same(format_general(-0.9536743, 3), "-0.954", "f'{-0.9536743:.3g}'");
+    same(format_general(-1e6, 3), "-1e+06", "f'{-1e6:.3g}'");
+    same(format_general(-0.0, 3), "-0", "f'{-0.0:.3g}'");
+}
+
+/// The non-finite values, at every spelling.
+///
+/// CPython prints a NaN **without a sign, ever**, even for one whose sign bit is
+/// set; glibc's `printf` prints `-nan` for that value. Found by an adversarial
+/// case rather than by reasoning: a knot vector holding an infinity produces
+/// `tol / ulp == inf / nan`, the NaN came out negative, and the two backends'
+/// messages differed by one character. Every spelling therefore intercepts these
+/// rather than handing them to `snprintf`.
+void check_non_finite() {
+    constexpr double infinity = std::numeric_limits<double>::infinity();
+    const double positive_nan = std::numeric_limits<double>::quiet_NaN();
+    const double negative_nan = -positive_nan;
+    PANTR_CHECK_MSG(std::signbit(negative_nan), "the negative NaN must really be negative");
+
+    for (const double nan : {positive_nan, negative_nan}) {
+        same(format_repr(nan), "nan", "repr(nan)");
+        same(format_general(nan, 3), "nan", "f'{nan:.3g}'");
+        same(format_fixed(nan, 0), "nan", "f'{nan:.0f}'");
+    }
+    same(format_general(infinity, 3), "inf", "f'{inf:.3g}'");
+    same(format_general(-infinity, 3), "-inf", "f'{-inf:.3g}'");
+    same(format_fixed(infinity, 0), "inf", "f'{inf:.0f}'");
+    same(format_fixed(-infinity, 0), "-inf", "f'{-inf:.0f}'");
 }
 
 /// `f"{v:.Nf}"`, at the precision the snapping message uses.
@@ -114,6 +144,9 @@ void check_fixed() {
     same(format_fixed(1.5, 0), "2", "f'{1.5:.0f}'");
     same(format_fixed(2.5, 0), "2", "f'{2.5:.0f}'");
     same(format_fixed(0.125, 2), "0.12", "f'{0.125:.2f}'");
+    same(format_fixed(-15.4, 0), "-15", "f'{-15.4:.0f}'");
+    same(format_fixed(-0.5, 0), "-0", "f'{-0.5:.0f}'");
+    same(format_fixed(-0.125, 2), "-0.12", "f'{-0.125:.2f}'");
 }
 
 }  // namespace
@@ -123,5 +156,6 @@ int main() {
     check_scalar();
     check_general();
     check_fixed();
+    check_non_finite();
     return pantr::test::summary("test_format");
 }

--- a/cpp/tests/test_lazy.cpp
+++ b/cpp/tests/test_lazy.cpp
@@ -1,0 +1,176 @@
+/// \file
+/// `pantr::LazySlot`: built once, published atomically, cold after a copy.
+///
+/// ## What can and cannot be checked here
+///
+/// Three of the four properties are ordinary single-threaded facts and are checked
+/// as such: the builder runs at most once, a throwing builder leaves the slot cold
+/// so the next caller retries, and copying or assigning leaves the target cold
+/// rather than carrying a value that describes the source's state.
+///
+/// The fourth -- that concurrent first touches are a data race under the
+/// unsynchronised spelling and are not under this one -- **cannot be checked by
+/// asserting a value**. It was measured: eight threads hammering a bare
+/// `mutable std::optional` produced 4 reports under g++ 14.4 `-fsanitize=thread`,
+/// and **60 of 60 correct answers without the sanitizer**. So a test that runs the
+/// threads and compares the total passes on the broken design, every time.
+///
+/// What the concurrency case below is for, therefore, is to be *the thing a
+/// sanitizer build runs*. It asserts the cheap invariants it can -- one build, one
+/// address, the right value from every thread -- and its real job is to put eight
+/// threads through `get` simultaneously so that `ctest --preset gcc-tsan` has
+/// something to look at. Reading a clean TSan run as evidence needs one further
+/// check, by analogy with the devirtualisation trap: confirm the threads really do
+/// contend, which the build counter below does by construction, since a builder
+/// that ran before the threads started would leave the slot already filled and the
+/// barrier unused.
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/core/lazy.hpp"
+
+namespace {
+
+using pantr::LazySlot;
+
+/// The slot builds on first use and never again.
+void check_built_once() {
+    LazySlot<std::vector<int>> slot;
+    int builds = 0;
+
+    PANTR_CHECK(!slot.filled());
+    const std::vector<int>& first = slot.get([&builds] {
+        ++builds;
+        return std::vector<int>{1, 2, 3};
+    });
+    PANTR_CHECK(slot.filled());
+    PANTR_CHECK(builds == 1);
+    PANTR_CHECK(first.size() == 3);
+
+    const std::vector<int>& second = slot.get([&builds] {
+        ++builds;
+        return std::vector<int>{9};
+    });
+    PANTR_CHECK_MSG(builds == 1, "the second get must not run its builder");
+    PANTR_CHECK_MSG(&second == &first, "the second get must return the same object");
+}
+
+/// A builder that throws leaves the slot cold, so the next caller retries.
+///
+/// The alternative -- publishing before the value exists, or marking the slot
+/// filled in a destructor -- would hand the next caller a half-built value with
+/// nothing raising, which is worse than the exception it swallowed.
+void check_a_throwing_builder_leaves_it_cold() {
+    LazySlot<int> slot;
+    bool threw = false;
+    try {
+        (void)slot.get([]() -> int { throw std::runtime_error("no"); });
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    PANTR_CHECK(threw);
+    PANTR_CHECK_MSG(!slot.filled(), "a failed build must not publish");
+    PANTR_CHECK(slot.get([] { return 7; }) == 7);
+}
+
+/// A copy or a move starts cold, and assignment clears the target.
+///
+/// The assignment case is the one that matters: the slot's value describes its
+/// owner's state, and assignment is what replaces that state underneath it. A slot
+/// that kept its value across an assignment would be a memo of something that is no
+/// longer there, and no value test on the owner would show it.
+void check_copies_start_cold() {
+    LazySlot<int> filled;
+    PANTR_CHECK(filled.get([] { return 5; }) == 5);
+    PANTR_CHECK(filled.filled());
+
+    const LazySlot<int> copied(filled);
+    PANTR_CHECK_MSG(!copied.filled(), "a copy must start cold");
+    PANTR_CHECK(copied.get([] { return 6; }) == 6);
+
+    LazySlot<int> moved(std::move(filled));
+    PANTR_CHECK_MSG(!moved.filled(), "a move must start cold");
+
+    LazySlot<int> target;
+    PANTR_CHECK(target.get([] { return 1; }) == 1);
+    target = copied;
+    PANTR_CHECK_MSG(!target.filled(), "assignment must clear the target");
+    PANTR_CHECK_MSG(target.get([] { return 2; }) == 2,
+                    "a cleared slot rebuilds from its new owner's state");
+}
+
+/// Eight threads first-touching one slot at once. The sanitizer's target.
+void check_concurrent_first_touch() {
+    constexpr int num_threads = 8;
+    constexpr std::size_t width = 4096;
+
+    LazySlot<std::vector<std::int64_t>> slot;
+    std::atomic<int> builds{0};
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    std::vector<const std::vector<std::int64_t>*> seen(num_threads, nullptr);
+    std::vector<std::int64_t> totals(num_threads, -1);
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([&, t] {
+            // A spin barrier rather than a sleep: the window this is meant to open
+            // is the one between the first `acquire` load and the `release` store,
+            // and a sleep makes it a race between one thread and nothing.
+            ready.fetch_add(1, std::memory_order_release);
+            while (!go.load(std::memory_order_acquire)) {
+            }
+            const std::vector<std::int64_t>& value = slot.get([&builds] {
+                builds.fetch_add(1, std::memory_order_relaxed);
+                std::vector<std::int64_t> built(width);
+                for (std::size_t i = 0; i < width; ++i) {
+                    built[i] = static_cast<std::int64_t>(i);
+                }
+                return built;
+            });
+            seen[static_cast<std::size_t>(t)] = &value;
+            std::int64_t total = 0;
+            for (const std::int64_t entry : value) {
+                total += entry;
+            }
+            totals[static_cast<std::size_t>(t)] = total;
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) < num_threads) {
+    }
+    go.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+
+    // `width * (width - 1) / 2`, computed here rather than copied from a run.
+    constexpr std::int64_t expected =
+        static_cast<std::int64_t>(width) * (static_cast<std::int64_t>(width) - 1) / 2;
+    PANTR_CHECK_MSG(builds.load() == 1, "the value must be built exactly once");
+    for (int t = 0; t < num_threads; ++t) {
+        const auto index = static_cast<std::size_t>(t);
+        PANTR_CHECK_MSG(seen[index] == seen[0], "every thread must see one object");
+        PANTR_CHECK_MSG(totals[index] == expected,
+                        "thread " + std::to_string(t) + " read a wrong total");
+    }
+}
+
+}  // namespace
+
+int main() {
+    check_built_once();
+    check_a_throwing_builder_leaves_it_cold();
+    check_copies_start_cold();
+    check_concurrent_first_touch();
+    return pantr::test::summary("test_lazy");
+}

--- a/cpp/tests/test_lazy.cpp
+++ b/cpp/tests/test_lazy.cpp
@@ -107,42 +107,73 @@ void check_copies_start_cold() {
                     "a cleared slot rebuilds from its new owner's state");
 }
 
-/// Eight threads first-touching one slot at once. The sanitizer's target.
+/// Many slots raced by many threads. The sanitizer's target.
+///
+/// ## Why this is not one slot
+///
+/// One slot touched once per thread is the obvious shape and it is the wrong one.
+/// Every thread then either builds under the lock or blocks on it and reads after
+/// acquiring it, and `std::mutex` already establishes that happens-before edge on
+/// its own -- so the whole case passes with the atomics made fully `relaxed`, and
+/// the **outer, lock-free fast path** is reached only if a straggler's check
+/// happens to observe `ready_ == true` while still racing the writer. Measured on
+/// exactly that shape: with `lazy.hpp` patched to `memory_order_relaxed`
+/// throughout, the sanitizer caught the injected race in roughly one run in three
+/// and reported nothing in the others, so a single `ctest --preset gcc-tsan` had a
+/// real chance of passing on a broken acquire/release pair. That is the line the
+/// design note calls load-bearing, and it was the line least covered.
+///
+/// So: many independent slots, and every thread walks all of them starting from a
+/// different offset. At any moment some threads are building slot `i` while others
+/// are reading a slot already published, which is what puts traffic through the
+/// fast path rather than through the mutex. The second wave then reads every slot
+/// again, when all of them are published and nothing takes the lock at all.
 void check_concurrent_first_touch() {
     constexpr int num_threads = 8;
-    constexpr std::size_t width = 4096;
+    constexpr int num_slots = 64;
+    constexpr std::size_t width = 512;
 
-    LazySlot<std::vector<std::int64_t>> slot;
+    std::vector<LazySlot<std::vector<std::int64_t>>> slots(num_slots);
     std::atomic<int> builds{0};
     std::atomic<int> ready{0};
     std::atomic<bool> go{false};
-    std::vector<const std::vector<std::int64_t>*> seen(num_threads, nullptr);
-    std::vector<std::int64_t> totals(num_threads, -1);
+    std::vector<std::int64_t> sums(static_cast<std::size_t>(num_threads) * 2, -1);
+
+    const auto build_slot = [&builds](int slot) {
+        return [&builds, slot] {
+            builds.fetch_add(1, std::memory_order_relaxed);
+            std::vector<std::int64_t> built(width);
+            for (std::size_t i = 0; i < width; ++i) {
+                built[i] = static_cast<std::int64_t>(i) + slot;
+            }
+            return built;
+        };
+    };
 
     std::vector<std::thread> threads;
     threads.reserve(num_threads);
     for (int t = 0; t < num_threads; ++t) {
         threads.emplace_back([&, t] {
             // A spin barrier rather than a sleep: the window this is meant to open
-            // is the one between the first `acquire` load and the `release` store,
-            // and a sleep makes it a race between one thread and nothing.
+            // is the one between the outer load and the release store, and a sleep
+            // makes it a race between one thread and nothing.
             ready.fetch_add(1, std::memory_order_release);
             while (!go.load(std::memory_order_acquire)) {
             }
-            const std::vector<std::int64_t>& value = slot.get([&builds] {
-                builds.fetch_add(1, std::memory_order_relaxed);
-                std::vector<std::int64_t> built(width);
-                for (std::size_t i = 0; i < width; ++i) {
-                    built[i] = static_cast<std::int64_t>(i);
+            for (int wave = 0; wave < 2; ++wave) {
+                std::int64_t total = 0;
+                for (int step = 0; step < num_slots; ++step) {
+                    // Each thread starts at its own offset, so the threads are
+                    // spread across the slots rather than queued on one mutex.
+                    const int slot = (t * (num_slots / num_threads) + step) % num_slots;
+                    const auto& value =
+                        slots[static_cast<std::size_t>(slot)].get(build_slot(slot));
+                    for (const std::int64_t entry : value) {
+                        total += entry;
+                    }
                 }
-                return built;
-            });
-            seen[static_cast<std::size_t>(t)] = &value;
-            std::int64_t total = 0;
-            for (const std::int64_t entry : value) {
-                total += entry;
+                sums[static_cast<std::size_t>(t * 2 + wave)] = total;
             }
-            totals[static_cast<std::size_t>(t)] = total;
         });
     }
 
@@ -153,15 +184,18 @@ void check_concurrent_first_touch() {
         thread.join();
     }
 
-    // `width * (width - 1) / 2`, computed here rather than copied from a run.
-    constexpr std::int64_t expected =
-        static_cast<std::int64_t>(width) * (static_cast<std::int64_t>(width) - 1) / 2;
-    PANTR_CHECK_MSG(builds.load() == 1, "the value must be built exactly once");
-    for (int t = 0; t < num_threads; ++t) {
-        const auto index = static_cast<std::size_t>(t);
-        PANTR_CHECK_MSG(seen[index] == seen[0], "every thread must see one object");
-        PANTR_CHECK_MSG(totals[index] == expected,
-                        "thread " + std::to_string(t) + " read a wrong total");
+    // Per slot `s`: `sum(i + s) for i in [0, width)`, summed over every slot.
+    // Computed here rather than copied from a run.
+    constexpr std::int64_t w = static_cast<std::int64_t>(width);
+    constexpr std::int64_t n = static_cast<std::int64_t>(num_slots);
+    constexpr std::int64_t expected = n * (w * (w - 1) / 2) + w * (n * (n - 1) / 2);
+
+    PANTR_CHECK_MSG(builds.load() == num_slots,
+                    "each slot must be built exactly once, whatever the interleaving");
+    for (std::size_t i = 0; i < sums.size(); ++i) {
+        PANTR_CHECK_MSG(sums[i] == expected,
+                        "thread " + std::to_string(i / 2) + " wave " + std::to_string(i % 2)
+                            + " read a wrong total");
     }
 }
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -304,6 +304,27 @@ cxx() {
     check "gcc-debug: build" cmake --build --preset gcc-debug
     check "gcc-debug: ctest" ctest --preset gcc-debug
 
+    # The thread sanitizer, which is a separate build for a mechanical reason:
+    # -fsanitize=thread cannot be combined with -fsanitize=address, so the leg
+    # above cannot carry it.
+    #
+    # What only this leg can see is a race in a lazily-filled memo, and it is the
+    # one defect class in the port that no assertion on a value will ever catch.
+    # Measured on the bare `mutable std::optional` spelling of pantr::LazySlot:
+    # 4 TSan reports with 8 threads, AND 60 correct answers in 60 unsanitized
+    # runs. A suite that checks totals reports success on it every time.
+    #
+    # A clean run here is only evidence if the threads really contend, which is
+    # the null-result trap design/bspline_derived_caches.md records. The control
+    # was run rather than assumed: replacing LazySlot's double-checked locking
+    # with an unsynchronised `optional` gave 23 data races and turned both
+    # threaded tests red on this tree, and restoring it gave 0 and 47/47. Re-run
+    # that control if this leg is ever green on a tree where it should not be.
+    rm -rf "$ROOT/build/gcc-tsan"
+    check "gcc-tsan: configure (tsan)" cmake --preset gcc-tsan
+    check "gcc-tsan: build" cmake --build --preset gcc-tsan
+    check "gcc-tsan: ctest" ctest --preset gcc-tsan
+
     # The version floor, built rather than merely accepted.
     #
     # `gates` above asserts that the floor compilers CONFIGURE. That is the gate's


### PR DESCRIPTION
## What this is

Slice 2 of 4 for #396. **C++ only**: no binding, no Python touched, `pantr.bspline`
untouched. `pantr.bspline.BsplineSpace1D` stays the oracle and nothing calls the new
type yet, which is deliberate — it is what lets slice 3 bind it against an
implementation that has already been checked.

Three headers and four test files:

| file | what |
|---|---|
| `cpp/include/pantr/core/format.hpp` | Python's float rendering, moved out of `aabb.hpp` and given two more spellings |
| `cpp/include/pantr/core/lazy.hpp` | `LazySlot<T>`, the memo built once and published atomically |
| `cpp/include/pantr/bspline/knots.hpp` | the knot vector: scale, tolerance, classes, basis count, snapping, two refusals |
| `cpp/include/pantr/bspline/space_1d.hpp` | `BsplineSpace1D<T>`, the value and everything it fixes |

Plus a `gcc-tsan` preset and a leg in `scripts/ci_local.sh`, which
`design/bspline_derived_caches.md` asks this ticket to establish.

## The decisions, and where they depart from the two design notes

Both notes were followed; four places depart from their sketches and say why.

**What the type owns.** State, plus every quantity that is a function of it. It owns
no *operations* — basis tabulation, the three extraction families, knot insertion,
subdivision, restriction are separate ports over free functions taking a
`const BsplineSpace1D&`, which is the split `pantr/bezier/bezier.hpp` already uses.
`get_cardinal_intervals` is an operation by that test and is **not** here.

**The derived block is one `LazySlot`, not fourteen memos.** As
`design/bspline_derived_caches.md` concludes. Grouped because one scan computes all
of it; the in-domain forms are subspans of the same buffer rather than a second
computation.

**Departure 1 — four named accessors, not `std::pair<span, span> unique_knots()`.**
The note sketches a pair. A pair of spans is an anonymous record standing in for two
named things, which `CLAUDE.md` rules out in either direction; `unique_knots()`,
`multiplicity()`, `unique_knots_in_domain()` and `multiplicity_in_domain()` cost
nothing and read at the call site.

**Departure 2 — the domain and the three clamping flags are computed, not eager
fields.** The note's table calls `_left_end_open` "a bounded scan of at most
`degree + 1` knots". It is not: it is two indexed reads (`_bspline_space_1d.py`
compares `knots[0]` against `knots[degree]`), and so are the others. There is
nothing to make eager, and not duplicating state is the tiebreak. The two quantities
that *do* need a full scan, `num_basis` and `num_intervals`, are eager fields as the
note asks.

**Departure 3 — `KnotSnapping` rather than a `bool`.** The oracle's fourth argument
is `snap_knots: bool`, which at a C++ call site reads
`BsplineSpace1D(knots, 2, false, true)`. `CLAUDE.md`'s rule about a boolean that
selects behaviour applies; the Python wrapper will present `snap_knots: bool`
unchanged, because that is the wrapper's job.

**Departure 4 — `LazySlot` is a type in `pantr/core/`, not three lines in this
header.** The note asks four other tickets for the same mechanism and names the
grid's `bvh_` as needing the repair. **#395: this is available to you**, and its
copy/assignment semantics are the part worth reading before adopting it.

## Three things that are load-bearing and would otherwise read as arbitrary

**The tolerance is a `double` at every knot width.** The oracle computes it in Python
floats and hands it to a numba kernel typed `float64` even when the knots are
`float32`, so the comparison widens the difference and tests it against a `double`
threshold. Storing it as `T` would round the threshold — a knot-classification
verdict, not a rounding. `8 * eps` is exact (both powers of two), so the only
rounding is the final multiply and the two backends agree on the threshold bit for
bit rather than merely within it.

**There are two ways of differencing two knots and they are not the same.** The class
scan, the snapping and the periodic multiplicity count reproduce numba expressions
over the knot array, so they subtract in `T` and widen only for the comparison;
`has_left_end_open`, `has_right_end_open` and the scale reproduce Python expressions
written `float(a) - float(b)`, so both operands widen first. Verified rather than
assumed: `njit(lambda k: k[1] - k[0])` on a `float32` array reports a `float32`
return type and the comparison against a Python float types as
`(float32[:], float64) -> bool`.

**Snapping decides its class boundaries on the original vector.** Rewriting in place
compares against a knot already moved onto its representative, which splits a chain
the correct scan keeps whole and yields a *legal space with a different interval
count*. The two implementations agree on every vector without a chain, which is why
the case has to be constructed.

## Verification

### `bash scripts/ci_local.sh`, in full

Every leg PASS except the two `g++-10` floor legs, with `clang++-10` green on the
same tree — which is what identifies those as #376 rather than as this branch. The
new `gcc-tsan` legs pass, and so does the out-of-tree consumer build, which is what
checks the exported `Threads` dependency actually resolves for an installed package.

### Mutation checks: 18 applied, 18 behaved as intended

Not "the tests pass" but "each claim was broken and something went red".

| mutation | caught by |
|---|---|
| snapping reads the vector it is writing | `check_snap_reads_the_original_vector` |
| merge predicate `>` → `>=`, in both scans | `check_the_boundary_step_merges` |
| clamping comparison `<=` → `<` | `check_the_boundary_clamping_gap_is_open` |
| clamping made relative at numpy's default `rtol` | `check_end_openness_is_absolute` |
| derived arrays handed out as a copy | `check_the_derived_block_is_shared_not_rebuilt` |
| tolerance factor 8 → 4 | `check_knot_tolerance` |
| stored basis count taken from the unsnapped vector | `check_stored_basis_count_comes_from_the_snapped_vector` |
| `first_basis` window `<` → `<=` | `check_repeated_interior_knot` |
| scale drops its coordinate magnitudes | four cases across both files |
| one refusal message reworded | `check_argument_refusals` |
| the memo rebuilds on every access | `check_built_once` |
| memory ordering → `relaxed` throughout | `test_lazy` under TSan, **15 of 15 runs** |
| `LazySlot` unsynchronised (bare `optional`) | TSan, **23 data races**, both threaded tests red |

**Two survived the first pass**, and that is why two of those tests exist: the merge
predicate's exact boundary and the clamping gap's exact boundary were nowhere near
any case's data, so flipping either left the whole suite green. Both cases had to be
built from the tolerance rather than stumbled on.

### A differential sweep against the oracle: 4311 cases, 0 mismatches

There is no binding yet, so this was done with a throwaway harness (not committed):
generate cases in Python, record what `pantr.bspline.BsplineSpace1D` says about each,
replay them through the C++ type, compare **every** field — stored knots bit for bit,
tolerance bit for bit, basis count, interval count, domain, all four clamping flags,
unique knots and multiplicities whole-vector and in-domain, per-interval first basis
index, and the refusal message character for character.

| sweep | cases | mismatches |
|---|---|---|
| random knot vectors, degrees 0–5, both widths, offsets 1e-6 to 1e8, periodic and not, snapping and not | 3000 | 0 |
| offsets swept across the resolvability boundary, where the two message-heavy refusals fire | 1260 | 0 |
| hand-built degenerates: all-zero, all-equal, signed zero, subnormal span, 1e300, the shortest legal vector, exactly `2*degree+2` | 42 | 0 |
| inputs failing two checks at once, and the `float32` range limit | 9 | 0 |

**The harness was shown to have teeth** before its null result was believed: three
injected divergences (in-place snapping, `repr` where the oracle uses `.3g`, the ulp
taken at `double` width) produced 8, 336 and 168 mismatches respectively.

A fourth injected divergence — widening the class-scan subtraction — produced **0
mismatches over 3000 cases**, which is not a gap but the predicted result: random
draws do not land in a band of relative width `2^-24`. Fuzzing aimed at the threshold
does, and finds it.

**This sweep is scaffolding.** Slice 3 replaces it with a committed
`tests/parity/test_bspline_space_1d.py` once the binding exists to run it from
Python.

### The sanitizer leg was checked against a null result

A clean TSan run is evidence only if the threads contend, which
`design/bspline_derived_caches.md` records as the trap. Control run rather than
assumed: replacing `LazySlot`'s double-checked locking with an unsynchronised
`optional` gives **23 data races** and turns both threaded tests red; restoring it
gives **0 races and 47 of 47 tests passing**.

## Self-review round

One `reviewer` per region. **No Critical.** Everything below is fixed in
`dcd4e74 self-review: correct two false claims and make the race test actually race`,
and every finding is listed rather than counted.

**I — the concurrency test only exercised the mutex, not the acquire/release pair.**
One slot touched once per thread means every thread either builds under the lock or
blocks on it, and `std::mutex` establishes that edge by itself. Measured on the old
shape with the ordering patched to `relaxed`: caught in roughly one run in three, so
a single `ctest --preset gcc-tsan` had a real chance of passing on a broken
acquire/release pair. It now races 64 independent slots with each thread at its own
offset, plus a second wave. Re-measured with the same mutation: **15 of 15 caught**,
15 of 15 clean when restored.

**I — `space_1d.hpp` claimed the oracle stores a floating-point knot array in place
while only the port copies. False.** `_bspline_space_1d.py:99-106` copies too and
says why. There was no divergence to record. The note now says so, and says it was
believed.

`pantr/bezier/bezier.hpp:60-65` makes the structurally similar claim about a control
net, and **that one is true** — checked by execution rather than assumed, because the
resemblance is exactly what made the space's claim look safe. `_BezierPython.__init__`
stores what `numpy.asarray` returns, which does not copy an array that already has the
right dtype, and a write through the caller's array *is* visible in the Bézier
afterwards. The two oracles genuinely differ: a space copies because it freezes its
knots read-only, a Bézier does not, and that is the defect FELIGN/pantr#375 fixes.
**Nothing to route.**

**R — `knots.hpp` opened with "they cannot disagree about a class boundary", which
its own derivation two paragraphs later contradicted.** Fuzzing the two spellings
against each other finds real `float32` disagreements inside the last ulp of the
tolerance, at about 0.05% of trials aimed at the threshold and none at `float64`.
The absolute claim is gone.

**R — only one of three check-order transitions was exercised by an input that fails
both of its checks**, so swapping two individually-correct checks left the suite
green. The other two transitions now have a case each.

**S — the unreachable formatting-overflow branch changed exception type** from
`std::invalid_argument` to `std::logic_error` when it moved out of `aabb.hpp`, which
contradicts one clause of `6700827`'s message. Kept, because `logic_error` is the
accurate type — the caller's argument is not what is wrong — and it maps to
`RuntimeError` rather than `ValueError` at the binding. Documented in `format.hpp`;
the correction to the commit's wording is this paragraph.

**S — `THREADS_PREFER_PTHREAD_FLAG` was missing.** Inert on every configuration
exercised today, which is exactly why it would go unnoticed on the first one where it
is not.

**N — `2 * degree + 2` was signed overflow** for a degree near the top of the range,
where Python's arbitrary-precision integers make the oracle exact. Divides now.

**N — `format_general` and `format_fixed` were never fed a negative value.** Three
cases each.

**N — a `noexcept` was justified by the wrong reason** in `lazy.hpp`.

**U — resolved.** Whether narrowing the scale into `float` saturates safely for a
`float32` vector whose *span* exceeds `float`'s range: it does, and pushing that case
through the differential sweep is what settled it — and is what turned up the NaN-sign
divergence below.

**U — carried, not mine.** `THREADS_PREFER_PTHREAD_FLAG` matters only on a platform
none of the CI runners use. Re-check `CMAKE_HAVE_LIBC_PTHREAD` if a macOS or musl
runner is ever added.

### One divergence found by an adversarial input rather than by review

**CPython prints a NaN without a sign at every format specifier; glibc prints
`-nan`.** A knot vector holding an infinity gives an infinite scale, so the tolerance
is infinite and the ulp at that scale is a NaN; `tol / ulp` is `inf / nan`, whose NaN
came out with its sign bit set. The two backends' messages then differed by one
character, in the middle of a 300-character string, on that input and nothing else.
It would have surfaced in slice 3 as a parity failure with no obvious cause; it
surfaced here because the edge-case generator carried infinities.

**The C++ side is what changed, and the direction is not arbitrary.** Three reasons,
in the order that decides it:

1. **A port reproduces its oracle; it does not edit it.** That is the rule this
   milestone has followed throughout, and `pantr/bezier/bezier.hpp` records it for a
   defect it declined to fix on the Python side.
2. **CPython's behaviour is the specified one and glibc's is a platform detail.**
   Python documents no sign on a NaN at any specifier and does it consistently;
   `-nan` is what this libc does, and another may not. Matching CPython therefore
   makes the C++ side platform-independent as well as parity-correct, which is a
   benefit that outlives the oracle.
3. **The message is user-facing text.** Changing the Python side would change what
   every existing caller sees, to no one's benefit.

**The regression test carries the exact triggering input** —
`check_the_non_finite_message` in `cpp/tests/test_bspline_space_1d.cpp`, the `float32`
vector `[-inf, 0, 0, inf]` at degree 1, run end to end through the constructor with
the **whole** message asserted rather than its prefix, because the divergence was one
character in the middle of it. Checked to fail against the behaviour it pins:
removing the non-finite interception from `format_fixed` turns it and `test_format`
red.

## FELIGN/pantr#376: this does not fix it, and it moves the site it names

Stated plainly because the header comment invites the opposite reading.
`format_repr` still calls the floating-point `std::to_chars` libstdc++ 10 does not
provide. Proved rather than assumed, with the ticket's own reproduction:

```
$ g++-10 -std=c++20 -Icpp/include -I<mdspan> -fsyntax-only <one-line TU>
core/format.hpp:93: error: no matching function for call to 'to_chars(..., double&, std::chars_format)'
```

for a TU including `pantr/core/format.hpp`, `pantr/geometry/aabb.hpp` **or**
`pantr/bspline/space_1d.hpp`.

**So this widens #376's surface**: a second module now fails on the floor where
before only `geometry` did. The marginal harm is nil — the floor is already not met,
and the installed header set ships wholesale, so a consumer on libstdc++ 10 is
already broken at `aabb.hpp` today. What it buys that ticket is **one file to probe
for** instead of the call spreading through the port a header at a time, which is the
shape its own specification (a configure-time probe naming the facility) wants.

**Ruled: proceed, do not wait on #376.** The floor is already not met — `aabb.hpp`
fails on libstdc++ 10 today and the headers install wholesale — so a second
translation unit failing the same way changes nothing a user can observe. The floor
claim is false before this change and false after, by the same amount.

And this makes #376 **cheaper** to fix. Before it, the repr rule was one copy in
`aabb.hpp` and would have become N copies as more types needed it, each to be found
first. After it there is one `format_repr` and one call site to repair.
Consolidating the broken thing ahead of fixing it is the right order. Reimplementing
around `to_chars` inside this slice is the alternative, and it is what #376's own
specification rules out: it chose a configure-time probe and warns that any second
formatting path needs its own verification sweep.

A comment on #376 names `core/format.hpp:93` as the second site and the now-single
place its fix lands.

## What slice 3 will need, and one note it dissolves

The `_bspline_locate.py` note from slice 1's review — `get_unique_knots_and_multiplicity`
called per axis per Newton-refine round, where the removed cache absorbed the repeats
— **dissolves in slice 3, both ways**:

- under the C++ backend it becomes a read of this `LazySlot` block: one `nb::ndarray`
  construction over storage already computed, with no scan and no key, which is
  strictly cheaper than the removed cache's hit (an O(n) `tobytes`, a hash, a compare);
- under the Python oracle, slice 3 splits the class into a wrapper and
  `_BsplineSpace1DPython`, and the oracle keeps a **per-object** memo for the two
  `in_domain` values. That is what `design/bspline_derived_caches.md` means by
  "ownership, not a better key": no process-global state, no key at all, nothing the
  backend could be missing from.

So it stops being unquantified rather than staying an open note, and it stops for the
oracle too rather than only after the backend switches.

## For #399: the unique-knot scan is in C++ **in this slice**, not in slice 3

#426 argues that three of #399's four pieces are blocked on this front, because the
1D extraction operator builders open with the unique-knot-and-multiplicity scan that
`design/bspline_derived_caches.md` assigns here, and a second copy would be the
duplicate implementation `design/cross_backend_types.md` forbids. The premise is
right and the sequencing is better than it looks:

**A C++ caller is unblocked by this PR.** The scan is a free function over a span in
`cpp/include/pantr/bspline/knots.hpp`, deliberately not a method, so nothing has to
go through a space or through Python to reach it:

| symbol | what it gives |
|---|---|
| `unique_knots_and_multiplicity(knots, degree, tol)` | the distinct knots, their multiplicities, and the in-domain subrange |
| `classify_knots(knots, degree, tol)` | the same class boundaries with no allocation, when only counts are wanted |
| `knot_tolerance(knots)` | the `tol` those two take |
| `num_basis`, `snap_knots` | the rest of what a builder needs before it starts |

`BsplineSpace1D::unique_knots()` / `multiplicity()` are the same arrays memoised per
space, for a caller that already holds one. All of it is templated on the scalar and
exercised at `float` and `double`.

**Slice 3 adds only the Python binding**, which a C++ extraction builder does not
need. So if #399's pieces are C++-side, they are unblocked the moment this merges; if
they need the scan from Python, they wait for slice 3. Worth settling which, because
the two answers are a slice apart.

One note from #426 that does **not** bite here: its finding that a `StrEnum` compared
inside a `nopython` kernel is dead in every branch. The only enum this PR introduces
is `KnotSnapping`, a C++ `enum class : std::uint8_t` that cannot reach numba, and
slice 3 will present `snap_knots: bool` to Python rather than a Python enum — so no
new Python enum is created on this front at all.

## The one shared file this collides on

`cpp/tests/CMakeLists.txt`, with #399. The resolution is **union** — both test targets
belong — and it is checked arithmetically rather than by eye: trunk lists 26 sources,
this branch adds 4 (`test_format`, `test_lazy`, `test_bspline_knots`,
`test_bspline_space_1d`), #399 adds 1 (`test_extraction_kernels`), the two additions
do not overlap and neither branch removes anything. **Whichever rebases second must
end with 31 entries**, all distinct.

Advances #396. `Closes` is deliberately absent: this bases on `proto/cpp`, where it
would not fire.
