### PR TITLE
feat(grid): own the HierarchicalGrid type in C++ (query half)

### DIFF
--- a/cpp/include/pantr/grid/hierarchical_grid.hpp
+++ b/cpp/include/pantr/grid/hierarchical_grid.hpp
@@ -53,12 +53,21 @@
 ///
 /// ## Where this diverges from the oracle deliberately, and why
 ///
-/// The oracle counts cells in Python's arbitrary-precision integers and cannot overflow;
-/// this type accumulates in `std::int64_t` and can. Both the total cell count and
-/// `factor ** level` are therefore checked and throw, which is the same trade
-/// `TensorProductGrid` already makes for its own cell-count product: a grid that large
-/// is unusable on either side, and raising is the smaller divergence than a positive but
-/// meaningless count.
+/// **Counts that do not fit are refused rather than wrapped.** The oracle counts cells in
+/// Python's arbitrary-precision integers and cannot overflow; this type accumulates in
+/// `std::int64_t` and can, so the total cell count, each block's own product and
+/// `factor ** level` are all checked and throw. Same trade `TensorProductGrid` already
+/// makes for its own cell-count product: a grid that large is unusable on either side,
+/// and raising beats a positive but meaningless count.
+///
+/// **A wrong-length `midx` is an error here and a `None` there.** `cell_id` and
+/// `is_active_leaf` throw `std::invalid_argument` where the oracle's `cell_id`
+/// (`_hierarchical_grid.py:1211`) folds a wrong-length index into its "not an active
+/// leaf" answer. That is the port's stated rule -- `pantr/core/error.hpp` puts value and
+/// range checks in C++ and leaves shape coercion to the Python wrapper -- but it is a
+/// real behavioural difference and not only a message one, so **the wrapper owes the
+/// `None`**: it must catch the length case before forwarding, or a parity test feeding a
+/// badly sized index sees the two backends disagree in kind.
 
 #include <algorithm>
 #include <cmath>
@@ -310,13 +319,18 @@ class HierarchicalGrid : public GridBase<HierarchicalGrid<T>> {
         const auto d = static_cast<std::size_t>(this->ndim());
         std::vector<std::int64_t> scaled_lo(d);
         std::vector<std::int64_t> scaled_hi(d);
+        std::vector<std::int64_t> scale(d);
         for (std::int64_t coarser = 0; coarser < level; ++coarser) {
+            // Per coarser level, not per block: the projection factor depends only on the
+            // level gap, and computing it is O(gap) checked multiplications.
+            for (std::size_t k = 0; k < d; ++k) {
+                scale[k] = checked_scale(1, factor_[k], level - coarser);
+            }
             const auto [lo, hi] = active_blocks(coarser);
             for (std::size_t b = 0; b < lo.extent(0); ++b) {
                 for (std::size_t k = 0; k < d; ++k) {
-                    const std::int64_t scale = checked_scale(1, factor_[k], level - coarser);
-                    scaled_lo[k] = lo(b, k) * scale;
-                    scaled_hi[k] = hi(b, k) * scale;
+                    scaled_lo[k] = lo(b, k) * scale[k];
+                    scaled_hi[k] = hi(b, k) * scale[k];
                 }
                 fill_box(mask, shape, scaled_lo, scaled_hi, 0U);
             }
@@ -494,14 +508,17 @@ class HierarchicalGrid : public GridBase<HierarchicalGrid<T>> {
         std::vector<std::int64_t> face_hi(d);
 
         for (std::int64_t level = 0; level <= max_level(); ++level) {
+            // Hoisted: `factor ** level` costs O(level) checked multiplications, and the
+            // block loop below would otherwise pay it once per block per axis for a
+            // quantity that only depends on the level.
+            const std::vector<std::int64_t> n_per_axis = level_shape(level);
             const auto [lo, hi] = active_blocks(level);
             for (std::size_t b = 0; b < lo.extent(0); ++b) {
                 const std::int64_t base = block_base_[
                     static_cast<std::size_t>(level_start_[static_cast<std::size_t>(level)])
                     + b];
                 for (std::size_t axis = 0; axis < d; ++axis) {
-                    const std::int64_t n_axis = level_cells_per_axis(
-                        level, static_cast<std::int64_t>(axis));
+                    const std::int64_t n_axis = n_per_axis[axis];
                     for (std::int64_t side = 0; side < 2; ++side) {
                         const bool touches =
                             (side == 0) ? lo(b, axis) == 0 : hi(b, axis) == n_axis;
@@ -708,7 +725,7 @@ class HierarchicalGrid : public GridBase<HierarchicalGrid<T>> {
                 state.block_lo.insert(state.block_lo.end(), block.lo.begin(), block.lo.end());
                 state.block_hi.insert(state.block_hi.end(), block.hi.begin(), block.hi.end());
                 state.block_base.push_back(cell_base);
-                cell_base = checked_add(cell_base, block_size(block));
+                cell_base = checked_add(cell_base, checked_block_size(block));
                 ++b;
             }
         }
@@ -1120,6 +1137,26 @@ class HierarchicalGrid : public GridBase<HierarchicalGrid<T>> {
     [[nodiscard]] static std::int64_t checked_scale(std::int64_t value, std::int64_t base,
                                                     std::int64_t exponent) {
         return checked_mul(value, int_pow(base, exponent));
+    }
+
+    /// A block's cell count, refusing to overflow.
+    ///
+    /// `blocks.hpp`'s `block_size` accumulates in `std::int64_t` without checking, and
+    /// says the guard belongs one level up. This is that level. Checking the product as
+    /// well as the running sum matters because the file's contract promises that an
+    /// invalid decomposition is a *wrong answer* and not undefined behaviour, and a
+    /// single block whose own extents multiply past `int64` would otherwise be signed
+    /// overflow -- a narrower promise than the one written down.
+    ///
+    /// \param block The rectangle.
+    /// \return Its cell count.
+    /// \throws std::overflow_error If the product exceeds `int64`.
+    [[nodiscard]] static std::int64_t checked_block_size(BlockView block) {
+        std::int64_t size = 1;
+        for (std::size_t k = 0; k < block.lo.size(); ++k) {
+            size = checked_mul(size, block.hi[k] - block.lo[k]);
+        }
+        return size;
     }
 
     /// Multiply, refusing to overflow.

--- a/cpp/include/pantr/grid/hierarchical_grid.hpp
+++ b/cpp/include/pantr/grid/hierarchical_grid.hpp
@@ -1,0 +1,1165 @@
+#pragma once
+
+/// \file
+/// The hierarchical grid type: a root tensor-product grid plus a per-level set of
+/// active-leaf rectangles.
+///
+/// Ports the query half of `src/pantr/grid/_hierarchical_grid.py`, which stays as the
+/// parity oracle. Refinement, coarsening and restriction are not here yet.
+///
+/// ## One representation, not two
+///
+/// The oracle keeps its active set twice: `_blocks`, a list of lists of tuples, and four
+/// packed `int64` arrays rebuilt from it on every construction, because its Numba
+/// kernels cannot take the first shape. There is no such constraint here, so this type
+/// stores **only** the packed form -- `block_lo_`, `block_hi_`, `block_base_`,
+/// `level_start_` -- and `active_blocks()` is a view into it rather than a copy.
+///
+/// That is sound because the two are the same object in a different spelling: blocks are
+/// packed level by level and, within a level, in the order the level's list holds them,
+/// which is the order flat cell ids are assigned in. Dropping the unpacked copy removes
+/// the only way the two could ever disagree.
+///
+/// The root's breakpoints are not copied either. `TensorProductGrid` already stores them
+/// in one flat buffer with a per-axis offset table, which is exactly the `knots_flat` /
+/// `knot_starts` pair the kernels in `pantr/grid/hierarchical.hpp` take, so this type
+/// borrows them. The oracle repacks them on every rebuild and says in a comment that it
+/// does so only to keep one construction path.
+///
+/// ## Flat cell ids, which are the observable this whole file has to get right
+///
+/// > Ids are assigned level by level from level 0, block by block within a level, and in
+/// > C-order (last axis fastest) within a block.
+///
+/// Two consequences that are easy to lose. **The partition is observable**: which
+/// rectangles a level is cut into decides which cell gets which number, so
+/// `normalize_blocks`' order-dependent merge is part of the contract rather than an
+/// implementation detail -- `pantr/grid/blocks.hpp` carries that argument. And **ids are
+/// not stable across a refinement**: every construction assigns them from scratch, so a
+/// caller tracking a cell keeps the `(level, midx)` pair, which is stable, and resolves
+/// it with `cell_id()`.
+///
+/// ## The floating-point discipline, in one line each
+///
+/// A cell's bounds are `root_lo + sub_index * size`, where `size` is the root cell's
+/// width divided by `factor ** level`. **The product is named rather than inlined**, at
+/// every site, for the reason `pantr/grid/hierarchical.hpp` sets out at length: written
+/// as one expression it is contractible into a fused multiply-add, `-ffp-contract=on`
+/// permits exactly that, the oracle never fuses, and in `locate`'s descent the result
+/// feeds a truncation -- so the two backends would disagree on a **cell id**, which
+/// `design/backend_parity.md` Rule 11 says no tolerance bounds. `factor ** level` is
+/// accumulated by repeated integer multiplication, matching the oracle, so the two
+/// cannot diverge through a floating-point exponentiation neither should be doing.
+///
+/// ## Where this diverges from the oracle deliberately, and why
+///
+/// The oracle counts cells in Python's arbitrary-precision integers and cannot overflow;
+/// this type accumulates in `std::int64_t` and can. Both the total cell count and
+/// `factor ** level` are therefore checked and throw, which is the same trade
+/// `TensorProductGrid` already makes for its own cell-count product: a grid that large
+/// is unusable on either side, and raising is the smaller divergence than a positive but
+/// meaningless count.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+#include "pantr/grid/blocks.hpp"
+#include "pantr/grid/grid.hpp"
+#include "pantr/grid/hierarchical.hpp"
+#include "pantr/grid/tensor_product_grid.hpp"
+
+namespace pantr::grid {
+
+template <Real T>
+class HierarchicalGrid;
+
+}  // namespace pantr::grid
+
+template <pantr::Real T>
+struct pantr::grid::grid_traits<pantr::grid::HierarchicalGrid<T>> {
+    /// The coordinate type.
+    using scalar_type = T;
+
+    /// The five defaults this grid replaces.
+    ///
+    /// `cell_level` because a hierarchy has real levels where the generic answer is
+    /// always zero; the other four because the packed descriptor answers them without a
+    /// per-cell or per-facet query. `restrict` is deliberately absent for now, so the
+    /// mixin's throwing default stands; it arrives with refinement.
+    static constexpr pantr::grid::Hook hooks =
+        pantr::grid::Hook::cell_level | pantr::grid::Hook::boundary_facets
+        | pantr::grid::Hook::hanging_neighbors | pantr::grid::Hook::locate_many
+        | pantr::grid::Hook::collect_cell_bounds;
+};
+
+namespace pantr::grid {
+
+/// A hierarchy of nested tensor-product grids, with the active leaves stored as blocks.
+///
+/// Level 0 is `root`; a level-`l` cell subdivides into `factor[k]` children along axis
+/// `k`. The active leaves at each level are held as sorted, non-overlapping,
+/// pairwise-non-mergeable integer rectangles in that level's own coordinates, and they
+/// partition the root's domain exactly.
+///
+/// Immutable after construction apart from the base's lazily built spatial index and its
+/// two tag registries.
+template <Real T>
+class HierarchicalGrid : public GridBase<HierarchicalGrid<T>> {
+  public:
+    /// The mixin, named publicly so a differential test can reach the hidden defaults.
+    using Base = GridBase<HierarchicalGrid<T>>;
+
+    /// Build an unrefined hierarchy: one level, one block spanning the whole root.
+    ///
+    /// \param root The level-0 grid.
+    /// \param factor Per-axis subdivision factor, length `root.ndim()`. Each entry must
+    ///        be `>= 1`; `1` on an axis prevents subdivision along it.
+    /// \throws std::invalid_argument If `factor` has the wrong length or any entry
+    ///         is `< 1`.
+    HierarchicalGrid(TensorProductGrid<T> root, std::span<const std::int64_t> factor)
+        : HierarchicalGrid(build_unrefined(std::move(root), factor)) {}
+
+    /// Build from per-level block lists: the constructor every non-default path uses.
+    ///
+    /// \param root The level-0 root grid of the hierarchy.
+    /// \param factor Per-axis subdivision factor.
+    /// \param blocks `blocks[l]` holds the active-leaf rectangles at level `l`, in
+    ///        level-`l` coordinates. Trailing empty levels are dropped.
+    /// \param unnormalized_levels The levels whose lists the caller may have altered and
+    ///        which must therefore be normalized here. Every other level is taken
+    ///        verbatim. An empty optional normalizes every level and is always safe.
+    /// \return The grid.
+    /// \throws std::invalid_argument If `factor` is malformed, a level's rectangle count
+    ///         disagrees with `root.ndim()`, or the total cell count overflows.
+    /// \note No check that `blocks` is a valid active-leaf decomposition. Callers owe
+    ///       non-overlapping rectangles at each level whose per-level sets collectively
+    ///       partition the root's cells consistently with `factor`. A violation is a
+    ///       wrong answer here and in the oracle alike, not undefined behaviour.
+    /// \warning `unnormalized_levels` is a **cost** switch and never a behavioural one,
+    ///          and naming too few levels is silent. Normalization is a fixed point, so
+    ///          a level holding another grid's already-normalized list normalizes to
+    ///          itself and skipping that re-run returns the same blocks in the same
+    ///          order. Declaring a level clean when it is not moves every flat cell id.
+    [[nodiscard]] static HierarchicalGrid from_blocks(
+        TensorProductGrid<T> root, std::span<const std::int64_t> factor,
+        std::vector<BlockList> blocks,
+        std::optional<std::span<const std::int64_t>> unnormalized_levels) {
+        return HierarchicalGrid(build(std::move(root), factor, std::move(blocks),
+                                      unnormalized_levels));
+    }
+
+    // ----------------------------------------------------------------
+    // This grid's own surface
+    // ----------------------------------------------------------------
+
+    /// The level-0 grid.
+    ///
+    /// \return A reference to a member of this grid, valid for as long as the grid is.
+    [[nodiscard]] const TensorProductGrid<T>& root() const noexcept { return root_; }
+
+    /// The per-axis subdivision factor.
+    ///
+    /// \return A view of length `ndim()`; every entry is `>= 1`.
+    [[nodiscard]] std::span<const std::int64_t> factor() const noexcept { return factor_; }
+
+    /// The index of the deepest level, `0` before any refinement.
+    ///
+    /// \return `n_levels - 1`.
+    [[nodiscard]] std::int64_t max_level() const noexcept {
+        return static_cast<std::int64_t>(level_start_.size()) - 2;
+    }
+
+    /// The number of cells along one axis of the level-`level` grid.
+    ///
+    /// A pure formula, so `level` need not exist: a value above `max_level()` gives the
+    /// count for the hypothetical finer grid further uniform subdivision would produce.
+    /// That is deliberately unlike `active_blocks`, which requires an existing level.
+    ///
+    /// \param level Hierarchy level; must be `>= 0`.
+    /// \param axis Axis index in `[0, ndim())`.
+    /// \return `root.cells_per_axis()[axis] * factor()[axis] ** level`.
+    /// \throws std::invalid_argument If `level < 0`.
+    /// \throws std::out_of_range If `axis` is out of range.
+    /// \throws std::overflow_error If the count exceeds `int64`. The oracle counts in
+    ///         Python integers and cannot reach this; see the file header.
+    [[nodiscard]] std::int64_t level_cells_per_axis(std::int64_t level,
+                                                    std::int64_t axis) const {
+        if (level < 0) {
+            throw std::invalid_argument("level must be >= 0; got " + std::to_string(level)
+                                        + ".");
+        }
+        if (axis < 0 || axis >= this->ndim()) {
+            throw std::out_of_range("axis " + std::to_string(axis) + " is out of range [0, "
+                                    + std::to_string(this->ndim()) + ").");
+        }
+        const auto k = static_cast<std::size_t>(axis);
+        return checked_scale(root_.cells_per_axis()[k], factor_[k], level);
+    }
+
+    /// The active-leaf rectangles at `level`, as views into this grid's own storage.
+    ///
+    /// \param level Hierarchy level in `[0, max_level()]`.
+    /// \return `(lo, hi)`, each `(n_blocks_at_level, ndim())` row-major, sorted
+    ///         lexicographically by lower corner. Valid for as long as the grid is.
+    /// \throws std::invalid_argument If `level` is outside `[0, max_level()]`.
+    [[nodiscard]] std::pair<span2d<const std::int64_t>, span2d<const std::int64_t>>
+    active_blocks(std::int64_t level) const {
+        check_level(level);
+        const auto l = static_cast<std::size_t>(level);
+        const auto first = static_cast<std::size_t>(level_start_[l]);
+        const auto count = static_cast<std::size_t>(level_start_[l + 1] - level_start_[l]);
+        const auto d = static_cast<std::size_t>(this->ndim());
+        return {span2d<const std::int64_t>(block_lo_.data() + first * d, count, d),
+                span2d<const std::int64_t>(block_hi_.data() + first * d, count, d)};
+    }
+
+    /// The per-axis index of cell `cid` in its own level's coordinates.
+    ///
+    /// \param cid Cell identifier.
+    /// \param out Receives the index; must have `ndim()` entries.
+    /// \throws std::out_of_range If `cid` is out of range.
+    /// \throws std::invalid_argument If `out` is the wrong length.
+    void cell_multi_index(std::int64_t cid, std::span<std::int64_t> out) const {
+        this->check_cid(cid);
+        require_ndim_span(out, "out");
+        (void)decode(cid, out);
+    }
+
+    /// The flat id of the active leaf at `(level, midx)`, if there is one.
+    ///
+    /// The inverse of `cell_level` and `cell_multi_index` taken together, and the way to
+    /// follow a cell across a refinement: `(level, midx)` is stable where a flat id is
+    /// not.
+    ///
+    /// \param level Hierarchy level.
+    /// \param midx Per-axis index in level-`level` coordinates, `ndim()` entries.
+    /// \return The flat id when `(level, midx)` is an active leaf; empty when it is out
+    ///         of range, not yet created, or refined away.
+    /// \throws std::invalid_argument If `midx` is the wrong length.
+    [[nodiscard]] std::optional<std::int64_t> cell_id(
+        std::int64_t level, std::span<const std::int64_t> midx) const {
+        require_ndim_span(midx, "midx");
+        if (level < 0 || level > max_level()) {
+            return std::nullopt;
+        }
+        if (std::any_of(midx.begin(), midx.end(), [](std::int64_t i) { return i < 0; })) {
+            return std::nullopt;
+        }
+        return encode(level, midx);
+    }
+
+    /// Whether `(level, midx)` is an active leaf.
+    ///
+    /// \param level Hierarchy level.
+    /// \param midx Per-axis index in level-`level` coordinates, `ndim()` entries.
+    /// \return `true` iff `cell_id(level, midx)` holds a value.
+    /// \throws std::invalid_argument If `midx` is the wrong length.
+    [[nodiscard]] bool is_active_leaf(std::int64_t level,
+                                      std::span<const std::int64_t> midx) const {
+        return cell_id(level, midx).has_value();
+    }
+
+    /// A mask of the active-leaf cells at `level`, over that level's whole cell grid.
+    ///
+    /// \param level Hierarchy level in `[0, max_level()]`.
+    /// \return `1` where the level-`level` cell is an active leaf, `0` elsewhere, in
+    ///         C-order over `level_cells_per_axis(level, .)`.
+    /// \throws std::invalid_argument If `level` is outside `[0, max_level()]`.
+    /// \throws std::overflow_error If the level's cell count exceeds `int64`.
+    /// \note `std::uint8_t` rather than `std::vector<bool>`: the proxy specialisation has
+    ///       no contiguous buffer, and a binding needs one to present the mask as an
+    ///       array without copying it element by element.
+    [[nodiscard]] std::vector<std::uint8_t> active_leaf_mask(std::int64_t level) const {
+        check_level(level);
+        const std::vector<std::int64_t> shape = level_shape(level);
+        std::vector<std::uint8_t> mask(static_cast<std::size_t>(level_count(shape)), 0U);
+        const auto [lo, hi] = active_blocks(level);
+        for (std::size_t b = 0; b < lo.extent(0); ++b) {
+            fill_box(mask, shape, block_row(lo, b), block_row(hi, b), 1U);
+        }
+        return mask;
+    }
+
+    /// A mask of the level-`level` refined subdomain.
+    ///
+    /// A level-`level` cell is in the subdomain iff it is **not** covered by an active
+    /// leaf of a coarser level. Computed by projecting every coarser block up to
+    /// `level`'s resolution and clearing what it covers, which is what makes the answer
+    /// independent of how the coarser levels happen to be cut into rectangles.
+    ///
+    /// \param level Hierarchy level in `[0, max_level()]`.
+    /// \return `1` inside the subdomain, `0` outside, in C-order over
+    ///         `level_cells_per_axis(level, .)`.
+    /// \throws std::invalid_argument If `level` is outside `[0, max_level()]`.
+    /// \throws std::overflow_error If the level's cell count exceeds `int64`.
+    [[nodiscard]] std::vector<std::uint8_t> subdomain_mask(std::int64_t level) const {
+        check_level(level);
+        const std::vector<std::int64_t> shape = level_shape(level);
+        std::vector<std::uint8_t> mask(static_cast<std::size_t>(level_count(shape)), 1U);
+        const auto d = static_cast<std::size_t>(this->ndim());
+        std::vector<std::int64_t> scaled_lo(d);
+        std::vector<std::int64_t> scaled_hi(d);
+        for (std::int64_t coarser = 0; coarser < level; ++coarser) {
+            const auto [lo, hi] = active_blocks(coarser);
+            for (std::size_t b = 0; b < lo.extent(0); ++b) {
+                for (std::size_t k = 0; k < d; ++k) {
+                    const std::int64_t scale = checked_scale(1, factor_[k], level - coarser);
+                    scaled_lo[k] = lo(b, k) * scale;
+                    scaled_hi[k] = hi(b, k) * scale;
+                }
+                fill_box(mask, shape, scaled_lo, scaled_hi, 0U);
+            }
+        }
+        return mask;
+    }
+
+    /// A compact representation, character for character the oracle's `repr`.
+    ///
+    /// \return `"HierarchicalGrid(ndim=..., root_cells=(...), factor=(...), "`
+    ///         `"num_cells=..., max_level=...)"`.
+    [[nodiscard]] std::string to_string() const {
+        return "HierarchicalGrid(ndim=" + std::to_string(this->ndim())
+               + ", root_cells=" + tuple_repr(root_.cells_per_axis())
+               + ", factor=" + tuple_repr(factor_)
+               + ", num_cells=" + std::to_string(this->num_cells())
+               + ", max_level=" + std::to_string(max_level()) + ")";
+    }
+
+    // ----------------------------------------------------------------
+    // The three primitives
+    // ----------------------------------------------------------------
+
+    /// The axis-aligned corners of cell `cid`.
+    ///
+    /// \param cid Cell identifier.
+    /// \param lo Receives the lower corner; must have `ndim()` entries.
+    /// \param hi Receives the upper corner; must have `ndim()` entries.
+    /// \throws std::out_of_range If `cid` is out of range.
+    /// \throws std::invalid_argument If either span is the wrong length.
+    void cell_bounds(std::int64_t cid, std::span<T> lo, std::span<T> hi) const {
+        this->check_cid(cid);
+        require_ndim_span(lo, "lo");
+        require_ndim_span(hi, "hi");
+        const auto d = static_cast<std::size_t>(this->ndim());
+        std::vector<std::int64_t> midx(d);
+        const std::int64_t level = decode(cid, midx);
+        bounds_at(level, midx, lo, hi);
+    }
+
+    /// The active leaf containing `pt`, by descent from the root level.
+    ///
+    /// \param pt A point in parametric coordinates, `ndim()` entries.
+    /// \return The cell id, or empty when `pt` is outside the grid's domain.
+    /// \throws std::invalid_argument If `pt` is the wrong length.
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const T> pt) const {
+        require_ndim_span(pt, "pt");
+        const std::optional<std::int64_t> root_cid = root_.locate(pt);
+        if (!root_cid) {
+            return std::nullopt;
+        }
+        const auto d = static_cast<std::size_t>(this->ndim());
+        std::vector<std::int64_t> midx(d);
+        root_.cell_multi_index(*root_cid, midx);
+
+        std::vector<T> lo(d);
+        std::vector<T> hi(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            const std::span<const T> bp = root_.breakpoints(static_cast<std::int64_t>(k));
+            lo[k] = bp[static_cast<std::size_t>(midx[k])];
+            hi[k] = bp[static_cast<std::size_t>(midx[k] + 1)];
+        }
+
+        const std::int64_t n_levels = max_level() + 1;
+        for (std::int64_t level = 0; level < n_levels; ++level) {
+            const std::optional<std::int64_t> cid = encode(level, midx);
+            if (cid) {
+                return cid;
+            }
+            if (level >= n_levels - 1) {
+                return std::nullopt;  // unreachable in a consistent grid
+            }
+            descend(pt, midx, lo, hi);
+        }
+        return std::nullopt;  // unreachable
+    }
+
+    /// The cell across local facet `lfid` of `cid`.
+    ///
+    /// Handles a hanging interface at **any** level difference, since nothing here
+    /// enforces 2:1 balance. A coarser neighbour is the active leaf covering the
+    /// position however many levels up; a finer one is the first active descendant
+    /// touching the shared face, in C-order along it. `hanging_neighbors` returns them
+    /// all.
+    ///
+    /// \param cid Cell identifier.
+    /// \param lfid Local facet identifier in `[0, 2 * ndim())`.
+    /// \return The neighbouring cell id, or empty on an outer-boundary facet.
+    /// \throws std::out_of_range If `cid` or `lfid` is out of range.
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t cid,
+                                                                    std::int64_t lfid) const {
+        const std::optional<FacetPosition> position = facet_neighbor_position(cid, lfid);
+        if (!position) {
+            return std::nullopt;
+        }
+        const std::optional<std::int64_t> conforming = encode(position->level, position->midx);
+        if (conforming) {
+            return conforming;
+        }
+        const std::optional<std::int64_t> coarser =
+            nearest_active_ancestor(position->level, position->midx);
+        if (coarser) {
+            return coarser;
+        }
+        std::vector<std::int64_t> finer;
+        active_face_descendants(position->level, position->midx, position->axis,
+                                position->face_j, finer);
+        if (finer.empty()) {
+            return std::nullopt;
+        }
+        return finer.front();
+    }
+
+    // ----------------------------------------------------------------
+    // The five hooks
+    // ----------------------------------------------------------------
+
+    /// The refinement level of cell `cid`.
+    ///
+    /// \param cid Cell identifier.
+    /// \return The level, `0` for an unrefined root cell.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] std::int64_t cell_level(std::int64_t cid) const {
+        this->check_cid(cid);
+        std::vector<std::int64_t> midx(static_cast<std::size_t>(this->ndim()));
+        return decode(cid, midx);
+    }
+
+    /// Every active cell sharing local facet `lfid` of `cid`.
+    ///
+    /// One neighbour for a conforming or coarser interface. For a hanging one, every
+    /// active leaf touching the face, descending as many levels as the interface needs,
+    /// depth-first along the face.
+    ///
+    /// \param cid Cell identifier.
+    /// \param lfid Local facet identifier in `[0, 2 * ndim())`.
+    /// \return The neighbouring cell ids; empty on an outer-boundary facet.
+    /// \throws std::out_of_range If `cid` or `lfid` is out of range.
+    [[nodiscard]] std::vector<std::int64_t> hanging_neighbors(std::int64_t cid,
+                                                              std::int64_t lfid) const {
+        const std::optional<FacetPosition> position = facet_neighbor_position(cid, lfid);
+        if (!position) {
+            return {};
+        }
+        const std::optional<std::int64_t> conforming = encode(position->level, position->midx);
+        if (conforming) {
+            return {*conforming};
+        }
+        const std::optional<std::int64_t> coarser =
+            nearest_active_ancestor(position->level, position->midx);
+        if (coarser) {
+            return {*coarser};
+        }
+        std::vector<std::int64_t> finer;
+        active_face_descendants(position->level, position->midx, position->axis,
+                                position->face_j, finer);
+        return finer;
+    }
+
+    /// Every outer-boundary facet, as `(cid, lfid)` rows.
+    ///
+    /// The generic default asks `2 * ndim` neighbour questions per cell. Here a
+    /// level-`l` cell's facet `(axis, side)` is on the outer boundary exactly when its
+    /// level-`l` index along `axis` is `0` or `level_cells_per_axis - 1`, which is the
+    /// same out-of-range test the neighbour query makes -- and since a block is a
+    /// rectangle of contiguous indices, that is decided **once per block face** rather
+    /// than once per cell.
+    ///
+    /// \return `2 * n` values: `n` row-major `(cid, lfid)` pairs, sorted by `(cid,
+    ///         lfid)`.
+    [[nodiscard]] std::vector<std::int64_t> boundary_facets() const {
+        const auto d = static_cast<std::size_t>(this->ndim());
+        std::vector<std::int64_t> rows;
+        std::vector<std::int64_t> face_lo(d);
+        std::vector<std::int64_t> face_hi(d);
+
+        for (std::int64_t level = 0; level <= max_level(); ++level) {
+            const auto [lo, hi] = active_blocks(level);
+            for (std::size_t b = 0; b < lo.extent(0); ++b) {
+                const std::int64_t base = block_base_[
+                    static_cast<std::size_t>(level_start_[static_cast<std::size_t>(level)])
+                    + b];
+                for (std::size_t axis = 0; axis < d; ++axis) {
+                    const std::int64_t n_axis = level_cells_per_axis(
+                        level, static_cast<std::int64_t>(axis));
+                    for (std::int64_t side = 0; side < 2; ++side) {
+                        const bool touches =
+                            (side == 0) ? lo(b, axis) == 0 : hi(b, axis) == n_axis;
+                        if (!touches) {
+                            continue;
+                        }
+                        // The boundary layer of the block: the normal axis pinned to the
+                        // single index on the face, every other axis spanning the block.
+                        for (std::size_t k = 0; k < d; ++k) {
+                            face_lo[k] = lo(b, k);
+                            face_hi[k] = hi(b, k);
+                        }
+                        if (side == 0) {
+                            face_hi[axis] = face_lo[axis] + 1;
+                        } else {
+                            face_lo[axis] = face_hi[axis] - 1;
+                        }
+                        emit_face(base, block_row(lo, b), block_row(hi, b), face_lo, face_hi,
+                                  2 * static_cast<std::int64_t>(axis) + side, rows);
+                    }
+                }
+            }
+        }
+        sort_facet_rows(rows);
+        return rows;
+    }
+
+    /// Locate a batch of points through the shared descent kernel.
+    ///
+    /// \param points `(npts, ndim())` row-major view of query points.
+    /// \return `npts` cell ids; `-1` for a point outside the domain.
+    /// \throws std::invalid_argument If `points.extent(1)` is not `ndim()`.
+    [[nodiscard]] std::vector<std::int64_t> locate_many(span2d<const T> points) const {
+        if (points.extent(1) != static_cast<std::size_t>(this->ndim())) {
+            throw std::invalid_argument("points must have ndim() columns.");
+        }
+        std::vector<std::int64_t> out(points.extent(0));
+        hier_locate_points<T>(points, root_.breakpoints_flat(), root_.axis_starts(),
+                              root_.cells_per_axis(), factor_, packed_lo(), packed_hi(),
+                              block_base_, level_start_, out);
+        return out;
+    }
+
+    /// Materialise per-cell `(lo, hi)` in flat-id order.
+    ///
+    /// \param cell_lo Output lo corners, shape `(num_cells(), ndim())`.
+    /// \param cell_hi Output hi corners, same shape.
+    /// \throws std::invalid_argument If either view is the wrong shape.
+    void collect_cell_bounds(span2d<T> cell_lo, span2d<T> cell_hi) const {
+        const auto n = static_cast<std::size_t>(this->num_cells());
+        const auto d = static_cast<std::size_t>(this->ndim());
+        if (cell_lo.extent(0) != n || cell_lo.extent(1) != d || cell_hi.extent(0) != n
+            || cell_hi.extent(1) != d) {
+            throw std::invalid_argument("cell_lo and cell_hi must have shape (num_cells, ndim).");
+        }
+        hier_collect_cell_bounds<T>(root_.breakpoints_flat(), root_.axis_starts(), factor_,
+                                    packed_lo(), packed_hi(), block_base_, level_start_,
+                                    cell_lo, cell_hi);
+    }
+
+  private:
+    /// Everything the constructor computes, so the mixin's sizes can be passed up.
+    ///
+    /// A CRTP base is initialised before any member, so `GridBase(ndim, num_cells)`
+    /// cannot read a member to find the cell count. `TensorProductGrid` solves this the
+    /// same way: one static function computes the whole state, and a private constructor
+    /// forwards its two sizes up and moves the rest in.
+    struct State {
+        TensorProductGrid<T> root;             ///< The level-0 grid.
+        std::vector<std::int64_t> factor;      ///< Per-axis subdivision factor.
+        std::vector<std::int64_t> block_lo;    ///< `(n_blocks, ndim)` lower corners.
+        std::vector<std::int64_t> block_hi;    ///< `(n_blocks, ndim)` upper corners.
+        std::vector<std::int64_t> block_base;  ///< Flat id of each block's first cell.
+        std::vector<std::int64_t> level_start; ///< Block index range per level, + sentinel.
+        std::int64_t num_cells;                ///< Total active cell count.
+    };
+
+    /// The same-level position across a facet, and how to reach the fine side of it.
+    struct FacetPosition {
+        std::int64_t level;                 ///< Level of the queried cell.
+        std::vector<std::int64_t> midx;     ///< The neighbour position at that level.
+        std::size_t axis;                   ///< The axis normal to the facet.
+        std::int64_t face_j;                ///< Child offset on `axis` touching the plane.
+    };
+
+    /// Adopt an already-computed state.
+    ///
+    /// \param state The state to move in.
+    explicit HierarchicalGrid(State&& state)
+        : Base(state.root.ndim(), state.num_cells),
+          root_(std::move(state.root)),
+          factor_(std::move(state.factor)),
+          block_lo_(std::move(state.block_lo)),
+          block_hi_(std::move(state.block_hi)),
+          block_base_(std::move(state.block_base)),
+          level_start_(std::move(state.level_start)) {}
+
+    /// The state of an unrefined hierarchy: one level, one block over the whole root.
+    ///
+    /// A function rather than a nested call in the delegating constructor's argument list,
+    /// and that is load-bearing rather than tidiness: arguments are evaluated in an
+    /// unspecified order, so a call that both moved `root` and read it to size the block
+    /// could read a moved-from grid. Statements inside a body are sequenced, so this
+    /// cannot.
+    ///
+    /// \param root The level-0 grid.
+    /// \param factor Per-axis subdivision factor.
+    /// \return The packed state.
+    [[nodiscard]] static State build_unrefined(TensorProductGrid<T> root,
+                                               std::span<const std::int64_t> factor) {
+        std::vector<BlockList> blocks = single_root_block(root);
+        return build(std::move(root), factor, std::move(blocks),
+                     std::span<const std::int64_t>{});
+    }
+
+    /// One level holding one block spanning the whole root.
+    ///
+    /// \param root The level-0 grid.
+    /// \return A single-level block list.
+    [[nodiscard]] static std::vector<BlockList> single_root_block(
+        const TensorProductGrid<T>& root) {
+        const auto d = static_cast<std::size_t>(root.ndim());
+        std::vector<std::int64_t> lo(d, 0);
+        const std::span<const std::int64_t> hi = root.cells_per_axis();
+        BlockList level0(root.ndim());
+        level0.push_back(BlockView{lo, hi});
+        return {std::move(level0)};
+    }
+
+    /// Validate, normalize where asked, and pack into the flat descriptor.
+    ///
+    /// \param root The level-0 grid.
+    /// \param factor Per-axis subdivision factor.
+    /// \param blocks Per-level block lists.
+    /// \param unnormalized_levels Levels to re-normalize; empty optional means all.
+    /// \return The packed state.
+    /// \throws std::invalid_argument If `factor` or a level's rectangle width is wrong.
+    /// \throws std::overflow_error If the total cell count exceeds `int64`.
+    [[nodiscard]] static State build(
+        TensorProductGrid<T> root, std::span<const std::int64_t> factor,
+        std::vector<BlockList> blocks,
+        std::optional<std::span<const std::int64_t>> unnormalized_levels) {
+        const std::int64_t ndim = root.ndim();
+        if (static_cast<std::int64_t>(factor.size()) != ndim) {
+            throw std::invalid_argument("factor must have " + std::to_string(ndim)
+                                        + " entries; got " + std::to_string(factor.size())
+                                        + ".");
+        }
+        for (const std::int64_t f : factor) {
+            if (f < 1) {
+                throw std::invalid_argument(
+                    "every factor entry must be >= 1 (1 = no subdivision on that axis).");
+            }
+        }
+        for (const BlockList& level : blocks) {
+            if (level.ndim() != ndim && !level.empty()) {
+                throw std::invalid_argument("every block list must span " + std::to_string(ndim)
+                                            + " axes.");
+            }
+        }
+
+        // Normalize the levels the caller did not vouch for. A level is clean exactly
+        // when it holds another grid's list verbatim; anything the caller built or
+        // clipped is not, and the default assumes nothing.
+        for (std::size_t l = 0; l < blocks.size(); ++l) {
+            const bool clean =
+                unnormalized_levels.has_value()
+                && std::find(unnormalized_levels->begin(), unnormalized_levels->end(),
+                             static_cast<std::int64_t>(l))
+                       == unnormalized_levels->end();
+            if (!clean) {
+                blocks[l] = normalize_blocks(blocks[l]);
+            }
+        }
+        while (blocks.size() > 1 && blocks.back().empty()) {
+            blocks.pop_back();
+        }
+
+        State state{std::move(root), {factor.begin(), factor.end()}, {}, {}, {},
+                    std::vector<std::int64_t>(blocks.size() + 1, 0), 0};
+        std::int64_t cell_base = 0;
+        std::int64_t b = 0;
+        for (std::size_t l = 0; l < blocks.size(); ++l) {
+            state.level_start[l] = b;
+            for (std::size_t i = 0; i < blocks[l].size(); ++i) {
+                const BlockView block = blocks[l][i];
+                state.block_lo.insert(state.block_lo.end(), block.lo.begin(), block.lo.end());
+                state.block_hi.insert(state.block_hi.end(), block.hi.begin(), block.hi.end());
+                state.block_base.push_back(cell_base);
+                cell_base = checked_add(cell_base, block_size(block));
+                ++b;
+            }
+        }
+        state.level_start[blocks.size()] = b;
+        state.num_cells = cell_base;
+        return state;
+    }
+
+    // ----------------------------------------------------------------
+    // Addressing
+    // ----------------------------------------------------------------
+
+    /// The packed lower corners as a two-dimensional view.
+    ///
+    /// \return `(n_blocks, ndim)` row-major.
+    [[nodiscard]] span2d<const std::int64_t> packed_lo() const noexcept {
+        return span2d<const std::int64_t>(block_lo_.data(), block_base_.size(),
+                                          static_cast<std::size_t>(this->ndim()));
+    }
+
+    /// The packed upper corners as a two-dimensional view.
+    ///
+    /// \return `(n_blocks, ndim)` row-major.
+    [[nodiscard]] span2d<const std::int64_t> packed_hi() const noexcept {
+        return span2d<const std::int64_t>(block_hi_.data(), block_base_.size(),
+                                          static_cast<std::size_t>(this->ndim()));
+    }
+
+    /// Flat id of `(level, midx)`, if it is an active leaf.
+    ///
+    /// \param level Hierarchy level.
+    /// \param midx Per-axis index, `ndim()` entries.
+    /// \return The flat id, or empty when the position is not an active leaf.
+    [[nodiscard]] std::optional<std::int64_t> encode(
+        std::int64_t level, std::span<const std::int64_t> midx) const {
+        if (level < 0 || level > max_level()) {
+            return std::nullopt;
+        }
+        const std::int64_t cid = block_of_midx(level, midx, packed_lo(), packed_hi(),
+                                               block_base_, level_start_);
+        if (cid < 0) {
+            return std::nullopt;
+        }
+        return cid;
+    }
+
+    /// Level and per-axis index of a flat id.
+    ///
+    /// \param cid Cell identifier; must be in range.
+    /// \param out Receives the index; must have `ndim()` entries.
+    /// \return The level.
+    [[nodiscard]] std::int64_t decode(std::int64_t cid, std::span<std::int64_t> out) const {
+        return decode_flat_id(cid, packed_lo(), packed_hi(), block_base_, level_start_, out);
+    }
+
+    /// The corners of the cell at `(level, midx)`.
+    ///
+    /// \param level Hierarchy level.
+    /// \param midx Per-axis index, `ndim()` entries.
+    /// \param lo Receives the lower corner.
+    /// \param hi Receives the upper corner.
+    void bounds_at(std::int64_t level, std::span<const std::int64_t> midx, std::span<T> lo,
+                   std::span<T> hi) const {
+        const auto d = static_cast<std::size_t>(this->ndim());
+        for (std::size_t k = 0; k < d; ++k) {
+            const std::int64_t m_pow = int_pow(factor_[k], level);
+            const std::int64_t root_ik = midx[k] / m_pow;
+            const std::int64_t sub_ik = midx[k] % m_pow;
+            const std::span<const T> bp = root_.breakpoints(static_cast<std::int64_t>(k));
+            const T root_lo_k = bp[static_cast<std::size_t>(root_ik)];
+            const T root_hi_k = bp[static_cast<std::size_t>(root_ik + 1)];
+            const T size_k =
+                static_cast<T>((root_hi_k - root_lo_k) / T(static_cast<double>(m_pow)));
+            // Named rather than inlined; see the file header. A fused multiply-add here
+            // would move a corner by an ulp against the oracle, and the same expression
+            // in `descend` decides a cell id.
+            const T offset = T(static_cast<double>(sub_ik)) * size_k;
+            lo[k] = root_lo_k + offset;
+            hi[k] = lo[k] + size_k;
+        }
+    }
+
+    /// Step one level down towards `pt`, updating the index and the bracketing box.
+    ///
+    /// The scalar counterpart of the loop inside `hier_locate_points`, and written to
+    /// match it statement for statement: the clamp, the named product, and the rewrite of
+    /// `hi` from the *new* `lo` are each observable through the id the descent returns.
+    ///
+    /// \param pt The query point.
+    /// \param midx Per-axis index, replaced by the child's.
+    /// \param lo The current cell's lower corner, replaced by the child's.
+    /// \param hi The current cell's upper corner, replaced by the child's.
+    void descend(std::span<const T> pt, std::span<std::int64_t> midx, std::span<T> lo,
+                 std::span<T> hi) const {
+        const auto d = static_cast<std::size_t>(this->ndim());
+        for (std::size_t k = 0; k < d; ++k) {
+            const std::int64_t fk = factor_[k];
+            const T size_k = static_cast<T>((hi[k] - lo[k]) / T(static_cast<double>(fk)));
+            auto j = static_cast<std::int64_t>(
+                value_of(static_cast<T>((pt[k] - lo[k]) / size_k)));
+            if (j < 0) {
+                j = 0;
+            } else if (j > fk - 1) {
+                j = fk - 1;
+            }
+            const T step = T(static_cast<double>(j)) * size_k;
+            lo[k] = lo[k] + step;
+            hi[k] = lo[k] + size_k;
+            midx[k] = midx[k] * fk + j;
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Neighbours
+    // ----------------------------------------------------------------
+
+    /// Resolve facet `lfid` of `cid` to the same-level position across it.
+    ///
+    /// \param cid Cell identifier.
+    /// \param lfid Local facet identifier.
+    /// \return The position, or empty when the facet is on the outer boundary.
+    /// \throws std::out_of_range If `cid` or `lfid` is out of range.
+    [[nodiscard]] std::optional<FacetPosition> facet_neighbor_position(
+        std::int64_t cid, std::int64_t lfid) const {
+        this->check_lfid(cid, lfid);
+        const auto axis = static_cast<std::size_t>(lfid / 2);
+        const std::int64_t side = lfid % 2;
+
+        std::vector<std::int64_t> midx(static_cast<std::size_t>(this->ndim()));
+        const std::int64_t level = decode(cid, midx);
+        const std::int64_t moved = midx[axis] + (side == 0 ? -1 : 1);
+        if (moved < 0
+            || moved >= level_cells_per_axis(level, static_cast<std::int64_t>(axis))) {
+            return std::nullopt;  // the grid's outer boundary
+        }
+        midx[axis] = moved;
+        const std::int64_t face_j = (side == 0) ? factor_[axis] - 1 : 0;
+        return FacetPosition{level, std::move(midx), axis, face_j};
+    }
+
+    /// The active leaf covering `(level, midx)` at a strictly coarser level.
+    ///
+    /// \param level Level of the queried position.
+    /// \param midx Per-axis index at that level.
+    /// \return The covering leaf's flat id, or empty when no ancestor is active.
+    [[nodiscard]] std::optional<std::int64_t> nearest_active_ancestor(
+        std::int64_t level, std::span<const std::int64_t> midx) const {
+        const auto d = static_cast<std::size_t>(this->ndim());
+        std::vector<std::int64_t> ancestor(midx.begin(), midx.end());
+        for (std::int64_t lvl = level - 1; lvl >= 0; --lvl) {
+            for (std::size_t k = 0; k < d; ++k) {
+                ancestor[k] /= factor_[k];
+            }
+            const std::optional<std::int64_t> cid = encode(lvl, ancestor);
+            if (cid) {
+                return cid;
+            }
+        }
+        return std::nullopt;
+    }
+
+    /// The active leaves inside `(level, midx)` that touch one of its faces.
+    ///
+    /// Descends the subdivision tree, keeping only the children on the facet plane and
+    /// enumerating the remaining axes in C-order, so the ids come out ordered along the
+    /// face. Stops at `(level, midx)` itself when that is an active leaf.
+    ///
+    /// \param level Level of the starting position.
+    /// \param midx Per-axis index at that level.
+    /// \param axis The axis normal to the face.
+    /// \param face_j Child offset on `axis` adjacent to the facet plane.
+    /// \param out Receives the ids, appended. Not cleared first.
+    void active_face_descendants(std::int64_t level, std::span<const std::int64_t> midx,
+                                 std::size_t axis, std::int64_t face_j,
+                                 std::vector<std::int64_t>& out) const {
+        const std::optional<std::int64_t> cid = encode(level, midx);
+        if (cid) {
+            out.push_back(*cid);
+            return;
+        }
+        if (level + 1 > max_level()) {
+            return;
+        }
+        const auto d = static_cast<std::size_t>(this->ndim());
+        // The odometer runs over every axis but `axis`, which is pinned to `face_j`.
+        std::vector<std::int64_t> offsets(d, 0);
+        offsets[axis] = face_j;
+        std::vector<std::int64_t> child(d);
+        while (true) {
+            for (std::size_t k = 0; k < d; ++k) {
+                child[k] = midx[k] * factor_[k] + offsets[k];
+            }
+            active_face_descendants(level + 1, child, axis, face_j, out);
+
+            std::size_t k = d;
+            bool carried = true;
+            while (k > 0 && carried) {
+                --k;
+                if (k == axis) {
+                    continue;  // pinned to the face
+                }
+                ++offsets[k];
+                if (offsets[k] < factor_[k]) {
+                    carried = false;
+                } else {
+                    offsets[k] = 0;
+                }
+            }
+            if (carried) {
+                return;
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Small shared helpers
+    // ----------------------------------------------------------------
+
+    /// One row of a packed block view, as a span.
+    ///
+    /// \param view The packed view.
+    /// \param b Row index.
+    /// \return A view of the row's `ndim` entries.
+    [[nodiscard]] static std::span<const std::int64_t> block_row(
+        span2d<const std::int64_t> view, std::size_t b) noexcept {
+        return std::span<const std::int64_t>(&view(b, 0), view.extent(1));
+    }
+
+    /// Reject a level outside the hierarchy.
+    ///
+    /// \param level The level to check.
+    /// \throws std::invalid_argument If `level` is outside `[0, max_level()]`.
+    void check_level(std::int64_t level) const {
+        if (level < 0 || level > max_level()) {
+            throw std::invalid_argument("level must be in [0, " + std::to_string(max_level())
+                                        + "]; got " + std::to_string(level) + ".");
+        }
+    }
+
+    /// Reject a span that is not `ndim()` long.
+    ///
+    /// \tparam U The span's element type.
+    /// \param s The span to check.
+    /// \param what Its name, for the message.
+    /// \throws std::invalid_argument If the length is wrong.
+    template <class U>
+    void require_ndim_span(std::span<U> s, const char* what) const {
+        if (s.size() != static_cast<std::size_t>(this->ndim())) {
+            throw std::invalid_argument(std::string(what) + " must have "
+                                        + std::to_string(this->ndim()) + " entries; got "
+                                        + std::to_string(s.size()) + ".");
+        }
+    }
+
+    /// The per-axis cell count of a level, as a shape.
+    ///
+    /// \param level Hierarchy level.
+    /// \return `ndim()` counts.
+    [[nodiscard]] std::vector<std::int64_t> level_shape(std::int64_t level) const {
+        std::vector<std::int64_t> shape(static_cast<std::size_t>(this->ndim()));
+        for (std::size_t k = 0; k < shape.size(); ++k) {
+            shape[k] = level_cells_per_axis(level, static_cast<std::int64_t>(k));
+        }
+        return shape;
+    }
+
+    /// The number of cells a shape holds.
+    ///
+    /// \param shape Per-axis counts.
+    /// \return Their product.
+    /// \throws std::overflow_error If the product exceeds `int64`.
+    [[nodiscard]] static std::int64_t level_count(std::span<const std::int64_t> shape) {
+        std::int64_t total = 1;
+        for (const std::int64_t n : shape) {
+            total = checked_mul(total, n);
+        }
+        return total;
+    }
+
+    /// Write `value` into every cell of `[lo, hi)` of a C-order mask over `shape`.
+    ///
+    /// \param mask The mask to write into.
+    /// \param shape Per-axis extents of the mask.
+    /// \param lo Lower corner, inclusive.
+    /// \param hi Upper corner, exclusive.
+    /// \param value The value to write.
+    static void fill_box(std::vector<std::uint8_t>& mask,
+                         std::span<const std::int64_t> shape,
+                         std::span<const std::int64_t> lo, std::span<const std::int64_t> hi,
+                         std::uint8_t value) {
+        const std::size_t d = shape.size();
+        std::vector<std::int64_t> index(lo.begin(), lo.end());
+        for (std::size_t k = 0; k < d; ++k) {
+            if (lo[k] >= hi[k]) {
+                return;
+            }
+        }
+        while (true) {
+            std::int64_t flat = 0;
+            for (std::size_t k = 0; k < d; ++k) {
+                flat = flat * shape[k] + index[k];
+            }
+            mask[static_cast<std::size_t>(flat)] = value;
+
+            std::size_t k = d;
+            bool carried = true;
+            while (k > 0 && carried) {
+                --k;
+                ++index[k];
+                if (index[k] < hi[k]) {
+                    carried = false;
+                } else {
+                    index[k] = lo[k];
+                }
+            }
+            if (carried) {
+                return;
+            }
+        }
+    }
+
+    /// Append `(cid, lfid)` for every cell of a block's boundary layer, in C-order.
+    ///
+    /// \param base Flat id of the block's first cell.
+    /// \param block_lo The block's lower corner.
+    /// \param block_hi The block's upper corner.
+    /// \param face_lo Lower corner of the layer, inside the block.
+    /// \param face_hi Upper corner of the layer.
+    /// \param lfid The local facet id to emit.
+    /// \param out Receives the pairs, appended.
+    static void emit_face(std::int64_t base, std::span<const std::int64_t> block_lo,
+                          std::span<const std::int64_t> block_hi,
+                          std::span<const std::int64_t> face_lo,
+                          std::span<const std::int64_t> face_hi, std::int64_t lfid,
+                          std::vector<std::int64_t>& out) {
+        const std::size_t d = block_lo.size();
+        std::vector<std::int64_t> index(face_lo.begin(), face_lo.end());
+        while (true) {
+            // C-order offset within the block, last axis fastest -- the order flat ids
+            // are assigned in.
+            std::int64_t offset = 0;
+            for (std::size_t k = 0; k < d; ++k) {
+                offset = offset * (block_hi[k] - block_lo[k]) + (index[k] - block_lo[k]);
+            }
+            out.push_back(base + offset);
+            out.push_back(lfid);
+
+            std::size_t k = d;
+            bool carried = true;
+            while (k > 0 && carried) {
+                --k;
+                ++index[k];
+                if (index[k] < face_hi[k]) {
+                    carried = false;
+                } else {
+                    index[k] = face_lo[k];
+                }
+            }
+            if (carried) {
+                return;
+            }
+        }
+    }
+
+    /// Sort `(cid, lfid)` pairs held flat, lexicographically.
+    ///
+    /// \param rows `2 * n` values, `n` pairs.
+    static void sort_facet_rows(std::vector<std::int64_t>& rows) {
+        const std::size_t n = rows.size() / 2;
+        std::vector<std::size_t> order(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            order[i] = i;
+        }
+        std::sort(order.begin(), order.end(), [&rows](std::size_t i, std::size_t j) {
+            if (rows[2 * i] != rows[2 * j]) {
+                return rows[2 * i] < rows[2 * j];
+            }
+            return rows[2 * i + 1] < rows[2 * j + 1];
+        });
+        std::vector<std::int64_t> sorted(rows.size());
+        for (std::size_t i = 0; i < n; ++i) {
+            sorted[2 * i] = rows[2 * order[i]];
+            sorted[2 * i + 1] = rows[2 * order[i] + 1];
+        }
+        rows = std::move(sorted);
+    }
+
+    /// `base ** exponent`, by repeated multiplication as the oracle does.
+    ///
+    /// \param base The base; non-negative.
+    /// \param exponent The exponent; non-negative.
+    /// \return The power.
+    /// \throws std::overflow_error If it exceeds `int64`.
+    [[nodiscard]] static std::int64_t int_pow(std::int64_t base, std::int64_t exponent) {
+        std::int64_t result = 1;
+        for (std::int64_t i = 0; i < exponent; ++i) {
+            result = checked_mul(result, base);
+        }
+        return result;
+    }
+
+    /// `value * base ** exponent`, checked.
+    ///
+    /// \param value The multiplicand.
+    /// \param base The base.
+    /// \param exponent The exponent.
+    /// \return The product.
+    /// \throws std::overflow_error If it exceeds `int64`.
+    [[nodiscard]] static std::int64_t checked_scale(std::int64_t value, std::int64_t base,
+                                                    std::int64_t exponent) {
+        return checked_mul(value, int_pow(base, exponent));
+    }
+
+    /// Multiply, refusing to overflow.
+    ///
+    /// Checked because the alternative is undefined behaviour rather than a wrong
+    /// number, and because the oracle multiplies in Python integers and never reaches it.
+    ///
+    /// \param a First factor; non-negative.
+    /// \param b Second factor; non-negative.
+    /// \return `a * b`.
+    /// \throws std::overflow_error If the product exceeds `int64`.
+    [[nodiscard]] static std::int64_t checked_mul(std::int64_t a, std::int64_t b) {
+        if (a != 0 && b > std::numeric_limits<std::int64_t>::max() / a) {
+            throw std::overflow_error(
+                "HierarchicalGrid: a cell count exceeds what int64 can hold, so the grid "
+                "has no representable size.");
+        }
+        return a * b;
+    }
+
+    /// Add, refusing to overflow.
+    ///
+    /// \param a First term; non-negative.
+    /// \param b Second term; non-negative.
+    /// \return `a + b`.
+    /// \throws std::overflow_error If the sum exceeds `int64`.
+    [[nodiscard]] static std::int64_t checked_add(std::int64_t a, std::int64_t b) {
+        if (b > std::numeric_limits<std::int64_t>::max() - a) {
+            throw std::overflow_error(
+                "HierarchicalGrid: the active cells exceed what int64 can count.");
+        }
+        return a + b;
+    }
+
+    /// Format a span of integers the way Python prints a tuple.
+    ///
+    /// \param values The values.
+    /// \return `"(a, b)"`, with the trailing comma Python gives a one-element tuple.
+    [[nodiscard]] static std::string tuple_repr(std::span<const std::int64_t> values) {
+        std::string out = "(";
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            out += std::to_string(values[i]);
+            if (i + 1 < values.size()) {
+                out += ", ";
+            }
+        }
+        if (values.size() == 1) {
+            out += ",";
+        }
+        return out + ")";
+    }
+
+    TensorProductGrid<T> root_;              ///< The level-0 grid.
+    std::vector<std::int64_t> factor_;       ///< Per-axis subdivision factor.
+    std::vector<std::int64_t> block_lo_;     ///< `(n_blocks, ndim)` lower corners.
+    std::vector<std::int64_t> block_hi_;     ///< `(n_blocks, ndim)` upper corners.
+    std::vector<std::int64_t> block_base_;   ///< Flat id of each block's first cell.
+    std::vector<std::int64_t> level_start_;  ///< Block index range per level, + sentinel.
+};
+
+}  // namespace pantr::grid

--- a/cpp/include/pantr/grid/hierarchical_grid.hpp
+++ b/cpp/include/pantr/grid/hierarchical_grid.hpp
@@ -61,6 +61,7 @@
 /// meaningless count.
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -531,8 +532,17 @@ class HierarchicalGrid : public GridBase<HierarchicalGrid<T>> {
     /// Locate a batch of points through the shared descent kernel.
     ///
     /// \param points `(npts, ndim())` row-major view of query points.
-    /// \return `npts` cell ids; `-1` for a point outside the domain.
+    /// \return `npts` cell ids; `-1` for a point outside the domain, and for one with a
+    ///         non-finite coordinate.
     /// \throws std::invalid_argument If `points.extent(1)` is not `ndim()`.
+    /// \note The kernel cannot answer the non-finite case itself and this masks it
+    ///       afterwards, exactly as the oracle does. Its root-containment test is
+    ///       `x < lo || x > hi`, and **every comparison against a NaN is false**, so the
+    ///       row passes the test, descends, and lands in a real cell -- a plausible wrong
+    ///       id rather than a crash. The scalar `locate` needs no such pass, because
+    ///       `TensorProductGrid::locate` writes the same test as a negated comparison
+    ///       that rejects a NaN and either infinity; the two spellings are not
+    ///       interchangeable and `tensor_product_grid.hpp` says so at its own site.
     [[nodiscard]] std::vector<std::int64_t> locate_many(span2d<const T> points) const {
         if (points.extent(1) != static_cast<std::size_t>(this->ndim())) {
             throw std::invalid_argument("points must have ndim() columns.");
@@ -541,6 +551,14 @@ class HierarchicalGrid : public GridBase<HierarchicalGrid<T>> {
         hier_locate_points<T>(points, root_.breakpoints_flat(), root_.axis_starts(),
                               root_.cells_per_axis(), factor_, packed_lo(), packed_hi(),
                               block_base_, level_start_, out);
+        for (std::size_t p = 0; p < points.extent(0); ++p) {
+            for (std::size_t k = 0; k < points.extent(1); ++k) {
+                if (!std::isfinite(value_of(points(p, k)))) {
+                    out[p] = -1;
+                    break;
+                }
+            }
+        }
         return out;
     }
 

--- a/cpp/include/pantr/grid/tensor_product_grid.hpp
+++ b/cpp/include/pantr/grid/tensor_product_grid.hpp
@@ -196,6 +196,26 @@ class TensorProductGrid : public GridBase<TensorProductGrid<T>> {
         return std::span<const T>(breakpoints_flat_.data() + start, count);
     }
 
+    /// Every axis's breakpoints, end to end in one buffer.
+    ///
+    /// Exposed because it is exactly the `knots_flat` half of the descriptor the
+    /// hierarchical kernels in `pantr/grid/hierarchical.hpp` take, so a grid built over
+    /// this one can borrow it instead of repacking a copy -- which is what the Python
+    /// oracle does on every rebuild, and says in a comment that it does only to keep one
+    /// construction path.
+    ///
+    /// \return A view of the whole buffer, valid for as long as the grid is.
+    [[nodiscard]] std::span<const T> breakpoints_flat() const noexcept {
+        return breakpoints_flat_;
+    }
+
+    /// Where each axis begins in `breakpoints_flat()`.
+    ///
+    /// \return `ndim` offsets; the `knot_starts` half of the descriptor above.
+    [[nodiscard]] std::span<const std::int64_t> axis_starts() const noexcept {
+        return axis_start_;
+    }
+
     /// Whether every axis's breakpoint spacing is constant.
     ///
     /// Constant to within `kUniformSpacingEpsFactor * eps * (|first| + |last|)`; see

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(PANTR_TEST_SOURCES
     test_grid_bvh.cpp
     test_grid_hierarchical.cpp
     test_grid_blocks.cpp
+    test_grid_hierarchical_type.cpp
     test_aabb.cpp
     test_affine.cpp
     test_bezier_type.cpp

--- a/cpp/tests/test_grid_hierarchical_type.cpp
+++ b/cpp/tests/test_grid_hierarchical_type.cpp
@@ -382,6 +382,42 @@ void test_scalar_and_batch_locate_agree() {
     }
 }
 
+/// A non-finite coordinate locates to nothing, through the batch path as well.
+///
+/// The batch kernel's containment test is `x < lo || x > hi`, which a NaN passes -- every
+/// comparison against it is false -- so the descent proceeds and lands in some cell. The
+/// oracle masks those rows after the kernel returns (`_grid_utils._mask_nonfinite_locate`),
+/// and `locate_many` here owes the same correction; the scalar `locate` never needed it,
+/// because `TensorProductGrid::locate` writes its test as a negated comparison that
+/// rejects a NaN.
+///
+/// Both paths are asserted, and so is their agreement: the failure mode this pins is not
+/// a crash but a plausible-looking wrong id, which is exactly what nothing else here
+/// would notice. The sibling `test_grid_tensor_product.cpp` pins the same case for the
+/// flat grid.
+void test_non_finite_points_locate_to_nothing() {
+    const Grid g = refined_1d();
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double inf = std::numeric_limits<double>::infinity();
+    const std::vector<double> xs{nan, inf, -inf, 0.25};
+
+    const std::vector<std::int64_t> batch =
+        g.locate_many(span2d<const double>(xs.data(), xs.size(), 1));
+    PANTR_CHECK(batch == std::vector<std::int64_t>({-1, -1, -1, 2}));
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+        const std::optional<std::int64_t> one = g.locate(std::span<const double>(&xs[i], 1));
+        PANTR_CHECK_MSG(batch[i] == (one ? *one : -1),
+                        "the scalar and batch paths disagree on a non-finite coordinate");
+    }
+
+    // In more than one dimension a single bad coordinate is enough to reject the row.
+    const Grid h = refined_2d();
+    const std::vector<double> pts{0.5, nan, nan, 0.5, 0.5, 0.5};
+    const std::vector<std::int64_t> got = h.locate_many(span2d<const double>(pts.data(), 3, 2));
+    PANTR_CHECK(got[0] == -1 && got[1] == -1);
+    PANTR_CHECK(got[2] >= 0);
+}
+
 /// Sorted by lower corner, the 1-D cells abut exactly and span the whole domain.
 ///
 /// Exact on a dyadic fixture: a shared corner is `root_lo + j * size` on one side and
@@ -813,6 +849,7 @@ int main() {
     test_locate_finds_each_cell(refined_1d(), "the refined 1-D grid");
     test_locate_finds_each_cell(refined_2d(), "the refined 2-D grid");
     test_scalar_and_batch_locate_agree();
+    test_non_finite_points_locate_to_nothing();
     test_the_cells_tile_the_domain(flat_1d(), "the flat grid");
     test_the_cells_tile_the_domain(refined_1d(), "the refined 1-D grid");
     test_the_cells_tile_the_domain(dyadic_unit(6), "the dyadic unit grid");

--- a/cpp/tests/test_grid_hierarchical_type.cpp
+++ b/cpp/tests/test_grid_hierarchical_type.cpp
@@ -1,0 +1,840 @@
+/// \file
+/// The `HierarchicalGrid` type: addressing, geometry, neighbours and the five hooks.
+///
+/// Nothing here compares the two backends -- `tests/parity/` is where that happens, and
+/// it needs the bindings. What this file can do, and does, is tie the type's answers to
+/// each other and to closed-form geometry, so that a divergence shows up as a named
+/// broken property rather than as a bare inequality in a parity sweep.
+///
+/// ## The four kinds of check, and why each is not a mirror of the code
+///
+/// **Two unrelated paths, compared bitwise.** `cell_bounds` decodes a flat id to
+/// `(level, midx)` by binary search and evaluates one cell; `collect_cell_bounds` walks
+/// blocks with an odometer and evaluates all of them. They share no code, so agreeing on
+/// every cell is a real statement. `locate` descends levels and truncates quotients,
+/// while `cell_bounds` does neither, so locating each cell's midpoint back to its own id
+/// is another. And every hook is compared against the mixin default it hides, reached by
+/// the qualified call `g.Base::name(...)` -- the C++ analogue of the unbound
+/// `Grid.boundary_facets(g)` in `tests/test_grid_hierarchical.py`.
+///
+/// **Closed form, where the arithmetic is exact.** On a dyadic root with a dyadic
+/// factor, a level-`l` cell's corners are exactly representable binary rationals, so the
+/// computed bound must equal the hand-written value **bitwise**. That is an
+/// oracle-independent statement about the geometry, not a comparison against another
+/// implementation.
+///
+/// **The same check where the arithmetic is not exact.** A closed-form test that only
+/// ever runs on exactly-representable inputs has not tested the arithmetic, it has
+/// tested the cases that cannot fail. So the non-dyadic fixture asserts both halves: the
+/// error against the exact rational is **nonzero** somewhere, and it is inside a bound
+/// derived from the operation count rather than fitted to the observation.
+///
+/// **Hand-computed values** for the block-level answers -- `boundary_facets`, the two
+/// masks, the neighbour cases -- on fixtures small enough to work out in a comment.
+///
+/// ## What is deliberately not here
+///
+/// Refinement, coarsening, restriction and the mesh export are not part of this type
+/// yet. The mixin's throwing `restrict` default stands, and the traits bitmask says so.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/blocks.hpp"
+#include "pantr/grid/hierarchical_grid.hpp"
+#include "pantr/grid/tensor_product_grid.hpp"
+
+namespace {
+
+using pantr::span2d;
+using pantr::grid::BlockList;
+using pantr::grid::BlockView;
+using pantr::grid::HierarchicalGrid;
+using pantr::grid::TensorProductGrid;
+
+using Grid = HierarchicalGrid<double>;
+using Ints = std::vector<std::int64_t>;
+
+/// A block list holding one rectangle, spelled `{lo..., hi...}`.
+///
+/// \param ndim Axis count.
+/// \param rects The rectangles.
+/// \return The list, in the order given.
+BlockList level(std::int64_t ndim, const std::vector<Ints>& rects) {
+    BlockList blocks(ndim);
+    const auto d = static_cast<std::size_t>(ndim);
+    for (const Ints& rect : rects) {
+        blocks.push_back(BlockView{std::span<const std::int64_t>(rect.data(), d),
+                                   std::span<const std::int64_t>(rect.data() + d, d)});
+    }
+    return blocks;
+}
+
+/// The root of every 1-D fixture: four unit cells on `[0, 4]`.
+///
+/// \return The root grid.
+TensorProductGrid<double> root_1d() {
+    return TensorProductGrid<double>({{0.0, 1.0, 2.0, 3.0, 4.0}});
+}
+
+/// Four unit cells, unrefined, factor 2. Flat ids are the root's own.
+///
+/// \return The grid.
+Grid flat_1d() {
+    const Ints factor{2};
+    return Grid(root_1d(), factor);
+}
+
+/// Root cells 0 and 1 refined once; cells 2 and 3 stay coarse.
+///
+/// level 0: block `[2, 4)` -- flat ids 0, 1, the cells `[2,3]` and `[3,4]`
+/// level 1: block `[0, 4)` -- flat ids 2..5, the cells `[0,0.5] ... [1.5,2]`
+///
+/// Six cells. Note the ordering trap the numbering makes concrete: the *coarse* cells
+/// come first because level 0 is packed first, even though they sit to the right.
+///
+/// \return The grid.
+Grid refined_1d() {
+    const Ints factor{2};
+    std::vector<BlockList> blocks;
+    blocks.push_back(level(1, {{2, 4}}));
+    blocks.push_back(level(1, {{0, 4}}));
+    return Grid::from_blocks(root_1d(), factor, std::move(blocks), std::nullopt);
+}
+
+/// A 2-by-2 root of unit cells on `[0,2] x [0,2]`, factor 2, with cell (0,0) refined.
+///
+/// level 0: blocks `[0,1) x [1,2)`, `[1,2) x [0,2)` -- three coarse cells
+/// level 1: block `[0,2) x [0,2)` -- the four children of root cell (0,0)
+///
+/// Seven cells.
+///
+/// \return The grid.
+Grid refined_2d() {
+    const Ints factor{2, 2};
+    std::vector<BlockList> blocks;
+    blocks.push_back(level(2, {{0, 1, 1, 2}, {1, 0, 2, 2}}));
+    blocks.push_back(level(2, {{0, 0, 2, 2}}));
+    return Grid::from_blocks(TensorProductGrid<double>({{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}),
+                             factor, std::move(blocks), std::nullopt);
+}
+
+/// The whole unit interval as one root cell, refined uniformly to `level`, factor 2.
+///
+/// Every corner is `k / 2**level`, a binary rational and therefore exact in `double`.
+/// This is the fixture the closed-form assertions run on.
+///
+/// \param depth The level to refine to.
+/// \return The grid.
+Grid dyadic_unit(std::int64_t depth) {
+    const Ints factor{2};
+    std::vector<BlockList> blocks;
+    for (std::int64_t l = 0; l < depth; ++l) {
+        blocks.push_back(level(1, {}));
+    }
+    blocks.push_back(level(1, {{0, std::int64_t{1} << depth}}));
+    return Grid::from_blocks(TensorProductGrid<double>({{0.0, 1.0}}), factor, std::move(blocks),
+                             std::nullopt);
+}
+
+/// One root cell `[0, 0.1]`, refined uniformly to level 2 with factor 3.
+///
+/// Nothing here is exact: `0.1` is not representable, and dividing it by 9 is not
+/// either. That is the point -- see the file header.
+///
+/// \return The grid.
+Grid non_dyadic() {
+    const Ints factor{3};
+    std::vector<BlockList> blocks;
+    blocks.push_back(level(1, {}));
+    blocks.push_back(level(1, {}));
+    blocks.push_back(level(1, {{0, 9}}));
+    return Grid::from_blocks(TensorProductGrid<double>({{0.0, 0.1}}), factor, std::move(blocks),
+                             std::nullopt);
+}
+
+/// One cell's corners.
+///
+/// \param g The grid.
+/// \param cid Cell identifier.
+/// \return `(lo, hi)`.
+std::pair<std::vector<double>, std::vector<double>> bounds(const Grid& g, std::int64_t cid) {
+    std::vector<double> lo(static_cast<std::size_t>(g.ndim()));
+    std::vector<double> hi(lo.size());
+    g.cell_bounds(cid, lo, hi);
+    return {lo, hi};
+}
+
+/// Every cell's corners, through the hook.
+///
+/// \param g The grid.
+/// \return `(cell_lo, cell_hi)`, each `num_cells * ndim` row-major.
+std::pair<std::vector<double>, std::vector<double>> all_bounds(const Grid& g) {
+    const auto n = static_cast<std::size_t>(g.num_cells());
+    const auto d = static_cast<std::size_t>(g.ndim());
+    std::vector<double> lo(n * d);
+    std::vector<double> hi(n * d);
+    g.collect_cell_bounds(span2d<double>(lo.data(), n, d), span2d<double>(hi.data(), n, d));
+    return {lo, hi};
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+/// The constructor rejects a malformed factor, on both counts.
+void test_construction_validates() {
+    bool threw = false;
+    try {
+        const Ints wrong_length{2, 2};
+        const Grid g(root_1d(), wrong_length);
+        (void)g;
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a factor of the wrong length must be refused");
+
+    threw = false;
+    try {
+        const Ints zero{0};
+        const Grid g(root_1d(), zero);
+        (void)g;
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a factor entry below 1 must be refused");
+
+    // 1 is legal and means "no subdivision on that axis", which is not the same as 0.
+    const Ints one{1};
+    const Grid g(root_1d(), one);
+    PANTR_CHECK(g.num_cells() == 4);
+}
+
+/// An unrefined hierarchy is its root, cell for cell and corner for corner.
+///
+/// Bitwise on the corners: level 0 divides the root cell's width by `factor ** 0 == 1`
+/// and adds an offset of zero, so every operation is exact and any difference at all
+/// would be a defect rather than a rounding.
+void test_the_unrefined_grid_is_its_root() {
+    const Grid g = flat_1d();
+    const TensorProductGrid<double>& root = g.root();
+
+    PANTR_CHECK(g.ndim() == 1);
+    PANTR_CHECK(g.num_cells() == root.num_cells());
+    PANTR_CHECK(g.max_level() == 0);
+
+    const auto [lo, hi] = g.active_blocks(0);
+    PANTR_CHECK(lo.extent(0) == 1);
+    PANTR_CHECK(lo(0, 0) == 0);
+    PANTR_CHECK(hi(0, 0) == 4);
+
+    for (std::int64_t cid = 0; cid < g.num_cells(); ++cid) {
+        std::vector<double> rlo(1);
+        std::vector<double> rhi(1);
+        root.cell_bounds(cid, rlo, rhi);
+        const auto got = bounds(g, cid);
+        PANTR_CHECK_MSG(got.first == rlo && got.second == rhi,
+                        "cell " + std::to_string(cid) + " must be the root's own cell");
+        PANTR_CHECK(g.cell_level(cid) == 0);
+    }
+}
+
+/// The refined fixtures are what their comments claim.
+void test_the_fixtures_are_what_they_claim() {
+    const Grid g = refined_1d();
+    PANTR_CHECK(g.num_cells() == 6);
+    PANTR_CHECK(g.max_level() == 1);
+    // The two coarse cells come first: level 0 is packed before level 1.
+    PANTR_CHECK(g.cell_level(0) == 0);
+    PANTR_CHECK(g.cell_level(1) == 0);
+    PANTR_CHECK(g.cell_level(2) == 1);
+    PANTR_CHECK(g.cell_level(5) == 1);
+    PANTR_CHECK(bounds(g, 0).first == std::vector<double>({2.0}));
+    PANTR_CHECK(bounds(g, 2).first == std::vector<double>({0.0}));
+    PANTR_CHECK(bounds(g, 2).second == std::vector<double>({0.5}));
+
+    const Grid h = refined_2d();
+    PANTR_CHECK(h.num_cells() == 7);
+    PANTR_CHECK(h.max_level() == 1);
+    PANTR_CHECK(h.ndim() == 2);
+}
+
+// ---------------------------------------------------------------------------
+// Addressing
+// ---------------------------------------------------------------------------
+
+/// `cell_id` inverts `cell_level` and `cell_multi_index`, for every cell.
+void test_the_address_round_trips(const Grid& g, const char* what) {
+    const auto d = static_cast<std::size_t>(g.ndim());
+    for (std::int64_t cid = 0; cid < g.num_cells(); ++cid) {
+        std::vector<std::int64_t> midx(d);
+        g.cell_multi_index(cid, midx);
+        const std::int64_t lvl = g.cell_level(cid);
+        const std::optional<std::int64_t> back = g.cell_id(lvl, midx);
+        PANTR_CHECK_MSG(back.has_value() && *back == cid,
+                        std::string(what) + ": cell " + std::to_string(cid)
+                            + " did not round-trip through (level, midx)");
+        PANTR_CHECK(g.is_active_leaf(lvl, midx));
+    }
+}
+
+/// A position that is not an active leaf answers empty rather than guessing.
+void test_inactive_positions_have_no_id() {
+    const Grid g = refined_1d();
+    // Level 0 cells 0 and 1 were refined away.
+    PANTR_CHECK(!g.cell_id(0, Ints{0}).has_value());
+    PANTR_CHECK(!g.cell_id(0, Ints{1}).has_value());
+    PANTR_CHECK(g.cell_id(0, Ints{2}).has_value());
+    // Out of range on every axis of failure.
+    PANTR_CHECK(!g.cell_id(0, Ints{-1}).has_value());
+    PANTR_CHECK(!g.cell_id(0, Ints{4}).has_value());
+    PANTR_CHECK(!g.cell_id(-1, Ints{0}).has_value());
+    PANTR_CHECK(!g.cell_id(2, Ints{0}).has_value());
+    PANTR_CHECK(!g.is_active_leaf(0, Ints{0}));
+}
+
+/// An out-of-range id is an error, not a wrong answer.
+void test_cell_id_range_is_checked() {
+    const Grid g = refined_1d();
+    bool threw = false;
+    try {
+        (void)g.cell_level(6);
+    } catch (const std::out_of_range&) {
+        threw = true;
+    }
+    PANTR_CHECK(threw);
+}
+
+// ---------------------------------------------------------------------------
+// Geometry: two unrelated paths, and closed form
+// ---------------------------------------------------------------------------
+
+/// `cell_bounds` and `collect_cell_bounds` agree bitwise on every cell.
+///
+/// One decodes a flat id by binary search and evaluates one cell; the other walks blocks
+/// with an odometer and evaluates all of them. They share no code. Bitwise rather than
+/// close, because they evaluate the same expression in the same order on the same
+/// inputs, so any difference is a defect and not a rounding.
+void test_the_two_bound_paths_agree(const Grid& g, const char* what) {
+    const auto d = static_cast<std::size_t>(g.ndim());
+    const auto [lo, hi] = all_bounds(g);
+    for (std::int64_t cid = 0; cid < g.num_cells(); ++cid) {
+        const auto one = bounds(g, cid);
+        for (std::size_t k = 0; k < d; ++k) {
+            const std::size_t at = static_cast<std::size_t>(cid) * d + k;
+            PANTR_CHECK_MSG(one.first[k] == lo[at] && one.second[k] == hi[at],
+                            std::string(what) + ": cell " + std::to_string(cid) + " axis "
+                                + std::to_string(k) + " differs between the two paths");
+        }
+    }
+}
+
+/// Locating each cell's own midpoint returns that cell.
+///
+/// `locate` descends levels and truncates a quotient at each one; `cell_bounds` decodes
+/// and evaluates. Neither can satisfy this by mirroring the other.
+void test_locate_finds_each_cell(const Grid& g, const char* what) {
+    const auto d = static_cast<std::size_t>(g.ndim());
+    std::vector<double> mid(d);
+    for (std::int64_t cid = 0; cid < g.num_cells(); ++cid) {
+        const auto one = bounds(g, cid);
+        for (std::size_t k = 0; k < d; ++k) {
+            mid[k] = 0.5 * (one.first[k] + one.second[k]);
+        }
+        const std::optional<std::int64_t> got = g.locate(mid);
+        PANTR_CHECK_MSG(got.has_value() && *got == cid,
+                        std::string(what) + ": the midpoint of cell " + std::to_string(cid)
+                            + " located to "
+                            + (got ? std::to_string(*got) : std::string("nothing")));
+    }
+}
+
+/// The scalar descent and the batch kernel return the same ids.
+///
+/// Two implementations of one descent -- a member walking `std::optional`s and a kernel
+/// over the packed descriptor -- so this is a real cross-check rather than a restatement.
+/// Points on cell boundaries are included deliberately: those are where a truncation
+/// disagreement would first show, and Rule 11 says no tolerance bounds a changed id.
+void test_scalar_and_batch_locate_agree() {
+    const Grid g = refined_1d();
+    const std::vector<double> xs{-0.5,  0.0, 0.25, 0.5, 0.75, 1.0, 1.25,
+                                 1.5,   2.0, 2.5,  3.0, 3.5,  4.0, 4.5};
+    const std::vector<std::int64_t> batch =
+        g.locate_many(span2d<const double>(xs.data(), xs.size(), 1));
+    PANTR_CHECK(batch.size() == xs.size());
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+        const std::optional<std::int64_t> one = g.locate(std::span<const double>(&xs[i], 1));
+        const std::int64_t as_batch = one ? *one : -1;
+        PANTR_CHECK_MSG(batch[i] == as_batch,
+                        "x = " + std::to_string(xs[i]) + ": scalar gave "
+                            + std::to_string(as_batch) + ", batch gave "
+                            + std::to_string(batch[i]));
+    }
+}
+
+/// Sorted by lower corner, the 1-D cells abut exactly and span the whole domain.
+///
+/// Exact on a dyadic fixture: a shared corner is `root_lo + j * size` on one side and
+/// `root_lo + (j-1) * size + size` on the other, and with dyadic `size` both are exact.
+/// That is why this assertion is confined to the dyadic fixtures; the non-dyadic one is
+/// checked against its closed form with a derived bound instead.
+void test_the_cells_tile_the_domain(const Grid& g, const char* what) {
+    const auto [lo, hi] = all_bounds(g);
+    std::vector<std::size_t> order(lo.size());
+    for (std::size_t i = 0; i < order.size(); ++i) {
+        order[i] = i;
+    }
+    std::sort(order.begin(), order.end(),
+              [&lo](std::size_t a, std::size_t b) { return lo[a] < lo[b]; });
+    const std::span<const double> bp = g.root().breakpoints(0);
+    PANTR_CHECK_MSG(lo[order.front()] == bp.front(),
+                    std::string(what) + ": the first cell must start at the domain");
+    PANTR_CHECK_MSG(hi[order.back()] == bp.back(),
+                    std::string(what) + ": the last cell must end at the domain");
+    for (std::size_t i = 1; i < order.size(); ++i) {
+        PANTR_CHECK_MSG(hi[order[i - 1]] == lo[order[i]],
+                        std::string(what) + ": cells must abut exactly");
+    }
+}
+
+/// **Closed form.** On a dyadic hierarchy every corner is the exact binary rational.
+///
+/// A level-`l` cell `k` of the unit interval spans `[k / 2**l, (k+1) / 2**l]`, and every
+/// one of those is representable, so the computed value must equal it **bitwise**. This
+/// is an oracle-free statement: it compares the code against the mathematics, which is
+/// what `design/backend_parity.md` asks of an accuracy check.
+void test_dyadic_bounds_are_exact() {
+    for (std::int64_t depth = 0; depth <= 10; ++depth) {
+        const Grid g = dyadic_unit(depth);
+        const std::int64_t n = std::int64_t{1} << depth;
+        PANTR_CHECK(g.num_cells() == n);
+        const double step = 1.0 / static_cast<double>(n);  // exact: a power of two
+        for (std::int64_t cid = 0; cid < n; ++cid) {
+            const auto one = bounds(g, cid);
+            const double want_lo = static_cast<double>(cid) * step;
+            const double want_hi = static_cast<double>(cid + 1) * step;
+            PANTR_CHECK_MSG(one.first[0] == want_lo && one.second[0] == want_hi,
+                            "depth " + std::to_string(depth) + " cell " + std::to_string(cid)
+                                + ": got [" + std::to_string(one.first[0]) + ", "
+                                + std::to_string(one.second[0]) + "]");
+        }
+    }
+}
+
+/// **The same check where the arithmetic is not exact**, both halves of it.
+///
+/// Root `[0, 0.1]`, factor 3, level 2: cell `k` should span `[0.1*k/9, 0.1*(k+1)/9]`, and
+/// none of those is representable. The bound is derived rather than fitted:
+///
+///   * `w = fl(0.1) - 0.0` is exact (a subtraction of representable operands, and `0.1`
+///     is itself the input, not a computed value);
+///   * `size = w / 9` commits one rounding, so `size = (w/9)(1 + d1)`, `|d1| <= u`;
+///   * `k * size` commits a second, and `lo + (k*size)` a third, giving
+///     `|lo_computed - w*k/9| <= 3u * |w*k/9| + O(u^2)`, and `w*k/9 <= 0.1`.
+///
+/// With `u = 2^-53` that is `4 * u * 0.1` after rounding the constant up, which is what
+/// is asserted. The reference value `0.1 * k / 9` is itself computed in `double` and
+/// carries two roundings of its own, so the comparison is against something within `2u`
+/// of the exact rational -- absorbed by taking the factor 4 rather than 3.
+///
+/// **And the error is asserted to be nonzero somewhere**, because a bound checked only
+/// on inputs that happen to be exact has not been checked at all: without that half,
+/// deleting the arithmetic and returning the reference would pass.
+void test_non_dyadic_bounds_are_bounded_and_not_exact() {
+    const Grid g = non_dyadic();
+    PANTR_CHECK(g.num_cells() == 9);
+
+    constexpr double kUnitRoundoff = 0.5 * std::numeric_limits<double>::epsilon();
+    const double bound = 4.0 * kUnitRoundoff * 0.1;
+
+    double worst = 0.0;
+    for (std::int64_t cid = 0; cid < 9; ++cid) {
+        const auto one = bounds(g, cid);
+        const double want = 0.1 * static_cast<double>(cid) / 9.0;
+        const double err = std::abs(one.first[0] - want);
+        worst = std::max(worst, err);
+        PANTR_CHECK_MSG(err <= bound, "cell " + std::to_string(cid) + " lo is off by "
+                                          + std::to_string(err));
+    }
+    PANTR_CHECK_MSG(worst > 0.0,
+                    "every non-dyadic corner came out exact, so this bound tested nothing");
+}
+
+// ---------------------------------------------------------------------------
+// The hooks, each against the default it hides
+// ---------------------------------------------------------------------------
+
+/// `cell_level` reports real levels where the generic default always says zero.
+///
+/// The differential that proves name hiding routed the call: if the hook were not picked
+/// up, the two would agree everywhere and this would pass silently, so the disagreement
+/// is asserted rather than the agreement.
+void test_cell_level_hook_replaces_the_default() {
+    const Grid g = refined_1d();
+    bool differs = false;
+    for (std::int64_t cid = 0; cid < g.num_cells(); ++cid) {
+        const std::int64_t generic = g.pantr::grid::GridBase<Grid>::cell_level(cid);
+        PANTR_CHECK(generic == 0);
+        differs = differs || (g.cell_level(cid) != generic);
+    }
+    PANTR_CHECK_MSG(differs, "the cell_level hook never differed from the default");
+}
+
+/// The batch locate hook agrees with the mixin default, which loops the primitive.
+void test_locate_many_agrees_with_the_default() {
+    const Grid g = refined_1d();
+    const std::vector<double> xs{0.0, 0.3, 0.6, 1.2, 1.9, 2.4, 3.7, 4.0, -1.0, 9.0};
+    const span2d<const double> view(xs.data(), xs.size(), 1);
+    PANTR_CHECK(g.locate_many(view) == g.pantr::grid::GridBase<Grid>::locate_many(view));
+}
+
+/// The bulk bounds hook agrees with the mixin default bitwise.
+///
+/// The default calls `cell_bounds` once per cell; the hook runs the block odometer. This
+/// is the same statement as `test_the_two_bound_paths_agree` reached through the
+/// dispatch mechanism, and it is worth both: one says the two algorithms agree, this one
+/// says the specialisation is the thing being called.
+void test_collect_cell_bounds_agrees_with_the_default() {
+    const Grid g = refined_2d();
+    const auto n = static_cast<std::size_t>(g.num_cells());
+    const auto d = static_cast<std::size_t>(g.ndim());
+    std::vector<double> hook_lo(n * d);
+    std::vector<double> hook_hi(n * d);
+    std::vector<double> base_lo(n * d);
+    std::vector<double> base_hi(n * d);
+    g.collect_cell_bounds(span2d<double>(hook_lo.data(), n, d),
+                          span2d<double>(hook_hi.data(), n, d));
+    g.pantr::grid::GridBase<Grid>::collect_cell_bounds(span2d<double>(base_lo.data(), n, d),
+                                      span2d<double>(base_hi.data(), n, d));
+    PANTR_CHECK(hook_lo == base_lo);
+    PANTR_CHECK(hook_hi == base_hi);
+}
+
+/// Boundary facets, hand-computed, and against the generic neighbour loop.
+///
+/// On `refined_1d` the domain is `[0, 4]`. Its outer boundary is two facets: the low face
+/// of the cell starting at 0 (flat id 2, the first level-1 cell, `lfid` 0) and the high
+/// face of the cell ending at 4 (flat id 1, `lfid` 1). Everything else is an interface.
+void test_boundary_facets() {
+    const Grid g = refined_1d();
+    const std::vector<std::int64_t> got = g.boundary_facets();
+    PANTR_CHECK(got == std::vector<std::int64_t>({1, 1, 2, 0}));
+
+    // The generic default asks `neighbor_across_facet` per facet, which is an unrelated
+    // route to the same answer -- and it is the route that would notice if the block-face
+    // shortcut were wrong about which faces are outer.
+    PANTR_CHECK(got == g.pantr::grid::GridBase<Grid>::boundary_facets());
+    const Grid h = refined_2d();
+    PANTR_CHECK(h.boundary_facets() == h.pantr::grid::GridBase<Grid>::boundary_facets());
+    const Grid f = flat_1d();
+    PANTR_CHECK(f.boundary_facets() == f.pantr::grid::GridBase<Grid>::boundary_facets());
+}
+
+/// Neighbours across a hanging interface, in both directions, hand-computed.
+///
+/// On `refined_1d`: flat id 0 is the coarse cell `[2,3]`, and across its low facet lies
+/// the fine cell `[1.5,2]`, which is flat id 5. From the fine side, cell 5's high facet
+/// leads back to the coarse cell 0. Both are level-crossing, which is the case the
+/// generic default cannot handle.
+void test_neighbours_across_a_hanging_interface() {
+    const Grid g = refined_1d();
+    PANTR_CHECK(g.neighbor_across_facet(0, 0) == std::optional<std::int64_t>(5));
+    PANTR_CHECK(g.neighbor_across_facet(5, 1) == std::optional<std::int64_t>(0));
+    // Conforming, within one level.
+    PANTR_CHECK(g.neighbor_across_facet(0, 1) == std::optional<std::int64_t>(1));
+    PANTR_CHECK(g.neighbor_across_facet(2, 1) == std::optional<std::int64_t>(3));
+    // The outer boundary.
+    PANTR_CHECK(!g.neighbor_across_facet(2, 0).has_value());
+    PANTR_CHECK(!g.neighbor_across_facet(1, 1).has_value());
+}
+
+/// `hanging_neighbors` returns every fine neighbour, and its first is the primitive's.
+///
+/// In 2-D the coarse cell `(1,0)` of `refined_2d` abuts the two fine children of root
+/// cell `(0,0)` along its low-`x` face, so this is the case where the generic default --
+/// which wraps the single answer from `neighbor_across_facet` -- is genuinely wrong, and
+/// the disagreement is asserted.
+void test_hanging_neighbors_collect_the_fine_side() {
+    const Grid g = refined_2d();
+    // Flat ids: level 0 blocks are `[0,1)x[1,2)` (id 0) then `[1,2)x[0,2)` (ids 1, 2);
+    // level 1 block `[0,2)x[0,2)` gives ids 3..6 in C-order over (i, j).
+    PANTR_CHECK(g.num_cells() == 7);
+    const std::vector<std::int64_t> fine = g.hanging_neighbors(1, 0);
+    PANTR_CHECK_MSG(fine.size() == 2, "the coarse cell's low-x face abuts two fine cells, got "
+                                          + std::to_string(fine.size()));
+    PANTR_CHECK(g.neighbor_across_facet(1, 0) == std::optional<std::int64_t>(fine.front()));
+    PANTR_CHECK_MSG(fine != g.pantr::grid::GridBase<Grid>::hanging_neighbors(1, 0),
+                    "the hook must differ from the default on a hanging interface");
+
+    // Every id it returns is an active leaf whose level is finer than the queried cell's.
+    for (const std::int64_t nbr : fine) {
+        PANTR_CHECK(nbr >= 0 && nbr < g.num_cells());
+        PANTR_CHECK(g.cell_level(nbr) > g.cell_level(1));
+    }
+}
+
+/// A neighbour query is symmetric where the interface is conforming.
+///
+/// Not asserted across a hanging interface, where it is false by construction: the
+/// coarse side names one of the fine cells and the others name the coarse one back.
+void test_conforming_neighbours_are_symmetric() {
+    const Grid g = refined_2d();
+    for (std::int64_t cid = 0; cid < g.num_cells(); ++cid) {
+        for (std::int64_t lfid = 0; lfid < 2 * g.ndim(); ++lfid) {
+            const std::optional<std::int64_t> nbr = g.neighbor_across_facet(cid, lfid);
+            if (!nbr || g.cell_level(*nbr) != g.cell_level(cid)) {
+                continue;
+            }
+            const std::int64_t back = lfid ^ 1;  // the opposite face on the same axis
+            PANTR_CHECK_MSG(g.neighbor_across_facet(*nbr, back)
+                                == std::optional<std::int64_t>(cid),
+                            "cell " + std::to_string(cid) + " facet " + std::to_string(lfid)
+                                + " is not symmetric");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The active set
+// ---------------------------------------------------------------------------
+
+/// The two masks, hand-computed, plus the invariant that ties them to `num_cells`.
+void test_masks() {
+    const Grid g = refined_1d();
+
+    // Level 0: cells 2 and 3 are active leaves; 0 and 1 were refined away.
+    PANTR_CHECK(g.active_leaf_mask(0) == std::vector<std::uint8_t>({0, 0, 1, 1}));
+    // Level 1: all eight positions exist, and the first four are the active children.
+    PANTR_CHECK(g.active_leaf_mask(1) == std::vector<std::uint8_t>({1, 1, 1, 1, 0, 0, 0, 0}));
+
+    // Omega_0 is everything; Omega_1 excludes what a coarser leaf already covers, which
+    // is root cells 2 and 3, i.e. level-1 positions 4..7.
+    PANTR_CHECK(g.subdomain_mask(0) == std::vector<std::uint8_t>({1, 1, 1, 1}));
+    PANTR_CHECK(g.subdomain_mask(1) == std::vector<std::uint8_t>({1, 1, 1, 1, 0, 0, 0, 0}));
+
+    // The invariant: the active leaves of every level, counted together, are the cells.
+    std::int64_t total = 0;
+    for (std::int64_t l = 0; l <= g.max_level(); ++l) {
+        const std::vector<std::uint8_t> mask = g.active_leaf_mask(l);
+        total += std::count(mask.begin(), mask.end(), std::uint8_t{1});
+    }
+    PANTR_CHECK(total == g.num_cells());
+
+    // An active leaf is always inside its own level's subdomain; the converse is false,
+    // which is what makes the two masks different objects.
+    for (std::int64_t l = 0; l <= g.max_level(); ++l) {
+        const std::vector<std::uint8_t> leaves = g.active_leaf_mask(l);
+        const std::vector<std::uint8_t> omega = g.subdomain_mask(l);
+        PANTR_CHECK(leaves.size() == omega.size());
+        for (std::size_t i = 0; i < leaves.size(); ++i) {
+            PANTR_CHECK(leaves[i] == 0 || omega[i] == 1);
+        }
+    }
+}
+
+/// `level_cells_per_axis` is a formula and answers above `max_level` too.
+void test_level_cells_per_axis() {
+    const Grid g = refined_1d();
+    PANTR_CHECK(g.level_cells_per_axis(0, 0) == 4);
+    PANTR_CHECK(g.level_cells_per_axis(1, 0) == 8);
+    // Deliberately above max_level: this one is a pure formula, unlike active_blocks.
+    PANTR_CHECK(g.level_cells_per_axis(5, 0) == 128);
+
+    bool threw = false;
+    try {
+        (void)g.level_cells_per_axis(-1, 0);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    PANTR_CHECK(threw);
+
+    threw = false;
+    try {
+        (void)g.level_cells_per_axis(0, 1);
+    } catch (const std::out_of_range&) {
+        threw = true;
+    }
+    PANTR_CHECK(threw);
+}
+
+/// A level count past `int64` is refused rather than wrapping into a positive lie.
+///
+/// The oracle counts in Python integers and cannot reach this, so it is a deliberate
+/// divergence -- the same one `TensorProductGrid` already makes for its own cell-count
+/// product. Both sides of the boundary are asserted, so a guard that rejected every large
+/// level would not satisfy this.
+void test_level_count_overflow_is_reported() {
+    const Grid g = flat_1d();  // 4 root cells, factor 2
+
+    // 4 * 2**60 = 2**62, which fits.
+    PANTR_CHECK(g.level_cells_per_axis(60, 0) == (std::int64_t{1} << 62));
+
+    // 4 * 2**61 = 2**63, which does not.
+    bool threw = false;
+    try {
+        (void)g.level_cells_per_axis(61, 0);
+    } catch (const std::overflow_error&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a level whose cell count exceeds int64 must be refused");
+}
+
+/// `active_blocks` rejects a level outside the hierarchy, on both sides.
+void test_active_blocks_range() {
+    const Grid g = refined_1d();
+    const auto [lo, hi] = g.active_blocks(1);
+    PANTR_CHECK(lo.extent(0) == 1 && lo(0, 0) == 0 && hi(0, 0) == 4);
+
+    for (const std::int64_t bad : {std::int64_t{-1}, std::int64_t{2}}) {
+        bool threw = false;
+        try {
+            (void)g.active_blocks(bad);
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        PANTR_CHECK(threw);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// from_blocks
+// ---------------------------------------------------------------------------
+
+/// Declaring a clean level clean changes nothing, which is what the fast path claims.
+///
+/// The property `refine` and `coarsen` will rest on: a level holding a previous call's
+/// output normalizes to itself, so skipping the re-run returns the same blocks in the
+/// same order -- and therefore the same flat cell ids. Checked by building one grid both
+/// ways and comparing every id's geometry, not just the count, because a re-partition
+/// preserves the count and moves the ids.
+void test_naming_a_clean_level_changes_nothing() {
+    const Grid reference = refined_1d();
+
+    // Rebuild from the reference's own (already normalized) blocks, once declaring every
+    // level clean and once normalizing everything.
+    std::vector<BlockList> blocks;
+    for (std::int64_t l = 0; l <= reference.max_level(); ++l) {
+        const auto [lo, hi] = reference.active_blocks(l);
+        BlockList list(reference.ndim());
+        for (std::size_t b = 0; b < lo.extent(0); ++b) {
+            list.push_back(BlockView{std::span<const std::int64_t>(&lo(b, 0), lo.extent(1)),
+                                     std::span<const std::int64_t>(&hi(b, 0), hi.extent(1))});
+        }
+        blocks.push_back(std::move(list));
+    }
+    std::vector<BlockList> copy = blocks;
+
+    const Ints factor{2};
+    const Ints none{};
+    const Grid clean =
+        Grid::from_blocks(root_1d(), factor, std::move(blocks), std::span<const std::int64_t>(none));
+    const Grid renormalized =
+        Grid::from_blocks(root_1d(), factor, std::move(copy), std::nullopt);
+
+    PANTR_CHECK(clean.num_cells() == renormalized.num_cells());
+    for (std::int64_t cid = 0; cid < clean.num_cells(); ++cid) {
+        PANTR_CHECK_MSG(bounds(clean, cid) == bounds(renormalized, cid),
+                        "cell " + std::to_string(cid)
+                            + " moved when a clean level was declared clean");
+    }
+}
+
+/// Trailing empty levels are dropped, so `max_level` means what it says.
+void test_trailing_empty_levels_are_dropped() {
+    const Ints factor{2};
+    std::vector<BlockList> blocks;
+    blocks.push_back(level(1, {{0, 4}}));
+    blocks.push_back(level(1, {}));
+    blocks.push_back(level(1, {}));
+    const Grid g = Grid::from_blocks(root_1d(), factor, std::move(blocks), std::nullopt);
+    PANTR_CHECK(g.max_level() == 0);
+    PANTR_CHECK(g.num_cells() == 4);
+}
+
+/// The representation is the oracle's, character for character.
+void test_to_string() {
+    PANTR_CHECK_MSG(refined_1d().to_string()
+                        == "HierarchicalGrid(ndim=1, root_cells=(4,), factor=(2,), "
+                           "num_cells=6, max_level=1)",
+                    refined_1d().to_string());
+    PANTR_CHECK_MSG(refined_2d().to_string()
+                        == "HierarchicalGrid(ndim=2, root_cells=(2, 2), factor=(2, 2), "
+                           "num_cells=7, max_level=1)",
+                    refined_2d().to_string());
+}
+
+/// `restrict` is not specialised yet, so the mixin's throwing default must still stand.
+void test_restrict_still_throws() {
+    const Grid g = flat_1d();
+    bool threw = false;
+    try {
+        const Ints ids{0};
+        (void)g.restrict(ids);
+    } catch (const std::logic_error&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "restrict must still be the mixin's throwing default");
+}
+
+}  // namespace
+
+// The census, at both scalars. `float` is a compile-time device only: it forces every
+// default body at a scalar no binding registers, which is what catches a hook that
+// hard-codes `double`. It is never bound and never compared, so it opens no parity claim.
+PANTR_GRID_CENSUS(pantr::grid::HierarchicalGrid<double>);
+PANTR_GRID_CENSUS(pantr::grid::HierarchicalGrid<float>);
+
+int main() {
+    test_construction_validates();
+    test_the_unrefined_grid_is_its_root();
+    test_the_fixtures_are_what_they_claim();
+
+    test_the_address_round_trips(flat_1d(), "the flat grid");
+    test_the_address_round_trips(refined_1d(), "the refined 1-D grid");
+    test_the_address_round_trips(refined_2d(), "the refined 2-D grid");
+    test_inactive_positions_have_no_id();
+    test_cell_id_range_is_checked();
+
+    test_the_two_bound_paths_agree(flat_1d(), "the flat grid");
+    test_the_two_bound_paths_agree(refined_1d(), "the refined 1-D grid");
+    test_the_two_bound_paths_agree(refined_2d(), "the refined 2-D grid");
+    test_the_two_bound_paths_agree(non_dyadic(), "the non-dyadic grid");
+    test_locate_finds_each_cell(flat_1d(), "the flat grid");
+    test_locate_finds_each_cell(refined_1d(), "the refined 1-D grid");
+    test_locate_finds_each_cell(refined_2d(), "the refined 2-D grid");
+    test_scalar_and_batch_locate_agree();
+    test_the_cells_tile_the_domain(flat_1d(), "the flat grid");
+    test_the_cells_tile_the_domain(refined_1d(), "the refined 1-D grid");
+    test_the_cells_tile_the_domain(dyadic_unit(6), "the dyadic unit grid");
+    test_dyadic_bounds_are_exact();
+    test_non_dyadic_bounds_are_bounded_and_not_exact();
+
+    test_cell_level_hook_replaces_the_default();
+    test_locate_many_agrees_with_the_default();
+    test_collect_cell_bounds_agrees_with_the_default();
+    test_boundary_facets();
+    test_neighbours_across_a_hanging_interface();
+    test_hanging_neighbors_collect_the_fine_side();
+    test_conforming_neighbours_are_symmetric();
+
+    test_masks();
+    test_level_cells_per_axis();
+    test_level_count_overflow_is_reported();
+    test_active_blocks_range();
+
+    test_naming_a_clean_level_changes_nothing();
+    test_trailing_empty_levels_are_dropped();
+    test_to_string();
+    test_restrict_still_throws();
+    return pantr::test::summary("test_grid_hierarchical_type");
+}

--- a/cpp/tests/test_grid_hierarchical_type.cpp
+++ b/cpp/tests/test_grid_hierarchical_type.cpp
@@ -163,6 +163,79 @@ Grid non_dyadic() {
                              std::nullopt);
 }
 
+/// A hanging interface normal to **axis 1** rather than axis 0.
+///
+/// Root `[0,1] x [0,2]`, two unit cells stacked in y, factor 2, with cell `(0,0)` refined.
+///
+/// level 0: block `[0,1) x [1,2)` -- one coarse cell, flat id 0
+/// level 1: block `[0,2) x [0,2)` -- ids 1..4 in C-order over `(i, j)`
+///
+/// This exists because every other hanging case in this file is normal to axis 0, and
+/// axis 0 is the one index for which `active_face_descendants`' odometer cannot get the
+/// pinned axis wrong: it is skipped on the last carry step, when the walk is about to end
+/// anyway. Deleting that skip leaves every other test in this file green. With the facet
+/// normal to axis 1 the skip is load-bearing, and a walk that ignored it would return
+/// three neighbours including one that does not touch the shared plane at all.
+///
+/// \return The grid.
+Grid hanging_axis1_2d() {
+    const Ints factor{2, 2};
+    std::vector<BlockList> blocks;
+    blocks.push_back(level(2, {{0, 1, 1, 2}}));
+    blocks.push_back(level(2, {{0, 0, 2, 2}}));
+    return Grid::from_blocks(TensorProductGrid<double>({{0.0, 1.0}, {0.0, 1.0, 2.0}}), factor,
+                             std::move(blocks), std::nullopt);
+}
+
+/// A hierarchy with an **empty middle level**, so an ancestor search must climb two.
+///
+/// Root `[0,1]` and `[1,2]`, factor 2. Cell 1 stays coarse; cell 0 is refined straight to
+/// level 2, leaving level 1 empty.
+///
+/// level 0: block `[1, 2)` -- flat id 0, the cell `[1,2]`
+/// level 1: empty
+/// level 2: block `[0, 4)` -- ids 1..4, the cells `[0,0.25] ... [0.75,1]`
+///
+/// Every other fixture here is exactly two levels deep, so `nearest_active_ancestor`'s
+/// loop never has to survive a level that answers nothing. Rebuilding the ancestor from
+/// the original index at each step instead of from the running one -- a plausible
+/// refactor -- leaves every other test green and breaks this one.
+///
+/// \return The grid.
+Grid deep_1d() {
+    const Ints factor{2};
+    std::vector<BlockList> blocks;
+    blocks.push_back(level(1, {{1, 2}}));
+    blocks.push_back(level(1, {}));
+    blocks.push_back(level(1, {{0, 4}}));
+    return Grid::from_blocks(TensorProductGrid<double>({{0.0, 1.0, 2.0}}), factor,
+                             std::move(blocks), std::nullopt);
+}
+
+/// Three axes, an anisotropic factor, and factor 1 on one of them.
+///
+/// Root `[0,2] x [0,1] x [0,1.5]`, cells `(2, 1, 2)`, factor `(2, 1, 3)`. The `x = 1`
+/// slab of root cells stays coarse; the `x = 0` slab is refined once.
+///
+/// level 0: block `[1,2) x [0,1) x [0,2)` -- 2 cells
+/// level 1: block `[0,2) x [0,1) x [0,6)` -- 12 cells, over a level-1 grid of `(4, 1, 6)`
+///
+/// Fourteen cells. Nothing else in this file has three axes, a factor that differs
+/// between them, or a factor of 1 on an axis that is also refined -- and an axis of
+/// extent 1 is exactly where an odometer or a stride is most likely to be wrong without
+/// showing it.
+///
+/// \return The grid.
+Grid anisotropic_3d() {
+    const Ints factor{2, 1, 3};
+    std::vector<BlockList> blocks;
+    blocks.push_back(level(3, {{1, 0, 0, 2, 1, 2}}));
+    blocks.push_back(level(3, {{0, 0, 0, 2, 1, 6}}));
+    return Grid::from_blocks(
+        TensorProductGrid<double>({{0.0, 1.0, 2.0}, {0.0, 1.0}, {0.0, 0.5, 1.5}}), factor,
+        std::move(blocks), std::nullopt);
+}
+
 /// One cell's corners.
 ///
 /// \param g The grid.
@@ -425,7 +498,13 @@ void test_non_finite_points_locate_to_nothing() {
 /// That is why this assertion is confined to the dyadic fixtures; the non-dyadic one is
 /// checked against its closed form with a derived bound instead.
 void test_the_cells_tile_the_domain(const Grid& g, const char* what) {
-    const auto [lo, hi] = all_bounds(g);
+    // Deliberately not a structured binding: the comparator below captures `lo`, and
+    // capturing a structured binding is C++20 (P1091), which the Clang 10 version floor
+    // does not implement. Declaring one is C++17 and fine -- only capturing one is not.
+    // `test_grid_hierarchical.cpp` carries the same note at the same construct.
+    const auto bounds = all_bounds(g);
+    const std::vector<double>& lo = bounds.first;
+    const std::vector<double>& hi = bounds.second;
     std::vector<std::size_t> order(lo.size());
     for (std::size_t i = 0; i < order.size(); ++i) {
         order[i] = i;
@@ -822,6 +901,209 @@ void test_restrict_still_throws() {
     PANTR_CHECK_MSG(threw, "restrict must still be the mixin's throwing default");
 }
 
+/// A hanging interface normal to axis 1 collects only the cells touching that plane.
+///
+/// Hand-worked on `hanging_axis1_2d`, and confirmed against the oracle: the coarse cell
+/// is id 0 at level 0 `(0,1)`, and the four children of root cell `(0,0)` are ids 1..4 in
+/// C-order, so `(0,0) -> 1`, `(0,1) -> 2`, `(1,0) -> 3`, `(1,1) -> 4`.
+///
+/// Facet 2 is `(axis 1, side 0)`, the low-y face of the coarse cell. Across it lies the
+/// refined-away level-0 position `(0,0)`, whose children touching the shared `y = 1`
+/// plane are the ones with `j`-offset `factor[1] - 1 = 1`: `(0,1)` and `(1,1)`, that is
+/// ids **2 and 4**. Id 3 is `(1,0)`, which sits below the plane and must not appear.
+void test_hanging_neighbours_normal_to_axis_one() {
+    const Grid g = hanging_axis1_2d();
+    PANTR_CHECK(g.num_cells() == 5);
+    PANTR_CHECK(g.cell_level(0) == 0);
+
+    const std::vector<std::int64_t> fine = g.hanging_neighbors(0, 2);
+    PANTR_CHECK_MSG(fine == std::vector<std::int64_t>({2, 4}),
+                    "expected the two children on the shared plane, got "
+                        + std::to_string(fine.size()) + " neighbours");
+    PANTR_CHECK(g.neighbor_across_facet(0, 2) == std::optional<std::int64_t>(2));
+
+    // Every one of them must actually touch the coarse cell's low-y face.
+    std::vector<double> clo(2);
+    std::vector<double> chi(2);
+    g.cell_bounds(0, clo, chi);
+    for (const std::int64_t nbr : fine) {
+        std::vector<double> nlo(2);
+        std::vector<double> nhi(2);
+        g.cell_bounds(nbr, nlo, nhi);
+        PANTR_CHECK_MSG(nhi[1] == clo[1], "neighbour " + std::to_string(nbr)
+                                              + " does not touch the shared plane");
+    }
+}
+
+/// An ancestor search climbs past a level that answers nothing.
+///
+/// Hand-worked on `deep_1d` and confirmed against the oracle. Cell 4 is the level-2 cell
+/// `[0.75,1]`, index 3. Across its high facet lies level-2 index 4, which is not active;
+/// level 1 is empty, so index 2 there is not active either; level 0 index 1 is the coarse
+/// cell `[1,2]`, id 0. Two levels of climbing, and the intermediate one must not stop it.
+void test_ancestor_search_climbs_more_than_one_level() {
+    const Grid g = deep_1d();
+    PANTR_CHECK(g.num_cells() == 5);
+    PANTR_CHECK(g.max_level() == 2);
+    PANTR_CHECK(g.cell_level(4) == 2);
+
+    PANTR_CHECK(g.neighbor_across_facet(4, 1) == std::optional<std::int64_t>(0));
+    PANTR_CHECK(g.hanging_neighbors(4, 1) == std::vector<std::int64_t>({0}));
+    // And symmetrically from the coarse side, which descends two levels instead.
+    PANTR_CHECK(g.hanging_neighbors(0, 0) == std::vector<std::int64_t>({4}));
+
+    // The empty middle level is real, and asking about it is legal.
+    const auto [lo, hi] = g.active_blocks(1);
+    PANTR_CHECK(lo.extent(0) == 0 && hi.extent(0) == 0);
+}
+
+/// Three axes, a per-axis factor, and an axis of extent 1 that is still refined.
+///
+/// No hand-computed table: the point of this fixture is the generic properties, which are
+/// what a dimension- or stride-generalisation bug breaks. The counts were confirmed
+/// against the oracle.
+void test_anisotropic_three_dimensional_grid() {
+    const Grid g = anisotropic_3d();
+    PANTR_CHECK(g.num_cells() == 14);
+    PANTR_CHECK(g.max_level() == 1);
+    PANTR_CHECK(g.level_cells_per_axis(1, 0) == 4);
+    PANTR_CHECK_MSG(g.level_cells_per_axis(1, 1) == 1, "factor 1 must not subdivide axis 1");
+    PANTR_CHECK(g.level_cells_per_axis(1, 2) == 6);
+    PANTR_CHECK_MSG(g.to_string()
+                        == "HierarchicalGrid(ndim=3, root_cells=(2, 1, 2), "
+                           "factor=(2, 1, 3), num_cells=14, max_level=1)",
+                    g.to_string());
+
+    test_the_address_round_trips(g, "the anisotropic 3-D grid");
+    test_the_two_bound_paths_agree(g, "the anisotropic 3-D grid");
+    test_locate_finds_each_cell(g, "the anisotropic 3-D grid");
+    PANTR_CHECK(g.boundary_facets() == g.pantr::grid::GridBase<Grid>::boundary_facets());
+
+    // The masks, over a level whose y extent is 1 -- where an odometer that assumed every
+    // axis has room to carry would go wrong.
+    const std::vector<std::uint8_t> leaves0 = g.active_leaf_mask(0);
+    const std::vector<std::uint8_t> leaves1 = g.active_leaf_mask(1);
+    PANTR_CHECK(std::count(leaves0.begin(), leaves0.end(), std::uint8_t{1}) == 2);
+    PANTR_CHECK(std::count(leaves1.begin(), leaves1.end(), std::uint8_t{1}) == 12);
+    const std::vector<std::uint8_t> omega1 = g.subdomain_mask(1);
+    PANTR_CHECK(std::count(omega1.begin(), omega1.end(), std::uint8_t{1}) == 12);
+}
+
+/// The masks over a level cut into several blocks.
+///
+/// `refined_1d` has one block per level, so nothing there distinguishes a mask filled
+/// block by block from one filled in a single sweep. `refined_2d`'s level 0 has two.
+void test_masks_over_a_multi_block_level() {
+    const Grid g = refined_2d();
+    PANTR_CHECK(g.active_leaf_mask(0) == std::vector<std::uint8_t>({0, 1, 1, 1}));
+    // Omega_1 excludes what the two coarse blocks cover, projected up by factor 2.
+    PANTR_CHECK(g.subdomain_mask(1)
+                == std::vector<std::uint8_t>({1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+}
+
+/// A point exactly on a breakpoint belongs to the cell below it.
+///
+/// The convention is not arbitrary and it is not tested anywhere else: the scalar and
+/// batch paths agree with each other by construction, since both run a lower-bound search
+/// and step back one, so a shared wrong convention would be invisible to their
+/// comparison. These values were read off the oracle.
+void test_a_point_on_a_breakpoint_takes_the_lower_cell() {
+    const Grid g = flat_1d();  // breakpoints 0, 1, 2, 3, 4
+    PANTR_CHECK(g.locate(std::vector<double>{0.0}) == std::optional<std::int64_t>(0));
+    PANTR_CHECK_MSG(g.locate(std::vector<double>{1.0}) == std::optional<std::int64_t>(0),
+                    "an interior breakpoint must take the lower cell");
+    PANTR_CHECK(g.locate(std::vector<double>{2.0}) == std::optional<std::int64_t>(1));
+    PANTR_CHECK_MSG(g.locate(std::vector<double>{4.0}) == std::optional<std::int64_t>(3),
+                    "the domain's far edge must take the last cell, not fall outside");
+}
+
+/// A span of the wrong length is refused rather than read past.
+///
+/// Documented on five entry points and exercised on none of them until now. In C++ the
+/// length is part of the argument, so a wrong one is a caller bug; the Python wrapper is
+/// where a wrong-length index becomes a `None`, and the header says so.
+void test_wrong_length_spans_are_refused() {
+    const Grid g = refined_2d();
+    const std::vector<double> short_pt{0.5};
+    std::vector<double> short_out{0.0};
+    std::vector<std::int64_t> short_idx{0};
+
+    int refused = 0;
+    const auto expect = [&refused](auto&& call) {
+        try {
+            call();
+        } catch (const std::invalid_argument&) {
+            ++refused;
+        }
+    };
+    expect([&] { (void)g.locate(short_pt); });
+    expect([&] { g.cell_multi_index(0, short_idx); });
+    expect([&] { (void)g.cell_id(0, short_idx); });
+    expect([&] { (void)g.is_active_leaf(0, short_idx); });
+    expect([&] { g.cell_bounds(0, short_out, short_out); });
+    PANTR_CHECK_MSG(refused == 5, "only " + std::to_string(refused) + " of 5 were refused");
+}
+
+/// A block list whose cell counts **sum** past `int64` is refused.
+///
+/// The sum guard, which is a different guard from the product one
+/// `test_level_count_overflow_is_reported` covers, and it has to be reached without
+/// tripping that one on the way. Reached through `from_blocks`, which documents that it
+/// does not validate the decomposition, so this hands it two blocks far larger than the
+/// root -- the only way to the accumulator's limit that does not require allocating an
+/// impossible grid.
+///
+/// **The two blocks are placed diagonally on purpose.** A first version of this test put
+/// them side by side, and `normalize_blocks` merged them into one rectangle of `2**63`
+/// cells, so the *product* guard fired and the sum guard was never reached -- the test
+/// passed either way and proved nothing. Offsetting them on both axes makes `try_merge`
+/// refuse, so two blocks of `2**62` survive to the accumulator and sum to `2**63`.
+void test_total_cell_count_overflow_is_reported() {
+    constexpr std::int64_t kHalf = std::int64_t{1} << 31;
+    const Ints factor{2, 2};
+
+    // Caught as `std::exception` and matched on the message, deliberately. Removing the
+    // sum guard does not make the call succeed -- the wrapped count comes out negative and
+    // `GridBase` rejects it with a *different* exception, so a bare "did it throw?" is
+    // satisfied by the bug as well as by the fix. Naming the guard is what distinguishes
+    // them, and it also fails cleanly instead of letting an uncaught type abort the run.
+    std::vector<BlockList> blocks;
+    blocks.push_back(level(2, {{0, 0, kHalf, kHalf},
+                               {kHalf, kHalf, 2 * kHalf, 2 * kHalf}}));
+    std::string message;
+    try {
+        const Grid g = Grid::from_blocks(TensorProductGrid<double>({{0.0, 1.0}, {0.0, 1.0}}),
+                                         factor, std::move(blocks), std::nullopt);
+        (void)g;
+    } catch (const std::exception& e) {
+        message = e.what();
+    }
+    PANTR_CHECK_MSG(message.find("int64 can count") != std::string::npos,
+                    "the total-count guard must be the one that fires; got: " + message);
+
+    // One such block on its own is fine, so the guard is not simply rejecting big blocks.
+    std::vector<BlockList> one;
+    one.push_back(level(2, {{0, 0, kHalf, kHalf}}));
+    const Grid g = Grid::from_blocks(TensorProductGrid<double>({{0.0, 1.0}, {0.0, 1.0}}),
+                                     factor, std::move(one), std::nullopt);
+    PANTR_CHECK(g.num_cells() == kHalf * kHalf);
+
+    // And a single block whose own extents multiply past int64 is refused by the product
+    // guard, which is the other half and would otherwise be signed overflow.
+    std::vector<BlockList> huge;
+    huge.push_back(level(2, {{0, 0, 2 * kHalf, 2 * kHalf}}));
+    message.clear();
+    try {
+        const Grid h = Grid::from_blocks(TensorProductGrid<double>({{0.0, 1.0}, {0.0, 1.0}}),
+                                         factor, std::move(huge), std::nullopt);
+        (void)h;
+    } catch (const std::exception& e) {
+        message = e.what();
+    }
+    PANTR_CHECK_MSG(message.find("representable size") != std::string::npos,
+                    "the per-block guard must be the one that fires; got: " + message);
+}
+
 }  // namespace
 
 // The census, at both scalars. `float` is a compile-time device only: it forces every
@@ -868,6 +1150,14 @@ int main() {
     test_level_cells_per_axis();
     test_level_count_overflow_is_reported();
     test_active_blocks_range();
+
+    test_hanging_neighbours_normal_to_axis_one();
+    test_ancestor_search_climbs_more_than_one_level();
+    test_anisotropic_three_dimensional_grid();
+    test_masks_over_a_multi_block_level();
+    test_a_point_on_a_breakpoint_takes_the_lower_cell();
+    test_wrong_length_spans_are_refused();
+    test_total_cell_count_overflow_is_reported();
 
     test_naming_a_clean_level_changes_nothing();
     test_trailing_empty_levels_are_dropped();


### PR DESCRIPTION
Slice 3 of **W2-G** (FELIGN/pantr#395): the `HierarchicalGrid` type itself. C++ only, no
bindings and no Python behaviour change.

> **Depends on #429**, and both base on `proto/cpp` because a PR based on another branch
> gets no CI at all here. So until #429 merges this diff also shows its five commits
> (`3620997`, `5a18257`, `443fc75`, `7ac413c`, `9b5741a`). **Review `ff99695` onwards**;
> the diff shrinks to those five commits once #429 lands.
>
> **Rebased onto trunk `7ba20d3`.** Two changes worth naming. My `gcc-tsan` preset commit
> was **dropped**: #428 landed an identically-named preset and CI block on the trunk, so
> this line now uses the trunk's rather than shipping a second one. And
> `test(core): make the memo's concurrency case able to fail` **moved to #429**, where the
> header it repairs already lived — it had briefly been here, which would have merged a
> note conceding the memo's ordering was untested one PR ahead of the test that disproves
> it.

## What is in it

`cpp/include/pantr/grid/hierarchical_grid.hpp` — the **query half** of
`src/pantr/grid/_hierarchical_grid.py`, which stays as the oracle: state, the packed
descriptor, `from_blocks` with its `unnormalized_levels` switch, the three primitives,
and five of the six hooks. Refinement, coarsening, `restrict` and `export_cells` are slice
4; the mixin's throwing `restrict` default still stands and the traits bitmask says so.

Two design calls worth naming.

**One representation, not two.** The oracle keeps its active set twice — a list of lists
of tuples, and four packed `int64` arrays rebuilt from it on every construction, because
its Numba kernels cannot take the first shape. Nothing forces that here, so this type
stores only the packed form and `active_blocks()` is a view into it. They are the same
object in a different spelling, since blocks are packed level by level and, within a
level, in the order flat cell ids are assigned; dropping the unpacked copy removes the
only way the two could disagree. Likewise the root's breakpoints are borrowed rather than
repacked, through two accessors added to `TensorProductGrid` in `a2a11ee` (additive only —
nothing deleted or reshaped, so the downstream-consumer check is not triggered).

**The floating-point discipline is now checked on both sides rather than asserted.** A
cell corner is `root_lo + sub_index * size`, and the product is named rather than inlined
at both sites, because as one expression it is contractible and `-ffp-contract=on` permits
exactly that — and in the descent the result feeds a truncation, so the backends would
disagree on a **cell id**, which Rule 11 says no tolerance bounds. Measured by disassembly
at `-march=native -ffp-contract=on`:

| site | named (as shipped) | inlined into one expression |
|---|---|---|
| `bounds_at` | 0 FMA, 2 separate mul/div | **1 FMA**, 1 mul/div |
| `descend` | 0 FMA, 3 separate mul/div | **1 FMA**, 2 mul/div |

That is the half a test cannot carry: `design/build_findings.md` forbids `-march` in the
build files, so on the shipped build nothing fuses either way and no runtime test can see
a re-inlining.

## Verification

**Full `scripts/ci_local.sh`, every leg, run last and alone on a clean tree: 52 PASS,
2 FAIL.** Both failures are `floor: g++-10 build` and `floor: g++-10 ctest`, **pre-existing
for #376** — reproduced on unmodified `4f79426` with the tree stashed, caused by
`std::to_chars` for floating point being absent from libstdc++ 10
(`geometry/aabb.hpp:116,136`) and a brace-init ambiguity in
`test_grid_tensor_product.cpp:79`, neither touched here. `clang++-10` builds and passes on
the same tree, which is the discriminator.

The `clang++-10` leg earned its keep on this slice: it rejected a lambda capturing a
structured binding (C++20 P1091, unimplemented there), which both dev compilers accept.

**End-to-end against the Python oracle, offline.** 400 random hierarchies — `ndim` 1 to 3,
per-axis factors including 1, dyadic and non-dyadic roots, up to three levels deep, built
by random `refine` calls on the oracle and replayed through `from_blocks` here. Compared:
`num_cells`, `max_level`, `repr`, `cell_level` and `cell_multi_index` per cell,
`collect_cell_bounds` and `cell_bounds` **bitwise**, `boundary_facets`,
`neighbor_across_facet` and `hanging_neighbors` (values *and* order) for every
`(cid, lfid)`, both masks per level, and `locate_many` against `locate`.

> **5896 cells, 8815 boundary facets, 16000 located points, 0 mismatches.**

This is offline because there is no binding yet; the permanent version arrives with slice
5's parity suite.

**Mutation checks — twelve, every one caught.** The C-order in the boundary-face walk; the
subdomain mask's projection scale; the two facet sides in `face_j`; the descent's clamp;
the `checked_mul` product guard; the `checked_add` sum guard; the odometer's skip of the
pinned axis; the ancestor rebuilt from the original index instead of the running one; the
non-finite mask; `require_ndim_span`; and the two FMA re-inlinings above.

## The bug this found, and how it was found

**`locate_many` returned a plausible wrong cell for a NaN coordinate.** The batch kernel's
containment test is `x < lo || x > hi`, which a NaN passes because every comparison against
it is false, so the row descended and landed in cell 0 instead of `-1`. The oracle has the
same kernel limitation and masks the rows afterwards; that pass was missing here. Fixed in
`1c8459e`, with the regression test committed **before** the fix in `f2cc970`.

Worth recording *how*: **not by the 400-hierarchy sweep**, which drew its query points from
a uniform distribution and so never fed one. A review round found it. The sweep's blind
spot was mine, and it is the reason the sweep is reported above with what it covered rather
than as a blanket claim.

## A gate transient worth knowing about on this box

One `scripts/ci_local.sh` run came back **51 PASS / 3 FAIL** with `gcc-debug: ctest` red
and **all 44 tests failing inside 28 seconds** — including files this branch never touches.
Re-running the same leg with **no code change** gave 46/46. Nothing was bisected and
nothing needed to be.

**Suspected, not confirmed:** ASan shadow-memory reservation failing under memory pressure,
this being a shared box with several agents building at once. I did not capture the
per-test output — `conda run` had buffered it away — so the cause is a hypothesis and the
*symptom* is the useful part.

The symptom is distinctive and worth recognising: a whole-suite ASan failure where
untouched tests fail too, and fast. **A re-run is the first check, not a bisect.**

## Self-review round

Findings, all fixed here, in `7ed81d8`:

- **C** — `locate_many` and NaN, above. Own commit, own regression test, test first.
- **I** — three coverage gaps, each proven by mutating the code and watching the suite stay
  green: every hanging case was normal to axis 0 (the one axis whose pinned slot the
  odometer cannot get wrong); every fixture was two levels deep, so the ancestor climb was
  never exercised; nothing had three axes, an anisotropic factor, or a factor of 1 on a
  refined axis. Three new fixtures close them, with every expected value read off the
  oracle.
- **I** — `build` fed the unchecked `block_size` into a checked accumulation, so a single
  oversized block was signed overflow — narrower than the contract the file writes down.
  Both the product and the sum are now checked and both are tested.
- **R** — `factor ** level` is O(level) checked multiplications and was recomputed once per
  block per axis in two loops whose point is per-block batching. Hoisted to once per level.
- **R** — the file claimed "exactly two deliberate divergences" from the oracle while
  carrying a third: `cell_id` throws on a wrong-length index where the oracle returns
  `None`. Kept (it is the port's stated rule) but now written down, **with the obligation
  it places on slice 5's wrapper**.
- **S** — one lambda captured a structured binding, which is C++20 (P1091) and which the
  clang 10 floor does not implement. Caught by building against the floor before the gate.

**One of my own corrections was itself defective and is worth flagging.** The first version
of the sum-guard test placed two huge blocks side by side; `normalize_blocks` merged them,
so the *product* guard fired and the test passed whether or not the sum guard existed. It
now offsets them on both axes and matches on the guard's message, because removing the sum
guard does not make the call succeed — the wrapped count comes out negative and `GridBase`
rejects it with a different exception, which a bare "did it throw?" accepts.

Not fixed, reported instead: `checked_mul`/`checked_add` duplicate arithmetic
`TensorProductGrid` hand-rolls inline, and there is no shared helper in `pantr/core` — a
pre-existing gap this continues rather than creates. And `active_face_descendants` recurses
once per level with no depth bound; not reachable today, since `refine` is not ported, but
worth a bound when it is.

Advances FELIGN/pantr#395.

