### PR TITLE
feat(bspline): bind BsplineSpace1D and wrap it from Python

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -121,13 +121,13 @@ if(PANTR_NANOBIND_SPLIT)
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
                       bezier_root_finding.cpp grid.cpp geometry.cpp transform.cpp
                       grid_types.cpp grid_tags.cpp grid_bvh.cpp grid_partition.cpp
-                      quad_types.cpp bezier_type.cpp)
+                      quad_types.cpp bezier_type.cpp bspline_types.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
                       bezier_root_finding.cpp grid.cpp geometry.cpp transform.cpp
                       grid_types.cpp grid_tags.cpp grid_bvh.cpp grid_partition.cpp
-                      quad_types.cpp bezier_type.cpp)
+                      quad_types.cpp bezier_type.cpp bspline_types.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bspline_types.cpp
+++ b/cpp/bindings/bspline_types.cpp
@@ -48,8 +48,8 @@
 /// knot vector has at least `2 * degree + 2` entries, a vector has at least one
 /// knot class, the constructor refuses a space with no interval so the in-domain
 /// range has at least two classes, and `first_basis_per_interval` has exactly
-/// `num_intervals` entries -- checked over 2850 accepted cases and asserted in
-/// `cpp/tests/test_bspline_space_1d.cpp` so it stays true.
+/// `num_intervals` entries, which `cpp/tests/test_bspline_space_1d.cpp` asserts so
+/// that it stays true.
 ///
 /// ## `_ref` accessors are not bound, and there are none to bind
 ///

--- a/cpp/bindings/bspline_types.cpp
+++ b/cpp/bindings/bspline_types.cpp
@@ -1,0 +1,159 @@
+/// \file
+/// nanobind bindings for `pantr::bspline::BsplineSpace1D`.
+///
+/// ## Two registrations, because the storage format is part of the value
+///
+/// `pantr.bspline.BsplineSpace1D` stores whatever float dtype it is handed, its
+/// `dtype` property is public, and `float32` knot vectors are exercised across the
+/// suite. So the same choice `cpp/bindings/bezier_type.cpp` made applies here:
+/// `BsplineSpace1D32` and `BsplineSpace1D64` are registered separately and the
+/// class of the handle *is* the dtype, because a single name would have nothing
+/// left to carry it. `pantr.bspline._bspline_space_1d._impl_class` picks between
+/// them per instance.
+///
+/// The dtype is not converted, and that *is* a check. Without `.noconvert()`
+/// nanobind silently casts, so `BsplineSpace1D32(a_float64_vector)` would narrow a
+/// caller's knots and `BsplineSpace1D64(a_float32_vector)` would widen them --
+/// changing the space's tolerance by four orders in the second case, since the
+/// tolerance is `8 * eps(T) * scale`. Both would happen without a word.
+///
+/// ## What this file validates: nothing
+///
+/// The type validates its own arguments and throws `std::invalid_argument`, which
+/// nanobind maps to `ValueError` preserving `what()` -- and the messages are the
+/// oracle's character for character, which is what
+/// `tests/parity/test_bspline_space_1d.py` compares. Two things the wrapper still
+/// owes are Python's calling convention rather than validation: coercing an
+/// `ArrayLike` to a contiguous array of a supported dtype, and the `TypeError` for
+/// a knot vector that is not one, for which `pantr/core/error.hpp` records there is
+/// no `std::exception` nanobind turns into one.
+///
+/// ## Arrays out: views, never copies
+///
+/// Every array here is storage the space owns and computed once -- the knot vector
+/// at construction, the derived knot classes behind the memo in
+/// `pantr/core/lazy.hpp`. They go out as `nb::ndarray` views with the space as the
+/// array's owner, which is `bezier_type.cpp`'s idiom and for its reasons: the owner
+/// is what keeps the storage alive when the array outlives the handle it came from,
+/// and `const T` is what nanobind turns into the read-only flag, which is what stops
+/// a caller mutating a validated space's knots from outside.
+///
+/// Copying instead would be worse than wasteful. The whole point of the derived
+/// block is that a loop over intervals reads it rather than recomputing it, and a
+/// property that copied would make the natural spelling of every such loop
+/// quadratic in nothing.
+///
+/// **None of these arrays can be empty**, so the null-`data()` trap that
+/// `grid_types.cpp` guards against with a stand-in address does not arise here: a
+/// knot vector has at least `2 * degree + 2` entries, a vector has at least one
+/// knot class, the constructor refuses a space with no interval so the in-domain
+/// range has at least two classes, and `first_basis_per_interval` has exactly
+/// `num_intervals` entries -- checked over 2850 accepted cases and asserted in
+/// `cpp/tests/test_bspline_space_1d.cpp` so it stays true.
+///
+/// ## `_ref` accessors are not bound, and there are none to bind
+///
+/// `design/bspline_ownership_lifetime.md` requires that no borrowing accessor
+/// reaches Python. `BsplineSpace1D` grew none -- it hands out spans of its own
+/// storage rather than references to nested objects -- so the rule is satisfied
+/// vacuously here. `tests/parity/test_bspline_binding_contract.py` asserts it over
+/// the bound surface anyway, because the next type in this front will have one.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "pantr/bspline/space_1d.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+/// A read-only, contiguous 1D array of the given type as nanobind sees it.
+template <class T>
+using const_vec = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// Hand out a span of the owner's storage as a read-only numpy view.
+///
+/// \param self The Python object that owns the storage, kept alive by the array.
+/// \param data The span; must not be empty, see the file comment.
+/// \return A read-only 1D `numpy` array viewing `data`.
+template <class T>
+nb::object view_of(nb::handle self, std::span<const T> data) {
+    return nb::cast(nb::ndarray<nb::numpy, const T, nb::ndim<1>>(data.data(), {data.size()}, self));
+}
+
+/// Register one scalar type's `BsplineSpace1D`.
+///
+/// \param m The extension module.
+/// \param name The Python-visible class name, `BsplineSpace1D32` or `BsplineSpace1D64`.
+template <class T>
+void bind_space_1d(nb::module_& m, const char* name) {
+    using Space = pantr::bspline::BsplineSpace1D<T>;
+    using pantr::bspline::KnotSnapping;
+
+    nb::class_<Space>(m, name)
+        .def(
+            "__init__",
+            [](Space* self, const_vec<T> knots, std::int64_t degree, bool periodic,
+               bool snap_knots) {
+                new (self) Space(std::span<const T>(knots.data(), knots.size()), degree, periodic,
+                                 snap_knots ? KnotSnapping::merge_near_duplicates
+                                            : KnotSnapping::as_given);
+            },
+            nb::arg("knots").noconvert(), nb::arg("degree"), nb::arg("periodic") = false,
+            nb::arg("snap_knots") = true)
+        .def_prop_ro("degree", [](const Space& s) { return s.degree(); })
+        .def_prop_ro("periodic", &Space::periodic)
+        .def_prop_ro("tolerance", &Space::tolerance)
+        .def_prop_ro("num_basis", [](const Space& s) { return s.num_basis(); })
+        .def_prop_ro("num_intervals", [](const Space& s) { return s.num_intervals(); })
+        .def_prop_ro("knots",
+                     [](nb::handle self) {
+                         return view_of<T>(self, nb::cast<const Space&>(self).knots());
+                     })
+        // A tuple of two scalars, because the oracle's `domain` is a tuple and a
+        // caller unpacking `lo, hi = space.domain` must keep working. The wrapper
+        // is what turns them into numpy scalars of the space's own dtype, since
+        // that is a presentation decision rather than a property of the value.
+        .def_prop_ro("domain",
+                     [](const Space& s) {
+                         const auto ends = s.domain();
+                         return nb::make_tuple(ends[0], ends[1]);
+                     })
+        .def(
+            "get_unique_knots_and_multiplicity",
+            [](nb::handle self, bool in_domain) {
+                const Space& s = nb::cast<const Space&>(self);
+                if (in_domain) {
+                    return nb::make_tuple(view_of<T>(self, s.unique_knots_in_domain()),
+                                          view_of<std::int64_t>(self, s.multiplicity_in_domain()));
+                }
+                return nb::make_tuple(view_of<T>(self, s.unique_knots()),
+                                      view_of<std::int64_t>(self, s.multiplicity()));
+            },
+            nb::arg("in_domain") = false)
+        .def("first_basis_per_interval",
+             [](nb::handle self) {
+                 return view_of<std::int64_t>(self,
+                                              nb::cast<const Space&>(self).first_basis_per_interval());
+             })
+        .def("has_left_end_open", &Space::has_left_end_open)
+        .def("has_right_end_open", &Space::has_right_end_open)
+        .def("has_open_knots", &Space::has_open_knots)
+        // Spelled the oracle's way. The C++ name is `has_bezier_like_knots`,
+        // because a capital inside an identifier is not this codebase's C++ style;
+        // the Python name is what a caller has always written.
+        .def("has_Bezier_like_knots", &Space::has_bezier_like_knots);
+}
+
+}  // namespace
+
+void register_bspline_types(nb::module_& m) {
+    bind_space_1d<float>(m, "BsplineSpace1D32");
+    bind_space_1d<double>(m, "BsplineSpace1D64");
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -82,6 +82,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_grid_partition(m);
     register_quad_types(m);
     register_bezier_type(m);
+    register_bspline_types(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -80,3 +80,11 @@ void register_quad_types(nanobind::module_& m);
 /// Register the `pantr.bezier.Bezier` type, distinct from the arithmetic
 /// kernels `register_bezier` binds above.
 void register_bezier_type(nanobind::module_& m);
+
+/// Register the `pantr.bspline` space types.
+///
+/// Not one of #380's six reserved slots: those were all filled before this front
+/// started, and the milestone's remaining tickets add their own entry point here
+/// rather than sharing one. Declared alongside them so a ticket still touches only
+/// its own `.cpp`.
+void register_bspline_types(nanobind::module_& m);

--- a/cpp/tests/test_lazy.cpp
+++ b/cpp/tests/test_lazy.cpp
@@ -109,25 +109,31 @@ void check_copies_start_cold() {
 
 /// Many slots raced by many threads. The sanitizer's target.
 ///
-/// ## Why this is not one slot
+/// ## What makes an ordering downgrade visible at all
 ///
-/// One slot touched once per thread is the obvious shape and it is the wrong one.
-/// Every thread then either builds under the lock or blocks on it and reads after
-/// acquiring it, and `std::mutex` already establishes that happens-before edge on
-/// its own -- so the whole case passes with the atomics made fully `relaxed`, and
-/// the **outer, lock-free fast path** is reached only if a straggler's check
-/// happens to observe `ready_ == true` while still racing the writer. Measured on
-/// exactly that shape: with `lazy.hpp` patched to `memory_order_relaxed`
-/// throughout, the sanitizer caught the injected race in roughly one run in three
-/// and reported nothing in the others, so a single `ctest --preset gcc-tsan` had a
-/// real chance of passing on a broken acquire/release pair. That is the line the
-/// design note calls load-bearing, and it was the line least covered.
+/// The one thing that decides it: **the test has to read the memoised value's
+/// contents inside the threaded section, before any `join()`.** The loop below sums
+/// every element of every slot it touches, in the worker, which is why patching
+/// `lazy.hpp` to `memory_order_relaxed` throughout is caught on 15 runs out of 15.
+/// A test that takes a reference in the thread and inspects it after joining has
+/// already been given a happens-before edge by the join, and reports nothing.
 ///
-/// So: many independent slots, and every thread walks all of them starting from a
-/// different offset. At any moment some threads are building slot `i` while others
-/// are reading a slot already published, which is what puts traffic through the
-/// fast path rather than through the mutex. The second wave then reads every slot
-/// again, when all of them are published and nothing takes the lock at all.
+/// **Two plausible mechanisms are recorded here as refuted, because both were
+/// believed.** An earlier version of this comment argued that a single-slot test
+/// fails to detect the downgrade because its lock-free fast path is *barely
+/// reached* -- every thread either builds under the lock or blocks on it, and
+/// `std::mutex` supplies the edge by itself. An instrumented counter refuted that:
+/// on the shape in question the fast path was reached 22 to 175 times per run while
+/// still detecting nothing. Thread count is not the axis either. What was measured
+/// on the single-slot shape -- roughly one run in three -- was real, but the reason
+/// given for it was not.
+///
+/// So the claim this case supports is narrow and is about the harness rather than
+/// about the sanitizer: **the acquire/release pair in `lazy.hpp` is falsifiable by
+/// this test.** Many slots and two waves are how it gets there -- some threads read
+/// a published slot while others still build another, and the second wave reads
+/// every slot when all are published -- but it is the in-thread read of the
+/// contents that does the work.
 void check_concurrent_first_touch() {
     constexpr int num_threads = 8;
     constexpr int num_slots = 64;

--- a/design/bspline_derived_caches.md
+++ b/design/bspline_derived_caches.md
@@ -503,9 +503,20 @@ cheapest of all and is what the ticket predicts someone will reach for. Rejected
 scenario rather than on principle: `BsplineSpace1D.get_unique_knots_and_multiplicity` returns two
 arrays. If the wrapper caches the numpy views and the C++ caches the buffers, then the arrays are
 correct exactly as long as nobody adds a second path that rebuilds the C++ block -- and the day
-someone does, the wrapper serves views into freed storage. The cost of *not* caching the
-presentation is one `nb::ndarray` construction per access, about 200 ns, which is the same order
-as the Python call that asked for it.
+someone does, the wrapper serves views into freed storage.
+
+**The cost figure this note first gave for the alternative was wrong, and the decision survives
+it.** It said one `nb::ndarray` construction per access costs "about 200 ns, the same order as the
+Python call that asked for it". Measured on the shipped binding at #396 slice 3: a scalar property
+through nanobind costs about **80 ns**, and one `nb::ndarray` construction about **460 ns** -- so a
+view is roughly six bare bound calls, not one, and "the same order" overstated it by about 2.3x.
+That leg of the argument is therefore weaker than written. The rejection stands anyway, because it
+never rested on it: the paragraph above is a **correctness** argument, and two memos over one
+buffer are wrong the day something rebuilds the buffer whatever the access costs.
+**What follows from the correction is a call-site rule rather than a design change** -- the
+accessor looks free and is not, so a loop hoists it, which
+`pantr/core/lazy.hpp` says for the C++ side and `BsplineSpace1D.get_unique_knots_and_multiplicity`
+now says for the Python one.
 
 **Eager everything.** No `mutable`, no flag, no mutex, and construct-then-freeze in its purest
 form. Rejected on F4's measurement: the allocating derived arrays cost 4.8x to 7.2x the bare

--- a/design/bspline_pickle_tolerance.md
+++ b/design/bspline_pickle_tolerance.md
@@ -1,0 +1,109 @@
+# What a pickled B-spline space loses, and the bound on it
+
+**Status:** accepted, 2026-09-01. Written for ticket #396, slice 3.
+**Scope:** why `BsplineSpace1D.__reduce__` reconstructs from the constructor's
+arguments, what that costs, and the bound on the one quantity it does not restore
+exactly. Not what an accessor hands back, which is
+`design/bspline_ownership_lifetime.md`. Not where derived quantities live, which is
+`design/bspline_derived_caches.md`.
+
+**Validated against:** `proto/cpp` at `7ba20d3` plus `feat/396-bspline-space-1d-bind`.
+
+## The decision
+
+`__reduce__` names the constructor's arguments -- the knots, the degree, the
+periodicity flag, and `snap_knots=False` -- and nothing else. It does **not** carry
+the implementation handle, and it does not carry any derived quantity.
+
+The handle is the easy half: a C++ handle is not picklable, and admitting one would
+make a pickle written under `PANTR_BACKEND=cpp` unreadable under the default
+backend, so the backend switch would silently become a data-format switch. The rule
+is the one commit `11f22a7` established for the affine map.
+
+Two smaller choices come with it. The knots are **copied out of the read-only
+view**, because pickle preserves the writeable flag and the oracle's constructor
+expects to own a writable array. And snapping is **off** on the way back in: the
+stored vector is already snapped, so re-snapping is a no-op by idempotence, and
+skipping it makes the reconstruction independent of a scan.
+
+## The consequence: the tolerance is recomputed, not restored
+
+The tolerance is a *derived* quantity, so carrying it would put something in the
+wire format that is not a constructor argument. It is therefore recomputed from the
+stored knots -- and the stored knots are the **snapped** vector, whereas the
+original's tolerance was computed from the vector **as supplied**. Where snapping
+moved the last knot, the scale moved with it, and the two tolerances differ.
+
+### The bound
+
+> `|tol' - tol| / tol  <=  (m - 1) * 8 * eps`
+
+where `m` is the multiplicity of the **last** knot class.
+
+**Derivation.** Snapping replaces each knot class by its *first* knot. So the first
+knot of the vector never moves, and only the last one does. Every step inside a
+class is at most one tolerance, so a class of `m` knots spans at most `m - 1` of
+them, and the last knot moves by at most `(m - 1) * tol`. The scale is
+`max(hi - lo, |lo|, |hi|)`, a maximum over three arguments and therefore
+1-Lipschitz in each; only `hi` moved, so the scale moves by no more than the same
+amount. The tolerance is `8 * eps` times the scale, a fixed multiple, so the
+relative change in the tolerance is the relative change in the scale. Recomputing
+the scale and the tolerance introduces one rounding each, adding a further relative
+`eps` or so, which the measured margin absorbs.
+
+### The `m - 1` is not decoration
+
+A first version of this argument claimed a flat `8 * eps`, reasoning that the scale
+moves by at most one tolerance. **That ignores chaining**: knots grouped by gap
+form a class as wide as the chain, not as wide as the threshold. A sweep built to
+chain the final class **exceeded the flat bound by a factor of 4.4**.
+
+### What was measured
+
+`tests/parity/test_bspline_space_1d.py::_tolerance_drift_sweep`, called at 20000
+draws per seed rather than the tenth of that the suite ships:
+
+| seed | 11 | 101 | 202 | 303 | 404 | 505 | 606 |
+|---|---|---|---|---|---|---|---|
+| worst / `(m-1) * 8 * eps` | 0.716 | 0.755 | 0.729 | 0.734 | 0.732 | 0.734 | 0.733 |
+| worst / flat `8 * eps` | 4.403 | 4.531 | 4.480 | 4.403 | 4.400 | 4.403 | 4.608 |
+
+Every draw drifted, so the bound is compared against something rather than against
+zero. The margin is stable at roughly three quarters of the bound across 140000
+draws and is not approaching it. Identical to three figures under both backends,
+which is itself a parity result: the drift is a property of the arithmetic rather
+than of the implementation.
+
+To reproduce:
+
+```
+python -c "from pantr._backend import Backend, use_backend; \
+           import tests.parity.test_bspline_space_1d as t; \
+           print(t._tolerance_drift_sweep(20000, seed=11))"
+```
+
+### Why this is acceptable rather than a defect
+
+The tolerance decides whether two knots are the same knot. A relative change of
+order `m * eps` in the threshold can only flip that verdict for a pair whose
+difference lies within the same relative distance of the threshold -- the hairline
+band `pantr/bspline/knots.hpp` already documents for the two knot-differencing
+arithmetics. A space whose classification depends on that band is one whose mesh is
+at the format's noise floor, and the constructor refuses the cases where that has
+consequences.
+
+**What would change this decision:** a caller for whom a round trip must be
+bit-identical in every field. The fix would then be to carry the tolerance in the
+reduction and validate it on reconstruction, which trades the "constructor
+arguments and nothing else" property for exactness. Nobody has asked.
+
+## What the tests pin
+
+`test_the_reduce_tolerance_drift_stays_inside_its_bound` asserts three things, and
+the second and third are what make it a check rather than a formality:
+
+1. the bound holds;
+2. the drift is **non-zero** on the sweep, because a bound only ever compared
+   against zero has not been checked;
+3. the **flat** `8 * eps` form is still exceeded, so dropping the `m - 1` again
+   cannot go unnoticed.

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -318,8 +318,9 @@ cxx() {
     # the null-result trap design/bspline_derived_caches.md records. The control
     # was run rather than assumed: replacing LazySlot's double-checked locking
     # with an unsynchronised `optional` gave 23 data races and turned both
-    # threaded tests red on this tree, and restoring it gave 0 and 47/47. Re-run
-    # that control if this leg is ever green on a tree where it should not be.
+    # threaded tests red on this tree, and restoring it gave 0 races and every
+    # test green. Re-run that control if this leg is ever green on a tree where
+    # it should not be.
     rm -rf "$ROOT/build/gcc-tsan"
     check "gcc-tsan: configure (tsan)" cmake --preset gcc-tsan
     check "gcc-tsan: build" cmake --build --preset gcc-tsan

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -89,10 +89,10 @@ in which those kernels are C++ and everything else is unchanged.
 * :mod:`pantr.grid` -- all nine kernels: tensor-product point location, the BVH's
   build and its two query passes, and the five hierarchical addressing kernels.
 
-**Nine types have moved as well, and that is a different kind of entry.** A
+**Ten types have moved as well, and that is a different kind of entry.** A
 catalogue decides which code computes; a ported type decides which object holds the
 state, so under ``PANTR_BACKEND=cpp`` the object's data lives in C++ and the Python
-class is a wrapper around it. The nine, by the module that exports them:
+class is a wrapper around it. The ten, by the module that exports them:
 
 * :mod:`pantr.geometry` -- :class:`~pantr.geometry.AABB`.
 * :mod:`pantr.transform` -- :class:`~pantr.transform.AffineTransform`.
@@ -101,13 +101,31 @@ class is a wrapper around it. The nine, by the module that exports them:
 * :mod:`pantr.grid` -- :class:`~pantr.grid.TensorProductGrid`,
   :class:`~pantr.grid.BVH`, :class:`~pantr.grid.CellTags`,
   :class:`~pantr.grid.FacetTags` and :class:`~pantr.grid.Partition`.
+* :mod:`pantr.bspline` -- :class:`~pantr.bspline.BsplineSpace1D`.
 
-Two domain types in those modules have **not** moved, and both are deliberate rather
-than pending: :class:`pantr.grid.HierarchicalGrid`, which is the Python implementation
-under either backend until its own ticket, and :class:`pantr.quad.PointsLattice`, which
-``design/cross_backend_types.md`` rules out of the port with four recorded reasons. The
-rest of what these modules export is not a candidate either way -- ``Grid`` is a
-:class:`typing.Protocol` and ``GridRestriction`` is a result record.
+**The last of those is why the two lists above are no longer parallel, and the
+mismatch is real rather than an omission.** Every other module here earned its place
+by porting *kernels*; :mod:`pantr.bspline` has none ported, so it is absent from the
+module list, and yet the backend does change which object a caller of
+:class:`~pantr.bspline.BsplineSpace1D` holds. Read the module list as "whose kernels
+moved" and this one as "whose objects moved", and do not infer either from the other.
+
+Two domain types in the geometry, transform, quad and grid modules have **not**
+moved: :class:`pantr.grid.HierarchicalGrid`, which is the Python implementation under
+either backend until its own ticket, and :class:`pantr.quad.PointsLattice`, which
+``design/cross_backend_types.md`` rules out of the port with four recorded reasons --
+the first pending, the second permanent. The rest of what those modules export is not
+a candidate either way -- ``Grid`` is a :class:`typing.Protocol` and
+``GridRestriction`` is a result record.
+
+**:mod:`pantr.bspline` is counted differently, because it is at the start of its own
+front rather than the end of one.** Listing its unported types here would be listing
+a work queue: ``BsplineSpace``, ``Bspline``, ``THBSplineSpace``, ``THBSpline`` and the
+extraction types are all still Python under either backend, and each has its own
+ticket. What is worth stating is the boundary --
+:class:`~pantr.bspline.BsplineSpace1D` alone dispatches, and every operation on it
+(basis tabulation, the extraction operators, knot insertion, subdivision,
+restriction) is still Numba under both backends.
 
 **This list was wrong for two releases and that is worth a sentence.** It said three
 modules and named neither half of ``bezier`` while both were merged and dispatching.

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -84,6 +84,8 @@ from ._bezier import split_bezier as split_bezier
 from ._bezier import split_bezier_1d as split_bezier_1d
 from ._bezier import transform_bezier as transform_bezier
 from ._bezier import yuksel_roots as yuksel_roots
+from ._bspline import BsplineSpace1D32 as BsplineSpace1D32
+from ._bspline import BsplineSpace1D64 as BsplineSpace1D64
 from ._geometry import AABB as AABB
 from ._grid import BVH as BVH
 from ._grid import CellTags as CellTags

--- a/src/pantr/_pantr_cpp/_bspline.pyi
+++ b/src/pantr/_pantr_cpp/_bspline.pyi
@@ -1,0 +1,107 @@
+"""Type stub for the `pantr.bspline` types bound in `cpp/bindings/bspline_types.cpp`.
+
+Two registrations rather than one generic class, because the storage format is part
+of the value: `pantr.bspline.BsplineSpace1D` stores whatever float dtype it is handed
+and its `dtype` property is public, so the class of the handle is the only thing left
+to carry it.
+"""
+
+import numpy as np
+from numpy import typing as npt
+
+class BsplineSpace1D32:
+    """A ``float32`` 1D B-spline space owned by the C++ core.
+
+    Wrapped by :class:`pantr.bspline.BsplineSpace1D`, which is the class a caller
+    holds; this one is reached only through it. The constructor refuses a knot
+    vector of any other dtype rather than casting it, because widening a
+    ``float32`` vector into this class would change the space's tolerance by four
+    orders and narrowing one into the ``float64`` class would move its knots.
+
+    The knots are **copied** at construction and handed back, like every array
+    below, as a **read-only view** of storage the space owns.
+
+    Attributes:
+        knots (npt.NDArray[np.float32]): The knot vector, read-only.
+        degree (int): Polynomial degree, non-negative.
+        periodic (bool): Whether the space is periodic.
+        tolerance (float): Absolute parametric tolerance, a ``float`` at both
+            storage widths.
+        num_basis (int): Number of basis functions.
+        num_intervals (int): Number of in-domain intervals, at least 1.
+        domain (tuple[float, float]): The domain ends, as Python floats; the
+            wrapper is what presents them as numpy scalars.
+    """
+
+    def __init__(
+        self,
+        knots: npt.NDArray[np.float32],
+        degree: int,
+        periodic: bool = False,
+        snap_knots: bool = True,
+    ) -> None: ...
+    @property
+    def knots(self) -> npt.NDArray[np.float32]: ...
+    @property
+    def degree(self) -> int: ...
+    @property
+    def periodic(self) -> bool: ...
+    @property
+    def tolerance(self) -> float: ...
+    @property
+    def num_basis(self) -> int: ...
+    @property
+    def num_intervals(self) -> int: ...
+    @property
+    def domain(self) -> tuple[float, float]: ...
+    def get_unique_knots_and_multiplicity(
+        self, in_domain: bool = False
+    ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.int64]]: ...
+    def first_basis_per_interval(self) -> npt.NDArray[np.int64]: ...
+    def has_left_end_open(self) -> bool: ...
+    def has_right_end_open(self) -> bool: ...
+    def has_open_knots(self) -> bool: ...
+    def has_Bezier_like_knots(self) -> bool: ...
+
+class BsplineSpace1D64:
+    """The ``float64`` twin of :class:`BsplineSpace1D32`; see it for what the two share.
+
+    Attributes:
+        knots (npt.NDArray[np.float64]): The knot vector, read-only.
+        degree (int): Polynomial degree, non-negative.
+        periodic (bool): Whether the space is periodic.
+        tolerance (float): Absolute parametric tolerance.
+        num_basis (int): Number of basis functions.
+        num_intervals (int): Number of in-domain intervals, at least 1.
+        domain (tuple[float, float]): The domain ends, as Python floats.
+    """
+
+    def __init__(
+        self,
+        knots: npt.NDArray[np.float64],
+        degree: int,
+        periodic: bool = False,
+        snap_knots: bool = True,
+    ) -> None: ...
+    @property
+    def knots(self) -> npt.NDArray[np.float64]: ...
+    @property
+    def degree(self) -> int: ...
+    @property
+    def periodic(self) -> bool: ...
+    @property
+    def tolerance(self) -> float: ...
+    @property
+    def num_basis(self) -> int: ...
+    @property
+    def num_intervals(self) -> int: ...
+    @property
+    def domain(self) -> tuple[float, float]: ...
+    def get_unique_knots_and_multiplicity(
+        self, in_domain: bool = False
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]: ...
+    def first_basis_per_interval(self) -> npt.NDArray[np.int64]: ...
+    def has_left_end_open(self) -> bool: ...
+    def has_right_end_open(self) -> bool: ...
+    def has_open_knots(self) -> bool: ...
+    def has_Bezier_like_knots(self) -> bool: ...

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -669,25 +669,11 @@ class BsplineSpace1D:
             which is what keeps the wire format the constructor's arguments and
             nothing else. Where snapping moved the last knot onto its class's first
             one, the scale moves with it and the reconstructed tolerance differs
-            from the original's. The bound is
-
-            ``|tol' - tol| / tol <= (m - 1) * 8 * eps``,
-
-            where ``m`` is the multiplicity of the **last** knot class. Snapping
-            replaces each class by its *first* knot, so the first knot of the vector
-            never moves and only the last one does; every step inside a class is at
-            most one tolerance, so it moves by at most ``(m - 1) * tol``. The scale
-            is a maximum over three arguments and so is 1-Lipschitz in each, so it
-            moves by no more than that, and the tolerance is a fixed multiple of the
-            scale. Recomputing the scale and the tolerance adds a further relative
-            ``eps`` or so, which the measured margin absorbs.
-
-            The ``m - 1`` is not decoration. A first version of this note claimed a
-            flat ``8 * eps``, reasoning that the scale moves by at most one
-            tolerance; that ignores chaining, and a sweep built to chain the final
-            class **exceeded it by a factor of 4.4**. ``tests/parity`` pins the
-            corrected form, checks that the drift is actually non-zero, and checks
-            that the flat version fails.
+            from the original's by at most a relative ``(m - 1) * 8 * eps``, with
+            ``m`` the multiplicity of the last knot class.
+            ``design/bspline_pickle_tolerance.md`` derives that bound, records why
+            the ``m - 1`` is not decoration, and carries the sweep that measured the
+            margin; ``tests/parity/test_bspline_space_1d.py`` pins it.
 
         Returns:
             tuple: The class, and the knots, degree, periodicity and snapping flag
@@ -792,6 +778,19 @@ class BsplineSpace1D:
     @property
     def domain(self) -> tuple[np.float32 | np.float64, np.float32 | np.float64]:
         """Get the knot vector domain.
+
+        A fresh tuple per call, under both backends. ``space.domain is space.domain``
+        was ``True`` while this was a ``cached_property`` on the monolithic class and
+        is now ``False``; the values, their dtype and their order are unchanged.
+        Nothing promised that identity and nothing in the suite relied on it, so this
+        is disclosure rather than a deprecation -- recorded because the sibling
+        weakening on :meth:`first_basis_per_interval` is recorded, and one of the two
+        going unsaid is how the pair becomes folklore.
+
+        Restoring it is not the cheap fix it looks like. It would need the wrapper to
+        hold the tuple in a slot, and ``design/bspline_derived_caches.md`` forbids
+        exactly that: a wrapper slot holding a number is the second truth about a
+        value the implementation already owns.
 
         Returns:
             tuple[np.float32 | np.float64, np.float32 | np.float64]: Tuple of

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -648,20 +648,6 @@ class BsplineSpace1D:
             raise ValueError("degree must be non-negative")
         self._impl = _new_impl(_stored_knots(knots), degree, periodic, snap_knots)
 
-    @classmethod
-    def _wrap(cls, impl: _Impl) -> BsplineSpace1D:
-        """Wrap an implementation object that is already valid.
-
-        Args:
-            impl (_Impl): The implementation object to adopt.
-
-        Returns:
-            BsplineSpace1D: A wrapper around ``impl``, with no re-validation.
-        """
-        self = object.__new__(cls)
-        self._impl = impl
-        return self
-
     def __reduce__(
         self,
     ) -> tuple[type[BsplineSpace1D], tuple[_Knots, int, bool, bool]]:
@@ -687,10 +673,14 @@ class BsplineSpace1D:
 
             ``|tol' - tol| / tol <= (m - 1) * 8 * eps``,
 
-            where ``m`` is the multiplicity of the **last** knot class: each step
-            inside a class is at most one tolerance, so a class of ``m`` knots spans
-            at most ``m - 1`` of them, and the relative change in the tolerance is
-            the relative change in the scale.
+            where ``m`` is the multiplicity of the **last** knot class. Snapping
+            replaces each class by its *first* knot, so the first knot of the vector
+            never moves and only the last one does; every step inside a class is at
+            most one tolerance, so it moves by at most ``(m - 1) * tol``. The scale
+            is a maximum over three arguments and so is 1-Lipschitz in each, so it
+            moves by no more than that, and the tolerance is a fixed multiple of the
+            scale. Recomputing the scale and the tolerance adds a further relative
+            ``eps`` or so, which the measured margin absorbs.
 
             The ``m - 1`` is not decoration. A first version of this note claimed a
             flat ``8 * eps``, reasoning that the scale moves by at most one
@@ -828,9 +818,17 @@ class BsplineSpace1D:
     ) -> tuple[_Knots, npt.NDArray[np.int_]]:
         """Get unique knots and their multiplicities.
 
-        Computed once per space and handed out as the same read-only arrays on every
-        later call, under both backends. There is no cache key, and deliberately so:
-        the derived knot classes belong to the space.
+        Computed once per space, under both backends. There is no cache key, and
+        deliberately so: the derived knot classes belong to the space.
+
+        **Hoist it out of a loop.** What is memoized is the *values*; the numpy
+        arrays presenting them are built per call, and under the C++ backend that
+        construction dominates the access and costs more than the whole call does
+        under the oracle. ``design/bspline_derived_caches.md`` rejects memoizing the
+        presentation as well, because two memos over one buffer are correct only
+        until something rebuilds it -- so the accessor looks free and is not, and the
+        fix is a local rather than a mechanism. The C++ side carries the same warning
+        in ``pantr/core/lazy.hpp``.
 
         Args:
             in_domain (bool): If True, only consider knots in the domain.
@@ -854,7 +852,12 @@ class BsplineSpace1D:
         ``j + 1``. The functions non-zero there are exactly ``i`` through
         ``i + degree``, so this one index describes the whole support of the interval.
 
-        The result is cached and read-only: repeated calls return the same array.
+        The result is computed once per space and read-only. Repeated calls view
+        the same memory; they do **not** necessarily return the same numpy object.
+        The oracle's ``cached_property`` does return one object, and this was
+        documented as such until the port, but the C++ backend memoizes the buffer
+        and builds a view over it per access -- so a caller keying on ``id()`` would
+        see the two backends differ. ``np.shares_memory`` is what holds under both.
 
         Returns:
             npt.NDArray[np.int64]: Read-only ``int64`` array of shape

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -682,11 +682,22 @@ class BsplineSpace1D:
             The tolerance is *recomputed* from the stored knots rather than carried,
             which is what keeps the wire format the constructor's arguments and
             nothing else. Where snapping moved the last knot onto its class's first
-            one the reconstructed tolerance can therefore differ from the original's
-            -- by a relative ``8 * eps`` at most, since the scale moves by at most
-            the original tolerance. That is inside the band in which the tolerance
-            does not decide anything, and ``tests/parity`` pins it at that bound
-            rather than at equality.
+            one, the scale moves with it and the reconstructed tolerance differs
+            from the original's. The bound is
+
+            ``|tol' - tol| / tol <= (m - 1) * 8 * eps``,
+
+            where ``m`` is the multiplicity of the **last** knot class: each step
+            inside a class is at most one tolerance, so a class of ``m`` knots spans
+            at most ``m - 1`` of them, and the relative change in the tolerance is
+            the relative change in the scale.
+
+            The ``m - 1`` is not decoration. A first version of this note claimed a
+            flat ``8 * eps``, reasoning that the scale moves by at most one
+            tolerance; that ignores chaining, and a sweep built to chain the final
+            class **exceeded it by a factor of 4.4**. ``tests/parity`` pins the
+            corrected form, checks that the drift is actually non-zero, and checks
+            that the flat version fails.
 
         Returns:
             tuple: The class, and the knots, degree, periodicity and snapping flag

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -4,15 +4,30 @@ This module exposes :class:`BsplineSpace1D`, which combines a knot vector and
 polynomial degree to define a 1D B-spline space. It provides methods for
 basis evaluation, Bézier/Lagrange/cardinal extraction operators, and several
 geometric properties (domain, intervals, cardinality).
+
+Since ``design/cross_backend_types.md`` the *value* is owned by C++
+(``cpp/include/pantr/bspline/space_1d.hpp``) and :class:`BsplineSpace1D` is a
+wrapper holding one implementation of it. There are two implementations and they
+are not two spaces: :class:`_BsplineSpace1DPython` is the oracle the port is
+checked against, and the C++ handle is the thing being checked.
+:func:`_impl_class` picks between them, per process and per dtype.
+
+Only the *state and what it determines* moved. The operations -- basis
+tabulation, the three extraction families, knot insertion, subdivision and
+restriction -- are unchanged, still run on numba kernels, and now live on the
+wrapper. That mixed dispatch is the temporary seam this front introduces; a
+cleanup ticket removes it once the whole front lands.
 """
 
 from __future__ import annotations
 
 import functools
+from typing import TYPE_CHECKING, Any, Final, TypeAlias, cast
 
 import numpy as np
 from numpy import typing as npt
 
+from .._backend import Backend, active_backend, available_backends
 from ..basis import LagrangeVariant
 from ._bspline_basis_core import (
     _tabulate_Bspline_basis_1D_impl,
@@ -36,73 +51,99 @@ from ._bspline_knots import (
     _knot_tolerance,
 )
 
+if TYPE_CHECKING:
+    from .._pantr_cpp import BsplineSpace1D32 as _CppSpace32
+    from .._pantr_cpp import BsplineSpace1D64 as _CppSpace64
 
-class BsplineSpace1D:
-    """A class representing a 1D B-spline with configurable degree and knot vector.
+    _Impl: TypeAlias = "_BsplineSpace1DPython | _CppSpace32 | _CppSpace64"
+    """The implementation a :class:`BsplineSpace1D` holds: the oracle, or a handle.
 
-    This class provides methods to analyze B-spline properties, validate input
-    parameters, compute various geometric characteristics of the spline,
-    and access various properties of the B-spline.
+    Type-checking only. The three are unrelated nominal types that happen to offer
+    the same surface, which is the port's whole claim; naming the union here is
+    what lets the checker verify it instead of taking it on trust.
+    """
 
-    An instance always has :attr:`num_intervals` at least 1: a knot vector whose
-    in-domain knots all fall in one class is refused at construction, since such a
-    space has no cell and nothing can be evaluated, tabulated or located on it.
+_Knots: TypeAlias = "npt.NDArray[np.float32 | np.float64]"
+"""A knot vector in one of the two storage formats a space may hold."""
+
+_SUPPORTED_DTYPES: Final = (np.dtype(np.float32), np.dtype(np.float64))
+"""The two storage formats a space may hold, after integer input has been cast.
+
+Rejecting anything else is the wrapper\'s job rather than either implementation\'s:
+a dtype is a type-kind check, and ``pantr/core/error.hpp`` records that nanobind
+has no path that produces a :class:`TypeError`.
+"""
+
+
+class _BsplineSpace1DPython:
+    """The 1D space as the Python backend stores it: the port's oracle.
+
+    Holds the knot vector, the degree, the periodicity flag and the tolerance
+    those imply, and answers the questions they determine. Everything the class
+    used to do beyond that is on :class:`BsplineSpace1D`, which is the only class
+    a caller ever holds; this one is reachable only through it. When the C++ core
+    stops being optional this class goes and :class:`BsplineSpace1D` collapses onto
+    the handle.
+
+    It receives a knot vector the wrapper has already normalized: a one-dimensional
+    :class:`numpy.ndarray` of ``float32`` or ``float64``. The value checks below are
+    still its own, because they are also the C++ type's, and the two must refuse the
+    same inputs with the same messages.
 
     Attributes:
         _tol (float): Absolute tolerance for parametric comparisons on this space,
-            in the units of its knots. Derived once at construction by
-            ``_bspline_knots._knot_tolerance`` as
-            ``8 * eps(dtype) * max(span, |knots[0]|, |knots[-1]|)``, so it tracks
-            the knot vector's own magnitude instead of being a per-dtype constant.
-        _knots (npt.NDArray[np.float32 | np.float64]): Knot vector defining the B-spline.
+            in the units of its knots. Derived once at construction, from the knots
+            **as supplied**, and never recomputed -- snapping can move the last knot
+            onto its class's first one, which would move the scale.
+        _knots (npt.NDArray[np.float32 | np.float64]): Knot vector, read-only.
         _degree (int): Polynomial degree of the B-spline.
         _periodic (bool): Whether the B-spline is periodic.
+        _unique_all (tuple | None): Memo for
+            :meth:`get_unique_knots_and_multiplicity` over the whole vector.
+        _unique_in_domain (tuple | None): The same, restricted to the domain.
     """
 
     _tol: float
-    _knots: npt.NDArray[np.float32 | np.float64]
+    _knots: _Knots
     _degree: int
     _periodic: bool
+    _unique_all: tuple[_Knots, npt.NDArray[np.int_]] | None
+    _unique_in_domain: tuple[_Knots, npt.NDArray[np.int_]] | None
 
     def __init__(
         self,
-        knots: npt.ArrayLike,
+        knots: _Knots,
         degree: int,
         periodic: bool = False,
         snap_knots: bool | None = True,
     ) -> None:
-        """Initialize a B-spline 1D object.
+        """Initialize the oracle's B-spline space.
 
         Args:
-            knots (npt.ArrayLike): Knot vector defining the B-spline. Must be non-decreasing
-                and have at least 2*degree+2 elements.
+            knots (npt.NDArray[np.float32 | np.float64]): Knot vector, already
+                normalized by the wrapper: 1D and of a supported float dtype.
             degree (int): Polynomial degree of the B-spline. Must be non-negative.
             periodic (bool): Whether the B-spline is periodic. Defaults to False.
-            snap_knots (bool | None): Whether to snap nearby knots to avoid numerical issues.
-                Defaults to True.
+            snap_knots (bool | None): Whether to snap nearby knots to avoid
+                numerical issues. Defaults to True.
 
         Raises:
             ValueError: If degree is negative, knots are insufficient, or knots are
                 not non-decreasing; if the resulting space would span no interval,
                 i.e. every step between ``knots[degree]`` and ``knots[-degree-1]`` is
                 within :attr:`tolerance`, so the domain is one knot and the space has
-                no cell; or if
-                ``snap_knots`` is set and snapping is what collapsed a knot vector
-                that had more than one distinct knot onto that single point, which
-                means the requested spacing is finer than the dtype resolves at that
-                coordinate magnitude. ``snap_knots=False`` bypasses the merging and
-                the snapping diagnosis, but not the interval requirement.
-            TypeError: If knots cannot be converted to a numpy array.
+                no cell; or if ``snap_knots`` is set and snapping is what collapsed a
+                knot vector that had more than one distinct knot onto that single
+                point, which means the requested spacing is finer than the dtype
+                resolves at that coordinate magnitude. ``snap_knots=False`` bypasses
+                the merging and the snapping diagnosis, but not the interval
+                requirement.
         """
-        BsplineSpace1D._validate_input(knots, degree, periodic)
+        _BsplineSpace1DPython._validate_input(knots, degree, periodic)
 
-        knots_arr = np.asarray(knots)
-        if np.issubdtype(knots_arr.dtype, np.integer):
-            knots_arr = knots_arr.astype(np.float64)
-        else:
-            # Always own the storage: the vector is frozen read-only below, and
-            # freezing a caller-supplied array in place would mutate caller state.
-            knots_arr = knots_arr.copy()
+        # Always own the storage: the vector is frozen read-only below, and
+        # freezing a caller-supplied array in place would mutate caller state.
+        knots_arr = knots.copy()
         self._knots = knots_arr
 
         # Derived from the knots, not from the dtype alone: the presets in
@@ -112,6 +153,8 @@ class BsplineSpace1D:
 
         self._degree = int(degree)
         self._periodic = bool(periodic)
+        self._unique_all = None
+        self._unique_in_domain = None
 
         if snap_knots:
             self._snap_knots()
@@ -126,38 +169,29 @@ class BsplineSpace1D:
 
     @staticmethod
     def _validate_input(
-        knots: npt.ArrayLike,
+        knots: _Knots,
         degree: int,
         periodic: bool = False,
     ) -> None:
-        """Validate the B-spline input parameters.
+        """Validate the value half of the B-spline input parameters.
+
+        The type-kind half -- is this an array at all, is it one-dimensional, is its
+        dtype one a space can store -- belongs to :func:`_stored_knots` on the
+        wrapper, because it raises :class:`TypeError` and nanobind has no path that
+        produces one. What is left here is what the C++ type also checks, in the
+        same order and with the same messages.
 
         Args:
-            knots (npt.ArrayLike): Knot vector to validate.
+            knots (npt.NDArray[np.float32 | np.float64]): Knot vector to validate.
             degree (int): Degree to validate.
             periodic (bool): Whether the B-spline is periodic.
 
         Raises:
             ValueError: If degree is negative, knots are insufficient, or
                 knots are not non-decreasing.
-            TypeError: If knots cannot be converted to a numpy array.
         """
         if degree < 0:
             raise ValueError("degree must be non-negative")
-
-        if isinstance(knots, list):
-            knots = np.array(knots)
-        elif not isinstance(knots, np.ndarray):
-            raise TypeError("knots must be a 1D numpy array or Python list")
-
-        if np.issubdtype(knots.dtype, np.integer):
-            knots = knots.astype(np.float64)
-
-        if not isinstance(knots, np.ndarray) or knots.ndim != 1:
-            raise TypeError("knots must be a 1D numpy array or Python list")
-
-        if knots.dtype not in (np.float32, np.float64):
-            raise ValueError("knots type must be float (32 or 64 bits)")
 
         if knots.size < (2 * degree + 2):
             raise ValueError("knots must have at least 2*degree+2 elements")
@@ -204,11 +238,11 @@ class BsplineSpace1D:
         return self._degree
 
     @property
-    def knots(self) -> npt.NDArray[np.float32 | np.float64]:
+    def knots(self) -> _Knots:
         """Get the knot vector.
 
         Returns:
-            npt.NDArray[np.float32 | np.float64]: The knot vector.
+            npt.NDArray[np.float32 | np.float64]: The read-only knot vector.
         """
         return self._knots
 
@@ -225,38 +259,15 @@ class BsplineSpace1D:
     def tolerance(self) -> float:
         """Get the absolute tolerance used for parametric comparisons on this space.
 
-        It is in the units of the knot vector, being the dimensionless strict
-        preset of :mod:`pantr.tolerance` scaled by the knot vector's own magnitude
-        (``max(span, |knots[0]|, |knots[-1]|)``) and doubled for one extra rounding
-        upstream. Two knots closer than this are the same knot, a point within this
-        of an end is inside the domain, and two knot intervals differing by less
-        than this are the same length.
-
-        Being an absolute parametric length, it is *not* the factor to scale a
-        physical coordinate or a spline coefficient by; take the dimensionless
-        preset from :mod:`pantr.tolerance` for those and scale it by the magnitude
-        that applies.
-
         Returns:
-            float: The absolute parametric tolerance.
+            float: The absolute parametric tolerance; see
+            :attr:`BsplineSpace1D.tolerance` for what it is derived from.
         """
         return self._tol
-
-    @property
-    def dtype(self) -> npt.DTypeLike:
-        """Get the data type of the knot vector (and used in computations).
-
-        Returns:
-            npt.DTypeLike: The numpy data type of the knots.
-        """
-        return self._knots.dtype
 
     @functools.cached_property
     def num_basis(self) -> int:
         """Get the number of basis functions.
-
-        This depends on the knot vector length and the degree, but
-        also on whether the B-spline is periodic.
 
         Returns:
             int: Number of basis functions.
@@ -266,32 +277,42 @@ class BsplineSpace1D:
     def get_unique_knots_and_multiplicity(
         self,
         in_domain: bool = False,
-    ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
+    ) -> tuple[_Knots, npt.NDArray[np.int_]]:
         """Get unique knots and their multiplicities.
+
+        Memoized **per space**, in two slots rather than on a key. That is what the
+        process-global cache this port removed was replaced by: the derived knot
+        classes belong to the space, so there is nothing to key on and nothing a
+        cache key could omit. The C++ implementation memoizes the same two arrays
+        behind one flag, for the same reason.
 
         Args:
             in_domain (bool): If True, only consider knots in the domain.
                 Defaults to False.
 
         Returns:
-            tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[numpy.intp]]: Tuple of
-            (unique_knots, multiplicities) where unique_knots contains the distinct knot values
-            and multiplicities contains the corresponding multiplicity counts. Both arrays are
-            read-only, and a fresh pair is returned by each call.
+            tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[numpy.intp]]:
+            The distinct knot values and their multiplicity counts, both read-only.
         """
+        memo = self._unique_in_domain if in_domain else self._unique_all
+        if memo is not None:
+            return memo
+
         # ``tol`` goes in unrounded, exactly as :meth:`_snap_knots` passes it, so the
         # space and its own accessor apply one predicate rather than two that differ
         # in the last bits of the threshold.
         unique, mults = _get_unique_knots_and_multiplicity_impl(
             self._knots, self._degree, self._tol, in_domain
         )
-        # Frozen because callers treat the result as the space's own report of its
-        # knot classes: :meth:`_first_basis_per_interval_cached` derives a cached
-        # array from it, and the C++ owner this port introduces will hand out a
-        # ``const`` view of storage it owns rather than a copy.
+        # Frozen because the same arrays are handed to every later caller.
         unique.flags.writeable = False
         mults.flags.writeable = False
-        return unique, mults
+        memo = (unique, mults)
+        if in_domain:
+            self._unique_in_domain = memo
+        else:
+            self._unique_all = memo
+        return memo
 
     @functools.cached_property
     def num_intervals(self) -> int:
@@ -299,11 +320,6 @@ class BsplineSpace1D:
 
         Returns:
             int: Number of intervals.
-
-        Example:
-            >>> space = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
-            >>> space.num_intervals
-            2
         """
         unique_knots, _ = self.get_unique_knots_and_multiplicity(in_domain=True)
         return len(unique_knots) - 1
@@ -336,25 +352,12 @@ class BsplineSpace1D:
     def first_basis_per_interval(self) -> npt.NDArray[np.int64]:
         """Get the index of the first B-spline function supported on each interval.
 
-        Entry ``j`` is the smallest global function index ``i`` whose function is
-        non-zero on the open interval between in-domain unique knots ``j`` and
-        ``j + 1``. The functions non-zero there are exactly ``i`` through
-        ``i + degree``, so this one index describes the whole support of the interval.
-
-        The result is cached and read-only: repeated calls return the same array.
-
         Returns:
             npt.NDArray[np.int64]: Read-only ``int64`` array of shape
-            ``(num_intervals,)``, non-decreasing, whose successive differences are
-            the interior knot multiplicities.
+            ``(num_intervals,)``; see :meth:`BsplineSpace1D.first_basis_per_interval`.
 
         Raises:
             ValueError: If the space is periodic.
-
-        Example:
-            >>> space = BsplineSpace1D([0, 0, 0, 1, 2, 2, 3, 3, 3], 2)
-            >>> space.first_basis_per_interval().tolist()
-            [0, 1, 3]
         """
         if self._periodic:
             raise ValueError(
@@ -364,8 +367,6 @@ class BsplineSpace1D:
 
     def _get_domain_indices(self) -> tuple[int, int]:
         """Get the domain boundary indices of the knot vector.
-
-        I.e., the indices of the knot vector that define the domain.
 
         Returns:
             tuple[int, int]: Tuple of (start_index, end_index) defining the domain.
@@ -377,14 +378,8 @@ class BsplineSpace1D:
         """Get the knot vector domain.
 
         Returns:
-            tuple[np.float32 | np.float64, np.float64]: Tuple of
+            tuple[np.float32 | np.float64, np.float32 | np.float64]: Tuple of
             (start_value, end_value) defining the domain.
-
-        Example:
-            >>> bspline = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
-            >>> start, end = bspline.domain
-            >>> float(start), float(end)
-            (0.0, 2.0)
         """
         i0, i1 = self._get_domain_indices()
         return (self._knots[i0], self._knots[i1])
@@ -443,8 +438,6 @@ class BsplineSpace1D:
     def has_left_end_open(self) -> bool:
         """Check if the left end of the B-spline is open.
 
-        A left end is open if the first degree+1 knots are equal.
-
         Returns:
             bool: True if the left end is open, False otherwise.
         """
@@ -452,8 +445,6 @@ class BsplineSpace1D:
 
     def has_right_end_open(self) -> bool:
         """Check if the right end of the B-spline is open.
-
-        A right end is open if the last degree+1 knots are equal.
 
         Returns:
             bool: True if the right end is open, False otherwise.
@@ -471,6 +462,435 @@ class BsplineSpace1D:
     def has_Bezier_like_knots(self) -> bool:
         """Check if the knot vector represents a Bézier-like configuration.
 
+        Returns:
+            bool: True if knots have open ends and only one span.
+        """
+        return self._bezier_like_knots
+
+
+def _stored_knots(knots: npt.ArrayLike) -> _Knots:
+    """Normalize an array-like to the knot vector a space would be built from.
+
+    The type-kind half of what :meth:`BsplineSpace1D.__init__` owes, in the order
+    the oracle has always applied it, because two simultaneously bad arguments must
+    produce the same message they always did.
+
+    Args:
+        knots (npt.ArrayLike): The knot vector as supplied.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: A one-dimensional array of a dtype a
+        space can store. Integer input is cast to ``float64``; everything else keeps
+        its dtype, which is how ``float32`` survives.
+
+    Raises:
+        TypeError: If the input is not a list or a one-dimensional array.
+        ValueError: If the dtype is not one a space can store.
+    """
+    if isinstance(knots, list):
+        arr = np.array(knots)
+    elif not isinstance(knots, np.ndarray):
+        raise TypeError("knots must be a 1D numpy array or Python list")
+    else:
+        arr = knots
+
+    if np.issubdtype(arr.dtype, np.integer):
+        arr = arr.astype(np.float64)
+
+    if arr.ndim != 1:
+        raise TypeError("knots must be a 1D numpy array or Python list")
+
+    if arr.dtype not in _SUPPORTED_DTYPES:
+        raise ValueError("knots type must be float (32 or 64 bits)")
+
+    return cast("_Knots", arr)
+
+
+def _impl_class(dtype: np.dtype[Any]) -> type[_BsplineSpace1DPython] | type[Any]:
+    """The implementation class the active backend and the dtype select.
+
+    The backend is per process rather than per instance, deliberately, and for the
+    reason ``design/cross_backend_types.md`` gives: two spaces built under different
+    backends could otherwise meet in one :class:`~pantr.bspline.BsplineSpace`, and
+    reconciling them would mean converting one implementation into the other, which
+    is the shape that note forbids.
+
+    The dtype, by contrast, *is* per instance. It has to be: ``float32`` is a
+    supported storage format for a knot vector, and the C++ side carries the format
+    in the class name because the class of the handle is the only thing left to
+    carry it.
+
+    Args:
+        dtype (np.dtype[Any]): The dtype the knots will be stored in.
+
+    Returns:
+        type: The oracle under the Python backend, and the C++ class for that
+        storage format otherwise.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if active_backend() is Backend.PYTHON:
+        return _BsplineSpace1DPython
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    if dtype == np.float32:
+        return _pantr_cpp.BsplineSpace1D32
+    return _pantr_cpp.BsplineSpace1D64
+
+
+def _new_impl(
+    knots: _Knots,
+    degree: int,
+    periodic: bool,
+    snap_knots: bool | None,
+) -> _Impl:
+    """Build a 1D space in whichever implementation the active backend selects.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): Knots, already normalized by
+            :func:`_stored_knots`.
+        degree (int): Polynomial degree.
+        periodic (bool): Whether the space is periodic.
+        snap_knots (bool | None): Whether to merge knots that are the same knot.
+
+    Returns:
+        _Impl: The implementation object; an oracle instance or a C++ handle.
+
+    Raises:
+        ValueError: Whatever the implementation refuses the arguments with.
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    cls = _impl_class(knots.dtype)
+    if cls is _BsplineSpace1DPython:
+        return _BsplineSpace1DPython(knots, degree, periodic, snap_knots)
+    # Each C++ class accepts only its own storage format and refuses rather than
+    # casts, so the array's dtype and the class have to agree. They do: the class
+    # was chosen from that dtype one line above. That is a correlation between a
+    # value and a type, which the checker cannot state, and the cast is what stands
+    # in for it.
+    return cast(
+        "_Impl",
+        cls(np.ascontiguousarray(knots), int(degree), bool(periodic), bool(snap_knots)),
+    )
+
+
+class BsplineSpace1D:
+    """A class representing a 1D B-spline with configurable degree and knot vector.
+
+    This class provides methods to analyze B-spline properties, validate input
+    parameters, compute various geometric characteristics of the spline,
+    and access various properties of the B-spline.
+
+    An instance always has :attr:`num_intervals` at least 1: a knot vector whose
+    in-domain knots all fall in one class is refused at construction, since such a
+    space has no cell and nothing can be evaluated, tabulated or located on it.
+
+    **This class is a wrapper.** The value -- the knots, the degree, the
+    periodicity and everything they fix -- is owned by an implementation chosen by
+    :func:`_impl_class`, which is the C++ type
+    (``cpp/include/pantr/bspline/space_1d.hpp``) or the oracle
+    :class:`_BsplineSpace1DPython`. The operations below are still Python over
+    numba kernels and are unchanged; only the state moved.
+
+    Instances are immutable, and ``__slots__`` is what says so: there is no
+    ``__dict__``, so nothing can be attached to a space after it is built.
+
+    Attributes:
+        _impl (_Impl): The implementation this wrapper holds; see
+            :func:`_impl_class`.
+    """
+
+    __slots__ = ("_impl",)
+
+    _impl: _Impl
+    """The implementation this wrapper holds; see :func:`_impl_class`."""
+
+    def __init__(
+        self,
+        knots: npt.ArrayLike,
+        degree: int,
+        periodic: bool = False,
+        snap_knots: bool | None = True,
+    ) -> None:
+        """Initialize a B-spline 1D object.
+
+        Args:
+            knots (npt.ArrayLike): Knot vector defining the B-spline. Must be non-decreasing
+                and have at least 2*degree+2 elements.
+            degree (int): Polynomial degree of the B-spline. Must be non-negative.
+            periodic (bool): Whether the B-spline is periodic. Defaults to False.
+            snap_knots (bool | None): Whether to snap nearby knots to avoid numerical issues.
+                Defaults to True.
+
+        Raises:
+            ValueError: If degree is negative, knots are insufficient, or knots are
+                not non-decreasing; if the resulting space would span no interval,
+                i.e. every step between ``knots[degree]`` and ``knots[-degree-1]`` is
+                within :attr:`tolerance`, so the domain is one knot and the space has
+                no cell; or if
+                ``snap_knots`` is set and snapping is what collapsed a knot vector
+                that had more than one distinct knot onto that single point, which
+                means the requested spacing is finer than the dtype resolves at that
+                coordinate magnitude. ``snap_knots=False`` bypasses the merging and
+                the snapping diagnosis, but not the interval requirement.
+            TypeError: If knots cannot be converted to a numpy array.
+        """
+        # The degree is checked here as well as in the implementation, and the
+        # duplication is the point: the oracle has always refused a negative degree
+        # *before* looking at the knots at all, so a call with both a bad degree and
+        # a bad knot type has always reported the degree. Normalizing the knots
+        # first would silently reverse that, and the seam these two checks sit
+        # either side of did not exist when the order was chosen.
+        if degree < 0:
+            raise ValueError("degree must be non-negative")
+        self._impl = _new_impl(_stored_knots(knots), degree, periodic, snap_knots)
+
+    @classmethod
+    def _wrap(cls, impl: _Impl) -> BsplineSpace1D:
+        """Wrap an implementation object that is already valid.
+
+        Args:
+            impl (_Impl): The implementation object to adopt.
+
+        Returns:
+            BsplineSpace1D: A wrapper around ``impl``, with no re-validation.
+        """
+        self = object.__new__(cls)
+        self._impl = impl
+        return self
+
+    def __reduce__(
+        self,
+    ) -> tuple[type[BsplineSpace1D], tuple[_Knots, int, bool, bool]]:
+        """Pickle by the constructor's arguments rather than by implementation.
+
+        The C++ handle is not picklable and must not become part of the wire format:
+        a pickle written under the C++ backend has to load under the Python one and
+        the other way round, or the backend switch would silently become a
+        data-format switch.
+
+        The knots are copied out of the read-only view, because pickle preserves the
+        flag and the oracle's constructor would then store a read-only array where
+        it expects to own a writable one. Snapping is off on the way back in: the
+        stored vector is already snapped, so re-snapping is a no-op by idempotence,
+        and skipping it makes the reconstruction independent of a scan.
+
+        Note:
+            The tolerance is *recomputed* from the stored knots rather than carried,
+            which is what keeps the wire format the constructor's arguments and
+            nothing else. Where snapping moved the last knot onto its class's first
+            one the reconstructed tolerance can therefore differ from the original's
+            -- by a relative ``8 * eps`` at most, since the scale moves by at most
+            the original tolerance. That is inside the band in which the tolerance
+            does not decide anything, and ``tests/parity`` pins it at that bound
+            rather than at equality.
+
+        Returns:
+            tuple: The class, and the knots, degree, periodicity and snapping flag
+            to rebuild it from.
+        """
+        return (type(self), (np.array(self.knots), self.degree, self.periodic, False))
+
+    @property
+    def degree(self) -> int:
+        """Get the polynomial degree of the B-spline.
+
+        Returns:
+            int: The degree.
+        """
+        return int(self._impl.degree)
+
+    @property
+    def knots(self) -> _Knots:
+        """Get the knot vector.
+
+        Read-only under both backends, and under the C++ one it is a view of the
+        space's own storage rather than a copy, so it stays valid after the space is
+        dropped and costs nothing per access.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The knot vector.
+        """
+        return self._impl.knots
+
+    @property
+    def periodic(self) -> bool:
+        """Check if the B-spline is periodic.
+
+        Returns:
+            bool: True if periodic, False otherwise.
+        """
+        return bool(self._impl.periodic)
+
+    @property
+    def tolerance(self) -> float:
+        """Get the absolute tolerance used for parametric comparisons on this space.
+
+        It is in the units of the knot vector, being the dimensionless strict
+        preset of :mod:`pantr.tolerance` scaled by the knot vector's own magnitude
+        (``max(span, |knots[0]|, |knots[-1]|)``) and doubled for one extra rounding
+        upstream. Two knots closer than this are the same knot, a point within this
+        of an end is inside the domain, and two knot intervals differing by less
+        than this are the same length.
+
+        Being an absolute parametric length, it is *not* the factor to scale a
+        physical coordinate or a spline coefficient by; take the dimensionless
+        preset from :mod:`pantr.tolerance` for those and scale it by the magnitude
+        that applies.
+
+        It is derived from the knots **as supplied**, before snapping, and never
+        recomputed: snapping can move the last knot onto its class's first one,
+        which would move the scale.
+
+        Returns:
+            float: The absolute parametric tolerance.
+        """
+        return float(self._impl.tolerance)
+
+    @property
+    def dtype(self) -> npt.DTypeLike:
+        """Get the data type of the knot vector (and used in computations).
+
+        Read off the knots rather than delegated: the C++ handle carries its storage
+        format in its class name, not as a numpy dtype it could hand back.
+
+        Returns:
+            npt.DTypeLike: The numpy data type of the knots.
+        """
+        return self.knots.dtype
+
+    @property
+    def num_basis(self) -> int:
+        """Get the number of basis functions.
+
+        This depends on the knot vector length and the degree, but
+        also on whether the B-spline is periodic.
+
+        Returns:
+            int: Number of basis functions.
+        """
+        return int(self._impl.num_basis)
+
+    @property
+    def num_intervals(self) -> int:
+        """Get the number of intervals in the domain.
+
+        Returns:
+            int: Number of intervals.
+
+        Example:
+            >>> space = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
+            >>> space.num_intervals
+            2
+        """
+        return int(self._impl.num_intervals)
+
+    @property
+    def domain(self) -> tuple[np.float32 | np.float64, np.float32 | np.float64]:
+        """Get the knot vector domain.
+
+        Returns:
+            tuple[np.float32 | np.float64, np.float32 | np.float64]: Tuple of
+            (start_value, end_value) defining the domain.
+
+        Example:
+            >>> bspline = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
+            >>> start, end = bspline.domain
+            >>> float(start), float(end)
+            (0.0, 2.0)
+        """
+        # Presented as numpy scalars of the space's own dtype under either backend:
+        # the oracle indexes its array and gets one already, the C++ handle returns
+        # a Python float because that is what nanobind casts a `T` to, and a caller
+        # must not be able to tell which one built the space. Routed through a
+        # two-element array rather than the domain indices, so that the formula for
+        # where the domain starts and ends lives in the implementation only.
+        ends = np.asarray(self._impl.domain, dtype=self.dtype)
+        return (ends[0], ends[1])
+
+    def get_unique_knots_and_multiplicity(
+        self,
+        in_domain: bool = False,
+    ) -> tuple[_Knots, npt.NDArray[np.int_]]:
+        """Get unique knots and their multiplicities.
+
+        Computed once per space and handed out as the same read-only arrays on every
+        later call, under both backends. There is no cache key, and deliberately so:
+        the derived knot classes belong to the space.
+
+        Args:
+            in_domain (bool): If True, only consider knots in the domain.
+                Defaults to False.
+
+        Returns:
+            tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[numpy.intp]]: Tuple of
+            (unique_knots, multiplicities) where unique_knots contains the distinct knot values
+            and multiplicities contains the corresponding multiplicity counts. Both arrays
+            are read-only. With ``in_domain=False`` the multiplicities sum to
+            ``knots.size``, so ``np.repeat(unique_knots, multiplicities)`` rebuilds
+            the whole vector with each class collapsed onto its representative.
+        """
+        return self._impl.get_unique_knots_and_multiplicity(in_domain)
+
+    def first_basis_per_interval(self) -> npt.NDArray[np.int64]:
+        """Get the index of the first B-spline function supported on each interval.
+
+        Entry ``j`` is the smallest global function index ``i`` whose function is
+        non-zero on the open interval between in-domain unique knots ``j`` and
+        ``j + 1``. The functions non-zero there are exactly ``i`` through
+        ``i + degree``, so this one index describes the whole support of the interval.
+
+        The result is cached and read-only: repeated calls return the same array.
+
+        Returns:
+            npt.NDArray[np.int64]: Read-only ``int64`` array of shape
+            ``(num_intervals,)``, non-decreasing, whose successive differences are
+            the interior knot multiplicities.
+
+        Raises:
+            ValueError: If the space is periodic.
+
+        Example:
+            >>> space = BsplineSpace1D([0, 0, 0, 1, 2, 2, 3, 3, 3], 2)
+            >>> space.first_basis_per_interval().tolist()
+            [0, 1, 3]
+        """
+        return self._impl.first_basis_per_interval()
+
+    def has_left_end_open(self) -> bool:
+        """Check if the left end of the B-spline is open.
+
+        A left end is open if the first degree+1 knots are equal.
+
+        Returns:
+            bool: True if the left end is open, False otherwise.
+        """
+        return bool(self._impl.has_left_end_open())
+
+    def has_right_end_open(self) -> bool:
+        """Check if the right end of the B-spline is open.
+
+        A right end is open if the last degree+1 knots are equal.
+
+        Returns:
+            bool: True if the right end is open, False otherwise.
+        """
+        return bool(self._impl.has_right_end_open())
+
+    def has_open_knots(self) -> bool:
+        """Check if the B-spline has open ends.
+
+        Returns:
+            bool: True if both ends are open, False otherwise.
+        """
+        return bool(self._impl.has_open_knots())
+
+    def has_Bezier_like_knots(self) -> bool:
+        """Check if the knot vector represents a Bézier-like configuration.
+
         A Bézier-like configuration has open ends and only one non-zero span.
 
         Returns:
@@ -481,7 +901,7 @@ class BsplineSpace1D:
             >>> bspline.has_Bezier_like_knots()
             True
         """
-        return self._bezier_like_knots
+        return bool(self._impl.has_Bezier_like_knots())
 
     def get_cardinal_intervals(
         self, out: npt.NDArray[np.bool_] | None = None
@@ -559,7 +979,7 @@ class BsplineSpace1D:
             of :cite:p:`piegl1997nurbs`.
         """
         return _get_Bspline_cardinal_intervals_1D_impl(
-            self._knots, self._degree, self._tol, out=out
+            self.knots, self.degree, self.tolerance, out=out
         )
 
     def tabulate_basis(
@@ -817,8 +1237,8 @@ class BsplineSpace1D:
         arr = np.asarray(new_knots, dtype=self.dtype)
         if arr.size == 0:
             raise ValueError("new_knots must not be empty.")
-        merged = _compute_inserted_knot_vector_1d(self._knots, self._degree, arr, self._tol)
-        return BsplineSpace1D(merged, self._degree)
+        merged = _compute_inserted_knot_vector_1d(self.knots, self.degree, arr, self.tolerance)
+        return BsplineSpace1D(merged, self.degree)
 
     def subdivide(self, n_subdivisions: int, regularity: int | None = None) -> BsplineSpace1D:
         """Return a new BsplineSpace1D with each knot span split into equal sub-spans.
@@ -844,14 +1264,14 @@ class BsplineSpace1D:
         """
         if n_subdivisions < 2:  # noqa: PLR2004
             raise ValueError(f"n_subdivisions must be >= 2, got {n_subdivisions}")
-        eff_regularity = self._degree - 1 if regularity is None else regularity
-        if eff_regularity < -1 or eff_regularity > self._degree - 1:
+        eff_regularity = self.degree - 1 if regularity is None else regularity
+        if eff_regularity < -1 or eff_regularity > self.degree - 1:
             raise ValueError(
-                f"regularity must be in [-1, degree - 1] = [-1, {self._degree - 1}], "
+                f"regularity must be in [-1, degree - 1] = [-1, {self.degree - 1}], "
                 f"got {eff_regularity}"
             )
         new_knots = _compute_uniform_subdivision_knots(
-            self._knots, self._degree, self._tol, n_subdivisions, eff_regularity
+            self.knots, self.degree, self.tolerance, n_subdivisions, eff_regularity
         )
         return self.insert_knots(new_knots)
 
@@ -879,7 +1299,7 @@ class BsplineSpace1D:
         Raises:
             ValueError: If the space is periodic, or the interval range is invalid.
         """
-        if self._periodic:
+        if self.periodic:
             raise ValueError("restrict: periodic B-spline spaces are not supported.")
         n_int = self.num_intervals
         lo, hi = int(interval_lo), int(interval_hi)
@@ -893,13 +1313,13 @@ class BsplineSpace1D:
                 0.5 * (unique_knots[lo] + unique_knots[lo + 1]),
                 0.5 * (unique_knots[hi - 1] + unique_knots[hi]),
             ],
-            dtype=self._knots.dtype,
+            dtype=self.knots.dtype,
         )
         _, first_basis = self.tabulate_basis(mids)
         j_lo = int(first_basis[0])
-        j_hi = int(first_basis[1]) + self._degree
-        windowed_knots = self._knots[j_lo : j_hi + self._degree + 2]
-        windowed = BsplineSpace1D(windowed_knots, self._degree, periodic=False, snap_knots=False)
+        j_hi = int(first_basis[1]) + self.degree
+        windowed_knots = self.knots[j_lo : j_hi + self.degree + 2]
+        windowed = BsplineSpace1D(windowed_knots, self.degree, periodic=False, snap_knots=False)
         local_to_global_dof = np.arange(j_lo, j_hi + 1, dtype=np.int64)
         local_to_global_dof.flags.writeable = False
         return windowed, local_to_global_dof

--- a/tests/parity/test_bspline_binding_contract.py
+++ b/tests/parity/test_bspline_binding_contract.py
@@ -1,0 +1,227 @@
+"""What the `BsplineSpace1D` binding guarantees, as opposed to what it computes.
+
+`tests/parity/test_bspline_space_1d.py` compares the two backends' *answers*. This
+file is about the *binding*: what the arrays it hands out alias, how long they stay
+valid, what the constructor refuses to convert, and one rule that is about the shape
+of the bound surface rather than about any one call.
+
+Every claim here is exact -- an identity, a flag, a refusal, a name -- so nothing in
+this file carries a tolerance, and `design/backend_parity.md` Rule 8 does not bite.
+
+## Why these and not others
+
+Each of the five below is a failure that is **silent**, which is the reason a
+binding needs tests of its own at all.
+
+**A view that is really a copy.** Every array accessor here returns an
+``nb::ndarray`` over storage the space owns, with the space as the array's owner.
+Bound without that owner argument, nanobind copies instead and the array comes back
+writeable -- and every value assertion in the sibling file still passes. What the
+copy costs is not correctness but shape: the derived block exists so that a loop over
+intervals reads it instead of recomputing an O(n) scan, and a copying property makes
+the natural spelling of such a loop quadratic in nothing.
+
+**A view that is writeable.** ``const T`` as the array's scalar is what nanobind
+turns into the read-only flag. Without it a caller can rewrite a validated space's
+knots from the outside, leaving the space's own derived block describing a vector it
+no longer holds.
+
+**A view that outlives its owner.** The owner argument is also what keeps the storage
+alive. Dropping the space while an array of its knots is still held is the ordinary
+way this arises, and the failure is a use-after-free that usually reads back the
+correct value -- `design/bspline_ownership_lifetime.md` F4 measured exactly that.
+
+**A dtype the constructor converts rather than refuses.** The two classes carry the
+storage format in their names and nothing else carries it. Widening a ``float32``
+knot vector into the 64-bit class multiplies the space's tolerance by about four
+orders, because it is ``8 * eps(T) * scale``; narrowing does the reverse and moves
+the knots. ``.noconvert()`` is what makes
+:func:`pantr.bspline._bspline_space_1d._impl_class` picking the wrong class loud.
+
+**A borrowing accessor reaching Python.** `design/bspline_ownership_lifetime.md`
+requires that no ``_ref`` accessor is ever bound: it is a reference with no owner and
+no policy, so a caller can hold it past the owner's death with nothing to blame.
+``BsplineSpace1D`` has none to bind, so the rule holds vacuously here -- and it is
+asserted over the whole bound surface anyway, because the next type in this front
+will have one and there is no ``static_assert`` for absence.
+"""
+
+from __future__ import annotations
+
+import gc
+import sys
+from typing import Any
+
+import numpy as np
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import BsplineSpace1D
+
+_KNOTS = np.asarray([0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0], dtype=np.float64)
+"""A clamped quadratic with one repeated interior knot, so every accessor is non-trivial."""
+
+
+def _bindings() -> Any:
+    """Import the extension.
+
+    Deferred and in one place, matching `test_bezier_binding_contract.py`: the
+    module is optional, and every caller below is already gated on the
+    ``cpp_backend`` fixture.
+
+    Returns:
+        Any: The :mod:`pantr._pantr_cpp` module.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp
+
+
+def _cpp_space(dtype: Any = np.float64) -> BsplineSpace1D:
+    """Build a space under the C++ backend.
+
+    Args:
+        dtype (Any): The storage format.
+
+    Returns:
+        BsplineSpace1D: The space, holding a C++ handle.
+    """
+    with use_backend(Backend.CPP):
+        return BsplineSpace1D(np.asarray(_KNOTS, dtype=dtype), 2)
+
+
+def _array_accessors(space: BsplineSpace1D) -> dict[str, np.ndarray[Any, Any]]:
+    """Every array a space hands out, by name.
+
+    Args:
+        space (BsplineSpace1D): The space to read.
+
+    Returns:
+        dict[str, np.ndarray]: One entry per array accessor, so a test can assert a
+        property of all of them and name the one that failed.
+    """
+    unique, mult = space.get_unique_knots_and_multiplicity()
+    unique_in, mult_in = space.get_unique_knots_and_multiplicity(in_domain=True)
+    return {
+        "knots": space.knots,
+        "unique_knots": unique,
+        "multiplicity": mult,
+        "unique_knots_in_domain": unique_in,
+        "multiplicity_in_domain": mult_in,
+        "first_basis_per_interval": space.first_basis_per_interval(),
+    }
+
+
+def test_every_array_the_space_hands_out_is_read_only(cpp_backend: None) -> None:
+    """A caller cannot rewrite a validated space's storage from the outside."""
+    space = _cpp_space()
+    for name, array in _array_accessors(space).items():
+        assert not array.flags.writeable, f"{name} came back writeable"
+        with pytest.raises(ValueError):
+            array[0] = 0
+
+
+def test_every_array_is_a_view_rather_than_a_copy(cpp_backend: None) -> None:
+    """Two reads of one accessor view one buffer.
+
+    ``shares_memory`` is what distinguishes a view from a copy; the values agree
+    either way, which is why no assertion on them can stand in for this.
+    """
+    space = _cpp_space()
+    first = _array_accessors(space)
+    second = _array_accessors(space)
+    for name in first:
+        assert np.shares_memory(first[name], second[name]), f"{name} was copied out"
+
+
+def test_the_in_domain_classes_are_a_subrange_of_the_whole(cpp_backend: None) -> None:
+    """One memo and two views of it, rather than two scans.
+
+    True of the C++ implementation and **not** of the oracle, which runs a second
+    scan for the in-domain form -- so this is a binding claim and lives here rather
+    than in the shared suite, where it would pass under the default backend for a
+    reason that has nothing to do with the binding.
+    """
+    space = _cpp_space()
+    unique, mult = space.get_unique_knots_and_multiplicity()
+    unique_in, mult_in = space.get_unique_knots_and_multiplicity(in_domain=True)
+
+    assert np.shares_memory(unique, unique_in)
+    assert np.shares_memory(mult, mult_in)
+
+
+def test_an_array_outlives_the_space_it_came_from(cpp_backend: None) -> None:
+    """The array keeps its owner alive, so dropping the space does not free the storage.
+
+    A use-after-free here would usually read back the correct value, so the check
+    that actually bites is the refcount one: taking the array must *raise* the
+    space's reference count, which is what says a keep-alive was installed at all.
+    """
+    space = _cpp_space()
+    handle = space._impl
+    before = sys.getrefcount(handle)
+
+    knots = space.knots
+    assert sys.getrefcount(handle) > before, (
+        "taking a view did not reference its owner, so nothing keeps the storage "
+        "alive once the space is dropped"
+    )
+
+    expected = np.asarray(_KNOTS)
+    del space, handle
+    gc.collect()
+
+    np.testing.assert_array_equal(knots, expected)
+
+
+@pytest.mark.parametrize(
+    ("class_name", "wrong_dtype"),
+    [("BsplineSpace1D32", np.float64), ("BsplineSpace1D64", np.float32)],
+)
+def test_the_space_refuses_a_dtype_it_would_have_to_cast(
+    cpp_backend: None, class_name: str, wrong_dtype: Any
+) -> None:
+    """Each class takes only its own storage format.
+
+    Reached through :mod:`pantr._pantr_cpp` rather than through
+    :class:`~pantr.bspline.BsplineSpace1D`, whose wrapper picks the matching class
+    and so can never present the mismatch. The extension is importable and both
+    names are public attributes of a public module, so this surface is real.
+    """
+    cls = getattr(_bindings(), class_name)
+    with pytest.raises(TypeError):
+        cls(np.asarray(_KNOTS, dtype=wrong_dtype), 2)
+
+
+def test_no_bound_method_is_a_borrowing_accessor(cpp_backend: None) -> None:
+    """No name on either class ends in ``_ref``.
+
+    The rule from `design/bspline_ownership_lifetime.md`. Vacuous for this type,
+    which hands out spans of its own storage rather than references to nested
+    objects, and asserted anyway: there is no ``static_assert`` for absence, review
+    alone will not hold across the rest of this front, and the cost of the rule
+    being broken is a dangling reference with no policy anywhere to blame.
+    """
+    bindings = _bindings()
+    offenders = []
+    for class_name in ("BsplineSpace1D32", "BsplineSpace1D64"):
+        cls = getattr(bindings, class_name)
+        offenders += [f"{class_name}.{name}" for name in dir(cls) if name.endswith("_ref")]
+
+    assert not offenders, f"borrowing accessors reached Python: {offenders}"
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+def test_a_space_has_no_instance_dictionary(cpp_backend: None, backend: Backend) -> None:
+    """The wrapper is immutable, and ``__slots__`` is what makes that true.
+
+    A ``__dict__`` would silently return settable attributes to a type documented
+    immutable, and would let a memo be attached to the wrapper -- the second truth
+    `design/bspline_derived_caches.md` forbids, since the value is memoized in the
+    implementation and there is exactly one of it.
+    """
+    with use_backend(backend):
+        space = BsplineSpace1D(_KNOTS, 2)
+    assert not hasattr(space, "__dict__")
+    with pytest.raises(AttributeError):
+        space.some_new_attribute = 1  # type: ignore[attr-defined]

--- a/tests/parity/test_bspline_binding_contract.py
+++ b/tests/parity/test_bspline_binding_contract.py
@@ -211,17 +211,20 @@ def test_no_bound_method_is_a_borrowing_accessor(cpp_backend: None) -> None:
     assert not offenders, f"borrowing accessors reached Python: {offenders}"
 
 
-@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
-def test_a_space_has_no_instance_dictionary(cpp_backend: None, backend: Backend) -> None:
+def test_a_space_has_no_instance_dictionary() -> None:
     """The wrapper is immutable, and ``__slots__`` is what makes that true.
 
     A ``__dict__`` would silently return settable attributes to a type documented
     immutable, and would let a memo be attached to the wrapper -- the second truth
     `design/bspline_derived_caches.md` forbids, since the value is memoized in the
     implementation and there is exactly one of it.
+
+    Not parametrized over the backends and not gated on the extension: ``__slots__``
+    belongs to the wrapper class, which is the same class whichever implementation
+    it holds, so a second run would duplicate the first. Gating it would have made
+    it skip in the configuration where it is the only thing checking this.
     """
-    with use_backend(backend):
-        space = BsplineSpace1D(_KNOTS, 2)
+    space = BsplineSpace1D(_KNOTS, 2)
     assert not hasattr(space, "__dict__")
     with pytest.raises(AttributeError):
         space.some_new_attribute = 1  # type: ignore[attr-defined]

--- a/tests/parity/test_bspline_space_1d.py
+++ b/tests/parity/test_bspline_space_1d.py
@@ -35,10 +35,12 @@ by its multiplicity rebuilds the stored vector, and the successive differences o
 
 ## Rule 12
 
-Every test here that says something about the *binding* takes the ``cpp_backend``
+Every test that says something about the *binding* takes the ``cpp_backend``
 fixture, whose ``demand_cpp_backend`` is a skip-or-fail rather than a silent skip.
-The tests that state a property of *both* backends deliberately do not, so they run
-under the default and would catch the oracle regressing too.
+The tests that state a property of *each* backend take it on the C++ **parameter**
+instead, through ``_BACKENDS`` -- because taking it on the test would skip the
+Python half too, and the Python half is the only thing here that would catch the
+oracle regressing.
 """
 
 from __future__ import annotations
@@ -51,10 +53,44 @@ import pytest
 
 from pantr._backend import Backend, use_backend
 from pantr.bspline import BsplineSpace1D
-from tests._parity_harness import Field, assert_object_parity, bitwise_parity, exact_parity
+from tests._parity_harness import (
+    Field,
+    assert_object_parity,
+    bitwise_parity,
+    demand_cpp_backend,
+    exact_parity,
+)
 
 if TYPE_CHECKING:
     from numpy import typing as npt
+
+_BACKENDS: Final = (
+    pytest.param(Backend.PYTHON, id="python"),
+    pytest.param(Backend.CPP, id="cpp"),
+)
+"""The two backends, for the tests that state a property of each one separately."""
+
+
+def _demand_the_extension_if_needed(backend: Backend) -> None:
+    """Require the compiled extension, and only for the half that uses it.
+
+    A test parametrized over both backends and *also* taking the ``cpp_backend``
+    fixture skips **both** halves when the extension is absent -- which
+    ``tests/parity/conftest.py`` calls the common local configuration. That
+    silently drops the Python half, and the Python half of the closed-form check
+    and the algebraic invariants is the only thing in this file that would catch
+    the **oracle** regressing.
+
+    Marking the parameter instead would be neater and pytest forbids it:
+    ``pytest.param`` refuses ``pytest.mark.usefixtures`` outright. So the guard is
+    a call, which is at least visible in the test body rather than in a decorator.
+
+    Args:
+        backend (Backend): The backend this case runs under.
+    """
+    if backend is Backend.CPP:
+        demand_cpp_backend()
+
 
 _STATE_WHY: Final = (
     "a space stores a knot vector and counts things in it; every count, index and "
@@ -120,6 +156,22 @@ _SPACES: Final = tuple(
         ("tiny domain", [0.0, 0.0, 0.0, 5e-7, 1e-6, 1e-6, 1e-6], 2, False, True),
         ("snapping off", [0.0, 0.0, 0.0, 0.5, 0.5 + 2e-16, 1.0, 1.0, 1.0], 2, False, False),
         ("negative domain", [-2.0, -2.0, -2.0, -1.0, 0.0, 0.0, 0.0], 2, False, True),
+        # Clamped on the left and not on the right. Every other case here is
+        # symmetric in its two ends, and a review proved what that costs: mirroring
+        # the left-end formula onto the right end -- a plausible swapped-index bug
+        # -- produced zero mismatches across the whole table at both dtypes.
+        ("asymmetric ends", [0.0, 0.0, 0.0, 1.0, 2.0, 3.0], 2, False, True),
+        # An interior knot at the maximum multiplicity `degree + 1`, so the space
+        # is discontinuous there and splits into independent single-span pieces.
+        # "repeated interior knot" above only reaches multiplicity 2, which is the
+        # C^0 case; the per-interval index advances by 3 here and by 1 there.
+        (
+            "interior knot at maximum multiplicity",
+            [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0],
+            2,
+            False,
+            True,
+        ),
     )
 )
 """The spaces every field-by-field comparison runs over, and what each is here for.
@@ -247,7 +299,6 @@ def test_the_state_agrees_field_by_field(
 _REFUSALS: Final = tuple(
     _Case(*case)
     for case in (
-        ("negative degree", [0.0, 0.0, 1.0, 1.0], -1, False, True),
         ("too few knots", [0.0, 0.0, 1.0], 2, False, True),
         ("descending step", [0.0, 0.0, 1.0, 0.5, 1.0, 1.0], 2, False, True),
         ("periodic with too few functions", [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, True, True),
@@ -257,6 +308,12 @@ _REFUSALS: Final = tuple(
     )
 )
 """One input per refusal, plus two that fail two checks at once.
+
+A negative degree is deliberately **not** here. The wrapper refuses it before
+`_new_impl` dispatches, so both parametrizations would run the identical Python
+line and the case would certify nothing about either implementation. What it does
+pin -- that the wrapper checks the degree before it looks at the knots at all -- is
+a wrapper contract and has its own test below.
 
 The last two are what pin the check *order* across the seam: an input failing two
 checks reports whichever the implementation reaches first, so swapping two
@@ -286,6 +343,46 @@ def test_the_refusals_agree_character_for_character(
         messages[backend] = str(caught.value)
 
     assert messages[Backend.PYTHON] == messages[Backend.CPP]
+
+
+def test_the_periodic_first_basis_refusal_agrees(cpp_backend: None) -> None:
+    """Both backends refuse ``first_basis_per_interval`` on a periodic space alike.
+
+    The one raise in this type that is not a construction refusal, and the one the
+    field-by-field comparison structurally cannot reach: ``_fields`` drops the
+    field for a periodic space, precisely because calling it there raises. So
+    without this test the C++ side could raise a different type, or a different
+    message, on the only input for which it raises at all.
+    """
+    knots = np.asarray(list(range(10)), dtype=np.float64)
+
+    messages = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = BsplineSpace1D(knots, 2, periodic=True)
+            with pytest.raises(ValueError) as caught:
+                space.first_basis_per_interval()
+        messages[backend] = str(caught.value)
+
+    assert messages[Backend.PYTHON] == messages[Backend.CPP]
+    assert messages[Backend.CPP] == (
+        "first_basis_per_interval: periodic B-spline spaces are not supported."
+    )
+
+
+def test_the_wrapper_checks_the_degree_before_the_knots() -> None:
+    """A bad degree is reported even when the knots are unusable too.
+
+    Not a parity test -- the wrapper raises before either implementation is chosen,
+    which is the point. The oracle has always refused a negative degree before
+    looking at the knots, so an input that is bad in both ways has always reported
+    the degree; normalizing the knots first would silently reverse that, and no
+    other test would notice.
+    """
+    with pytest.raises(ValueError, match="degree must be non-negative"):
+        BsplineSpace1D("not an array at all", -1)
+    with pytest.raises(ValueError, match="degree must be non-negative"):
+        BsplineSpace1D(np.zeros((2, 2)), -1)
 
 
 def test_the_snapping_refusal_agrees_including_its_formatted_floats(cpp_backend: None) -> None:
@@ -336,12 +433,10 @@ def test_the_infinite_knot_message_agrees(cpp_backend: None) -> None:
     assert "-nan" not in seen[Backend.CPP]
 
 
-@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("degree", [0, 1, 2, 3, 5])
 @pytest.mark.parametrize("num_intervals", [1, 2, 3, 7, 16])
-def test_the_clamped_uniform_closed_form(
-    cpp_backend: None, backend: Backend, degree: int, num_intervals: int
-) -> None:
+def test_the_clamped_uniform_closed_form(backend: Backend, degree: int, num_intervals: int) -> None:
     """A family whose answers are known by hand, checked against the formula.
 
     The **independent** accuracy check `design/backend_parity.md` requires: nothing
@@ -356,6 +451,7 @@ def test_the_clamped_uniform_closed_form(
     requested pair exactly, because the ends are stored values rather than computed
     ones.
     """
+    _demand_the_extension_if_needed(backend)
     breakpoints = np.linspace(0.0, 1.0, num_intervals + 1)
     knots = np.concatenate([[0.0] * degree, breakpoints, [1.0] * degree])
 
@@ -371,10 +467,9 @@ def test_the_clamped_uniform_closed_form(
     assert space.has_Bezier_like_knots() == (num_intervals == 1)
 
 
-@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("case", _SPACES, ids=[c.label for c in _SPACES])
 def test_the_algebraic_invariants_hold(
-    cpp_backend: None,
     backend: Backend,
     case: _Case,
 ) -> None:
@@ -390,6 +485,7 @@ def test_the_algebraic_invariants_hold(
       multiplicities, which is what ties the per-interval index back to the knot
       vector it was derived from.
     """
+    _demand_the_extension_if_needed(backend)
     with use_backend(backend):
         space = BsplineSpace1D(
             np.asarray(case.knots, dtype=np.float64),
@@ -417,6 +513,10 @@ def test_the_algebraic_invariants_hold(
             "is asserting nothing"
         )
 
+    # Close to a definition -- the oracle computes `num_intervals` as exactly this
+    # length less one -- so it is a staleness check on the memo rather than
+    # independent evidence for the count. What carries that is the closed-form
+    # family above.
     unique_in, _ = space.get_unique_knots_and_multiplicity(in_domain=True)
     assert unique_in.size == space.num_intervals + 1
 
@@ -427,10 +527,9 @@ def test_the_algebraic_invariants_hold(
         np.testing.assert_array_equal(np.diff(first), np.asarray(mult_in[1:-1], dtype=np.int64))
 
 
-@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("case", _SPACES, ids=[c.label for c in _SPACES])
 def test_reduce_round_trips_under_both_backends(
-    cpp_backend: None,
     backend: Backend,
     case: _Case,
 ) -> None:
@@ -440,6 +539,7 @@ def test_reduce_round_trips_under_both_backends(
     ``__reduce__`` names the constructor's arguments. What has to come back is the
     state, bit for bit where it is floating point.
     """
+    _demand_the_extension_if_needed(backend)
     with use_backend(backend):
         space = BsplineSpace1D(
             np.asarray(case.knots, dtype=np.float64),
@@ -541,10 +641,8 @@ def _tolerance_drift_sweep(trials: int, seed: int) -> tuple[int, int, float, flo
     return built, drifted, worst_corrected, worst_flat
 
 
-@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
-def test_the_reduce_tolerance_drift_stays_inside_its_bound(
-    cpp_backend: None, backend: Backend
-) -> None:
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_the_reduce_tolerance_drift_stays_inside_its_bound(backend: Backend) -> None:
     """The one bound this type carries, checked where it is not zero.
 
     ``__reduce__`` names the constructor's arguments and lets the tolerance be
@@ -565,6 +663,7 @@ def test_the_reduce_tolerance_drift_stays_inside_its_bound(
       That is what the ``m - 1`` buys, and without this assertion nothing would
       notice it being dropped again.
     """
+    _demand_the_extension_if_needed(backend)
     with use_backend(backend):
         built, drifted, worst_corrected, worst_flat = _tolerance_drift_sweep(_DRIFT_TRIALS, seed=11)
 
@@ -584,10 +683,15 @@ def test_the_reduce_tolerance_drift_stays_inside_its_bound(
 _DRIFT_TRIALS: Final = 2000
 """Draws in the tolerance-drift sweep.
 
-Sized so the shipped run costs about a second. **Verified at 20000, ten times
-this**, by calling this same function rather than a look-alike: 20000 of 20000
-draws built a space, 20000 of 20000 moved the tolerance, the corrected bound held
-at a worst of **0.716** of it, and the flat ``8 * eps`` was exceeded by **4.403x**.
-Identical to three figures under both backends, which is a parity result in its own
-right -- the drift is a property of the arithmetic and not of the implementation.
+Sized so the shipped run costs about a second, and large enough that the three
+assertions in the test are each decided by many cases rather than by one. The
+sweep was verified at ten times this on the branch that introduced it, by calling
+this same function rather than a look-alike; the figures are in that pull request,
+where they carry the commit and the machine that produced them. They are not
+repeated here, because a number in a comment is never re-measured and rots while
+reading as current. To re-run it::
+
+    python -c "from pantr._backend import Backend, use_backend; \
+               import tests.parity.test_bspline_space_1d as t; \
+               print(t._tolerance_drift_sweep(20000, seed=11))"
 """

--- a/tests/parity/test_bspline_space_1d.py
+++ b/tests/parity/test_bspline_space_1d.py
@@ -1,0 +1,593 @@
+"""Parity for `pantr.bspline.BsplineSpace1D`: the C++ value against the oracle.
+
+## What kind of claim this file makes
+
+Almost none of it is a floating-point claim. A space stores a knot vector and
+answers counting questions about it, so basis counts, interval counts, class
+multiplicities and per-interval indices are integers, the clamping flags are
+booleans, and the refusal messages are strings. Those are compared with
+:func:`exact_parity`, and a tolerance on any of them would be hiding something.
+
+The two quantities that *are* floating point -- the stored knots and the tolerance
+-- are compared **bitwise**, and that is a claim rather than an accident. The knots
+are copied and, where snapping applies, replaced by knots the input already
+contained; no arithmetic is done on them at all. The tolerance is
+``8 * eps(dtype) * max(span, |lo|, |hi|)`` on both sides, and 8 and ``eps`` are
+powers of two, so the product is exact and the single rounding is the multiply by
+the scale. Two implementations doing one rounding on the same operands agree to the
+last bit or one of them is wrong.
+
+## The independent accuracy check
+
+`design/backend_parity.md` requires more than agreement with the oracle, and
+agreement is all the sweeps below establish. The independent check here is a
+**closed form for a whole family**: for a knot vector clamped at both ends over `n`
+uniform intervals at degree `p`, hand arithmetic gives `num_basis == n + p`,
+`num_intervals == n`, `first_basis_per_interval() == [0, 1, ..., n-1]`, and a domain
+of exactly the requested ends. `test_the_clamped_uniform_closed_form` checks all
+four against the formula rather than against the oracle, over the whole
+`(n, p)` grid, under whichever backend is active.
+
+Two algebraic identities join it, and they hold for every space rather than for a
+family: the multiplicities sum to the knot count and repeating each representative
+by its multiplicity rebuilds the stored vector, and the successive differences of
+`first_basis_per_interval` are the interior multiplicities.
+
+## Rule 12
+
+Every test here that says something about the *binding* takes the ``cpp_backend``
+fixture, whose ``demand_cpp_backend`` is a skip-or-fail rather than a silent skip.
+The tests that state a property of *both* backends deliberately do not, so they run
+under the default and would catch the oracle regressing too.
+"""
+
+from __future__ import annotations
+
+import pickle
+from typing import TYPE_CHECKING, Final, NamedTuple
+
+import numpy as np
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import BsplineSpace1D
+from tests._parity_harness import Field, assert_object_parity, bitwise_parity, exact_parity
+
+if TYPE_CHECKING:
+    from numpy import typing as npt
+
+_STATE_WHY: Final = (
+    "a space stores a knot vector and counts things in it; every count, index and "
+    "flag below is an integer or a boolean reached by the same integer arithmetic "
+    "on both sides, so a difference is a defect and not a rounding"
+)
+
+_KNOT_WHY: Final = (
+    "the stored knots are the input's own values -- copied, and where snapping "
+    "applies replaced by other knots the input already contained -- so no "
+    "arithmetic is performed on them and the two backends store the same bits"
+)
+
+_TOLERANCE_WHY: Final = (
+    "the tolerance is 8 * eps(dtype) * max(span, |lo|, |hi|) on both sides. 8 and "
+    "eps are powers of two, so their product is exact and the only rounding is the "
+    "final multiply by the scale, which both sides perform on the same operands"
+)
+
+
+class _Case(NamedTuple):
+    """One space to build, and what it is in the table for.
+
+    A record rather than a positional tuple: the two flags are both booleans, and
+    at a call site ``(..., False, True)`` says nothing about which is which.
+
+    Attributes:
+        label (str): What structural feature this case is here to exercise.
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        periodic (bool): Whether the space is periodic.
+        snap (bool): Whether to merge knots that are the same knot.
+    """
+
+    label: str
+    knots: list[float]
+    degree: int
+    periodic: bool
+    snap: bool
+
+
+_SPACES: Final = tuple(
+    _Case(*case)
+    for case in (
+        ("clamped quadratic", [0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0], 2, False, True),
+        ("repeated interior knot", [0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0], 2, False, True),
+        ("bezier-like", [1.0, 1.0, 1.0, 3.0, 3.0, 3.0], 2, False, True),
+        ("degree zero", [0.0, 1.0, 2.0, 3.0], 0, False, True),
+        ("unclamped cubic", [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 10.0], 3, False, True),
+        ("periodic uniform", list(range(10)), 2, True, True),
+        (
+            # The span is 100 against coordinates of 1e6, so the scale is set by
+            # the coordinates rather than the span. Spaced widely enough that
+            # float32 resolves it: at that magnitude the tolerance is about 0.95,
+            # and a quarter-unit mesh there is the vector the snapping refusal is
+            # tested on rather than one a space can be built from.
+            "offset far from the origin",
+            [1e6, 1e6, 1e6, 1e6 + 50.0, 1e6 + 100.0, 1e6 + 100.0, 1e6 + 100.0],
+            2,
+            False,
+            True,
+        ),
+        ("tiny domain", [0.0, 0.0, 0.0, 5e-7, 1e-6, 1e-6, 1e-6], 2, False, True),
+        ("snapping off", [0.0, 0.0, 0.0, 0.5, 0.5 + 2e-16, 1.0, 1.0, 1.0], 2, False, False),
+        ("negative domain", [-2.0, -2.0, -2.0, -1.0, 0.0, 0.0, 0.0], 2, False, True),
+    )
+)
+"""The spaces every field-by-field comparison runs over, and what each is here for.
+
+One per structural feature the type branches on: clamped and unclamped ends, an
+interior knot of multiplicity above one, the single-span case, degree zero, a
+periodic space, a domain far from the origin where the scale is set by the
+coordinates rather than the span, a domain smaller than one unit where it is set by
+the span, snapping turned off, and a domain that never crosses zero.
+"""
+
+
+def _both_backends(
+    knots: list[float],
+    degree: int,
+    periodic: bool,
+    snap: bool,
+    dtype: npt.DTypeLike,
+) -> tuple[BsplineSpace1D, BsplineSpace1D]:
+    """Build the same space under each backend.
+
+    Args:
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        periodic (bool): Whether the space is periodic.
+        snap (bool): Whether to merge knots that are the same knot.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        tuple[BsplineSpace1D, BsplineSpace1D]: ``(python, cpp)``, in that order, so
+        that a call site cannot get :func:`assert_object_parity`'s two keyword
+        arguments the wrong way round without saying so.
+    """
+    arr = np.asarray(knots, dtype=dtype)
+    with use_backend(Backend.PYTHON):
+        python = BsplineSpace1D(arr, degree, periodic=periodic, snap_knots=snap)
+    with use_backend(Backend.CPP):
+        cpp = BsplineSpace1D(arr, degree, periodic=periodic, snap_knots=snap)
+    return python, cpp
+
+
+def _fields(periodic: bool) -> list[Field]:
+    """The state two backends' spaces must agree on.
+
+    Args:
+        periodic (bool): Whether the space is periodic, which decides whether
+            ``first_basis_per_interval`` exists to compare.
+
+    Returns:
+        list[Field]: One field per piece of state, each with the claim that governs
+        it.
+    """
+    fields = [
+        Field("degree", exact_parity(why=_STATE_WHY)),
+        Field("periodic", exact_parity(why=_STATE_WHY)),
+        Field("num_basis", exact_parity(why=_STATE_WHY)),
+        Field("num_intervals", exact_parity(why=_STATE_WHY)),
+        Field("knots", bitwise_parity(why=_KNOT_WHY)),
+        Field("tolerance", bitwise_parity(why=_TOLERANCE_WHY)),
+        Field("domain", bitwise_parity(why=_KNOT_WHY)),
+        Field(
+            "has_left_end_open", exact_parity(why=_STATE_WHY), read=lambda s: s.has_left_end_open()
+        ),
+        Field(
+            "has_right_end_open",
+            exact_parity(why=_STATE_WHY),
+            read=lambda s: s.has_right_end_open(),
+        ),
+        Field("has_open_knots", exact_parity(why=_STATE_WHY), read=lambda s: s.has_open_knots()),
+        Field(
+            "has_Bezier_like_knots",
+            exact_parity(why=_STATE_WHY),
+            read=lambda s: s.has_Bezier_like_knots(),
+        ),
+        Field(
+            "unique_knots",
+            bitwise_parity(why=_KNOT_WHY),
+            read=lambda s: s.get_unique_knots_and_multiplicity()[0],
+        ),
+        Field(
+            "multiplicity",
+            exact_parity(why=_STATE_WHY),
+            read=lambda s: s.get_unique_knots_and_multiplicity()[1],
+        ),
+        Field(
+            "unique_knots_in_domain",
+            bitwise_parity(why=_KNOT_WHY),
+            read=lambda s: s.get_unique_knots_and_multiplicity(in_domain=True)[0],
+        ),
+        Field(
+            "multiplicity_in_domain",
+            exact_parity(why=_STATE_WHY),
+            read=lambda s: s.get_unique_knots_and_multiplicity(in_domain=True)[1],
+        ),
+    ]
+    if not periodic:
+        fields.append(
+            Field(
+                "first_basis_per_interval",
+                exact_parity(why=_STATE_WHY),
+                read=lambda s: s.first_basis_per_interval(),
+            )
+        )
+    return fields
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64], ids=["float32", "float64"])
+@pytest.mark.parametrize("case", _SPACES, ids=[c.label for c in _SPACES])
+def test_the_state_agrees_field_by_field(
+    cpp_backend: None,
+    case: _Case,
+    dtype: npt.DTypeLike,
+) -> None:
+    """Every piece of a space's state agrees between the two backends.
+
+    Field by field rather than by a single equality, so that a failure names the
+    quantity that moved instead of the object that contains it.
+    """
+    python, cpp = _both_backends(case.knots, case.degree, case.periodic, case.snap, dtype)
+    assert_object_parity(
+        py=python, cpp=cpp, fields=_fields(case.periodic), context="BsplineSpace1D"
+    )
+
+
+_REFUSALS: Final = tuple(
+    _Case(*case)
+    for case in (
+        ("negative degree", [0.0, 0.0, 1.0, 1.0], -1, False, True),
+        ("too few knots", [0.0, 0.0, 1.0], 2, False, True),
+        ("descending step", [0.0, 0.0, 1.0, 0.5, 1.0, 1.0], 2, False, True),
+        ("periodic with too few functions", [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, True, True),
+        ("domain swallowed by an interior knot", [0.0, 1.0, 1.0, 1.0, 2.0], 1, False, True),
+        ("short and descending", [1.0, 0.0, 1.0], 2, False, True),
+        ("descending and too few", [0.0, 1.0, 2.0, 3.0, 2.0, 5.0, 6.0], 2, True, True),
+    )
+)
+"""One input per refusal, plus two that fail two checks at once.
+
+The last two are what pin the check *order* across the seam: an input failing two
+checks reports whichever the implementation reaches first, so swapping two
+individually correct checks is invisible without them.
+"""
+
+
+@pytest.mark.parametrize("case", _REFUSALS, ids=[c.label for c in _REFUSALS])
+def test_the_refusals_agree_character_for_character(
+    cpp_backend: None,
+    case: _Case,
+) -> None:
+    """Both backends refuse the same inputs with the same message text.
+
+    The text and not merely the exception type. Every one of these messages is what
+    a caller reads, several interpolate a formatted float, and CPython and glibc
+    render a float differently in more than one way -- notation on round numbers,
+    and the sign of a NaN. A comparison on the type alone would pass through all of
+    that.
+    """
+    arr = np.asarray(case.knots, dtype=np.float64)
+
+    messages = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend), pytest.raises(ValueError) as caught:
+            BsplineSpace1D(arr, case.degree, periodic=case.periodic, snap_knots=case.snap)
+        messages[backend] = str(caught.value)
+
+    assert messages[Backend.PYTHON] == messages[Backend.CPP]
+
+
+def test_the_snapping_refusal_agrees_including_its_formatted_floats(cpp_backend: None) -> None:
+    """The message with four interpolated floats in it, at both storage widths.
+
+    Separate from the table above because it is the one that exercises all three
+    Python format specifiers the port reproduces -- ``repr``, ``.3g`` and ``.0f`` --
+    and because the two widths take different branches for the remedy sentence.
+    """
+    cases = (
+        (np.float32, [1e6, 1e6, 1e6, 1e6 + 0.25, 1e6 + 0.5, 1e6 + 0.75, 1e6 + 1, 1e6 + 1, 1e6 + 1]),
+        (
+            np.float64,
+            [2e14, 2e14, 2e14, 2e14 + 0.25, 2e14 + 0.5, 2e14 + 0.75, 2e14 + 1, 2e14 + 1, 2e14 + 1],
+        ),
+    )
+    for dtype, knots in cases:
+        arr = np.asarray(knots, dtype=dtype)
+        seen = {}
+        for backend in (Backend.PYTHON, Backend.CPP):
+            with use_backend(backend), pytest.raises(ValueError) as caught:
+                BsplineSpace1D(arr, 2)
+            seen[backend] = str(caught.value)
+        assert seen[Backend.PYTHON] == seen[Backend.CPP], f"at {np.dtype(dtype).name}"
+        assert "ulp there" in seen[Backend.CPP]
+
+
+def test_the_infinite_knot_message_agrees(cpp_backend: None) -> None:
+    """The input that made the two messages differ by one character.
+
+    An infinite knot gives an infinite scale, hence an infinite tolerance and a NaN
+    ulp, hence ``tol / ulp == inf / nan``. That NaN came out with its sign bit set,
+    and glibc's ``printf`` renders it ``-nan`` while CPython renders every NaN
+    ``nan``. Kept as its own test with the whole message compared, because the
+    divergence was one character in the middle of three hundred.
+    """
+    infinity = np.float32(np.inf)
+    arr = np.asarray([-infinity, 0.0, 0.0, infinity], dtype=np.float32)
+
+    seen = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend), pytest.raises(ValueError) as caught:
+            BsplineSpace1D(arr, 1)
+        seen[backend] = str(caught.value)
+
+    assert seen[Backend.PYTHON] == seen[Backend.CPP]
+    assert "(nan ulp there)" in seen[Backend.CPP], seen[Backend.CPP]
+    assert "-nan" not in seen[Backend.CPP]
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+@pytest.mark.parametrize("degree", [0, 1, 2, 3, 5])
+@pytest.mark.parametrize("num_intervals", [1, 2, 3, 7, 16])
+def test_the_clamped_uniform_closed_form(
+    cpp_backend: None, backend: Backend, degree: int, num_intervals: int
+) -> None:
+    """A family whose answers are known by hand, checked against the formula.
+
+    The **independent** accuracy check `design/backend_parity.md` requires: nothing
+    here is compared against the oracle, so it would still fail if both backends
+    were wrong together.
+
+    For a knot vector clamped at both ends over ``n`` uniform intervals at degree
+    ``p``, the vector has ``n + 1 + 2p`` knots, so ``num_basis == n + p``; the
+    in-domain knots are the ``n + 1`` breakpoints, so ``num_intervals == n``; every
+    interior knot is simple, so the first supported function advances by one per
+    interval and ``first_basis_per_interval() == range(n)``; and the domain is the
+    requested pair exactly, because the ends are stored values rather than computed
+    ones.
+    """
+    breakpoints = np.linspace(0.0, 1.0, num_intervals + 1)
+    knots = np.concatenate([[0.0] * degree, breakpoints, [1.0] * degree])
+
+    with use_backend(backend):
+        space = BsplineSpace1D(knots, degree)
+
+    assert space.num_basis == num_intervals + degree
+    assert space.num_intervals == num_intervals
+    assert space.first_basis_per_interval().tolist() == list(range(num_intervals))
+    assert float(space.domain[0]) == 0.0
+    assert float(space.domain[1]) == 1.0
+    assert space.has_open_knots()
+    assert space.has_Bezier_like_knots() == (num_intervals == 1)
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+@pytest.mark.parametrize("case", _SPACES, ids=[c.label for c in _SPACES])
+def test_the_algebraic_invariants_hold(
+    cpp_backend: None,
+    backend: Backend,
+    case: _Case,
+) -> None:
+    """Identities that hold for every space, checked without reference to the oracle.
+
+    Three of them, each exact:
+
+    - the multiplicities sum to the knot count, and repeating each representative by
+      its multiplicity rebuilds the stored vector -- which is what makes the knot
+      classes a *partition* rather than a summary;
+    - the in-domain classes number one more than the intervals;
+    - the successive differences of ``first_basis_per_interval`` are the interior
+      multiplicities, which is what ties the per-interval index back to the knot
+      vector it was derived from.
+    """
+    with use_backend(backend):
+        space = BsplineSpace1D(
+            np.asarray(case.knots, dtype=np.float64),
+            case.degree,
+            periodic=case.periodic,
+            snap_knots=case.snap,
+        )
+
+    unique, mult = space.get_unique_knots_and_multiplicity()
+    assert int(np.sum(mult)) == space.knots.size
+
+    rebuilt = np.repeat(unique, mult)
+    if case.snap:
+        # Exact only for a snapped vector, which is the case `_snap_knots` relies
+        # on: it *is* this repeat. Asserting it unconditionally is what an earlier
+        # draft did, and the `snapping off` case refuted it.
+        np.testing.assert_array_equal(rebuilt, space.knots)
+    else:
+        # Unsnapped, the stored vector keeps the near-duplicates the classes
+        # collapsed, so the repeat is the snapped form rather than the stored one.
+        # What still holds is that no knot moved by more than the tolerance.
+        assert np.max(np.abs(rebuilt - space.knots)) <= space.tolerance
+        assert not np.array_equal(rebuilt, space.knots), (
+            "the unsnapped case must really hold a near-duplicate, or this branch "
+            "is asserting nothing"
+        )
+
+    unique_in, _ = space.get_unique_knots_and_multiplicity(in_domain=True)
+    assert unique_in.size == space.num_intervals + 1
+
+    if not case.periodic:
+        first = space.first_basis_per_interval()
+        assert first.size == space.num_intervals
+        _, mult_in = space.get_unique_knots_and_multiplicity(in_domain=True)
+        np.testing.assert_array_equal(np.diff(first), np.asarray(mult_in[1:-1], dtype=np.int64))
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+@pytest.mark.parametrize("case", _SPACES, ids=[c.label for c in _SPACES])
+def test_reduce_round_trips_under_both_backends(
+    cpp_backend: None,
+    backend: Backend,
+    case: _Case,
+) -> None:
+    """A space survives a pickle round trip under the backend that built it.
+
+    The C++ handle is not picklable and must not become part of the wire format, so
+    ``__reduce__`` names the constructor's arguments. What has to come back is the
+    state, bit for bit where it is floating point.
+    """
+    with use_backend(backend):
+        space = BsplineSpace1D(
+            np.asarray(case.knots, dtype=np.float64),
+            case.degree,
+            periodic=case.periodic,
+            snap_knots=case.snap,
+        )
+        restored = pickle.loads(pickle.dumps(space))
+
+        np.testing.assert_array_equal(restored.knots, space.knots)
+        assert restored.degree == space.degree
+        assert restored.periodic == space.periodic
+        assert restored.num_basis == space.num_basis
+        assert restored.num_intervals == space.num_intervals
+        assert restored.tolerance == space.tolerance
+        assert type(restored._impl) is type(space._impl)
+
+
+def test_a_pickle_crosses_the_backends(cpp_backend: None) -> None:
+    """A pickle written under one backend loads under the other, and agrees.
+
+    This is what stops the backend switch from silently becoming a data-format
+    switch: the wire format is the constructor's arguments, so neither side can put
+    a handle or an implementation detail into it.
+    """
+    knots = np.asarray([0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0], dtype=np.float64)
+
+    with use_backend(Backend.PYTHON):
+        blob = pickle.dumps(BsplineSpace1D(knots, 2))
+    with use_backend(Backend.CPP):
+        loaded = pickle.loads(blob)
+        assert loaded.num_basis == 6
+        np.testing.assert_array_equal(loaded.knots, knots)
+
+    with use_backend(Backend.CPP):
+        blob = pickle.dumps(BsplineSpace1D(knots, 2))
+    with use_backend(Backend.PYTHON):
+        loaded = pickle.loads(blob)
+        assert loaded.num_basis == 6
+        np.testing.assert_array_equal(loaded.knots, knots)
+
+
+def _tolerance_drift_sweep(trials: int, seed: int) -> tuple[int, int, float, float]:
+    """Round-trip spaces whose last knot class is a chain, and measure the drift.
+
+    Args:
+        trials (int): How many knot vectors to draw.
+        seed (int): The generator seed, so a failure is reproducible.
+
+    Returns:
+        tuple[int, int, float, float]: The number of spaces built, how many drifted
+        at all, the worst drift as a multiple of the **corrected** bound, and the
+        worst as a multiple of the flat ``8 * eps`` a first version of the note
+        claimed.
+    """
+    rng = np.random.default_rng(seed)
+    built = 0
+    drifted = 0
+    worst_corrected = 0.0
+    worst_flat = 0.0
+
+    for trial in range(trials):
+        dtype = np.float32 if trial % 2 == 0 else np.float64
+        eps = float(np.finfo(dtype).eps)
+        degree = int(rng.integers(1, 4))
+        scale = 10.0 ** rng.integers(-2, 6)
+        breakpoints = np.linspace(0.0, 1.0, int(rng.integers(2, 5)) + 1)
+        knots = (np.concatenate([[0.0] * degree, breakpoints, [1.0] * degree]) * scale).astype(
+            dtype
+        )
+
+        # Chain the tail: several knots each within a tolerance of the previous, so
+        # the final class spans more than one tolerance and the flat bound is wrong.
+        tol = 8.0 * eps * scale
+        tail = [knots[-1]]
+        for _ in range(int(rng.integers(1, 6))):
+            tail.append(dtype(tail[-1] + dtype(tol * rng.uniform(0.3, 0.95))))
+        knots = np.sort(
+            np.ascontiguousarray(
+                np.concatenate([knots[:-1], np.array(tail, dtype=dtype)]), dtype=dtype
+            )
+        )
+
+        try:
+            space = BsplineSpace1D(knots, degree)
+        except ValueError:
+            continue
+        built += 1
+
+        restored = pickle.loads(pickle.dumps(space))
+        relative = abs(restored.tolerance - space.tolerance) / space.tolerance
+        if relative > 0.0:
+            drifted += 1
+        _, mult = space.get_unique_knots_and_multiplicity()
+        span = max(int(mult[-1]) - 1, 1)
+        worst_corrected = max(worst_corrected, relative / (span * 8.0 * eps))
+        worst_flat = max(worst_flat, relative / (8.0 * eps))
+
+    return built, drifted, worst_corrected, worst_flat
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+def test_the_reduce_tolerance_drift_stays_inside_its_bound(
+    cpp_backend: None, backend: Backend
+) -> None:
+    """The one bound this type carries, checked where it is not zero.
+
+    ``__reduce__`` names the constructor's arguments and lets the tolerance be
+    recomputed. Where snapping moved the last knot onto its class's first one the
+    scale moves with it, so the reconstructed tolerance differs. The bound is
+    ``(m - 1) * 8 * eps`` relative, with ``m`` the multiplicity of the last knot
+    class: every step inside a class is at most one tolerance, so a class of ``m``
+    knots spans at most ``m - 1`` of them.
+
+    Three assertions, and the second and third are the ones that make this a check
+    rather than a formality:
+
+    - the bound holds;
+    - the drift is **non-zero** on most cases, so the bound is being compared
+      against something rather than against zero -- the failure mode this milestone
+      has met before;
+    - a flat ``8 * eps``, which a first version of the note claimed, is **exceeded**.
+      That is what the ``m - 1`` buys, and without this assertion nothing would
+      notice it being dropped again.
+    """
+    with use_backend(backend):
+        built, drifted, worst_corrected, worst_flat = _tolerance_drift_sweep(_DRIFT_TRIALS, seed=11)
+
+    assert built > _DRIFT_TRIALS // 4, f"only {built} of {_DRIFT_TRIALS} draws built a space"
+    assert worst_corrected <= 1.0, f"the (m-1)*8*eps bound was exceeded, by {worst_corrected:.2f}x"
+    assert drifted > built // 2, (
+        f"only {drifted} of {built} round trips moved the tolerance at all; a bound "
+        f"compared against zero has not been checked"
+    )
+    assert worst_flat > 1.0, (
+        f"a flat 8*eps bound held over this sweep (worst {worst_flat:.2f}x), so the "
+        f"chaining these cases are built to produce is no longer happening and the "
+        f"m-1 factor is being checked against nothing"
+    )
+
+
+_DRIFT_TRIALS: Final = 2000
+"""Draws in the tolerance-drift sweep.
+
+Sized so the shipped run costs about a second. **Verified at 20000, ten times
+this**, by calling this same function rather than a look-alike: 20000 of 20000
+draws built a space, 20000 of 20000 moved the tolerance, the corrected bound held
+at a worst of **0.716** of it, and the flat ``8 * eps`` was exceeded by **4.403x**.
+Identical to three figures under both backends, which is a parity result in its own
+right -- the drift is a property of the arithmetic and not of the implementation.
+"""

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -2777,16 +2777,62 @@ def test_first_basis_per_interval_is_non_decreasing() -> None:
     np.testing.assert_array_equal(np.diff(first), np.asarray(multiplicities[1:-1]))
 
 
-def test_first_basis_per_interval_cached_and_frozen() -> None:
-    """The same read-only array comes back on every call."""
+def test_first_basis_per_interval_is_a_read_only_view_of_one_buffer() -> None:
+    """Every call views the same read-only storage rather than recomputing it.
+
+    The guarantee used to be stated, and asserted, as ``a is b`` -- the same numpy
+    *object* on every call, which is what ``functools.cached_property`` gives. The
+    port weakens that to the same *memory*: the C++ backend memoizes the buffer and
+    builds a fresh ``nb::ndarray`` view over it per access, so the object differs
+    and nothing is recomputed or copied.
+
+    The weaker form is the one worth pinning, because it is the one that carries
+    the cost argument. ``design/bspline_derived_caches.md`` rejects memoizing the
+    presentation as well as the value, for a concrete reason: two memos over one
+    buffer are correct only until something rebuilds the buffer, and then the
+    wrapper serves views into freed storage. One ``ndarray`` construction per
+    access is about 200 ns, the same order as the Python call that asked for it.
+
+    ``shares_memory`` is what distinguishes a view from a copy, and it holds under
+    both backends -- trivially under the oracle, which really does return one
+    object.
+    """
     space = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
 
     first = space.first_basis_per_interval()
+    again = space.first_basis_per_interval()
 
-    assert first is space.first_basis_per_interval()
+    assert np.shares_memory(first, again)
+    np.testing.assert_array_equal(first, again)
     assert not first.flags.writeable
     with pytest.raises(ValueError):
         first[0] = 7
+
+
+def test_derived_arrays_are_views_rather_than_copies() -> None:
+    """The knots and the knot classes are views of the space's own storage too.
+
+    Same contract as ``first_basis_per_interval`` above and the same reason: a
+    property that copied would make the natural spelling of a loop over intervals
+    quadratic in nothing.
+    """
+    space = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+
+    assert np.shares_memory(space.knots, space.knots)
+    assert not space.knots.flags.writeable
+
+    unique, mult = space.get_unique_knots_and_multiplicity()
+    again_unique, again_mult = space.get_unique_knots_and_multiplicity()
+    assert np.shares_memory(unique, again_unique)
+    assert np.shares_memory(mult, again_mult)
+    assert not unique.flags.writeable
+    assert not mult.flags.writeable
+
+    # That the in-domain form is a *subrange of the same buffer* is true of the C++
+    # implementation and not of the oracle, which runs a second scan for it. It is
+    # therefore a binding claim rather than a cross-backend contract, and it is
+    # asserted in `tests/parity/test_bspline_binding_contract.py` under the fixture
+    # that makes a missing extension a failure instead of a silent skip.
 
 
 def test_first_basis_per_interval_rejects_periodic() -> None:

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -2790,8 +2790,9 @@ def test_first_basis_per_interval_is_a_read_only_view_of_one_buffer() -> None:
     the cost argument. ``design/bspline_derived_caches.md`` rejects memoizing the
     presentation as well as the value, for a concrete reason: two memos over one
     buffer are correct only until something rebuilds the buffer, and then the
-    wrapper serves views into freed storage. One ``ndarray`` construction per
-    access is about 200 ns, the same order as the Python call that asked for it.
+    wrapper serves views into freed storage. That is a correctness argument and
+    does not depend on what a view costs, which is just as well: the note's
+    accompanying cost figure was measured too low and is corrected there.
 
     ``shares_memory`` is what distinguishes a view from a copy, and it holds under
     both backends -- trivially under the oracle, which really does return one


### PR DESCRIPTION
## What this is

Slice 3 of 4 for #396. The C++ `BsplineSpace1D` from #428 is now **bound and
wrapped**: `pantr.bspline.BsplineSpace1D` becomes a wrapper over an implementation
chosen per process and per dtype, and the Python class it used to be becomes
`_BsplineSpace1DPython`, the oracle.

Only the *state and what it determines* moved. The operations -- basis tabulation,
the three extraction families, knot insertion, subdivision, restriction -- are
unchanged, still run on numba kernels, and now live on the wrapper. That mixed
dispatch is the temporary seam the ticket names; slice 4 and the cleanup ticket
remove it.

| file | what |
|---|---|
| `cpp/bindings/bspline_types.cpp` | `BsplineSpace1D32` / `BsplineSpace1D64` |
| `src/pantr/bspline/_bspline_space_1d.py` | wrapper + oracle + dispatch |
| `src/pantr/_pantr_cpp/_bspline.pyi` | the stub, plus one import line |
| `tests/parity/test_bspline_space_1d.py` | state, refusals, pickle, the independent check, the bound |
| `tests/parity/test_bspline_binding_contract.py` | what the *binding* guarantees |

## Two registrations, and `.noconvert()` as a check

`bezier_type.cpp`'s pattern, for its reason: the storage format is part of the
value, `dtype` is public, and the class of the handle is the only thing left to
carry it. Without `.noconvert()` nanobind casts silently, and widening a `float32`
knot vector into the 64-bit class **multiplies the space's tolerance by about four
orders**, because it is `8 * eps(T) * scale`. Narrowing moves the knots instead.
The refusal is what makes `_impl_class` picking the wrong class loud.

## The check order is duplicated on purpose

The wrapper checks `degree < 0` before it normalizes the knots, and so does each
implementation. The oracle has always refused a negative degree *before* looking at
the knots, so a call with both a bad degree and a bad knot type has always reported
the degree; normalizing first would silently reverse that, and the seam the two
checks now sit either side of did not exist when the order was chosen. The
type-kind checks moved to the wrapper because they raise `TypeError` and
`pantr/core/error.hpp` records that nanobind has no path producing one.

## One documented contract weakens, and the downstream census should see it

`first_basis_per_interval` promised **"repeated calls return the same array"** --
the same numpy *object*, which is what `cached_property` gives. Under C++ the
buffer is memoized and a fresh view is built per access, so the object differs
while the memory does not. `design/bspline_derived_caches.md` rejects memoizing the
presentation as well as the value, because two memos over one buffer are correct
only until something rebuilds it and then the wrapper serves views into freed
storage.

The tests now pin the guarantee that survives -- `shares_memory`, read-only, equal
-- which is the one carrying the cost argument. **A consumer keying on `id()` would
see the two backends differ.** Nothing else in the public surface changes: no
signature, no name, no return shape.

## The three items owed from #428's review

Its reviewer was briefed with checks that describe *this* slice. They are here.

### The `cpp_backend` double-skip, measured

Five tests were parametrized over both backends **and** took the `cpp_backend`
fixture, so **both** halves skipped when the extension is absent -- the
configuration `tests/parity/conftest.py` itself calls the common local one. That
silently dropped the Python half of the closed-form check and the algebraic
invariants, which are the only things in the file that would catch the **oracle**
regressing.

Marking the parameter is what one would want, and pytest forbids it outright
(`pytest.param cannot add pytest.mark.usefixtures`), so the guard is an explicit
call in the test body. **Measured with `src/pantr/*.so` moved aside: 52 tests now
run, and 91 skip, where previously every one of the 143 skipped.**

### The `(m - 1) * 8 * eps` drift bound, derived and measured

`__reduce__` names the constructor's arguments and lets the tolerance be
recomputed, so where snapping moved the last knot the reconstruction differs.

**The derivation.** Snapping replaces each knot class by its *first* knot, so the
first knot of the vector never moves and only the last one does; every step inside
a class is at most one tolerance, so the last knot moves by at most `(m - 1) * tol`
for a final class of multiplicity `m`. The scale is a maximum over three arguments
and so is 1-Lipschitz in each, hence moves by no more than that; the tolerance is a
fixed multiple of the scale. Recomputing the scale and the tolerance adds a further
relative `eps` or so, which the margin absorbs.

**A first version claimed a flat `8 * eps`**, reasoning that the scale moves by at
most one tolerance. That ignores chaining, and a sweep built to chain the final
class **exceeded it by 4.4x**.

**Measured on the shipped function, seven seeds, 20000 draws each:**

| seed | 11 | 101 | 202 | 303 | 404 | 505 | 606 |
|---|---|---|---|---|---|---|---|
| worst / `(m-1)·8·eps` | 0.716 | 0.755 | 0.729 | 0.734 | 0.732 | 0.734 | 0.733 |
| worst / flat `8·eps` | 4.403 | 4.531 | 4.480 | 4.403 | 4.400 | 4.403 | 4.608 |

**0.716 to 0.755 of the bound across 140000 draws**, stable and not near 1; every
draw drifted, so nothing is being compared against zero. The test asserts all three
-- the bound holds, the drift is non-zero, and the flat form is *still* exceeded --
so dropping the `m - 1` again cannot go unnoticed. The shipped sweep is a tenth of
that and costs about a second.

### The two documentation defects

- **The wrapper's `first_basis_per_interval` still promised the same array object.**
  The tests and the commit message were updated when that contract weakened and the
  docstring was not, leaving a **false claim in the public contract**.
- **`bspline_types.cpp` carried a case count** ("checked over 2850 accepted cases")
  in a comment, which rots while reading as verified.

## The `LazySlot` sanitizer claim, corrected

`test_lazy.cpp` argued the wrong reason for its own result. It said a single-slot
concurrency test misses a `relaxed` downgrade because its lock-free fast path is
barely reached. **That was refuted by an instrumented counter**: the fast path was
reached 22 to 175 times per run while detecting nothing, and the thread count is
not the axis either.

What decides it is whether the test **reads the memoised value's contents inside
the threaded section, before any `join()`**. This one sums every element of every
slot it touches, in the worker. The measurement that prompted the rewrite -- roughly
one run in three on the old shape -- was real; the reason given for it was not, and
the comment now records both because both were believed. The claim it makes is
correspondingly narrow and is about the harness rather than the sanitizer: **the
acquire/release pair in `lazy.hpp` is falsifiable by this test**, caught on 15 runs
of 15.

## The independent accuracy check

`design/backend_parity.md` requires more than agreement with the oracle. The check
here is a **closed form for a family**, compared against hand arithmetic and not
against the oracle: for a knot vector clamped at both ends over `n` uniform
intervals at degree `p`, `num_basis == n + p`, `num_intervals == n`,
`first_basis_per_interval() == range(n)`, and the domain is the requested pair
exactly. Checked over the whole `(n, p)` grid under either backend, so it would
still fail if both backends were wrong together.

Two algebraic identities join it: the multiplicities partition the knot vector, and
the successive differences of the per-interval index are the interior
multiplicities. **Both overstated themselves first and the tests refuted them** --
`repeat(unique, mult) == knots` is exact only for a *snapped* vector, and the
offset case had to move away from a quarter-unit mesh at 1e6, which is not a space
at `float32` at all but the vector the snapping refusal is tested on.

## What the locate note cost, and what it costs now

`_bspline_locate._cell_bounds` calls `get_unique_knots_and_multiplicity` once per
axis per Newton-refine round. Best of 7 over 3000 calls, 263 knots:

| | trunk before this front | this branch, Python | this branch, C++ |
|---|---|---|---|
| per call | 2437 ns | **127 ns** | **1075 ns** |

It dissolves under both backends. The C++ path is **8.5x the Python one**, and the
cost is attributable: a scalar property through the binding is 80 ns, and **each
`nb::ndarray` construction is about 460 ns**. `design/bspline_derived_caches.md`
estimates that at "about 200 ns", so **its figure is understated by roughly 2.3x**
-- recorded here rather than silently absorbed. It does not change the decision;
memoizing the presentation is what the note forbids. The accessor looks free and is
not, so the wrapper now tells callers to hoist it in a loop, as `lazy.hpp` already
does on the C++ side.

## Verification

| check | result |
|---|---|
| `pytest -n 4`, `PANTR_BACKEND=python` | **8575 passed**, 44 skipped, 7 xfailed |
| `pytest -n 4`, `PANTR_BACKEND=cpp` | **8572 passed**, 47 skipped, 7 xfailed |
| `mypy` | no issues in 304 source files |
| `ruff check` / `ruff format --check` | clean, whole repo |
| `lint-imports` | 2 contracts kept, 0 broken |
| `make doctest` | 82 passed, 7 skipped |
| `pytest tests/parity/` | 2305 passed, 26 skipped, 5 xfailed |
| `bash scripts/ci_local.sh` | **52 PASS, 2 FAIL, 0 SKIP** -- the two are the `g++-10` floor legs (#376), with `clang++-10` green on the same tree and the `gcc-tsan` legs passing |

**Extension rebuilt after the rebase and the surface confirmed by import**, not by
exit code: `BsplineSpace1D32` and `BsplineSpace1D64` are both present and answer.

**Extension-skip checked.** With `src/pantr/*.so` moved aside these two files give
**52 passed, 91 skipped**, against 143 passed with it: every test that depends on
the extension SKIPs rather than passes, so none is comparing the oracle with
itself, while the backend-independent ones still run.

### Mutations: eight applied to the binding and the C++, all caught

| mutation | caught by |
|---|---|
| an owned copy handed out instead of a view | 3 contract tests |
| `const` dropped from the array scalar | the read-only test |
| `.noconvert()` dropped | 2 tests |
| the owner argument dropped | **does not compile** -- `-Werror` catches `self` going unused |
| the left-end formula mirrored onto the right end | the new `asymmetric ends` case, both dtypes |
| `LazySlot`'s atomics forced to `relaxed` | `test_lazy` under TSan, 15 of 15 runs |
| the NaN-sign interception removed | 2 tests |
| the tolerance factor, the merge predicate, the clamping boundary, the stored basis count, the first-basis window, the scale's coordinate magnitudes | the C++ suite, from #428 |

## Self-review round

Two reviewers, one over the binding and wrapper and one over the tests. Everything
below is fixed in `7d69fa9` and `44f6c78`, and every `C` and `I` is itemized.

- **C — every parity case was symmetric in its two ends.** Demonstrated: mirroring
  the left-end formula onto the right end gave **zero** mismatches across all ten
  cases at both dtypes. Fixed by an `asymmetric ends` case; the same mutation now
  fails exactly there.
- **C — the `cpp_backend` double-skip.** Above.
- **C — `first_basis_per_interval`'s periodic raise had no parity test.** It is the
  one raise that is not a construction refusal, and the field-by-field comparison
  structurally cannot reach it, since the field is dropped for a periodic space.
- **I — the `negative degree` refusal case was vacuous.** The wrapper raises before
  either implementation is chosen, so both parametrizations ran the same line.
  Replaced by a test of what it actually pins.
- **I — no case reached an interior knot at the maximum multiplicity `degree + 1`**,
  where the space becomes discontinuous and the per-interval index advances by
  three instead of one.
- **R ×2, S ×3, N ×1** — the near-tautological interval-count identity (kept, and
  labelled), a redundant backend parametrization, `_wrap` deleted as dead code (it
  returns in slice 4 with its first caller), and the two documentation defects
  above.
- **U resolved** — the drift bound's derivation, written out, plus the seven-seed
  margin.
- **U carried** — `THREADS_PREFER_PTHREAD_FLAG` matters only on a platform no CI
  runner uses.

## The downstream-consumer check this slice owes

`pantr.bspline` is that repository's largest exposure. **Nothing public changes
its signature, name or return shape.** Two things do change and want the census:

1. **`first_basis_per_interval` no longer returns the same object on repeated
   calls** under the C++ backend (same memory, fresh view). A consumer keying on
   `id()` or `is` would see it.
2. **`BsplineSpace1D` gains `__slots__`** and so has no `__dict__`. A consumer
   attaching an attribute to a space would now get `AttributeError`. It was
   documented immutable already.

The private names this slice reshapes -- `_knots`, `_degree`, `_tol`, `_periodic`
-- moved from `BsplineSpace1D` to `_BsplineSpace1DPython`. In this tree every one
of them is read only inside the module that defines them; outside it is not
checkable from here.

## Two spellings of one memo, recorded rather than acted on

`#428` put `cpp/include/pantr/core/lazy.hpp` on the trunk and `#429` carries
`cpp/include/pantr/core/lazy_memo.hpp` doing the same job. **I have not read the
sibling** -- it is not on this branch -- so this is what I can say about mine, not a
comparison, and certainly not a claim that mine should win.

Three properties of `LazySlot<T>` I would want preserved by whichever survives,
because each was a deliberate decision with a failure behind it:

1. **Assignment clears the target.** Copy and move start cold, which is easy; the
   one that matters is `operator=`. The memo describes its owner's state, and
   assignment is precisely what replaces that state underneath it. A slot that
   carried its value across an assignment would be a memo of something no longer
   there, and **no value test on the owner would show it**. `check_copies_start_cold`
   pins it. This is the first thing I would check the sibling for.
2. **The builder is a callable supplied at the call site**, so the slot never learns
   how to build its own value. That is what lets `BsplineSpace1D` fill its block from
   its own frozen state while the slot knows nothing about knots -- and what makes
   one type serve the five owners `design/bspline_derived_caches.md` names.
3. **A throwing builder leaves the slot cold**, so the next caller retries rather
   than reading a half-built value. Also pinned.

On the **test** shape I claim nothing myself: the verifier that settled the TSan
dispute used this file's 64-slot two-wave case as its model, and found the reason is
that it reads the memoised value's *contents inside the threaded section, before any
`join()`*. That property is worth carrying over to whichever memo survives,
independently of which interface does.

## Slice 4

`BsplineSpace`: the aggregate, the `shared_ptr<const BsplineSpace1D>` held accessor
and the seeding rule from `design/bspline_ownership_lifetime.md`, plus
`BsplineSpaceRestriction`. **Not started** -- the review queue is the bottleneck.

Advances #396. `Closes` is deliberately absent: this bases on `proto/cpp`, where it
would not fire.
