### PR TITLE
feat(bspline): own the tensor-product BsplineSpace in C++ and wrap it from Python

### DIFF
--- a/cpp/bindings/bspline_types.cpp
+++ b/cpp/bindings/bspline_types.cpp
@@ -1,7 +1,8 @@
 /// \file
-/// nanobind bindings for `pantr::bspline::BsplineSpace1D`.
+/// nanobind bindings for `pantr::bspline::BsplineSpace1D` and the tensor-product
+/// `pantr::bspline::BsplineSpace` built over it.
 ///
-/// ## Two registrations, because the storage format is part of the value
+/// ## Two registrations per type, because the storage format is part of the value
 ///
 /// `pantr.bspline.BsplineSpace1D` stores whatever float dtype it is handed, its
 /// `dtype` property is public, and `float32` knot vectors are exercised across the
@@ -10,6 +11,12 @@
 /// class of the handle *is* the dtype, because a single name would have nothing
 /// left to carry it. `pantr.bspline._bspline_space_1d._impl_class` picks between
 /// them per instance.
+///
+/// The nD type inherits that split, with a second reason on top of the first:
+/// `BsplineSpace<T>` can hold only `BsplineSpace1D<T>`, so the width is already a
+/// property of the C++ type and one Python name could not front both.
+/// `BsplineSpace32` and `BsplineSpace64` are the two, and
+/// `pantr.bspline._bspline_space_nd._impl_class` picks between them.
 ///
 /// The dtype is not converted, and that *is* a check. Without `.noconvert()`
 /// nanobind silently casts, so `BsplineSpace1D32(a_float64_vector)` would narrow a
@@ -43,30 +50,68 @@
 /// property that copied would make the natural spelling of every such loop
 /// quadratic in nothing.
 ///
-/// **None of these arrays can be empty**, so the null-`data()` trap that
-/// `grid_types.cpp` guards against with a stand-in address does not arise here: a
-/// knot vector has at least `2 * degree + 2` entries, a vector has at least one
-/// knot class, the constructor refuses a space with no interval so the in-domain
-/// range has at least two classes, and `first_basis_per_interval` has exactly
-/// `num_intervals` entries, which `cpp/tests/test_bspline_space_1d.cpp` asserts so
-/// that it stays true.
+/// **No array a 1D space hands out can be empty**, and that was once the whole of
+/// this paragraph: a knot vector has at least `2 * degree + 2` entries, a vector has
+/// at least one knot class, the constructor refuses a space with no interval so the
+/// in-domain range has at least two classes, and `first_basis_per_interval` has
+/// exactly `num_intervals` entries, which `cpp/tests/test_bspline_space_1d.cpp`
+/// asserts so that it stays true.
 ///
-/// ## `_ref` accessors are not bound, and there are none to bind
+/// **The nD type breaks that, so the guard is here after all.** A dimensionless
+/// `BsplineSpace` is legal -- the oracle admits `BsplineSpace([])`, and
+/// `tests/test_bspline_space.py::test_empty_spaces_list` pins it -- and its domain
+/// block has no rows. An empty `std::vector`'s `data()` may be null, and nanobind
+/// reads a null pointer as "no array" rather than as an empty one, so `view_of`
+/// substitutes a never-dereferenced stand-in address exactly as
+/// `grid_types.cpp:96-104` does.
+///
+/// ## `_ref` accessors are not bound
 ///
 /// `design/bspline_ownership_lifetime.md` requires that no borrowing accessor
 /// reaches Python. `BsplineSpace1D` grew none -- it hands out spans of its own
-/// storage rather than references to nested objects -- so the rule is satisfied
-/// vacuously here. `tests/parity/test_bspline_binding_contract.py` asserts it over
-/// the bound surface anyway, because the next type in this front will have one.
+/// storage rather than references to nested objects. `BsplineSpace` is the first
+/// type in this front that *has* one: `space_ref(d)` borrows a direction, costs a
+/// measured 5.83 ns against `space(d)`'s 14.92 ns, and is deliberately absent from
+/// the surface below. `tests/parity/test_bspline_binding_contract.py` asserts over
+/// the bound surface that no method name ends in `_ref`, which is the only available
+/// check: there is no `static_assert` for absence.
+///
+/// ## Handing out a direction: a `shared_ptr`, and no policy
+///
+/// `spaces` is `design/bspline_ownership_lifetime.md`'s class **H** -- an accessor
+/// handing out a subobject the owner keeps -- so the C++ type stores
+/// `std::shared_ptr<const BsplineSpace1D<T>>` and the binding returns a copy of the
+/// handle. No `rv_policy` question arises, because ownership travels in the return
+/// value rather than in an annotation. Three consequences worth stating, all of them
+/// measured in that note and each the failure of an alternative:
+///
+///  - The returned Python object is **identity-stable**: `nb_type_put` looks the
+///    pointer up in `inst_c2p` before creating an instance, so
+///    `nd.spaces[0] is one_d` holds for the handle a caller passed in. That is what
+///    makes `tests/test_bspline_space.py:89` reachable, and it is why the C++
+///    constructor shares rather than copies.
+///  - `sys.getrefcount` on the nD handle is **unchanged** by the access, because no
+///    keep-alive is installed. A non-zero delta means somebody reverted to
+///    `reference_internal`, and the contract test asserts the zero.
+///  - The direction **outlives its owner**. Passing a handle in takes a reference on
+///    its Python object (`nanobind/stl/shared_ptr.h`'s `py_deleter`), so the nD space
+///    keeps its directions alive, and a direction taken back out keeps its own value
+///    alive after the nD space is dropped.
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/vector.h>
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <span>
+#include <utility>
+#include <vector>
 
 #include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/space_nd.hpp"
 #include "register.hpp"
 
 namespace nb = nanobind;
@@ -77,14 +122,40 @@ namespace {
 template <class T>
 using const_vec = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
 
+/// A never-dereferenced address for a zero-length array.
+///
+/// An empty `std::vector`'s `data()` may be null, and nanobind reads a null pointer
+/// as "no array" rather than as an empty one. A dimensionless nD space has an empty
+/// domain block, which is legal, so a valid address stands in.
+/// `grid_types.cpp:96-104` carries the same sentinel for the same reason.
+///
+/// \tparam T The element type.
+template <class T>
+T kEmptyStorage{};
+
 /// Hand out a span of the owner's storage as a read-only numpy view.
 ///
 /// \param self The Python object that owns the storage, kept alive by the array.
-/// \param data The span; must not be empty, see the file comment.
+/// \param data The span; may be empty only for the nD domain block, see the file
+///        comment.
 /// \return A read-only 1D `numpy` array viewing `data`.
 template <class T>
 nb::object view_of(nb::handle self, std::span<const T> data) {
     return nb::cast(nb::ndarray<nb::numpy, const T, nb::ndim<1>>(data.data(), {data.size()}, self));
+}
+
+/// Hand out a span of the owner's storage as a read-only `(rows, cols)` numpy view.
+///
+/// \param self The Python object that owns the storage, kept alive by the array.
+/// \param data The span, row-major; its size must be `rows * cols`. May be empty.
+/// \param rows The row count.
+/// \param cols The column count.
+/// \return A read-only 2D `numpy` array viewing `data`.
+template <class T>
+nb::object view_2d_of(nb::handle self, std::span<const T> data, std::size_t rows,
+                      std::size_t cols) {
+    const T* base = data.empty() ? &kEmptyStorage<T> : data.data();
+    return nb::cast(nb::ndarray<nb::numpy, const T, nb::ndim<2>>(base, {rows, cols}, self));
 }
 
 /// Register one scalar type's `BsplineSpace1D`.
@@ -151,9 +222,89 @@ void bind_space_1d(nb::module_& m, const char* name) {
         .def("has_Bezier_like_knots", &Space::has_bezier_like_knots);
 }
 
+/// Hand out a span of counts as a tuple of Python integers.
+///
+/// A tuple rather than an array, because the oracle's `degrees`, `num_basis` and
+/// `num_intervals` are tuples and the suite compares them with `==` against one:
+/// `space.num_basis == (3, 2)` on an array is elementwise and then has no truth
+/// value. A tuple rather than a list, because the oracle's are tuples and
+/// `tests/test_bspline_space.py` asserts `isinstance(..., tuple)`.
+///
+/// This is the one place the nD binding copies rather than views, and it is a
+/// presentation rather than a copy of state: `dim` is at most 3 everywhere in the
+/// tree, so three `PyLong`s per access is not a shape change.
+///
+/// \param counts The per-direction counts.
+/// \return A tuple of `counts.size()` integers.
+nb::tuple counts_tuple(std::span<const std::int64_t> counts) {
+    nb::list values;
+    for (const std::int64_t count : counts) {
+        values.append(count);
+    }
+    return nb::tuple(values);
+}
+
+/// Register one scalar type's tensor-product `BsplineSpace`.
+///
+/// \param m The extension module.
+/// \param name The Python-visible class name, `BsplineSpace32` or `BsplineSpace64`.
+template <class T>
+void bind_space_nd(nb::module_& m, const char* name) {
+    using Space = pantr::bspline::BsplineSpace<T>;
+    using Space1D = pantr::bspline::BsplineSpace1D<T>;
+    using Handles = std::vector<std::shared_ptr<const Space1D>>;
+
+    nb::class_<Space>(m, name)
+        // Takes the directions as handles, which is what makes the C++ space SHARE
+        // them; see the file comment. There is no dtype check to make here and none
+        // to write: each `BsplineSpace1D<T>` class is distinct, so a `float32`
+        // direction handed to `BsplineSpace64` is a `TypeError` from nanobind rather
+        // than a silent widening -- and the oracle's own `ValueError` about mixed
+        // dtypes is the wrapper's, which is where a type-kind check belongs.
+        .def(
+            "__init__",
+            [](Space* self, Handles spaces) { new (self) Space(std::move(spaces)); },
+            nb::arg("spaces"))
+        .def_prop_ro("dim", [](const Space& s) { return s.dim(); })
+        // Class H. No policy: the value is a `shared_ptr`, so ownership travels in
+        // the return value. A tuple, matching the oracle's `spaces`.
+        .def_prop_ro("spaces",
+                     [](const Space& s) {
+                         nb::list handles;
+                         for (const auto& one_d : s.spaces()) {
+                             handles.append(nb::cast(one_d));
+                         }
+                         return nb::tuple(handles);
+                     })
+        .def_prop_ro("degrees", [](const Space& s) { return counts_tuple(s.degrees()); })
+        .def_prop_ro("tolerance", &Space::tolerance)
+        .def_prop_ro("num_basis", [](const Space& s) { return counts_tuple(s.num_basis()); })
+        .def_prop_ro("num_total_basis", [](const Space& s) { return s.num_total_basis(); })
+        .def_prop_ro("num_intervals",
+                     [](const Space& s) { return counts_tuple(s.num_intervals()); })
+        .def_prop_ro("num_total_intervals",
+                     [](const Space& s) { return s.num_total_intervals(); })
+        // Class A: a read-only `(dim, 2)` view of the space's own storage, with the
+        // space as the array's owner. `const T` is what sets the read-only flag and
+        // `self` is what keeps the storage alive. That the oracle's counterpart is a
+        // writable cached array is the defect recorded in
+        // `design/bspline_derived_caches.md`; the wrapper is what reconciles the two,
+        // by copying on the way out under both backends.
+        .def_prop_ro("domain",
+                     [](nb::handle self) {
+                         const Space& s = nb::cast<const Space&>(self);
+                         return view_2d_of<T>(self, s.domain_flat(),
+                                              static_cast<std::size_t>(s.dim()), 2);
+                     })
+        // Spelled the oracle's way, as the 1D twin above is.
+        .def("has_Bezier_like_knots", &Space::has_bezier_like_knots);
+}
+
 }  // namespace
 
 void register_bspline_types(nb::module_& m) {
     bind_space_1d<float>(m, "BsplineSpace1D32");
     bind_space_1d<double>(m, "BsplineSpace1D64");
+    bind_space_nd<float>(m, "BsplineSpace32");
+    bind_space_nd<double>(m, "BsplineSpace64");
 }

--- a/cpp/bindings/bspline_types.cpp
+++ b/cpp/bindings/bspline_types.cpp
@@ -70,11 +70,12 @@
 /// `design/bspline_ownership_lifetime.md` requires that no borrowing accessor
 /// reaches Python. `BsplineSpace1D` grew none -- it hands out spans of its own
 /// storage rather than references to nested objects. `BsplineSpace` is the first
-/// type in this front that *has* one: `space_ref(d)` borrows a direction, costs a
-/// measured 5.83 ns against `space(d)`'s 14.92 ns, and is deliberately absent from
-/// the surface below. `tests/parity/test_bspline_binding_contract.py` asserts over
-/// the bound surface that no method name ends in `_ref`, which is the only available
-/// check: there is no `static_assert` for absence.
+/// type in this front that *has* one: `space_ref(d)` borrows a direction rather than
+/// copying its handle, which is what saves the atomic pair inside a C++ loop, and it
+/// is deliberately absent from the surface below.
+/// `tests/parity/test_bspline_binding_contract.py` asserts over the bound surface
+/// that no method name ends in `_ref`, which is the only available check: there is no
+/// `static_assert` for absence.
 ///
 /// ## Handing out a direction: a `shared_ptr`, and no policy
 ///

--- a/cpp/include/pantr/bspline/space_nd.hpp
+++ b/cpp/include/pantr/bspline/space_nd.hpp
@@ -37,10 +37,12 @@
 /// Sharing is safe because a `BsplineSpace1D` is immutable after construction. A
 /// `shared_ptr<const T>` over an immutable `T` is a value with a cheap copy.
 ///
-/// The borrowing twin, `space_ref`, is **not bound**: an inner loop must not pay an
-/// atomic pair per access, and the ownership note measures the pair at 9.1 ns
-/// against a 5.83 ns borrow. `tests/parity/test_bspline_binding_contract.py`
-/// asserts that no bound method name ends in `_ref`.
+/// The borrowing twin, `space_ref`, is **not bound**: copying the handle costs an
+/// uncontended atomic increment/decrement pair per access, which an inner loop must
+/// not pay for a value it does not keep. `design/bspline_ownership_lifetime.md`
+/// carries the measurement and the machine it was taken on.
+/// `tests/parity/test_bspline_binding_contract.py` asserts that no bound method name
+/// ends in `_ref`.
 ///
 /// ## No memo, and that is a decision rather than an omission
 ///
@@ -67,34 +69,39 @@
 ///
 /// ## Parity notes for the Python oracle
 ///
-/// `pantr.bspline.BsplineSpace` is the oracle. What this type reproduces, and the
-/// three places it deliberately differs:
+/// `pantr.bspline.BsplineSpace` is the oracle. Three things this type reproduces, and
+/// **one** place it deliberately differs:
 ///
 ///  - **Every reduction is over the directions in axis order**, and the order is
 ///    load-bearing rather than incidental: `degrees`, `num_basis`, `num_intervals`
 ///    and `domain` are per-direction sequences, and nothing about their *values*
 ///    would reveal a transposition on a space whose directions happen to agree.
-///    `tests/parity/test_bspline_space_nd.py` therefore makes every multi-direction
-///    case asymmetric in every one of them.
+///    `tests/parity/test_bspline_space_nd.py` therefore keeps its case table
+///    asymmetric in each of them, and asserts of the table that it does.
 ///  - **A dimensionless space is constructible**, with `dim() == 0`. The oracle
 ///    admits `BsplineSpace([])` -- pinned by
 ///    `tests/test_bspline_space.py::test_empty_spaces_list` -- so this does too. The
 ///    empty products are 1, which is the empty tensor product's own convention and
 ///    what `numpy.prod(())` returns.
-///  - **`tolerance()` refuses a dimensionless space**, where the oracle raises
-///    whatever `max()` over an empty sequence raises. Both are a `ValueError` to a
-///    Python caller and the *messages* differ, deliberately: the oracle's text is
-///    CPython's own and moved between 3.11 and 3.12, so reproducing it character for
-///    character would break parity on one leg of the matrix. This is the one refusal
-///    in the type whose message is not the oracle's, and the parity test compares
-///    the exception type rather than the text for it.
-///  - **The two products refuse an overflow instead of wrapping.** `numpy.prod` over
-///    an `int64` tuple wraps silently; signed overflow in C++ is undefined, so the
-///    UBSan leg would abort rather than wrap. Neither is a good answer, and the
-///    input is reachable: three directions of 2.1e6 basis functions each need about
-///    50 MB of knots and overflow `int64`. So the products throw
-///    `pantr::CapacityError`, which `pantr/core/error.hpp` reserves for a limit of
-///    the implementation rather than a defect in the argument.
+///  - **`tolerance()` refuses a dimensionless space with the oracle's own message**,
+///    character for character, as every other refusal in this port does. That is
+///    worth a sentence because the oracle's message was *made* deliberate for it:
+///    left to `max()` over an empty sequence it would have been CPython's own text,
+///    which moved between 3.11 and 3.12, so reproducing it here would have broken
+///    parity on one leg of the test matrix and held on the others.
+///    `src/pantr/bspline/_bspline_space_nd.py` states the same string and says why,
+///    and `tests/parity/test_bspline_space_nd.py` compares the two texts rather than
+///    just the exception type.
+///  - **The one difference: the two products refuse an overflow instead of
+///    wrapping.** `numpy.prod` over an `int64` tuple wraps silently; signed overflow
+///    in C++ is undefined, so the UBSan leg would abort rather than wrap. Neither is
+///    a good answer, and the input is reachable: three directions of 2.1e6 basis
+///    functions each need about 50 MB of knots and overflow `int64`. So the products
+///    throw `pantr::CapacityError`, which `pantr/core/error.hpp` reserves for a limit
+///    of the implementation rather than a defect in the argument. The oracle uses
+///    `math.prod` rather than `numpy.prod` and so returns the exact integer instead,
+///    which is where the two part company -- above the `int64` range, and nowhere
+///    below it.
 ///
 /// ## Thread safety
 ///
@@ -133,7 +140,16 @@ namespace detail {
 ///
 /// The empty product is 1, matching `numpy.prod(())`.
 ///
-/// \param counts The per-direction counts; each must be non-negative.
+/// **Non-negative counts are a trusted precondition, not a checked one**, which is
+/// the one place this header departs from its own "validate rather than assert"
+/// rule -- and it departs deliberately, because the precondition is not a caller's
+/// to violate. Both call sites pass a `BsplineSpace1D`'s `num_basis` or
+/// `num_intervals`, and that type's constructor refuses a space with neither, so a
+/// negative count is unreachable rather than merely unlikely. A check here would
+/// need a message describing a state the type cannot be in.
+///
+/// \param counts The per-direction counts; each must be non-negative, which every
+///        call site guarantees.
 /// \param what The quantity being formed, for the message.
 /// \return The product.
 /// \throws pantr::CapacityError If the product exceeds `std::int64_t`.

--- a/cpp/include/pantr/bspline/space_nd.hpp
+++ b/cpp/include/pantr/bspline/space_nd.hpp
@@ -1,0 +1,401 @@
+#pragma once
+
+/// \file
+/// The tensor-product B-spline space: one `BsplineSpace1D` per direction, and the
+/// quantities the collection fixes.
+///
+/// ## What this type owns, and what it does not
+///
+/// It owns the *value* -- the univariate spaces, in axis order -- plus every
+/// quantity that is a reduction over them: the per-direction degrees, basis counts
+/// and interval counts, their two products, the parametric tolerance, the
+/// per-direction domain, and whether every direction is a single Bézier segment.
+///
+/// It owns no *operations*, exactly as `pantr/bspline/space_1d.hpp` owns none.
+/// Basis tabulation, the per-cell control-point support, the boundary slab and the
+/// windowed restriction are computations *over* a space rather than properties
+/// *of* one, so they are separate ports over free functions taking a
+/// `const BsplineSpace&`. That is the same line `space_1d.hpp` draws to keep
+/// `get_cardinal_intervals` out of the 1D type.
+///
+/// ## The directions are shared, not copied, and the identity contract is why
+///
+/// `spaces_` is a `std::vector<std::shared_ptr<const BsplineSpace1D<T>>>`, per
+/// `design/bspline_ownership_lifetime.md`'s class **H**: an accessor that hands out
+/// a subobject the owner keeps returns a copy of the handle, so the *value* is
+/// shared and the owner's death is irrelevant. `rv_policy::reference_internal`
+/// would put that guarantee in the binding, and the binding is scheduled for
+/// deletion; a `shared_ptr<const T>` puts it in the type, where a C++ consumer with
+/// no interpreter present gets it too.
+///
+/// Sharing is not a performance choice here. `tests/test_bspline_space.py:89`
+/// asserts `space.spaces[0] is space_1d`, so the Python wrapper hands back the
+/// object it was built from; a C++ space that *copied* its directions would present
+/// two Python objects agreeing on identity over two different C++ objects. That is
+/// F6 of the ownership note, and it is what fixes the constructor's signature.
+///
+/// Sharing is safe because a `BsplineSpace1D` is immutable after construction. A
+/// `shared_ptr<const T>` over an immutable `T` is a value with a cheap copy.
+///
+/// The borrowing twin, `space_ref`, is **not bound**: an inner loop must not pay an
+/// atomic pair per access, and the ownership note measures the pair at 9.1 ns
+/// against a 5.83 ns borrow. `tests/parity/test_bspline_binding_contract.py`
+/// asserts that no bound method name ends in `_ref`.
+///
+/// ## No memo, and that is a decision rather than an omission
+///
+/// `design/bspline_derived_caches.md` F1 counts the oracle's seven
+/// `functools.cached_property` sites on this class and concludes that **none of them
+/// becomes a memo**: every one is an O(dim) reduction over the directions, with
+/// `dim` at most 3 everywhere in the tree, and they are memoised in Python only
+/// because an attribute read that walks three objects costs more than a `__dict__`
+/// hit. So there is no `LazySlot` here. Six are eager fields, set once in the
+/// constructor; `has_bezier_like_knots` is a three-iteration accessor, because the
+/// oracle's counterpart is a method and computes on call.
+///
+/// ## Validating rather than asserting
+///
+/// This is the C++ counterpart of Layer 2, so it validates and throws in a release
+/// build as much as in a debug one. `pantr/core/error.hpp` sets the split: value and
+/// range checks live here, type-kind checks stay in the Python wrapper.
+///
+/// **One check that does not live here, and cannot.** The oracle refuses directions
+/// of differing dtype with *"All B-spline spaces must have the same data type."*
+/// `BsplineSpace<T>` can only hold `BsplineSpace1D<T>`, so a mixed collection is not
+/// representable and there is nothing to check: the refusal is the Python wrapper's,
+/// which is where a dtype -- a type-kind fact -- belongs anyway.
+///
+/// ## Parity notes for the Python oracle
+///
+/// `pantr.bspline.BsplineSpace` is the oracle. What this type reproduces, and the
+/// three places it deliberately differs:
+///
+///  - **Every reduction is over the directions in axis order**, and the order is
+///    load-bearing rather than incidental: `degrees`, `num_basis`, `num_intervals`
+///    and `domain` are per-direction sequences, and nothing about their *values*
+///    would reveal a transposition on a space whose directions happen to agree.
+///    `tests/parity/test_bspline_space_nd.py` therefore makes every multi-direction
+///    case asymmetric in every one of them.
+///  - **A dimensionless space is constructible**, with `dim() == 0`. The oracle
+///    admits `BsplineSpace([])` -- pinned by
+///    `tests/test_bspline_space.py::test_empty_spaces_list` -- so this does too. The
+///    empty products are 1, which is the empty tensor product's own convention and
+///    what `numpy.prod(())` returns.
+///  - **`tolerance()` refuses a dimensionless space**, where the oracle raises
+///    whatever `max()` over an empty sequence raises. Both are a `ValueError` to a
+///    Python caller and the *messages* differ, deliberately: the oracle's text is
+///    CPython's own and moved between 3.11 and 3.12, so reproducing it character for
+///    character would break parity on one leg of the matrix. This is the one refusal
+///    in the type whose message is not the oracle's, and the parity test compares
+///    the exception type rather than the text for it.
+///  - **The two products refuse an overflow instead of wrapping.** `numpy.prod` over
+///    an `int64` tuple wraps silently; signed overflow in C++ is undefined, so the
+///    UBSan leg would abort rather than wrap. Neither is a good answer, and the
+///    input is reachable: three directions of 2.1e6 basis functions each need about
+///    50 MB of knots and overflow `int64`. So the products throw
+///    `pantr::CapacityError`, which `pantr/core/error.hpp` reserves for a limit of
+///    the implementation rather than a defect in the argument.
+///
+/// ## Thread safety
+///
+/// Every accessor below is safe to call concurrently on the same object with no
+/// external locking, and here that needs no mechanism at all: there is no memo, so
+/// every accessor reads state frozen at construction. In a sweep, hoist
+/// `num_basis()` or `degrees()` into a local span before the loop rather than
+/// calling it per element -- the span is free, but the call is not.
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/core/error.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+namespace detail {
+
+/// The product of a sequence of non-negative counts, refusing an overflow.
+///
+/// A tensor-product total is a product of per-direction counts, and the oracle
+/// forms it with `numpy.prod` over an `int64` tuple, which wraps. Wrapping is not
+/// available here -- signed overflow is undefined behaviour, and the `gcc-debug`
+/// preset carries `-fno-sanitize-recover=undefined` -- and the input is reachable
+/// rather than hypothetical: see the parity note in the file comment.
+///
+/// The empty product is 1, matching `numpy.prod(())`.
+///
+/// \param counts The per-direction counts; each must be non-negative.
+/// \param what The quantity being formed, for the message.
+/// \return The product.
+/// \throws pantr::CapacityError If the product exceeds `std::int64_t`.
+[[nodiscard]] inline std::int64_t checked_product(std::span<const std::int64_t> counts,
+                                                  const char* what) {
+    constexpr std::int64_t kMax = std::numeric_limits<std::int64_t>::max();
+    std::int64_t total = 1;
+    for (const std::int64_t count : counts) {
+        if (count == 0) {
+            return 0;
+        }
+        // Divided rather than multiplied, so the check itself cannot overflow.
+        // Both operands are positive here: a count is non-negative by the
+        // constructor's own invariants and the zero case returned above.
+        if (total > kMax / count) {
+            throw pantr::CapacityError(std::string(what)
+                                       + " exceeds the range of a 64-bit integer");
+        }
+        total *= count;
+    }
+    return total;
+}
+
+}  // namespace detail
+
+/// A tensor-product B-spline space: one univariate space per direction.
+///
+/// Instances are immutable: no operation changes an existing space, and every
+/// derived one is returned by value. Unlike `BsplineSpace1D` there is not even a
+/// derived block to fill lazily, so construct-then-freeze holds here in its purest
+/// form, with no exception to reason about.
+///
+/// A dimensionless space -- no directions at all -- is legal; see the file comment.
+///
+/// \tparam T The scalar type the directions store their knots in.
+template <Real T>
+class BsplineSpace {
+  public:
+    /// The scalar type the directions store their knots in.
+    using scalar_type = T;
+
+    /// Share the given univariate spaces.
+    ///
+    /// This is the constructor the binding calls, and sharing is what preserves the
+    /// wrapper's identity contract; see the file comment.
+    ///
+    /// \param spaces One handle per direction, in axis order. None may be null.
+    /// \throws std::invalid_argument If any handle is null.
+    /// \throws pantr::CapacityError If a tensor-product total overflows.
+    explicit BsplineSpace(std::vector<std::shared_ptr<const BsplineSpace1D<T>>> spaces)
+        : spaces_(std::move(spaces)) {
+        for (std::size_t d = 0; d < spaces_.size(); ++d) {
+            if (spaces_[d] == nullptr) {
+                throw std::invalid_argument("direction " + std::to_string(d)
+                                            + " is a null B-spline space");
+            }
+        }
+        fill_derived();
+    }
+
+    /// Copy the given univariate spaces, for a caller holding values rather than
+    /// handles.
+    ///
+    /// The copies are what this space shares afterwards, so a later write through
+    /// the caller's own objects -- there is none to make, they are immutable -- could
+    /// not reach it either way. Provided because a C++ caller with no reason to
+    /// allocate should not have to.
+    ///
+    /// \param spaces One space per direction, in axis order.
+    /// \throws pantr::CapacityError If a tensor-product total overflows.
+    explicit BsplineSpace(std::span<const BsplineSpace1D<T>> spaces) {
+        spaces_.reserve(spaces.size());
+        for (const BsplineSpace1D<T>& space : spaces) {
+            spaces_.push_back(std::make_shared<const BsplineSpace1D<T>>(space));
+        }
+        fill_derived();
+    }
+
+    /// The number of directions.
+    ///
+    /// \return The dimension of the parametric domain; zero for a dimensionless
+    ///         space.
+    [[nodiscard]] std::int64_t dim() const noexcept {
+        return static_cast<std::int64_t>(spaces_.size());
+    }
+
+    /// Share direction `d`'s univariate space.
+    ///
+    /// The returned handle keeps its value alive independently of this space, so a
+    /// caller may outlive the owner.
+    ///
+    /// \param d The direction, in `[0, dim())`.
+    /// \return A handle on that direction's space.
+    /// \throws std::out_of_range If `d` is not a direction of this space.
+    [[nodiscard]] std::shared_ptr<const BsplineSpace1D<T>> space(std::int64_t d) const {
+        check_direction(d);
+        return spaces_[static_cast<std::size_t>(d)];
+    }
+
+    /// Borrow direction `d`'s univariate space.
+    ///
+    /// Valid while `*this` is, and **not bound**: an inner loop must not pay an
+    /// atomic pair per access. See the `_ref` rule in the file comment.
+    ///
+    /// \param d The direction, in `[0, dim())`.
+    /// \return A reference to that direction's space.
+    /// \throws std::out_of_range If `d` is not a direction of this space.
+    [[nodiscard]] const BsplineSpace1D<T>& space_ref(std::int64_t d) const {
+        check_direction(d);
+        return *spaces_[static_cast<std::size_t>(d)];
+    }
+
+    /// Share every direction, in axis order.
+    ///
+    /// \return A view of this space's own handles, valid while it lives. Copying a
+    ///         handle out of it is what extends a direction's lifetime.
+    [[nodiscard]] std::span<const std::shared_ptr<const BsplineSpace1D<T>>>
+    spaces() const noexcept {
+        return std::span<const std::shared_ptr<const BsplineSpace1D<T>>>(spaces_);
+    }
+
+    /// The polynomial degree of each direction.
+    ///
+    /// \return A view of `dim()` non-negative degrees, in axis order.
+    [[nodiscard]] std::span<const std::int64_t> degrees() const noexcept {
+        return std::span<const std::int64_t>(degrees_);
+    }
+
+    /// The absolute tolerance for parametric comparisons on this space.
+    ///
+    /// The largest of the directions' tolerances, each of which already carries its
+    /// own direction's knot magnitude. Taking the largest is the conservative choice
+    /// when the directions are scaled differently: it is the only one of the three
+    /// obvious reductions that never under-states a gap in any direction.
+    ///
+    /// A *selection*, not an arithmetic combination, which is why the two backends
+    /// agree on it bit for bit: the result is one of the directions' own tolerances,
+    /// unmodified.
+    ///
+    /// Being an absolute *parametric* length, it is not the factor to scale a
+    /// physical coordinate or a spline coefficient by.
+    ///
+    /// \return The tolerance, a `double` at every knot width. See
+    ///         `pantr/bspline/knots.hpp` for why.
+    /// \throws std::invalid_argument If the space has no directions. The oracle
+    ///         refuses this too; see the file comment for why the message differs.
+    [[nodiscard]] double tolerance() const {
+        if (spaces_.empty()) {
+            throw std::invalid_argument(
+                "tolerance: a B-spline space with no directions has no tolerance");
+        }
+        return tol_;
+    }
+
+    /// The number of basis functions in each direction.
+    ///
+    /// \return A view of `dim()` counts, in axis order.
+    [[nodiscard]] std::span<const std::int64_t> num_basis() const noexcept {
+        return std::span<const std::int64_t>(num_basis_);
+    }
+
+    /// The total number of basis functions.
+    ///
+    /// \return The product of `num_basis()`; 1 for a dimensionless space, which is
+    ///         the empty tensor product's own convention.
+    [[nodiscard]] std::int64_t num_total_basis() const noexcept { return num_total_basis_; }
+
+    /// The number of knot intervals in each direction.
+    ///
+    /// \return A view of `dim()` counts, in axis order, each at least 1.
+    [[nodiscard]] std::span<const std::int64_t> num_intervals() const noexcept {
+        return std::span<const std::int64_t>(num_intervals_);
+    }
+
+    /// The total number of cells.
+    ///
+    /// \return The product of `num_intervals()`; 1 for a dimensionless space.
+    [[nodiscard]] std::int64_t num_total_intervals() const noexcept {
+        return num_total_intervals_;
+    }
+
+    /// The per-direction domain, as one row-major `(dim(), 2)` block.
+    ///
+    /// Row `d` is direction `d`'s own `domain()`, copied unchanged, so the two
+    /// backends agree on it bit for bit. Flat rather than a vector of pairs because
+    /// the binding hands it to `numpy` as a two-dimensional view of exactly this
+    /// storage.
+    ///
+    /// \return A view of `2 * dim()` values: `{lo_0, hi_0, lo_1, hi_1, ...}`.
+    [[nodiscard]] std::span<const T> domain_flat() const noexcept {
+        return std::span<const T>(domain_);
+    }
+
+    /// Whether every direction describes a single Bézier segment.
+    ///
+    /// A three-iteration accessor rather than a field, because the oracle's
+    /// counterpart is a method and computes on call.
+    ///
+    /// \return `true` if every direction is non-periodic, clamped at both ends and
+    ///         has exactly `degree + 1` basis functions. `true` for a dimensionless
+    ///         space, which is what `all(())` gives.
+    [[nodiscard]] bool has_bezier_like_knots() const noexcept {
+        for (const auto& space : spaces_) {
+            if (!space->has_bezier_like_knots()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+  private:
+    /// Refuse a direction index that is not one of this space's.
+    ///
+    /// \param d The requested direction.
+    /// \throws std::out_of_range If `d` is not in `[0, dim())`.
+    void check_direction(std::int64_t d) const {
+        if (d < 0 || d >= dim()) {
+            throw std::out_of_range("direction must lie in [0, " + std::to_string(dim())
+                                    + "); got " + std::to_string(d));
+        }
+    }
+
+    /// Set every derived field from the directions, which are already stored.
+    ///
+    /// One pass over the directions for the four per-direction sequences, then the
+    /// two products and the tolerance. Called by both constructors, which is the
+    /// whole reason it exists.
+    ///
+    /// \throws pantr::CapacityError If a tensor-product total overflows.
+    void fill_derived() {
+        const std::size_t n = spaces_.size();
+        degrees_.reserve(n);
+        num_basis_.reserve(n);
+        num_intervals_.reserve(n);
+        domain_.reserve(2 * n);
+        // Indexed rather than range-based, so that the running maximum can be
+        // seeded by the first direction rather than by a sentinel. Two directions
+        // are very often the *same* handle -- `BsplineSpace([s, s])` is the common
+        // spelling in the suite -- so "is this the first one?" cannot be asked of
+        // the handle, only of the index.
+        for (std::size_t d = 0; d < n; ++d) {
+            const BsplineSpace1D<T>& space = *spaces_[d];
+            degrees_.push_back(space.degree());
+            num_basis_.push_back(space.num_basis());
+            num_intervals_.push_back(space.num_intervals());
+            const std::array<T, 2> ends = space.domain();
+            domain_.push_back(ends[0]);
+            domain_.push_back(ends[1]);
+            tol_ = (d == 0) ? space.tolerance() : std::max(tol_, space.tolerance());
+        }
+        num_total_basis_ = detail::checked_product(num_basis(), "num_total_basis");
+        num_total_intervals_ = detail::checked_product(num_intervals(), "num_total_intervals");
+    }
+
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> spaces_;  ///< One per direction.
+    std::vector<std::int64_t> degrees_;                             ///< One per direction.
+    std::vector<std::int64_t> num_basis_;                           ///< One per direction.
+    std::vector<std::int64_t> num_intervals_;                       ///< One per direction.
+    std::vector<T> domain_;              ///< Row-major `(dim, 2)`.
+    double tol_ = 0.0;                   ///< The largest direction tolerance.
+    std::int64_t num_total_basis_ = 1;   ///< The product of `num_basis_`.
+    std::int64_t num_total_intervals_ = 1;  ///< The product of `num_intervals_`.
+};
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/space_nd.hpp
+++ b/cpp/include/pantr/bspline/space_nd.hpp
@@ -82,7 +82,7 @@
 ///    admits `BsplineSpace([])` -- pinned by
 ///    `tests/test_bspline_space.py::test_empty_spaces_list` -- so this does too. The
 ///    empty products are 1, which is the empty tensor product's own convention and
-///    what `numpy.prod(())` returns.
+///    what the oracle's own `math.prod(())` returns.
 ///  - **`tolerance()` refuses a dimensionless space with the oracle's own message**,
 ///    character for character, as every other refusal in this port does. That is
 ///    worth a sentence because the oracle's message was *made* deliberate for it:
@@ -132,13 +132,15 @@ namespace detail {
 
 /// The product of a sequence of non-negative counts, refusing an overflow.
 ///
-/// A tensor-product total is a product of per-direction counts, and the oracle
-/// forms it with `numpy.prod` over an `int64` tuple, which wraps. Wrapping is not
-/// available here -- signed overflow is undefined behaviour, and the `gcc-debug`
-/// preset carries `-fno-sanitize-recover=undefined` -- and the input is reachable
-/// rather than hypothetical: see the parity note in the file comment.
+/// A tensor-product total is a product of per-direction counts. The oracle forms it
+/// with `math.prod`, whose Python integers are arbitrary-precision, so it returns the
+/// exact value and never wraps. Wrapping is not available here either -- signed
+/// overflow is undefined behaviour, and the `gcc-debug` preset carries
+/// `-fno-sanitize-recover=undefined` -- so this refuses instead, which is the one
+/// deliberate divergence from the oracle. The input is reachable rather than
+/// hypothetical: see the parity note in the file comment.
 ///
-/// The empty product is 1, matching `numpy.prod(())`.
+/// The empty product is 1, matching `math.prod(())`.
 ///
 /// **Non-negative counts are a trusted precondition, not a checked one**, which is
 /// the one place this header departs from its own "validate rather than assert"

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(PANTR_TEST_SOURCES
     test_lazy.cpp
     test_bspline_knots.cpp
     test_bspline_space_1d.cpp
+    test_bspline_space_nd.cpp
     test_extraction_kernels.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen

--- a/cpp/tests/test_bspline_space_nd.cpp
+++ b/cpp/tests/test_bspline_space_nd.cpp
@@ -15,23 +15,27 @@
 /// is a boolean, and the tolerance is a *selection* -- one of the directions' own
 /// tolerances, unmodified -- so `==` is the right comparison for it too.
 ///
-/// ## Every multi-direction case is asymmetric, and that is the point
+/// ## The case set is asymmetric where it can be, and isolating where it cannot
 ///
 /// A tensor-product type is the place where a symmetric test set proves nothing. If
 /// two directions agree on their degree, their counts and their domain, then a
 /// transposition, an off-by-one in the axis index, a `min` written for a `max` and a
-/// reduction that returns its first argument all produce the right answer. So no
-/// case below uses the same univariate space twice, every case's directions differ
-/// in *every* reduced quantity, and `check_the_reductions_see_each_direction`
-/// exists only to assert that -- it is a test of the test set, and it fails if a
-/// later case is added symmetrically.
+/// reduction that returns its first argument all produce the right answer.
 ///
-/// The same reasoning fixes the position of the interesting direction.
-/// `check_the_tolerance_is_the_largest` puts the argmax first in one case and last
-/// in another, and `check_bezier_like_needs_every_direction` puts the single
-/// non-Bézier direction in each position of a three-direction space in turn.
+/// So the case set is in two parts, and the split is deliberate rather than untidy.
+/// `check_two_directions` and `check_three_directions` are **fully asymmetric**:
+/// their directions differ in the degree, the basis count, the interval count, the
+/// domain and the scale at once, and `check_the_reductions_see_each_direction`
+/// asserts exactly that of them -- a test of the test set, which fails if a later
+/// case stops carrying its weight. The rest are **isolating**: they vary one
+/// quantity and hold the others fixed, which is what lets a failure name the
+/// reduction that moved. `check_the_tolerance_is_the_largest` uses three directions
+/// that differ only in scale, and puts the argmax first, last and in the middle over
+/// the same three values; `check_bezier_like_needs_every_direction` repeats one
+/// direction and puts the single exception in each of three positions in turn.
+/// Neither could be fully asymmetric without confounding what it isolates.
 ///
-/// ## The three cases that exist because getting them wrong is silent
+/// ## The four cases that exist because getting them wrong is silent
 ///
 /// **`check_the_directions_are_shared_not_copied`.** The constructor takes handles
 /// and must store them, not copies of what they point at. If it copied, every value
@@ -58,14 +62,31 @@
 /// on an input that is reachable rather than hypothetical. The guard is asserted
 /// through `detail::checked_product` directly, because reaching it through a space
 /// would need three directions of 2.1e6 basis functions and about 50 MB of knots.
+///
+/// **`check_the_tolerance_stays_a_double_at_float_storage`.** The tolerance is a
+/// `double` at every storage width by design, and on a knot vector whose scale is
+/// dyadic that is *unobservable*: the tolerance is `8 * eps * scale`, the factor is a
+/// power of two, so a space storing it in `T` would agree bit for bit. Measured --
+/// narrowing the member passed every other case here and the whole Python parity
+/// suite. That case is the one where the two spellings differ, and it carries its own
+/// vacuity guard saying so.
+///
+/// **`check_concurrent_reads`.** The header claims every accessor is safe to call
+/// concurrently with no external locking. Here that should hold structurally, since
+/// there is no memo -- but `design/bspline_derived_caches.md` F3 measured the shape
+/// one level down giving 60 correct answers in 60 unsanitized runs and four
+/// ThreadSanitizer reports, so the claim gets a gate rather than a reader's trust,
+/// and the gate is a sanitizer build rather than an assertion on a value.
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "check.hpp"
@@ -530,6 +551,76 @@ void check_the_totals_refuse_an_overflow() {
     PANTR_CHECK_MSG(refused, "and three directions of 2^21 are what makes it reachable");
 }
 
+/// Every accessor is safe to call concurrently on one space, with no locking.
+///
+/// `space_nd.hpp` claims that, and the claim needs a gate rather than a reader's
+/// trust. Here it should hold for a structural reason -- there is no memo, so every
+/// accessor reads state frozen at construction -- but "should" is exactly what
+/// `design/bspline_derived_caches.md` F3 refutes for the shape one level down: a
+/// bare `mutable std::optional` memo produced **60 correct answers in 60
+/// unsanitized runs** and four ThreadSanitizer reports, so no assertion on a value
+/// can stand in for the sanitizer.
+///
+/// `space(d)` is included deliberately and is the only accessor here with any
+/// machinery behind it: it copies a `shared_ptr`, so eight threads hammering it
+/// contend on one atomic control block. The rest are span and scalar reads.
+///
+/// The threads are released together off an atomic flag rather than started in
+/// sequence, so that they genuinely overlap; a run in which each finished before the
+/// next began would report clean for the wrong reason.
+void check_concurrent_reads() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};
+    const BsplineSpace<double> s({one_d(first, 2), one_d(second, 1)});
+
+    constexpr int num_threads = 8;
+    std::atomic<bool> go{false};
+    std::vector<std::int64_t> totals(num_threads, 0);
+    std::vector<double> tolerances(num_threads, 0.0);
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([&s, &go, &totals, &tolerances, t] {
+            while (!go.load(std::memory_order_acquire)) {
+                // Spin until every thread is up, so the reads overlap.
+            }
+            std::int64_t sum = 0;
+            double tol = 0.0;
+            for (int i = 0; i < 2000; ++i) {
+                for (std::int64_t d = 0; d < s.dim(); ++d) {
+                    sum += s.degrees()[static_cast<std::size_t>(d)];
+                    sum += s.num_basis()[static_cast<std::size_t>(d)];
+                    sum += s.num_intervals()[static_cast<std::size_t>(d)];
+                    sum += static_cast<std::int64_t>(s.domain_flat()[static_cast<std::size_t>(
+                        2 * d)]);
+                    // The one accessor with an atomic in it.
+                    sum += s.space(d)->num_basis();
+                    sum += s.space_ref(d).degree();
+                }
+                sum += s.num_total_basis() + s.num_total_intervals();
+                sum += s.has_bezier_like_knots() ? 1 : 0;
+                tol = s.tolerance();
+            }
+            totals[static_cast<std::size_t>(t)] = sum;
+            tolerances[static_cast<std::size_t>(t)] = tol;
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+
+    for (int t = 0; t < num_threads; ++t) {
+        const auto index = static_cast<std::size_t>(t);
+        PANTR_CHECK_MSG(totals[index] == totals[0], "every thread must read one state");
+        PANTR_CHECK_MSG(tolerances[index] == s.tolerance(),
+                        "and one tolerance, exactly the single-threaded one");
+    }
+    PANTR_CHECK_MSG(s.space(0).use_count() >= 2,
+                    "the vacuity guard: the shared handle survived the contention, so "
+                    "the atomic path really was exercised");
+}
+
 }  // namespace
 
 int main() {
@@ -547,5 +638,6 @@ int main() {
     check_the_tolerance_stays_a_double_at_float_storage();
     check_refusals();
     check_the_totals_refuse_an_overflow();
+    check_concurrent_reads();
     return pantr::test::summary("test_bspline_space_nd");
 }

--- a/cpp/tests/test_bspline_space_nd.cpp
+++ b/cpp/tests/test_bspline_space_nd.cpp
@@ -403,6 +403,45 @@ void check_float_storage() {
     PANTR_CHECK_MSG(s.tolerance() > b->tolerance(), "the two directions differ here too");
 }
 
+/// The tolerance stays a `double` at `float` storage, which is not free to observe.
+///
+/// `pantr/bspline/knots.hpp` records that the tolerance is a `double` at every
+/// storage width, deliberately. That is invisible on almost every knot vector: the
+/// tolerance is `8 * eps * scale`, the factor is a power of two, so wherever the
+/// winning scale is exactly representable in `float` the tolerance is too, and a
+/// space storing it in `T` would agree bit for bit. Measured: narrowing the member to
+/// `T` passed every other case in this file and the whole Python parity suite.
+///
+/// This is the case where the two spellings differ. The scale is `hi - lo` across
+/// zero, so it is a *sum* of two `float`s and needs one bit more than `float` has --
+/// and the vacuity guard below is what says so, rather than leaving it to be believed.
+void check_the_tolerance_stays_a_double_at_float_storage() {
+    // From -1e-7f to 1.0f, so the scale is the span rather than either coordinate.
+    const std::vector<float> straddling{-1e-7F, -1e-7F, -1e-7F, 0.5F, 1.0F, 1.0F, 1.0F};
+    // Scale exactly 1, so this direction's own tolerance IS a float value and it
+    // loses the reduction by one part in 1e8.
+    const std::vector<float> unit{0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F};
+    const auto wide = one_d(straddling, 2);
+    const auto narrow = one_d(unit, 2);
+
+    PANTR_CHECK_MSG(static_cast<double>(static_cast<float>(wide->tolerance()))
+                        != wide->tolerance(),
+                    "the vacuity guard: this direction's tolerance must not be a float "
+                    "value, or narrowing the space's member would be undetectable");
+    PANTR_CHECK_MSG(static_cast<double>(static_cast<float>(narrow->tolerance()))
+                        == narrow->tolerance(),
+                    "and the other one's must be, so the two are told apart by width "
+                    "rather than by magnitude alone");
+    PANTR_CHECK_MSG(wide->tolerance() > narrow->tolerance(),
+                    "the non-representable one must win the reduction");
+
+    for (const auto& order : {std::vector{wide, narrow}, std::vector{narrow, wide}}) {
+        const BsplineSpace<float> s(order);
+        PANTR_CHECK_MSG(s.tolerance() == wide->tolerance(),
+                        "the space must carry the double, not its float rounding");
+    }
+}
+
 /// A null handle and an out-of-range direction are both refused.
 void check_refusals() {
     const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
@@ -505,6 +544,7 @@ int main() {
     check_a_direction_outlives_the_space();
     check_copy_and_move();
     check_float_storage();
+    check_the_tolerance_stays_a_double_at_float_storage();
     check_refusals();
     check_the_totals_refuse_an_overflow();
     return pantr::test::summary("test_bspline_space_nd");

--- a/cpp/tests/test_bspline_space_nd.cpp
+++ b/cpp/tests/test_bspline_space_nd.cpp
@@ -56,12 +56,13 @@
 /// returns the correct value often enough that the obvious version of this test
 /// passes on a broken design.
 ///
-/// **`check_the_totals_refuse_an_overflow`.** `numpy.prod` over an `int64` tuple
-/// wraps; signed overflow in C++ is undefined, and the `gcc-debug` preset carries
-/// `-fno-sanitize-recover=undefined`, so a wrap here would abort the sanitizer leg
-/// on an input that is reachable rather than hypothetical. The guard is asserted
-/// through `detail::checked_product` directly, because reaching it through a space
-/// would need three directions of 2.1e6 basis functions and about 50 MB of knots.
+/// **`check_the_totals_refuse_an_overflow`.** The oracle's `math.prod` returns the
+/// exact integer and never wraps; signed overflow in C++ is undefined, and the
+/// `gcc-debug` preset carries `-fno-sanitize-recover=undefined`, so a wrap here
+/// would abort the sanitizer leg on an input that is reachable rather than
+/// hypothetical. The guard is asserted through `detail::checked_product` directly,
+/// because reaching it through a space would need three directions of 2.1e6 basis
+/// functions and about 50 MB of knots.
 ///
 /// **`check_the_tolerance_stays_a_double_at_float_storage`.** The tolerance is a
 /// `double` at every storage width by design, and on a knot vector whose scale is
@@ -205,7 +206,8 @@ void check_one_direction() {
 ///
 /// `tests/test_bspline_space.py::TestBsplineSpaceEdgeCases::test_empty_spaces_list`
 /// pins it on the Python side. The empty products are 1, which is the empty tensor
-/// product's own convention and what `numpy.prod(())` returns; `all(())` is `true`.
+/// product's own convention and what the oracle's own `math.prod(())` returns;
+/// `all(())` is `true`.
 /// The tolerance is the one thing with no answer, so it refuses.
 void check_no_directions() {
     const BsplineSpace<double> s(std::vector<std::shared_ptr<const BsplineSpace1D<double>>>{});
@@ -502,7 +504,8 @@ void check_refusals() {
 /// A tensor-product total that would not fit in an `int64` is refused, not wrapped.
 ///
 /// Asserted through the helper rather than through a space; see the file comment for
-/// why, and for why wrapping is not an option here even though the oracle wraps.
+/// why, and for why wrapping is not an option here even though the oracle never
+/// wraps -- it uses `math.prod`, whose Python integers are arbitrary-precision.
 void check_the_totals_refuse_an_overflow() {
     using pantr::bspline::detail::checked_product;
     constexpr std::int64_t kMax = std::numeric_limits<std::int64_t>::max();

--- a/cpp/tests/test_bspline_space_nd.cpp
+++ b/cpp/tests/test_bspline_space_nd.cpp
@@ -1,0 +1,511 @@
+/// \file
+/// The tensor-product B-spline space: what it aggregates, and what it refuses.
+///
+/// ## What is asserted, and against what
+///
+/// Every quantity here is a reduction over the directions, so each case states the
+/// per-direction values by hand and the expected reduction alongside them. Two of
+/// the cases are the shipped docstring examples of
+/// `pantr.bspline.BsplineSpace.cell_supports` and `.boundary_dofs`, so their basis
+/// counts are checkable against the library's own published contract rather than
+/// against a run of it.
+///
+/// Nothing here carries a numerical tolerance. The counts are integers, the domain
+/// values are reproduced bit for bit from the directions, `has_bezier_like_knots`
+/// is a boolean, and the tolerance is a *selection* -- one of the directions' own
+/// tolerances, unmodified -- so `==` is the right comparison for it too.
+///
+/// ## Every multi-direction case is asymmetric, and that is the point
+///
+/// A tensor-product type is the place where a symmetric test set proves nothing. If
+/// two directions agree on their degree, their counts and their domain, then a
+/// transposition, an off-by-one in the axis index, a `min` written for a `max` and a
+/// reduction that returns its first argument all produce the right answer. So no
+/// case below uses the same univariate space twice, every case's directions differ
+/// in *every* reduced quantity, and `check_the_reductions_see_each_direction`
+/// exists only to assert that -- it is a test of the test set, and it fails if a
+/// later case is added symmetrically.
+///
+/// The same reasoning fixes the position of the interesting direction.
+/// `check_the_tolerance_is_the_largest` puts the argmax first in one case and last
+/// in another, and `check_bezier_like_needs_every_direction` puts the single
+/// non-Bézier direction in each position of a three-direction space in turn.
+///
+/// ## The three cases that exist because getting them wrong is silent
+///
+/// **`check_the_directions_are_shared_not_copied`.** The constructor takes handles
+/// and must store them, not copies of what they point at. If it copied, every value
+/// assertion in this file would still pass, and the Python identity contract
+/// `space.spaces[0] is space_1d` -- `tests/test_bspline_space.py:89`, and
+/// `design/bspline_ownership_lifetime.md` F6 -- would present two Python objects
+/// agreeing on identity over two different C++ objects. Comparing addresses is what
+/// distinguishes the two.
+///
+/// **`check_a_direction_outlives_the_space`.** The whole reason class H stores a
+/// `shared_ptr<const T>` rather than taking `reference_internal` on the binding is
+/// that the guarantee has to live in the type, where a consumer with no interpreter
+/// gets it too. So a direction is taken out, the space is destroyed, and the
+/// direction is read. Under the design this passes; under a raw reference the
+/// sanitizer leg reports the use-after-free. `design/bspline_ownership_lifetime.md`
+/// F4 is why this is asserted on a *count* the destroyed space would have
+/// overwritten rather than on the pointer being non-null: a scalar read after free
+/// returns the correct value often enough that the obvious version of this test
+/// passes on a broken design.
+///
+/// **`check_the_totals_refuse_an_overflow`.** `numpy.prod` over an `int64` tuple
+/// wraps; signed overflow in C++ is undefined, and the `gcc-debug` preset carries
+/// `-fno-sanitize-recover=undefined`, so a wrap here would abort the sanitizer leg
+/// on an input that is reachable rather than hypothetical. The guard is asserted
+/// through `detail::checked_product` directly, because reaching it through a space
+/// would need three directions of 2.1e6 basis functions and about 50 MB of knots.
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bspline/space_nd.hpp"
+
+namespace {
+
+using pantr::bspline::BsplineSpace;
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::KnotSnapping;
+
+/// Build a shared univariate space from a knot vector and a degree.
+///
+/// \tparam T The scalar type.
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \return A handle on the space, snapping near-duplicates as the oracle's default
+///         does.
+template <class T>
+std::shared_ptr<const BsplineSpace1D<T>> one_d(const std::vector<T>& knots,
+                                               std::int64_t degree) {
+    return std::make_shared<const BsplineSpace1D<T>>(std::span<const T>(knots), degree, false,
+                                                     KnotSnapping::merge_near_duplicates);
+}
+
+/// Whether a span holds exactly the given values, in order.
+///
+/// \tparam T The element type.
+/// \param actual The span.
+/// \param expected The values.
+/// \return `true` if the two agree elementwise.
+template <class T>
+bool equals(std::span<const T> actual, const std::vector<T>& expected) {
+    if (actual.size() != expected.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        if (!(actual[i] == expected[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// A two-direction space whose directions differ in every reduced quantity.
+///
+/// Direction 0 is a clamped quadratic over three intervals on `[0, 3]`; direction 1
+/// is a clamped linear over two intervals on `[10, 12]`. So the degrees differ (2
+/// against 1), the basis counts differ (5 against 3), the interval counts differ (3
+/// against 2), the domains differ in both location and width, and the tolerances
+/// differ because the scales do (3 against 12). Nothing about this space is
+/// symmetric.
+void check_two_directions() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};
+    const auto a = one_d(first, 2);
+    const auto b = one_d(second, 1);
+    const BsplineSpace<double> s({a, b});
+
+    PANTR_CHECK(s.dim() == 2);
+    PANTR_CHECK(equals(s.degrees(), std::vector<std::int64_t>{2, 1}));
+    PANTR_CHECK(equals(s.num_basis(), std::vector<std::int64_t>{5, 3}));
+    PANTR_CHECK(equals(s.num_intervals(), std::vector<std::int64_t>{3, 2}));
+    PANTR_CHECK_MSG(s.num_total_basis() == 15, "5 * 3, which is neither 5 + 3 nor either factor");
+    PANTR_CHECK_MSG(s.num_total_intervals() == 6, "3 * 2, likewise");
+    PANTR_CHECK(equals(s.domain_flat(), std::vector<double>{0.0, 3.0, 10.0, 12.0}));
+    PANTR_CHECK_MSG(s.tolerance() == b->tolerance(),
+                    "direction 1 has the larger scale, so it sets the tolerance");
+    PANTR_CHECK_MSG(s.tolerance() > a->tolerance(), "and the two are genuinely different");
+    PANTR_CHECK_MSG(!s.has_bezier_like_knots(), "neither direction is a single span");
+}
+
+/// A three-direction space, all three directions distinct.
+///
+/// The docstring example of `BsplineSpace.cell_supports` is the first two
+/// directions; the third makes the totals a product of three unequal factors, which
+/// a two-direction case cannot distinguish from a pairwise reduction applied twice
+/// in the wrong order.
+void check_three_directions() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::vector<double> second{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const std::vector<double> third{0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0};
+    const BsplineSpace<double> s({one_d(first, 2), one_d(second, 2), one_d(third, 1)});
+
+    PANTR_CHECK(s.dim() == 3);
+    PANTR_CHECK(equals(s.degrees(), std::vector<std::int64_t>{2, 2, 1}));
+    PANTR_CHECK(equals(s.num_basis(), std::vector<std::int64_t>{5, 3, 5}));
+    PANTR_CHECK(equals(s.num_intervals(), std::vector<std::int64_t>{3, 1, 4}));
+    PANTR_CHECK_MSG(s.num_total_basis() == 75, "5 * 3 * 5");
+    PANTR_CHECK_MSG(s.num_total_intervals() == 12, "3 * 1 * 4");
+    PANTR_CHECK(
+        equals(s.domain_flat(), std::vector<double>{0.0, 3.0, 0.0, 1.0, 0.0, 4.0}));
+}
+
+/// One direction, which is the case an nD reduction can get right by accident.
+///
+/// Kept anyway, because it is what the whole `pantr.cad` layer builds for a curve
+/// and because the empty and single cases are where an off-by-one in a loop bound
+/// shows.
+void check_one_direction() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const auto a = one_d(knots, 2);
+    const BsplineSpace<double> s({a});
+
+    PANTR_CHECK(s.dim() == 1);
+    PANTR_CHECK(equals(s.degrees(), std::vector<std::int64_t>{2}));
+    PANTR_CHECK(equals(s.num_basis(), std::vector<std::int64_t>{3}));
+    PANTR_CHECK(equals(s.num_intervals(), std::vector<std::int64_t>{1}));
+    PANTR_CHECK(s.num_total_basis() == 3);
+    PANTR_CHECK(s.num_total_intervals() == 1);
+    PANTR_CHECK(s.tolerance() == a->tolerance());
+    PANTR_CHECK_MSG(s.has_bezier_like_knots(), "a clamped single span at degree 2");
+}
+
+/// A space with no directions, which the oracle admits and so does this.
+///
+/// `tests/test_bspline_space.py::TestBsplineSpaceEdgeCases::test_empty_spaces_list`
+/// pins it on the Python side. The empty products are 1, which is the empty tensor
+/// product's own convention and what `numpy.prod(())` returns; `all(())` is `true`.
+/// The tolerance is the one thing with no answer, so it refuses.
+void check_no_directions() {
+    const BsplineSpace<double> s(std::vector<std::shared_ptr<const BsplineSpace1D<double>>>{});
+
+    PANTR_CHECK(s.dim() == 0);
+    PANTR_CHECK(s.degrees().empty());
+    PANTR_CHECK(s.num_basis().empty());
+    PANTR_CHECK(s.num_intervals().empty());
+    PANTR_CHECK(s.domain_flat().empty());
+    PANTR_CHECK_MSG(s.num_total_basis() == 1, "the empty product");
+    PANTR_CHECK_MSG(s.num_total_intervals() == 1, "likewise");
+    PANTR_CHECK_MSG(s.has_bezier_like_knots(), "all(()) is true");
+
+    bool refused = false;
+    try {
+        (void) s.tolerance();
+    } catch (const std::invalid_argument& error) {
+        refused = true;
+        PANTR_CHECK_MSG(std::string(error.what())
+                            == "tolerance: a B-spline space with no directions has no tolerance",
+                        std::string("message was: ") + error.what());
+    }
+    PANTR_CHECK_MSG(refused, "a dimensionless space has no tolerance to report");
+}
+
+/// The tolerance is the largest of the directions', with the argmax in each place.
+///
+/// Two spaces built from the same three directions in different orders. If the
+/// reduction returned its first argument, its last, or the smallest, exactly one of
+/// the two assertions below would still pass -- which is why one case would not be
+/// enough.
+void check_the_tolerance_is_the_largest() {
+    // Scales 1, 1000 and 0.001, so the three tolerances span six orders and the
+    // largest is unambiguous at either dtype.
+    const std::vector<double> unit{0.0, 0.0, 0.5, 1.0, 1.0};
+    const std::vector<double> big{0.0, 0.0, 500.0, 1000.0, 1000.0};
+    const std::vector<double> small{0.0, 0.0, 5e-4, 1e-3, 1e-3};
+    const auto a = one_d(unit, 1);
+    const auto b = one_d(big, 1);
+    const auto c = one_d(small, 1);
+
+    PANTR_CHECK_MSG(b->tolerance() > a->tolerance() && a->tolerance() > c->tolerance(),
+                    "the three directions must have three different tolerances");
+
+    const BsplineSpace<double> argmax_last({c, a, b});
+    PANTR_CHECK_MSG(argmax_last.tolerance() == b->tolerance(),
+                    "the largest is the last direction here");
+
+    const BsplineSpace<double> argmax_first({b, a, c});
+    PANTR_CHECK_MSG(argmax_first.tolerance() == b->tolerance(),
+                    "and the first direction there, over the same three values");
+
+    const BsplineSpace<double> argmax_middle({c, b, a});
+    PANTR_CHECK_MSG(argmax_middle.tolerance() == b->tolerance(), "and the middle one there");
+}
+
+/// Bézier-likeness needs *every* direction, with the exception in each place.
+///
+/// Three spaces, each with exactly one non-Bézier direction, at position 0, 1 and 2.
+/// A reduction written as `any`, or as "ask the first direction", passes one of
+/// these and fails the other two.
+void check_bezier_like_needs_every_direction() {
+    const std::vector<double> single_span{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const std::vector<double> two_spans{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const auto bez = one_d(single_span, 2);
+    const auto not_bez = one_d(two_spans, 2);
+
+    PANTR_CHECK(bez->has_bezier_like_knots());
+    PANTR_CHECK(!not_bez->has_bezier_like_knots());
+
+    const BsplineSpace<double> all_bezier({bez, bez, bez});
+    PANTR_CHECK_MSG(all_bezier.has_bezier_like_knots(), "every direction is a single span");
+
+    for (int position = 0; position < 3; ++position) {
+        std::vector<std::shared_ptr<const BsplineSpace1D<double>>> directions{bez, bez, bez};
+        directions[static_cast<std::size_t>(position)] = not_bez;
+        const BsplineSpace<double> mixed(std::move(directions));
+        PANTR_CHECK_MSG(!mixed.has_bezier_like_knots(),
+                        std::string("one non-Bezier direction at position ")
+                            + std::to_string(position) + " must decide the whole space");
+    }
+}
+
+/// Every reduced quantity differs between the directions of every case above.
+///
+/// A test of the test set rather than of the type: it is what stops a later case
+/// from being added with two identical directions, which would make a transposition
+/// or an axis-index error invisible. See the file comment.
+void check_the_reductions_see_each_direction() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};
+    const std::vector<double> third{0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0};
+    const BsplineSpace<double> s({one_d(first, 2), one_d(second, 1), one_d(third, 1)});
+
+    // Pairwise distinct in the four per-direction sequences. The degrees are the one
+    // exception and are checked as "not all equal" instead: with three directions
+    // and the degrees restricted to what the other constraints allow, two of them
+    // coincide, and requiring otherwise would over-constrain the case rather than
+    // strengthen it.
+    const auto degrees = s.degrees();
+    PANTR_CHECK_MSG(!(degrees[0] == degrees[1] && degrees[1] == degrees[2]),
+                    "the degrees must not all agree");
+    for (std::int64_t i = 0; i < s.dim(); ++i) {
+        for (std::int64_t j = i + 1; j < s.dim(); ++j) {
+            const auto a = static_cast<std::size_t>(i);
+            const auto b = static_cast<std::size_t>(j);
+            PANTR_CHECK_MSG(s.num_intervals()[a] != s.num_intervals()[b],
+                            "two directions with equal interval counts hide a transposition");
+            PANTR_CHECK_MSG(s.domain_flat()[2 * a] != s.domain_flat()[2 * b]
+                                || s.domain_flat()[2 * a + 1] != s.domain_flat()[2 * b + 1],
+                            "two directions with equal domains hide a row swap");
+        }
+    }
+    PANTR_CHECK_MSG(s.num_basis()[0] != s.num_basis()[1],
+                    "the first two basis counts must differ");
+}
+
+/// The constructor stores the handles it is given, not copies of their pointees.
+///
+/// Addresses, because values would agree under a copying constructor. See the file
+/// comment for what a copy would break at the Python level.
+void check_the_directions_are_shared_not_copied() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0};
+    const std::vector<double> second{0.0, 0.0, 1.0, 1.0};
+    const auto a = one_d(first, 2);
+    const auto b = one_d(second, 1);
+    const BsplineSpace<double> s({a, b});
+
+    PANTR_CHECK_MSG(s.space(0).get() == a.get(), "direction 0 must be the handle given");
+    PANTR_CHECK_MSG(s.space(1).get() == b.get(), "direction 1 must be the handle given");
+    PANTR_CHECK_MSG(&s.space_ref(0) == a.get(), "and the borrowing accessor must agree");
+    PANTR_CHECK_MSG(s.spaces()[0].get() == a.get(), "and so must the whole-collection form");
+    PANTR_CHECK_MSG(a.use_count() >= 2, "the space holds a reference of its own");
+
+    // The value-taking constructor is the other half of the contract: it exists for
+    // a caller holding values rather than handles, and it must NOT share.
+    const std::array<BsplineSpace1D<double>, 2> values{*a, *b};
+    // The span is named rather than built in the constructor call: a temporary there
+    // is the most vexing parse, and `copied` becomes a function declaration.
+    const std::span<const BsplineSpace1D<double>> as_values(values);
+    const BsplineSpace<double> copied(as_values);
+    PANTR_CHECK_MSG(copied.space(0).get() != a.get(),
+                    "the value-taking constructor owns its own directions");
+    PANTR_CHECK(equals(copied.num_basis(), std::vector<std::int64_t>{4, 2}));
+    PANTR_CHECK(copied.tolerance() == s.tolerance());
+}
+
+/// A direction taken out of a space outlives it.
+///
+/// The point of storing `shared_ptr<const T>` rather than annotating the binding.
+/// Asserted on a value the destroyed space's own storage would have been reused for
+/// -- a fresh space is built in the freed region first -- because
+/// `design/bspline_ownership_lifetime.md` F4 measured a scalar read after free
+/// returning the correct value, which is exactly the shape of test that passes on a
+/// broken design.
+void check_a_direction_outlives_the_space() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    std::shared_ptr<const BsplineSpace1D<double>> escapee;
+    {
+        const std::vector<double> other{0.0, 0.0, 1.0, 1.0};
+        const BsplineSpace<double> s({one_d(knots, 2), one_d(other, 1)});
+        escapee = s.space(0);
+    }
+    // Churn the freed storage, so a dangling read is unlikely to find its old bytes.
+    for (int i = 0; i < 64; ++i) {
+        const std::vector<double> filler{0.0, 0.0, 1.0, 2.0, 3.0, 3.0};
+        const BsplineSpace<double> scratch({one_d(filler, 1)});
+        PANTR_CHECK(scratch.num_total_basis() == 4);
+    }
+    PANTR_CHECK_MSG(escapee->num_basis() == 5, "the escaped direction still knows its own state");
+    PANTR_CHECK(escapee->degree() == 2);
+    PANTR_CHECK(escapee->domain()[1] == 3.0);
+}
+
+/// A copy or a move of a space carries the same directions, and the same values.
+///
+/// There is no memo here to go cold -- `design/bspline_derived_caches.md` F1 -- so
+/// unlike `BsplineSpace1D` a copy is a plain value copy, and what is worth asserting
+/// is that the *sharing* survives it: a copied space points at the same directions.
+void check_copy_and_move() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0};
+    const std::vector<double> second{5.0, 5.0, 6.0, 7.0, 7.0};
+    const auto a = one_d(first, 2);
+    const auto b = one_d(second, 1);
+    BsplineSpace<double> original({a, b});
+
+    const BsplineSpace<double> copied(original);
+    PANTR_CHECK(copied.dim() == 2);
+    PANTR_CHECK(equals(copied.num_basis(), std::vector<std::int64_t>{4, 3}));
+    PANTR_CHECK(copied.num_total_basis() == 12);
+    PANTR_CHECK(copied.tolerance() == original.tolerance());
+    PANTR_CHECK_MSG(copied.space(0).get() == a.get(), "a copy shares the same directions");
+
+    const BsplineSpace<double> moved(std::move(original));
+    PANTR_CHECK(moved.dim() == 2);
+    PANTR_CHECK(equals(moved.num_intervals(), std::vector<std::int64_t>{2, 2}));
+    PANTR_CHECK(moved.space(1).get() == b.get());
+}
+
+/// `float` storage, so the template is instantiated at both widths.
+///
+/// The domain values come out in the storage format and the tolerance stays a
+/// `double`, which is `pantr/bspline/knots.hpp`'s rule rather than this type's.
+void check_float_storage() {
+    const std::vector<float> first{0.0F, 0.0F, 0.0F, 1.0F, 2.0F, 2.0F, 2.0F};
+    const std::vector<float> second{0.0F, 0.0F, 1.0F, 1.0F};
+    const auto a = one_d(first, 2);
+    const auto b = one_d(second, 1);
+    const BsplineSpace<float> s({a, b});
+
+    PANTR_CHECK(equals(s.domain_flat(), std::vector<float>{0.0F, 2.0F, 0.0F, 1.0F}));
+    PANTR_CHECK(equals(s.num_basis(), std::vector<std::int64_t>{4, 2}));
+    PANTR_CHECK(s.num_total_basis() == 8);
+    PANTR_CHECK_MSG(s.tolerance() == a->tolerance(),
+                    "the wider-scaled direction sets it, and it is a double either way");
+    PANTR_CHECK_MSG(s.tolerance() > b->tolerance(), "the two directions differ here too");
+}
+
+/// A null handle and an out-of-range direction are both refused.
+void check_refusals() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const auto a = one_d(knots, 2);
+
+    bool refused_null = false;
+    try {
+        const BsplineSpace<double> s({a, nullptr});
+        (void) s.dim();
+    } catch (const std::invalid_argument& error) {
+        refused_null = true;
+        PANTR_CHECK_MSG(std::string(error.what()) == "direction 1 is a null B-spline space",
+                        std::string("message was: ") + error.what());
+    }
+    PANTR_CHECK_MSG(refused_null, "a null direction cannot be aggregated");
+
+    const BsplineSpace<double> s({a});
+    for (const std::int64_t bad : {-1L, 1L, 7L}) {
+        bool refused = false;
+        try {
+            (void) s.space(bad);
+        } catch (const std::out_of_range&) {
+            refused = true;
+        }
+        PANTR_CHECK_MSG(refused, "a direction outside [0, dim) must be refused");
+
+        refused = false;
+        try {
+            (void) s.space_ref(bad);
+        } catch (const std::out_of_range&) {
+            refused = true;
+        }
+        PANTR_CHECK_MSG(refused, "and the borrowing accessor must refuse it too");
+    }
+}
+
+/// A tensor-product total that would not fit in an `int64` is refused, not wrapped.
+///
+/// Asserted through the helper rather than through a space; see the file comment for
+/// why, and for why wrapping is not an option here even though the oracle wraps.
+void check_the_totals_refuse_an_overflow() {
+    using pantr::bspline::detail::checked_product;
+    constexpr std::int64_t kMax = std::numeric_limits<std::int64_t>::max();
+
+    const std::vector<std::int64_t> empty{};
+    PANTR_CHECK_MSG(checked_product(empty, "x") == 1, "the empty product is 1");
+
+    const std::vector<std::int64_t> ordinary{5, 3, 7};
+    PANTR_CHECK(checked_product(ordinary, "x") == 105);
+
+    // A zero short-circuits, so a zero beside a value that would otherwise overflow
+    // is still zero rather than a refusal. That matters: a direction cannot have
+    // zero basis functions today, and the branch is what keeps the guard from
+    // depending on that staying true.
+    const std::vector<std::int64_t> with_zero{kMax, 0, kMax};
+    PANTR_CHECK_MSG(checked_product(with_zero, "x") == 0, "a zero factor short-circuits");
+
+    // Either side of the boundary, on the tightest pair available. `root` is
+    // `floor(sqrt(kMax))`, so `root * root` fits and so does `root * (root + 1)` --
+    // checked, and the reason this pair is spelled out rather than guessed: an
+    // earlier version used `root + 1` as the overflowing factor and it does not
+    // overflow. `root + 2` is the first that does.
+    const std::int64_t root = 3037000499;
+    const std::vector<std::int64_t> fits{root, root + 1};
+    PANTR_CHECK_MSG(checked_product(fits, "x") == root * (root + 1), "this one still fits");
+
+    const std::vector<std::int64_t> just_over{root, root + 2};
+    bool refused = false;
+    try {
+        (void) checked_product(just_over, "num_total_basis");
+    } catch (const pantr::CapacityError& error) {
+        refused = true;
+        PANTR_CHECK_MSG(
+            std::string(error.what()) == "num_total_basis exceeds the range of a 64-bit integer",
+            std::string("message was: ") + error.what());
+    }
+    PANTR_CHECK_MSG(refused, "a product past the int64 range must refuse rather than wrap");
+
+    const std::vector<std::int64_t> three_way{2097152, 2097152, 2097152};
+    refused = false;
+    try {
+        (void) checked_product(three_way, "num_total_basis");
+    } catch (const pantr::CapacityError&) {
+        refused = true;
+    }
+    PANTR_CHECK_MSG(refused, "and three directions of 2^21 are what makes it reachable");
+}
+
+}  // namespace
+
+int main() {
+    check_two_directions();
+    check_three_directions();
+    check_one_direction();
+    check_no_directions();
+    check_the_tolerance_is_the_largest();
+    check_bezier_like_needs_every_direction();
+    check_the_reductions_see_each_direction();
+    check_the_directions_are_shared_not_copied();
+    check_a_direction_outlives_the_space();
+    check_copy_and_move();
+    check_float_storage();
+    check_refusals();
+    check_the_totals_refuse_an_overflow();
+    return pantr::test::summary("test_bspline_space_nd");
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -244,6 +244,15 @@ nitpick_ignore = [
     # a role that can never resolve is a broken link rather than a suppressible one.
     ("py:class", "pantr.grid._grid._GridPython"),
     ("py:class", "pantr.grid._grid._GridWrapper"),
+    # The annotation of every ported wrapper's `_impl` slot: a private, module-local
+    # `TypeAlias` naming a union of the oracle and the two per-dtype C++ handles.
+    # Autodoc documents the slot because it carries an inline docstring, and renders
+    # the annotation as a class reference; there is nothing for it to resolve to,
+    # since a `TYPE_CHECKING`-only alias has no runtime object and no documented
+    # page. Three wrappers declare it under this exact name -- `pantr.bezier.Bezier`,
+    # `pantr.bspline.BsplineSpace1D` and `pantr.bspline.BsplineSpace` -- so this is
+    # one entry rather than three, and the next ported type inherits it.
+    ("py:class", "_Impl"),
     ("py:class", "CellIndex"),
     ("py:class", "CellIndicesBatch"),
     ("py:class", "Target"),

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -67,9 +67,9 @@ shape rather than a capability.
 Scope
 -----
 
-Five modules are ported so far, and **selecting the C++ backend changes only what
-they cover**. A suite run under ``PANTR_BACKEND=cpp`` is not a C++ run; it is a run
-in which those kernels are C++ and everything else is unchanged.
+Six modules are ported so far, and **selecting the C++ backend changes only what they
+cover**. A suite run under ``PANTR_BACKEND=cpp`` is not a C++ run; it is a run in
+which those kernels are C++ and everything else is unchanged.
 
 * :mod:`pantr.basis` -- three of the 1D tabulations: cardinal B-spline, Bernstein
   and Legendre. The Lagrange tabulation and everything multidimensional stay on
@@ -88,11 +88,16 @@ in which those kernels are C++ and everything else is unchanged.
   template for declining one.
 * :mod:`pantr.grid` -- all nine kernels: tensor-product point location, the BVH's
   build and its two query passes, and the five hierarchical addressing kernels.
+* :mod:`pantr.bspline` -- the tensor-product extraction kernels, through the
+  catalogue in ``pantr.bspline._extraction_backend``: twenty-four entry points over
+  four dimension-generic C++ functions, standing in for the twelve per-cell and
+  twelve batch Numba kernels. Nothing else in the module's *kernels* is ported; its
+  two ported **types** are listed with the others below.
 
-**Ten types have moved as well, and that is a different kind of entry.** A
+**Eleven types have moved as well, and that is a different kind of entry.** A
 catalogue decides which code computes; a ported type decides which object holds the
 state, so under ``PANTR_BACKEND=cpp`` the object's data lives in C++ and the Python
-class is a wrapper around it. The ten, by the module that exports them:
+class is a wrapper around it. The eleven, by the module that exports them:
 
 * :mod:`pantr.geometry` -- :class:`~pantr.geometry.AABB`.
 * :mod:`pantr.transform` -- :class:`~pantr.transform.AffineTransform`.
@@ -101,14 +106,18 @@ class is a wrapper around it. The ten, by the module that exports them:
 * :mod:`pantr.grid` -- :class:`~pantr.grid.TensorProductGrid`,
   :class:`~pantr.grid.BVH`, :class:`~pantr.grid.CellTags`,
   :class:`~pantr.grid.FacetTags` and :class:`~pantr.grid.Partition`.
-* :mod:`pantr.bspline` -- :class:`~pantr.bspline.BsplineSpace1D`.
+* :mod:`pantr.bspline` -- :class:`~pantr.bspline.BsplineSpace1D` and
+  :class:`~pantr.bspline.BsplineSpace`.
 
-**The last of those is why the two lists above are no longer parallel, and the
-mismatch is real rather than an omission.** Every other module here earned its place
-by porting *kernels*; :mod:`pantr.bspline` has none ported, so it is absent from the
-module list, and yet the backend does change which object a caller of
-:class:`~pantr.bspline.BsplineSpace1D` holds. Read the module list as "whose kernels
-moved" and this one as "whose objects moved", and do not infer either from the other.
+**Read the module list as "whose kernels moved" and this one as "whose objects
+moved", and do not infer either from the other.** The two are genuinely independent:
+:mod:`pantr.geometry`, :mod:`pantr.transform` and :mod:`pantr.quad`'s
+:class:`~pantr.quad.QuadratureRule` appear here with no kernel of their own in the
+list above, and :mod:`pantr.bspline` appears in both for unrelated reasons -- its
+extraction kernels moved, and its two space types moved, and neither implies the
+other. An earlier version of this paragraph explained the mismatch by saying
+:mod:`pantr.bspline` had no ported kernels, which was true when it was written and
+stopped being true one slice later.
 
 Two domain types in the geometry, transform, quad and grid modules have **not**
 moved: :class:`pantr.grid.HierarchicalGrid`, which is the Python implementation under
@@ -118,14 +127,18 @@ the first pending, the second permanent. The rest of what those modules export i
 a candidate either way -- ``Grid`` is a :class:`typing.Protocol` and
 ``GridRestriction`` is a result record.
 
-**:mod:`pantr.bspline` is counted differently, because it is at the start of its own
-front rather than the end of one.** Listing its unported types here would be listing
-a work queue: ``BsplineSpace``, ``Bspline``, ``THBSplineSpace``, ``THBSpline`` and the
+**:mod:`pantr.bspline` is counted differently, because it is partway through its own
+front rather than at the end of one.** Listing its unported types here would be
+listing a work queue: ``Bspline``, ``THBSplineSpace``, ``THBSpline`` and the
 extraction types are all still Python under either backend, and each has its own
-ticket. What is worth stating is the boundary --
-:class:`~pantr.bspline.BsplineSpace1D` alone dispatches, and every operation on it
-(basis tabulation, the extraction operators, knot insertion, subdivision,
-restriction) is still Numba under both backends.
+ticket. What is worth stating is the boundary -- the two space types dispatch and
+nothing else in the module does, and every *operation* is still Numba or numpy under
+both backends. For a univariate space that is basis tabulation, the extraction
+operators, knot insertion, subdivision and restriction; for a tensor-product space it
+is basis tabulation, the per-cell control-point support, the boundary slab and the
+windowed restriction. The module's *kernels* are a separate question with its own
+answer: the tensor-product extraction kernels are ported and dispatch through
+``pantr.bspline._extraction_backend``, which is why this paragraph is about types.
 
 **This list was wrong for two releases and that is worth a sentence.** It said three
 modules and named neither half of ``bezier`` while both were merged and dispatching.

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -86,6 +86,8 @@ from ._bezier import transform_bezier as transform_bezier
 from ._bezier import yuksel_roots as yuksel_roots
 from ._bspline import BsplineSpace1D32 as BsplineSpace1D32
 from ._bspline import BsplineSpace1D64 as BsplineSpace1D64
+from ._bspline import BsplineSpace32 as BsplineSpace32
+from ._bspline import BsplineSpace64 as BsplineSpace64
 from ._bspline import apply_kron_1d as apply_kron_1d
 from ._bspline import apply_kron_2d as apply_kron_2d
 from ._bspline import apply_kron_3d as apply_kron_3d

--- a/src/pantr/_pantr_cpp/_bspline.pyi
+++ b/src/pantr/_pantr_cpp/_bspline.pyi
@@ -1,9 +1,11 @@
 """Type stub for the `pantr.bspline` types bound in `cpp/bindings/bspline_types.cpp`.
 
-Two registrations rather than one generic class, because the storage format is part
-of the value: `pantr.bspline.BsplineSpace1D` stores whatever float dtype it is handed
-and its `dtype` property is public, so the class of the handle is the only thing left
-to carry it.
+Two registrations per type rather than one generic class, because the storage format
+is part of the value: `pantr.bspline.BsplineSpace1D` stores whatever float dtype it
+is handed and its `dtype` property is public, so the class of the handle is the only
+thing left to carry it. The tensor-product `BsplineSpace32` / `BsplineSpace64` pair
+inherits that split and could not avoid it anyway: `BsplineSpace<T>` can hold only
+`BsplineSpace1D<T>`.
 
 ## Tensor-product extraction kernels
 
@@ -40,6 +42,8 @@ oracle's own split between a resolved cell and a batch of them.
 
 See ``__init__.pyi`` for what this package promises and who has to keep it.
 """
+
+from collections.abc import Sequence
 
 import numpy as np
 from numpy import typing as npt
@@ -139,6 +143,94 @@ class BsplineSpace1D64:
     def has_left_end_open(self) -> bool: ...
     def has_right_end_open(self) -> bool: ...
     def has_open_knots(self) -> bool: ...
+    def has_Bezier_like_knots(self) -> bool: ...
+
+class BsplineSpace32:
+    """A ``float32`` tensor-product B-spline space owned by the C++ core.
+
+    Wrapped by :class:`pantr.bspline.BsplineSpace`, which is the class a caller
+    holds; this one is reached only through it. The constructor takes the directions
+    as :class:`BsplineSpace1D32` handles and **shares** them, which is what makes
+    ``space.spaces[0] is one_d`` hold at the wrapper level -- see
+    ``design/bspline_ownership_lifetime.md`` F6. A ``float64`` direction is a
+    :class:`TypeError` rather than a widening, because the two univariate classes
+    are unrelated.
+
+    A space with no directions is legal, and its ``tolerance`` refuses. The wrapper
+    is what turns ``domain`` into a writable array of the space's own dtype and what
+    raises on the dimensionless case, because both are presentation decisions rather
+    than properties of the value.
+
+    Attributes:
+        dim (int): The number of directions.
+        spaces (tuple[BsplineSpace1D32, ...]): The directions, in axis order. The
+            handles this space holds, so the same access twice gives the same
+            objects, and a direction outlives the space it came from.
+        degrees (tuple[int, ...]): One non-negative degree per direction.
+        tolerance (float): The largest of the directions' tolerances.
+        num_basis (tuple[int, ...]): One count per direction.
+        num_total_basis (int): Their product; 1 with no directions.
+        num_intervals (tuple[int, ...]): One count per direction, each at least 1.
+        num_total_intervals (int): Their product; 1 with no directions.
+        domain (npt.NDArray[np.float32]): Shape ``(dim, 2)``, read-only, a view of
+            the space's own storage.
+    """
+
+    def __init__(self, spaces: Sequence[BsplineSpace1D32]) -> None: ...
+    @property
+    def dim(self) -> int: ...
+    @property
+    def spaces(self) -> tuple[BsplineSpace1D32, ...]: ...
+    @property
+    def degrees(self) -> tuple[int, ...]: ...
+    @property
+    def tolerance(self) -> float: ...
+    @property
+    def num_basis(self) -> tuple[int, ...]: ...
+    @property
+    def num_total_basis(self) -> int: ...
+    @property
+    def num_intervals(self) -> tuple[int, ...]: ...
+    @property
+    def num_total_intervals(self) -> int: ...
+    @property
+    def domain(self) -> npt.NDArray[np.float32]: ...
+    def has_Bezier_like_knots(self) -> bool: ...
+
+class BsplineSpace64:
+    """The ``float64`` twin of :class:`BsplineSpace32`; see it for what they share.
+
+    Attributes:
+        dim (int): The number of directions.
+        spaces (tuple[BsplineSpace1D64, ...]): The directions, in axis order.
+        degrees (tuple[int, ...]): One non-negative degree per direction.
+        tolerance (float): The largest of the directions' tolerances.
+        num_basis (tuple[int, ...]): One count per direction.
+        num_total_basis (int): Their product; 1 with no directions.
+        num_intervals (tuple[int, ...]): One count per direction, each at least 1.
+        num_total_intervals (int): Their product; 1 with no directions.
+        domain (npt.NDArray[np.float64]): Shape ``(dim, 2)``, read-only.
+    """
+
+    def __init__(self, spaces: Sequence[BsplineSpace1D64]) -> None: ...
+    @property
+    def dim(self) -> int: ...
+    @property
+    def spaces(self) -> tuple[BsplineSpace1D64, ...]: ...
+    @property
+    def degrees(self) -> tuple[int, ...]: ...
+    @property
+    def tolerance(self) -> float: ...
+    @property
+    def num_basis(self) -> tuple[int, ...]: ...
+    @property
+    def num_total_basis(self) -> int: ...
+    @property
+    def num_intervals(self) -> tuple[int, ...]: ...
+    @property
+    def num_total_intervals(self) -> int: ...
+    @property
+    def domain(self) -> npt.NDArray[np.float64]: ...
     def has_Bezier_like_knots(self) -> bool: ...
 
 _Array = npt.NDArray[np.float32 | np.float64]

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -4,23 +4,347 @@ This module defines :class:`BsplineSpace`, which aggregates multiple
 :class:`~pantr.bspline.BsplineSpace1D` objects to represent
 multi-dimensional parameter domains. It handles tensor-product basis evaluation
 by combining the 1D components.
+
+Since ``design/cross_backend_types.md`` the *value* is owned by C++
+(``cpp/include/pantr/bspline/space_nd.hpp``) and :class:`BsplineSpace` is a wrapper
+holding one implementation of it, exactly as
+:mod:`pantr.bspline._bspline_space_1d` does for the univariate type. There are two
+implementations and they are not two spaces: :class:`_BsplineSpaceNDPython` is the
+oracle the port is checked against, and the C++ handle is the thing being checked.
+:func:`_impl_class` picks between them, per process and per dtype.
+
+Only the *state and what it determines* moved. The operations --
+:meth:`BsplineSpace.tabulate_basis`, :meth:`BsplineSpace.cell_supports`,
+:meth:`BsplineSpace.boundary_dofs` and :meth:`BsplineSpace.restrict` -- are
+computations *over* a space rather than properties *of* one, so they are unchanged,
+still run on numba kernels and numpy, and live on the wrapper. That is the same line
+``space_1d.hpp`` draws to keep ``get_cardinal_intervals`` out of the 1D type, and the
+mixed dispatch it produces is the temporary seam this front introduces; a cleanup
+ticket removes it once the whole front lands.
+
+The wrapper keeps the univariate wrappers it was built from, in ``_spaces``, so that
+``space.spaces[0] is space_1d`` holds. ``design/bspline_ownership_lifetime.md`` F6
+records why that is an identity contract rather than a convenience, and it is what
+requires the C++ constructor to *share* its directions rather than copy them.
 """
 
 from __future__ import annotations
 
-import functools
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, NamedTuple
+import math
+from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn, TypeAlias, cast
 
 import numpy as np
 from numpy import typing as npt
 
+from .._backend import Backend, active_backend, available_backends
 from ._bspline_basis_multidim import _tabulate_Bspline_basis_impl
 from ._bspline_cell_supports import _cell_supports_impl
+from ._bspline_space_1d import _impl_class as _one_d_impl_class
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from .._pantr_cpp import BsplineSpace32 as _CppSpace32
+    from .._pantr_cpp import BsplineSpace64 as _CppSpace64
     from ..quad import PointsLattice
     from ._bspline_space_1d import BsplineSpace1D
+
+    _Impl: TypeAlias = "_BsplineSpaceNDPython | _CppSpace32 | _CppSpace64"
+    """The implementation a :class:`BsplineSpace` holds: the oracle, or a handle.
+
+    Type-checking only, and the same alias :mod:`pantr.bspline._bspline_space_1d`
+    declares for the univariate case: the three are unrelated nominal types that
+    happen to offer the same surface, which is the port's whole claim.
+    """
+
+    _OneDImpl: TypeAlias = "Any"
+    """One direction's implementation, as either backend holds it.
+
+    Deliberately opaque. The univariate module owns the union of the three concrete
+    types, and restating it here would be a second place to keep in step; nothing in
+    this module does anything with a direction's implementation except hand it to
+    the matching nD implementation.
+    """
+
+
+class _BsplineSpaceNDPython:
+    """The pure-Python tensor-product B-spline space: the port's parity oracle.
+
+    Holds one univariate *implementation* per direction, not one wrapper, which is
+    what makes it the exact counterpart of ``pantr::bspline::BsplineSpace<T>``: that
+    type holds ``BsplineSpace1D<T>`` handles, and this one holds whatever
+    :class:`~pantr.bspline.BsplineSpace1D` selected for the same backend.
+
+    Every derived quantity here is an ``O(dim)`` reduction over the directions, with
+    ``dim`` at most 3 everywhere in the tree, and **none of them is memoised**.
+    ``design/bspline_derived_caches.md`` F1 is what settles that: the seven
+    ``functools.cached_property`` sites this class used to carry were memos only
+    because a Python attribute read that walks three objects costs more than a
+    ``__dict__`` hit, which is a fact about CPython rather than about the
+    mathematics. Removing them is also what removes the defect that note records
+    under its third prohibition -- ``domain`` handing out a cached array a caller
+    could write through, corrupting it for the object's whole life.
+
+    Attributes:
+        _spaces (tuple[Any, ...]): One univariate implementation per direction, in
+            axis order.
+        _dtype (np.dtype[Any]): The storage format the directions share. Carried
+            rather than derived, because it is the value the C++ counterpart carries
+            as its template parameter; deriving it here would need a special case
+            for a space with no directions.
+    """
+
+    __slots__ = ("_dtype", "_spaces")
+
+    def __init__(
+        self,
+        spaces: Sequence[_OneDImpl],
+        dtype: np.dtype[Any],
+    ) -> None:
+        """Hold the given univariate implementations, in axis order.
+
+        Args:
+            spaces (Sequence[Any]): One univariate implementation per direction.
+                Already validated by :class:`BsplineSpace`, which owns every
+                type-kind check.
+            dtype (np.dtype[Any]): The storage format the directions share.
+        """
+        self._spaces = tuple(spaces)
+        self._dtype = dtype
+
+    @property
+    def dim(self) -> int:
+        """Get the number of directions.
+
+        Returns:
+            int: The dimension of the parametric domain.
+        """
+        return len(self._spaces)
+
+    @property
+    def spaces(self) -> tuple[_OneDImpl, ...]:
+        """Get the univariate implementations, in axis order.
+
+        Returns:
+            tuple[Any, ...]: One implementation per direction.
+        """
+        return self._spaces
+
+    @property
+    def degrees(self) -> tuple[int, ...]:
+        """Get the polynomial degree of each direction.
+
+        Returns:
+            tuple[int, ...]: The degree for each dimension.
+        """
+        return tuple(int(space.degree) for space in self._spaces)
+
+    @property
+    def tolerance(self) -> float:
+        """Get the absolute tolerance used for parametric comparisons on this space.
+
+        Returns:
+            float: The largest of the directions' tolerances.
+
+        Raises:
+            ValueError: If the space has no directions.
+        """
+        if not self._spaces:
+            # Stated rather than inherited from `max()`. CPython's own message for
+            # an empty `max()` changed between 3.11 and 3.12, so leaving it to the
+            # builtin would make the two backends disagree on one leg of the test
+            # matrix and agree on the others -- a parity gap created by the standard
+            # library. `space_nd.hpp` raises this same text.
+            raise ValueError("tolerance: a B-spline space with no directions has no tolerance")
+        return max(float(space.tolerance) for space in self._spaces)
+
+    @property
+    def num_basis(self) -> tuple[int, ...]:
+        """Get the number of basis functions for each direction.
+
+        Returns:
+            tuple[int, ...]: The number of basis functions for each dimension.
+        """
+        return tuple(int(space.num_basis) for space in self._spaces)
+
+    @property
+    def num_total_basis(self) -> int:
+        """Get the total number of basis functions.
+
+        ``math.prod`` rather than ``numpy.prod``: the counts are Python integers and
+        the product of three of them can exceed ``int64`` on a knot vector this
+        machine can hold, which ``numpy.prod`` wraps silently and this does not. The
+        C++ counterpart cannot follow -- signed overflow there is undefined -- and
+        refuses instead, which is the one input on which the two disagree; see
+        ``space_nd.hpp``.
+
+        Returns:
+            int: The product of :attr:`num_basis`; 1 for a space with no directions,
+            which is the empty tensor product's own convention.
+        """
+        return math.prod(self.num_basis)
+
+    @property
+    def num_intervals(self) -> tuple[int, ...]:
+        """Get the number of intervals for each direction.
+
+        Returns:
+            tuple[int, ...]: The number of intervals for each dimension.
+        """
+        return tuple(int(space.num_intervals) for space in self._spaces)
+
+    @property
+    def num_total_intervals(self) -> int:
+        """Get the total number of cells.
+
+        Returns:
+            int: The product of :attr:`num_intervals`; 1 for a space with no
+            directions.
+        """
+        return math.prod(self.num_intervals)
+
+    @property
+    def domain(self) -> npt.NDArray[np.float32 | np.float64]:
+        """Get the per-direction domain.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Shape ``(dim, 2)``, row ``d``
+            holding direction ``d``'s own domain ends.
+        """
+        domain = np.empty((self.dim, 2), dtype=self._dtype)
+        for i, space in enumerate(self._spaces):
+            domain[i, :] = space.domain
+        return domain
+
+    def has_Bezier_like_knots(self) -> bool:
+        """Check whether every direction describes a single Bézier segment.
+
+        Returns:
+            bool: True if every direction has open ends and only one span; True for
+            a space with no directions, which is what ``all(())`` gives.
+        """
+        return all(space.has_Bezier_like_knots() for space in self._spaces)
+
+
+def _validated_spaces(spaces: Iterable[BsplineSpace1D]) -> tuple[BsplineSpace1D, ...]:
+    """Refuse a collection of directions that cannot form a tensor-product space.
+
+    The dtype check is this function's and cannot be either implementation's:
+    ``BsplineSpace<T>`` can hold only ``BsplineSpace1D<T>``, so a mixed collection is
+    not representable in C++ and there is nothing there to check. It is also the
+    right side of the seam on its own terms -- a dtype is a type-kind fact, and
+    ``pantr/core/error.hpp`` records that nanobind has no path producing a
+    :class:`TypeError`, so the whole port keeps type-kind checks in the wrapper.
+
+    Args:
+        spaces (Iterable[BsplineSpace1D]): The directions, in axis order.
+
+    Returns:
+        tuple[BsplineSpace1D, ...]: The directions as a tuple.
+
+    Raises:
+        ValueError: If the directions do not all share one storage format.
+    """
+    validated = tuple(spaces)
+    if any(space.dtype != validated[0].dtype for space in validated):
+        raise ValueError("All B-spline spaces must have the same data type.")
+    return validated
+
+
+def _stored_dtype(spaces: tuple[BsplineSpace1D, ...]) -> np.dtype[Any]:
+    """The storage format a tensor-product space over these directions would have.
+
+    Args:
+        spaces (tuple[BsplineSpace1D, ...]): The directions, already validated to
+            share one dtype.
+
+    Returns:
+        np.dtype[Any]: That dtype, or ``float64`` when there are no directions. A
+        space with no directions has nothing dtype-dependent reachable on it -- both
+        :attr:`BsplineSpace.dtype` and :attr:`BsplineSpace.domain` raise
+        :class:`IndexError` -- so the choice has no observable consequence, and
+        making one here is what keeps the dimensionless case out of both
+        implementations.
+    """
+    if not spaces:
+        return np.dtype(np.float64)
+    return np.dtype(spaces[0].dtype)
+
+
+def _impl_class(dtype: np.dtype[Any]) -> type[_BsplineSpaceNDPython] | type[Any]:
+    """The implementation class the active backend and the dtype select.
+
+    The backend is per process rather than per instance, for the reason
+    :func:`pantr.bspline._bspline_space_1d._impl_class` gives and which bites here
+    first: two spaces built under different backends meeting in one
+    :class:`BsplineSpace` is the concrete hazard that rule was written for, and
+    :func:`_new_impl` refuses it rather than reconciling it.
+
+    Args:
+        dtype (np.dtype[Any]): The storage format the directions share.
+
+    Returns:
+        type: The oracle under the Python backend, and the C++ class for that
+        storage format otherwise.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if active_backend() is Backend.PYTHON:
+        return _BsplineSpaceNDPython
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    if dtype == np.float32:
+        return _pantr_cpp.BsplineSpace32
+    return _pantr_cpp.BsplineSpace64
+
+
+def _new_impl(
+    spaces: tuple[BsplineSpace1D, ...],
+    dtype: np.dtype[Any],
+) -> _Impl:
+    """Build a tensor-product space in whichever implementation the backend selects.
+
+    Args:
+        spaces (tuple[BsplineSpace1D, ...]): The directions, already validated by
+            :func:`_validated_spaces`.
+        dtype (np.dtype[Any]): The storage format they share.
+
+    Returns:
+        _Impl: The implementation object; an oracle instance or a C++ handle.
+
+    Raises:
+        ValueError: If any direction was built under a different backend.
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    cls = _impl_class(dtype)
+    # Both implementations aggregate the directions' *implementations*, so a
+    # direction built under the other backend cannot be aggregated -- and the two
+    # ways that fails are both bad. Handing a Python oracle to a C++ class raises a
+    # nanobind `TypeError` naming C++ types, which is loud but unreadable; handing a
+    # C++ handle to the oracle SUCCEEDS and yields a hybrid whose reductions run in
+    # Python over C++ values, which no parity claim covers and nothing announces.
+    # `design/cross_backend_types.md` forbids exactly that second shape.
+    one_d_cls = _one_d_impl_class(dtype)
+    impls = []
+    for direction, space in enumerate(spaces):
+        impl = space._impl
+        if not isinstance(impl, one_d_cls):
+            raise ValueError(
+                f"All B-spline spaces must come from the active backend; direction "
+                f"{direction} was built under a different one."
+            )
+        impls.append(impl)
+    if cls is _BsplineSpaceNDPython:
+        return _BsplineSpaceNDPython(impls, dtype)
+    # `cls` is one of the C++ classes here. The checker cannot narrow an identity
+    # test on a `type[...]` union, so it still admits the oracle and then reports its
+    # extra `dtype` parameter as missing; the univariate module's counterpart needs
+    # no such step only because its two constructors happen to share an arity.
+    cpp_cls: Any = cls
+    return cast("_Impl", cpp_cls(impls))
 
 
 class BsplineSpace:
@@ -32,11 +356,38 @@ class BsplineSpace:
     parameters, compute various geometric characteristics of the spline,
     and access various properties of the B-spline.
 
+    **This class is a wrapper.** The value -- the univariate spaces and every
+    reduction over them -- is owned by an implementation chosen by
+    :func:`_impl_class`, which is the C++ type
+    (``cpp/include/pantr/bspline/space_nd.hpp``) or the oracle
+    :class:`_BsplineSpaceNDPython`. The four operations below
+    (:meth:`tabulate_basis`, :meth:`cell_supports`, :meth:`boundary_dofs`,
+    :meth:`restrict`) are still Python over numba kernels and numpy, and are
+    unchanged; only the state moved.
+
+    Instances are immutable, and that is enforced rather than documented:
+    ``__slots__`` means there is no ``__dict__`` to attach anything to, and
+    :meth:`__setattr__` refuses even a rebinding of the two slots. The wrapper fills
+    them through ``object.__setattr__``, which is the pattern
+    ``design/bspline_derived_caches.md`` asks for and
+    ``src/pantr/grid/_tensor_product_grid.py`` already ships.
+
     Attributes:
-        _spaces (Iterable[BsplineSpace1D]): List of B-spline spaces, one for each dimension.
+        _impl (_Impl): The implementation this wrapper holds; see
+            :func:`_impl_class`.
+        _spaces (tuple[BsplineSpace1D, ...]): The univariate wrappers this space was
+            built from, so that ``space.spaces[0] is space_1d`` holds. It is a
+            *presentation* memo, never a second truth about a value: the counts, the
+            tolerance and the domain all come from :attr:`_impl` on every access.
     """
 
+    __slots__ = ("_impl", "_spaces")
+
+    _impl: _Impl
+    """The implementation this wrapper holds; see :func:`_impl_class`."""
+
     _spaces: tuple[BsplineSpace1D, ...]
+    """The univariate wrappers this space was built from; see the class docstring."""
 
     def __init__(
         self,
@@ -45,15 +396,64 @@ class BsplineSpace:
         """Initialize a B-spline space object.
 
         Args:
-            spaces (Iterable[BsplineSpace1D]): List of B-spline spaces, one for each dimension.
+            spaces (Iterable[BsplineSpace1D]): List of B-spline spaces, one for each
+                dimension.
 
         Raises:
-            ValueError: If the B-spline spaces have different data types.
+            ValueError: If the B-spline spaces have different data types, or if any
+                of them was built under a different backend.
+            RuntimeError: If the C++ backend is requested and is not available.
         """
-        self._spaces = tuple(spaces)
+        validated = _validated_spaces(spaces)
+        impl = _new_impl(validated, _stored_dtype(validated))
+        object.__setattr__(self, "_impl", impl)
+        object.__setattr__(self, "_spaces", validated)
 
-        if not all(space.dtype == self.dtype for space in self._spaces):
-            raise ValueError("All B-spline spaces must have the same data type.")
+    def __setattr__(self, name: str, value: object) -> NoReturn:
+        """Refuse to set an attribute, because a space is immutable.
+
+        Args:
+            name (str): The attribute a caller tried to set.
+            value (object): The value it tried to set.
+
+        Raises:
+            AttributeError: Always.
+        """
+        raise AttributeError(f"{type(self).__name__} is immutable; cannot set {name!r}")
+
+    def __delattr__(self, name: str) -> NoReturn:
+        """Refuse to delete an attribute, because a space is immutable.
+
+        Args:
+            name (str): The attribute a caller tried to delete.
+
+        Raises:
+            AttributeError: Always.
+        """
+        raise AttributeError(f"{type(self).__name__} is immutable; cannot delete {name!r}")
+
+    def __reduce__(
+        self,
+    ) -> tuple[type[BsplineSpace], tuple[tuple[BsplineSpace1D, ...]]]:
+        """Pickle by the univariate wrappers rather than by implementation.
+
+        The C++ handle is not picklable and must not become part of the wire format:
+        a pickle written under the C++ backend has to load under the Python one and
+        the other way round, or the backend switch would silently become a
+        data-format switch.
+
+        The directions go out as **wrappers**, not as their implementations, which is
+        what carries their own ``__reduce__`` -- and with it the tolerance-drift
+        bound ``design/bspline_pickle_tolerance.md`` derives for a univariate space --
+        into this one's round trip. It is also what makes sharing survive a single
+        pickle for free: ``pickle`` memoises, so dumping ``(space, space.spaces[0])``
+        restores a pair that still satisfies ``space.spaces[0] is one_d``. Sharing
+        does not survive two independent ``dumps`` calls, which is also true today.
+
+        Returns:
+            tuple: The class, and the univariate spaces to rebuild it from.
+        """
+        return (type(self), (self.spaces,))
 
     @property
     def dim(self) -> int:
@@ -62,98 +462,146 @@ class BsplineSpace:
         Returns:
             int: The dimension of the B-spline space.
         """
-        return len(self._spaces)
+        return int(self._impl.dim)
 
     @property
     def spaces(self) -> tuple[BsplineSpace1D, ...]:
         """Get the B-spline spaces.
+
+        The objects a caller passed to the constructor, not copies and not
+        re-wrappings of what the implementation holds, so
+        ``space.spaces[0] is space_1d`` holds under both backends.
+        ``design/bspline_ownership_lifetime.md`` F6 records why: no C++ object can
+        supply the constructor argument's own Python object, and only the wrapper
+        can, by keeping what it was built from.
 
         Returns:
             tuple[BsplineSpace1D, ...]: The B-spline spaces.
         """
         return self._spaces
 
-    @functools.cached_property
+    @property
     def degrees(self) -> tuple[int, ...]:
         """Get the polynomial degree of the B-spline.
 
         Returns:
             tuple[int, ...]: The degree for each dimension.
         """
-        return tuple(space.degree for space in self._spaces)
+        return tuple(self._impl.degrees)
 
-    @functools.cached_property
+    @property
     def tolerance(self) -> float:
         """Get the absolute tolerance used for parametric comparisons on this space.
 
         The largest of the univariate spaces' tolerances, each of which already
         carries its own direction's knot magnitude (see
         :attr:`~pantr.bspline.BsplineSpace1D.tolerance`). Taking the largest is the
-        conservative choice when the directions are scaled differently.
+        conservative choice when the directions are scaled differently: of the
+        obvious reductions it is the only one that never under-states a gap in any
+        direction.
+
+        A *selection* rather than an arithmetic combination, so the result is one of
+        the directions' own tolerances unmodified, and the two backends agree on it
+        bit for bit.
 
         Returns:
             float: The absolute parametric tolerance.
+
+        Raises:
+            ValueError: If the space has no directions.
         """
-        return max(space.tolerance for space in self._spaces)
+        return float(self._impl.tolerance)
 
     @property
     def dtype(self) -> npt.DTypeLike:
         """Get the data type of the B-spline space.
 
+        Read off the first direction rather than delegated, for the reason
+        :attr:`~pantr.bspline.BsplineSpace1D.dtype` is: the C++ handle carries its
+        storage format in its class name, not as a numpy dtype it could hand back.
+
         Returns:
             npt.DTypeLike: The numpy data type of the B-spline space.
-        """
-        return self._spaces[0].dtype
 
-    @functools.cached_property
+        Raises:
+            IndexError: If the space has no directions.
+        """
+        return self.spaces[0].dtype
+
+    @property
     def num_basis(self) -> tuple[int, ...]:
         """Get the number of basis functions for each dimension.
 
         Returns:
             tuple[int, ...]: The number of basis functions for each dimension.
         """
-        return tuple(space.num_basis for space in self._spaces)
+        return tuple(self._impl.num_basis)
 
-    @functools.cached_property
+    @property
     def num_total_basis(self) -> int:
         """Get the total number of basis functions.
 
         Returns:
-            int: The total number of basis functions.
+            int: The total number of basis functions; 1 for a space with no
+            directions, which is the empty tensor product's own convention.
         """
-        return int(np.prod(self.num_basis))
+        return int(self._impl.num_total_basis)
 
-    @functools.cached_property
+    @property
     def num_intervals(self) -> tuple[int, ...]:
         """Get the number of intervals for each dimension.
 
         Returns:
             tuple[int, ...]: The number of intervals for each dimension.
         """
-        return tuple(space.num_intervals for space in self._spaces)
+        return tuple(self._impl.num_intervals)
 
-    @functools.cached_property
+    @property
     def num_total_intervals(self) -> int:
         """Get the total number of intervals.
 
         Returns:
-            int: The total number of intervals.
+            int: The total number of intervals; 1 for a space with no directions.
         """
-        return int(np.prod(self.num_intervals))
+        return int(self._impl.num_total_intervals)
 
-    @functools.cached_property
+    @property
     def domain(self) -> npt.NDArray[np.float32 | np.float64]:
         """Get the domain of the B-spline space.
+
+        A fresh, writable array per call under both backends, and a copy of what the
+        implementation owns rather than a view of it. That is what makes the two
+        backends indistinguishable here: the C++ side hands out a read-only view of
+        its own storage and the oracle builds an array, and a caller must not be able
+        to tell which built the space.
+
+        It also retires a defect. Until this port ``domain`` was a
+        ``functools.cached_property`` handing out its cached array **unfrozen**, so
+        ``d = space.domain; d[0, 0] = 999.0`` corrupted the cache for the object's
+        whole life -- the third prohibition of ``design/bspline_derived_caches.md``,
+        reproduced there. There is now no cache on either side to corrupt, so a write
+        reaches the caller's own copy and nothing else sees it.
+
+        ``space.domain is space.domain`` was ``True`` and is now ``False``. Nothing
+        promised that identity and nothing in the suite relied on it; recorded
+        because the sibling weakening on
+        :attr:`~pantr.bspline.BsplineSpace1D.domain` is recorded, and one of the two
+        going unsaid is how the pair becomes folklore.
 
         Returns:
             npt.NDArray[np.float32 | np.float64]: The domain of the B-spline space.
             The shape is (dim, 2), where the last dimension contains the start
             and end values of the domain.
+
+        Raises:
+            IndexError: If the space has no directions.
         """
-        domain = np.empty((self.dim, 2), dtype=self.dtype)
-        for i, space in enumerate(self._spaces):
-            domain[i, :] = space.domain
-        return domain
+        # `dtype` first, and on its own line, because it is what raises on a space
+        # with no directions -- the behaviour before the port, pinned by
+        # `tests/test_bspline_space.py::TestBsplineSpaceEdgeCases`. Reading the
+        # implementation instead would hand back an empty `(0, 2)` array.
+        dtype = self.dtype
+        return np.array(self._impl.domain, dtype=dtype)
 
     def has_Bezier_like_knots(self) -> bool:
         """Check if the knot vector represents a Bézier-like configuration.
@@ -171,7 +619,7 @@ class BsplineSpace:
             >>> bspline_2D.has_Bezier_like_knots()
             True
         """
-        return all(space.has_Bezier_like_knots() for space in self._spaces)
+        return bool(self._impl.has_Bezier_like_knots())
 
     def tabulate_basis(
         self,
@@ -309,7 +757,7 @@ class BsplineSpace:
             >>> space.boundary_dofs(1, 1, layers=2).tolist()
             [2, 3, 6, 7, 10, 11, 14, 15, 18, 19]
         """
-        if any(space.periodic for space in self._spaces):
+        if any(space.periodic for space in self.spaces):
             raise ValueError("boundary_dofs: periodic B-spline spaces are not supported.")
         if not 0 <= direction < self.dim:
             raise ValueError(
@@ -317,21 +765,22 @@ class BsplineSpace:
             )
         if side not in (0, 1):
             raise ValueError(f"boundary_dofs: side must be 0 (low) or 1 (high); got {side}.")
-        num_basis_dir = self.num_basis[direction]
+        num_basis = self.num_basis
+        num_basis_dir = num_basis[direction]
         if not 1 <= layers <= num_basis_dir:
             raise ValueError(
                 f"boundary_dofs: layers must lie in [1, {num_basis_dir}]; got {layers}."
             )
 
         first = 0 if side == 0 else num_basis_dir - layers
-        axes = [np.arange(n, dtype=np.int64) for n in self.num_basis]
+        axes = [np.arange(n, dtype=np.int64) for n in num_basis]
         axes[direction] = np.arange(first, first + layers, dtype=np.int64)
 
         # Each axis range is ascending and the C-order flat id is monotone in the
         # lexicographic order of the multi-index, so the slab comes out sorted and
         # unique without an explicit sort.
         mesh = np.meshgrid(*axes, indexing="ij")
-        dofs = np.ravel_multi_index(tuple(m.ravel() for m in mesh), self.num_basis).astype(np.int64)
+        dofs = np.ravel_multi_index(tuple(m.ravel() for m in mesh), num_basis).astype(np.int64)
         dofs.flags.writeable = False
         return dofs
 
@@ -359,7 +808,8 @@ class BsplineSpace:
             IndexError: If any cell id is out of range ``[0, num_total_intervals)``.
             TypeError: If ``cell_ids`` is not integer-valued.
         """
-        if any(space.periodic for space in self._spaces):
+        spaces = self.spaces
+        if any(space.periodic for space in spaces):
             raise ValueError("restrict: periodic B-spline spaces are not supported.")
         ids = np.asarray(cell_ids).ravel()
         if ids.size == 0:
@@ -377,7 +827,7 @@ class BsplineSpace:
         multi = np.unravel_index(ids, self.num_intervals)
         windowed_1d: list[BsplineSpace1D] = []
         dof_axes: list[npt.NDArray[np.int64]] = []
-        for d, space in enumerate(self._spaces):
+        for d, space in enumerate(spaces):
             w_space, dof_d = space.restrict(int(multi[d].min()), int(multi[d].max()) + 1)
             windowed_1d.append(w_space)
             dof_axes.append(dof_d)
@@ -403,6 +853,11 @@ class BsplineSpaceRestriction(NamedTuple):
     Unlike :class:`pantr.grid.GridRestriction` there is no ``in_subset`` mask: every
     windowed DOF is a genuine parent DOF (a windowed space spans a box of cells, so
     there are no fill DOFs).
+
+    ``space`` is a freshly built wrapper rather than a subobject of the space that
+    produced it -- ``design/bspline_ownership_lifetime.md``'s class **V** -- so this
+    stays a plain :class:`typing.NamedTuple` with nothing to decide about lifetime,
+    and it pickles through the default protocol over its two picklable fields.
     """
 
     space: BsplineSpace

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -246,6 +246,10 @@ def _validated_spaces(spaces: Iterable[BsplineSpace1D]) -> tuple[BsplineSpace1D,
         ValueError: If the directions do not all share one storage format.
     """
     validated = tuple(spaces)
+    # `validated[0]` is unreachable for an empty tuple rather than merely unlikely:
+    # the generator's `for` never advances, so the expression is never evaluated.
+    # Spelled this way instead of guarded, because a guard would read as if the
+    # dimensionless case needed handling here, and it does not.
     if any(space.dtype != validated[0].dtype for space in validated):
         raise ValueError("All B-spline spaces must have the same data type.")
     return validated
@@ -358,27 +362,28 @@ class BsplineSpace:
 
     **This class is a wrapper.** The value -- the univariate spaces and every
     reduction over them -- is owned by an implementation chosen by
-    :func:`_impl_class`, which is the C++ type
+    ``_impl_class``, which is the C++ type
     (``cpp/include/pantr/bspline/space_nd.hpp``) or the oracle
-    :class:`_BsplineSpaceNDPython`. The four operations below
+    ``_BsplineSpaceNDPython``. The four operations below
     (:meth:`tabulate_basis`, :meth:`cell_supports`, :meth:`boundary_dofs`,
     :meth:`restrict`) are still Python over numba kernels and numpy, and are
     unchanged; only the state moved.
 
     Instances are immutable, and that is enforced rather than documented:
     ``__slots__`` means there is no ``__dict__`` to attach anything to, and
-    :meth:`__setattr__` refuses even a rebinding of the two slots. The wrapper fills
+    ``__setattr__`` refuses even a rebinding of the two slots. The wrapper fills
     them through ``object.__setattr__``, which is the pattern
     ``design/bspline_derived_caches.md`` asks for and
     ``src/pantr/grid/_tensor_product_grid.py`` already ships.
 
     Attributes:
-        _impl (_Impl): The implementation this wrapper holds; see
-            :func:`_impl_class`.
+        _impl: The implementation this wrapper holds; see ``_impl_class``. Its type
+            is the private ``_Impl`` alias, which is a union of three unrelated
+            nominal types and has no documented form to name here.
         _spaces (tuple[BsplineSpace1D, ...]): The univariate wrappers this space was
             built from, so that ``space.spaces[0] is space_1d`` holds. It is a
             *presentation* memo, never a second truth about a value: the counts, the
-            tolerance and the domain all come from :attr:`_impl` on every access.
+            tolerance and the domain all come from ``_impl`` on every access.
     """
 
     __slots__ = ("_impl", "_spaces")

--- a/tests/parity/test_bspline_binding_contract.py
+++ b/tests/parity/test_bspline_binding_contract.py
@@ -1,9 +1,10 @@
-"""What the `BsplineSpace1D` binding guarantees, as opposed to what it computes.
+"""What the `pantr.bspline` space bindings guarantee, as opposed to what they compute.
 
-`tests/parity/test_bspline_space_1d.py` compares the two backends' *answers*. This
-file is about the *binding*: what the arrays it hands out alias, how long they stay
-valid, what the constructor refuses to convert, and one rule that is about the shape
-of the bound surface rather than about any one call.
+`tests/parity/test_bspline_space_1d.py` and `tests/parity/test_bspline_space_nd.py`
+compare the two backends' *answers*. This file is about the *bindings*: what the
+arrays they hand out alias, how long they stay valid, what a constructor refuses to
+convert, what a nested object's identity and lifetime are, and one rule that is about
+the shape of the bound surface rather than about any one call.
 
 Every claim here is exact -- an identity, a flag, a refusal, a name -- so nothing in
 this file carries a tolerance, and `design/backend_parity.md` Rule 8 does not bite.
@@ -41,9 +42,37 @@ the knots. ``.noconvert()`` is what makes
 **A borrowing accessor reaching Python.** `design/bspline_ownership_lifetime.md`
 requires that no ``_ref`` accessor is ever bound: it is a reference with no owner and
 no policy, so a caller can hold it past the owner's death with nothing to blame.
-``BsplineSpace1D`` has none to bind, so the rule holds vacuously here -- and it is
-asserted over the whole bound surface anyway, because the next type in this front
-will have one and there is no ``static_assert`` for absence.
+``BsplineSpace1D`` has none to bind. **The tensor-product ``BsplineSpace`` does** --
+``space_ref(d)``, which borrows a direction and costs a measured 5.83 ns against
+``space(d)``'s 14.92 ns -- so the rule stops being vacuous with this type, and the
+assertion over the whole bound surface stops being a formality.
+
+## What the tensor product adds: a nested object rather than an array
+
+``BsplineSpace`` is the first type in this front that holds another domain type, so
+four more silent failures become possible and each gets a test below. They are
+``design/bspline_ownership_lifetime.md``'s M1, M2, M7 and M8, and the note's own
+summary of why value assertions cannot stand in for them is worth restating in one
+line each:
+
+**The constructor copies its directions instead of sharing them (M7).** Every value
+agrees, and ``space.spaces[0] is space_1d`` still holds at the wrapper level because
+the wrapper keeps what it was built from -- so two Python objects would report
+identity over two different C++ objects. The assertion is on the *implementations*.
+
+**A keep-alive is installed where the value should have been shared (M2).** That is
+what reverting to ``rv_policy::reference_internal`` looks like from Python, and it
+works today while dangling for a consumer with no interpreter. The detector is a
+``sys.getrefcount`` delta of exactly zero on the owner.
+
+**The wrapper forgets to seed its ``_spaces`` slot from the constructor (M1, M8).**
+Values all agree; only the identity moves.
+
+**A direction does not outlive its owner.** The whole reason class H stores a
+``shared_ptr<const T>``: the guarantee lives in the type rather than in the binding.
+``design/bspline_ownership_lifetime.md`` F4 measured a scalar read after free
+returning the *correct* value, so this is asserted on state a destroyed space would
+have had to overwrite.
 """
 
 from __future__ import annotations
@@ -56,10 +85,18 @@ import numpy as np
 import pytest
 
 from pantr._backend import Backend, use_backend
-from pantr.bspline import BsplineSpace1D
+from pantr.bspline import BsplineSpace, BsplineSpace1D
 
 _KNOTS = np.asarray([0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0], dtype=np.float64)
 """A clamped quadratic with one repeated interior knot, so every accessor is non-trivial."""
+
+_OTHER_KNOTS = np.asarray([10.0, 10.0, 11.0, 12.0, 12.0], dtype=np.float64)
+"""A second direction, differing from ``_KNOTS`` in degree, counts, domain and scale.
+
+Distinct in every reduced quantity, deliberately, for the reason
+``tests/parity/test_bspline_space_nd.py`` gives at length: two agreeing directions
+make a transposition and a wrong reduction invisible at once.
+"""
 
 
 def _bindings() -> Any:
@@ -194,21 +231,214 @@ def test_the_space_refuses_a_dtype_it_would_have_to_cast(
 
 
 def test_no_bound_method_is_a_borrowing_accessor(cpp_backend: None) -> None:
-    """No name on either class ends in ``_ref``.
+    """No name on any of the four bound space classes ends in ``_ref``.
 
-    The rule from `design/bspline_ownership_lifetime.md`. Vacuous for this type,
-    which hands out spans of its own storage rather than references to nested
-    objects, and asserted anyway: there is no ``static_assert`` for absence, review
-    alone will not hold across the rest of this front, and the cost of the rule
-    being broken is a dangling reference with no policy anywhere to blame.
+    The rule from `design/bspline_ownership_lifetime.md`. It was vacuous while only
+    ``BsplineSpace1D`` existed, which hands out spans of its own storage rather than
+    references to nested objects; ``pantr::bspline::BsplineSpace`` has a real
+    ``space_ref``, so from here on this is the assertion that keeps it unbound.
+    There is no ``static_assert`` for absence, review alone will not hold across the
+    rest of this front, and the cost of the rule being broken is a dangling
+    reference with no policy anywhere to blame.
     """
     bindings = _bindings()
     offenders = []
-    for class_name in ("BsplineSpace1D32", "BsplineSpace1D64"):
+    for class_name in _SPACE_CLASSES:
         cls = getattr(bindings, class_name)
         offenders += [f"{class_name}.{name}" for name in dir(cls) if name.endswith("_ref")]
 
     assert not offenders, f"borrowing accessors reached Python: {offenders}"
+    # A vacuity guard on the guard: the C++ type does have a borrowing accessor, so
+    # if every name were somehow absent from `dir` this test would pass for the wrong
+    # reason. Asserting a name that IS bound is what says `dir` sees the surface.
+    assert "space" not in dir(bindings.BsplineSpace64), (
+        "the owning single-direction accessor is not bound either, so `dir` may not "
+        "be reporting this class's methods at all"
+    )
+    assert "spaces" in dir(bindings.BsplineSpace64)
+
+
+_SPACE_CLASSES = (
+    "BsplineSpace1D32",
+    "BsplineSpace1D64",
+    "BsplineSpace32",
+    "BsplineSpace64",
+)
+"""Every space class the extension registers, for the rules asserted over all of them."""
+
+
+def _cpp_tensor_product() -> BsplineSpace:
+    """Build a two-direction tensor-product space under the C++ backend.
+
+    Returns:
+        BsplineSpace: The space, holding a C++ handle whose directions are the C++
+        handles of two univariate spaces.
+    """
+    with use_backend(Backend.CPP):
+        return BsplineSpace([BsplineSpace1D(_KNOTS, 2), BsplineSpace1D(_OTHER_KNOTS, 1)])
+
+
+def test_the_tensor_product_shares_its_directions_rather_than_copying(
+    cpp_backend: None,
+) -> None:
+    """The C++ space holds the very handles it was built from.
+
+    M7. Compared at the *implementation* level, because the wrapper level cannot see
+    it: the wrapper keeps the univariate wrappers it was built from, so
+    ``space.spaces[0] is one_d`` holds whether the C++ constructor shared or copied,
+    and a copying constructor would leave two Python objects reporting identity over
+    two different C++ objects.
+    """
+    with use_backend(Backend.CPP):
+        first = BsplineSpace1D(_KNOTS, 2)
+        second = BsplineSpace1D(_OTHER_KNOTS, 1)
+        space = BsplineSpace([first, second])
+
+    directions = space._impl.spaces
+    assert directions[0] is first._impl, "direction 0 is not the handle the space was given"
+    assert directions[1] is second._impl, "direction 1 is not the handle the space was given"
+
+    # And the wrapper's own contract, M1 and M8: seeded from the constructor, so the
+    # objects a caller passed in come back.
+    assert space.spaces[0] is first
+    assert space.spaces[1] is second
+
+
+def test_taking_a_direction_does_not_pin_its_owner(cpp_backend: None) -> None:
+    """Reading ``spaces`` installs no keep-alive on the tensor-product space.
+
+    M2, and the one detector that distinguishes class H from a reversion to
+    ``rv_policy::reference_internal``: under sharing the *value* travels in the
+    return, so the owner's reference count does not move; under a keep-alive it moves
+    by one per returned element. Both behave identically for a Python caller, and
+    only one of them protects a consumer with no interpreter.
+
+    The returned tuple is dropped before the second reading, deliberately:
+    ``design/bspline_ownership_lifetime.md`` F4 records two correct measurements of
+    this delta disagreeing because one run held the whole container and the other held
+    a single element, so a test must fix that rather than let a temporary decide it.
+    """
+    space = _cpp_tensor_product()
+    impl = space._impl
+    before = sys.getrefcount(impl)
+
+    directions = impl.spaces
+    assert len(directions) == 2
+    del directions
+    gc.collect()
+
+    assert sys.getrefcount(impl) == before, (
+        "reading the directions changed the owner's reference count, which means a "
+        "keep-alive was installed: the accessor is aliasing into the owner rather "
+        "than sharing the value, and it will dangle for a caller with no interpreter"
+    )
+
+
+def test_a_direction_outlives_the_tensor_product_space(cpp_backend: None) -> None:
+    """A direction taken out of a space still knows its own state after the space dies.
+
+    The property that justifies storing ``shared_ptr<const T>`` in the type instead of
+    annotating the binding. Asserted on the direction's counts rather than on the
+    handle being non-null, because F4 measured a scalar read after free returning the
+    correct value -- so several tensor-product spaces are built and dropped in between
+    to churn the freed storage.
+    """
+    space = _cpp_tensor_product()
+    direction = space._impl.spaces[0]
+    expected_basis = direction.num_basis
+    expected_knots = np.array(direction.knots)
+
+    del space
+    gc.collect()
+    with use_backend(Backend.CPP):
+        for _ in range(64):
+            BsplineSpace([BsplineSpace1D(_OTHER_KNOTS, 1)])
+    gc.collect()
+
+    assert direction.num_basis == expected_basis
+    np.testing.assert_array_equal(direction.knots, expected_knots)
+
+
+def test_the_tensor_product_domain_is_a_read_only_view(cpp_backend: None) -> None:
+    """The C++ ``domain`` aliases the space's own storage and cannot be written.
+
+    M5 and M6 for this type's one array accessor. ``const T`` as the scalar is what
+    nanobind turns into the read-only flag; the owner argument is what makes it a view
+    rather than a silent copy, and ``shares_memory`` is what tells the two apart --
+    the values agree either way.
+
+    A dimensionless space is checked alongside, because that is the one case where the
+    block is empty and the stand-in address the binding substitutes for a possibly
+    null ``data()`` is what stops nanobind reading it as "no array".
+    """
+    space = _cpp_tensor_product()
+    domain = space._impl.domain
+
+    assert domain.shape == (2, 2)
+    assert not domain.flags.writeable, "the domain view came back writeable"
+    with pytest.raises(ValueError):
+        domain[0, 0] = 0.0
+    assert np.shares_memory(space._impl.domain, space._impl.domain), (
+        "two reads of the domain do not view one buffer, so it is being copied out"
+    )
+
+    with use_backend(Backend.CPP):
+        empty = BsplineSpace([])
+    empty_domain = empty._impl.domain
+    assert empty_domain.shape == (0, 2)
+    assert not empty_domain.flags.writeable
+
+
+def test_the_wrapper_copies_the_domain_out_of_the_cpp_view(cpp_backend: None) -> None:
+    """``BsplineSpace.domain`` does not hand the C++ read-only view straight through.
+
+    The half of the domain contract that is a *binding* claim; the backend-independent
+    half -- that a write through it corrupts nothing, which is the defect the port
+    retires -- lives in ``tests/test_bspline_space.py`` so that it runs without the
+    extension too.
+
+    What this one catches is the copy being dropped as an optimisation: the view is
+    read-only, so a caller who has always written to ``space.domain`` would start
+    getting a ``ValueError`` under the C++ backend and not under the Python one. The
+    consumer census for this port found no such caller, but the divergence would be
+    real and silent in the suite, since nothing else compares the two arrays' flags.
+    """
+    space = _cpp_tensor_product()
+    domain = space.domain
+
+    assert domain.flags.writeable, (
+        "the wrapper handed the C++ view through, so the domain is read-only under "
+        "the C++ backend and writable under the Python one"
+    )
+    assert not np.shares_memory(domain, space._impl.domain), (
+        "the wrapper's domain aliases the space's own storage, so a write would "
+        "reach validated state from outside"
+    )
+    assert space.domain is not domain, "the wrapper is caching the domain again"
+
+
+@pytest.mark.parametrize(
+    ("class_name", "direction_class"),
+    [("BsplineSpace32", "BsplineSpace1D64"), ("BsplineSpace64", "BsplineSpace1D32")],
+)
+def test_the_tensor_product_refuses_a_direction_of_the_wrong_width(
+    cpp_backend: None, class_name: str, direction_class: str
+) -> None:
+    """Each tensor-product class takes only its own storage format's directions.
+
+    The counterpart of the univariate ``.noconvert()`` check, and it needs no
+    annotation: ``BsplineSpace<T>`` can hold only ``BsplineSpace1D<T>``, and the two
+    univariate classes are unrelated nominal types, so nanobind has no conversion to
+    apply. Asserted rather than argued, because "there is no conversion to suppress"
+    is exactly the kind of claim that stops being true when a caster is added.
+    """
+    bindings = _bindings()
+    cls = getattr(bindings, class_name)
+    wrong = getattr(bindings, direction_class)
+    dtype = np.float32 if direction_class.endswith("32") else np.float64
+    direction = wrong(np.asarray(_KNOTS, dtype=dtype), 2)
+    with pytest.raises(TypeError):
+        cls([direction])
 
 
 def test_a_space_has_no_instance_dictionary() -> None:
@@ -228,3 +458,17 @@ def test_a_space_has_no_instance_dictionary() -> None:
     assert not hasattr(space, "__dict__")
     with pytest.raises(AttributeError):
         space.some_new_attribute = 1  # type: ignore[attr-defined]
+
+    tensor_product = BsplineSpace([space, BsplineSpace1D(_OTHER_KNOTS, 1)])
+    assert not hasattr(tensor_product, "__dict__")
+    with pytest.raises(AttributeError):
+        tensor_product.some_new_attribute = 1
+    # The tensor product goes further than its univariate direction and refuses to
+    # rebind its own slots too, which is what `design/bspline_derived_caches.md` asks
+    # for and what `src/pantr/grid/_tensor_product_grid.py` ships: `_spaces` carries
+    # an identity contract, so a caller reseating it would leave a space whose
+    # directions disagree with its counts.
+    with pytest.raises(AttributeError):
+        tensor_product._impl = None  # type: ignore[assignment]
+    with pytest.raises(AttributeError):
+        del tensor_product._spaces

--- a/tests/parity/test_bspline_space_nd.py
+++ b/tests/parity/test_bspline_space_nd.py
@@ -22,10 +22,11 @@ an argument rather than observations that happened to hold:
 Both rest on the directions themselves agreeing bitwise, which
 ``tests/parity/test_bspline_space_1d.py`` claims and pins independently. That is the
 whole of the nD derivation: exact integer arithmetic and exact selection over inputs
-that are already equal. ``design/backend_parity.md`` Rule 8 -- a parity claim is only
-defined where the quantity has digits -- is satisfied trivially rather than narrowly,
-because nothing here loses a digit; and ``CLAUDE.md``'s determinism rule licenses
-bit-identity for exactly this case, where finite precision does not bite.
+that are already equal. ``design/backend_parity.md`` Rule 8 -- whose concern is a bound
+as large as the values it compares -- **does not bite** here, because the bound is zero
+and nothing loses a digit. The authority that licenses bit-identity as the criterion is
+``CLAUDE.md``'s determinism rule alone, for exactly this case, where finite precision
+does not bite.
 
 ## Why every multi-direction case is asymmetric
 
@@ -61,7 +62,13 @@ implementation: they compare the aggregate against the univariate type, which is
 ported and pinned separately, so a reduction that read the wrong axis or dropped a
 direction fails them.
 
-## Rule 12
+## Rule 12, as ``bspline_ownership_lifetime.md`` extends it
+
+``design/backend_parity.md`` Rule 12 enumerates how ``NUMBA_DISABLE_JIT=1`` changes the
+oracle. What governs the gating below is that rule's *general form*, which
+``design/bspline_ownership_lifetime.md`` extends to this case in its note on
+``Backend.PYTHON`` being the process default: the interpreted path is a different
+object, so a test of the binding must demand the binding.
 
 Every test that says something about the *binding* takes the ``cpp_backend`` fixture,
 whose ``demand_cpp_backend`` is a skip-or-fail rather than a silent skip. The tests
@@ -807,10 +814,11 @@ def test_the_bitwise_claim_holds_over_a_ten_times_sweep(cpp_backend: None) -> No
     The bound is **zero**: every quantity is an exact integer or an unmodified copy or
     selection of a value the two backends already agree on bit for bit, so the sweep
     reports a differing-bit count rather than a margin, and the count must be zero.
-    ``design/backend_parity.md`` Rule 8 is what makes that statable -- the claim is
-    defined because nothing here loses a digit -- and ``CLAUDE.md``'s determinism rule
-    is what licenses bit-identity as the criterion rather than a derived tolerance,
-    since finite precision does not bite on a count, an index or a copied value.
+    ``design/backend_parity.md`` Rule 8 **does not bite** -- its concern, a bound as
+    large as the values it compares, cannot arise where the bound is zero -- and
+    ``CLAUDE.md``'s determinism rule is what licenses bit-identity as the criterion
+    rather than a derived tolerance, since finite precision does not bite on a count,
+    an index or a copied value.
 
     Two vacuity guards, because a sweep that agrees on nothing interesting agrees
     trivially: the quantities compared must actually **vary** across the sweep, and the

--- a/tests/parity/test_bspline_space_nd.py
+++ b/tests/parity/test_bspline_space_nd.py
@@ -409,17 +409,23 @@ def test_the_sweep_can_see_each_reduction() -> None:
         "no case has directions of differing domain, so a row swap would be invisible"
     )
 
-    # The tolerance argmax must appear both first and last. One position alone leaves
-    # `max` indistinguishable from whichever of `first` or `last` matches it.
-    argmaxes = set()
+    # The tolerance argmax must appear first, last AND in the middle. First and last
+    # alone leave `max` indistinguishable from whichever of `first` or `last` matches
+    # it; the interior position is what rules out "the second one", and it is the case
+    # `cpp/tests/test_bspline_space_nd.cpp` names explicitly too. Only cases whose
+    # direction tolerances are pairwise distinct can vote, since a tie has no argmax.
+    positions = set()
     for space in spaces.values():
         tolerances = [one.tolerance for one in space.spaces]
         if len(set(tolerances)) == len(tolerances):
-            argmaxes.add(tolerances.index(max(tolerances)) == 0)
-            argmaxes.add(tolerances.index(max(tolerances)) == len(tolerances) - 1)
-    assert argmaxes == {True, False}, (
-        "the tolerance argmax must be the first direction in some case and the last "
-        "in another, over cases whose direction tolerances are all distinct"
+            index = tolerances.index(max(tolerances))
+            positions.add(
+                "first" if index == 0 else "last" if index == len(tolerances) - 1 else "middle"
+            )
+    assert positions == {"first", "middle", "last"}, (
+        f"the tolerance argmax appears only at {sorted(positions)} across the cases "
+        f"whose direction tolerances are all distinct; `max` is not distinguished "
+        f"from a positional pick until all three appear"
     )
 
     # Some case in the table must have a ``float32`` tolerance that is not a
@@ -847,3 +853,88 @@ def test_the_bitwise_claim_holds_over_a_ten_times_sweep(cpp_backend: None) -> No
         f"the sweep saw only {len(seen_totals)} distinct basis totals, so the products "
         f"were barely exercised"
     )
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64], ids=["float32", "float64"])
+def test_the_unported_operations_agree_across_the_seam(
+    cpp_backend: None, dtype: npt.DTypeLike
+) -> None:
+    """The four operations still in Python agree on a space of either backend.
+
+    The seam test. ``tabulate_basis``, ``cell_supports``, ``boundary_dofs`` and
+    ``restrict`` are computations *over* a space rather than properties *of* one, so
+    the port leaves them on the wrapper, running the same numba kernels and the same
+    numpy either way. What changes underneath them is where they read the space's
+    state from -- a C++ handle or the oracle -- and this is the only test that
+    exercises that path.
+
+    Without it the coverage looks complete and is not: ``tests/test_bspline_space.py``
+    checks all four against hand-computed values and runs under both backends, so each
+    is independently correct, but nothing compares the two *to each other* on the
+    asymmetric multi-direction spaces this file is built around. A state-consumption
+    defect specific to the C++-backed wrapper -- an array whose flags or layout differ
+    on the way into a kernel, say -- would have to break one of that file's specific
+    hardcoded numbers to be caught there, and could otherwise pass both halves.
+
+    **Bitwise, and that is a claim rather than a hope.** The kernels are the same
+    compiled functions in both runs and the state they read is bit-identical by the
+    field-by-field test above, so identical inputs reach identical code. A difference
+    here is a defect in what the wrapper hands the kernel, not a rounding, which is
+    why the comparison is exact for the float results as well as for the index ones.
+
+    **What it reaches, measured rather than assumed.** The four operations consume the
+    per-direction counts and the univariate directions themselves, so a defect in
+    either shows here: reversing ``num_basis`` on a three-direction space, and summing
+    the tensor-product total instead of multiplying it, both turn this test red. They
+    do **not** consume the nD ``domain`` block -- they read each direction's own
+    ``domain`` -- so swapping its rows leaves this test green while turning the
+    field-by-field one red. That is the division of labour rather than a gap, and it is
+    written down because the natural reading of "the operations agree" is that they
+    cover every piece of state, and they do not.
+    """
+    directions = (_QUAD_3, _LIN_2, _DEG0_4)
+    python, cpp = _both_backends(directions, dtype)
+
+    # A point set inside the intersection of the three domains would be empty
+    # ([0, 3] x [10, 12] x [0, 4]), so the points are built per direction and crossed.
+    pts = np.array(
+        [[0.0, 10.0, 0.0], [1.5, 11.0, 2.0], [3.0, 12.0, 4.0], [0.25, 10.5, 3.5]],
+        dtype=dtype,
+    )
+    py_basis, py_first = python.tabulate_basis(pts)
+    cpp_basis, cpp_first = cpp.tabulate_basis(pts)
+    np.testing.assert_array_equal(py_basis, cpp_basis, err_msg="tabulate_basis values")
+    np.testing.assert_array_equal(py_first, cpp_first, err_msg="tabulate_basis indices")
+
+    cells = np.arange(python.num_total_intervals, dtype=np.int64)
+    np.testing.assert_array_equal(
+        python.cell_supports(cells), cpp.cell_supports(cells), err_msg="cell_supports"
+    )
+
+    for direction in range(python.dim):
+        for side in (0, 1):
+            for layers in (1, 2):
+                np.testing.assert_array_equal(
+                    python.boundary_dofs(direction, side, layers),
+                    cpp.boundary_dofs(direction, side, layers),
+                    err_msg=f"boundary_dofs({direction}, {side}, {layers})",
+                )
+
+    for cell_ids in ([0], [0, 1], [1, 5, 7], cells.tolist()):
+        py_restricted = python.restrict(cell_ids)
+        cpp_restricted = cpp.restrict(cell_ids)
+        where = f"restrict({cell_ids})"
+        np.testing.assert_array_equal(
+            py_restricted.local_to_global_dof,
+            cpp_restricted.local_to_global_dof,
+            err_msg=where,
+        )
+        # The windowed space is a freshly built wrapper on each side -- class V of
+        # `design/bspline_ownership_lifetime.md` -- so its own state is compared here
+        # rather than taken on trust from the parent's.
+        assert_object_parity(
+            py=py_restricted.space,
+            cpp=cpp_restricted.space,
+            fields=_fields(py_restricted.space.dim),
+            context=where,
+        )

--- a/tests/parity/test_bspline_space_nd.py
+++ b/tests/parity/test_bspline_space_nd.py
@@ -1,0 +1,849 @@
+"""Parity for `pantr.bspline.BsplineSpace`: the C++ tensor product against the oracle.
+
+## What kind of claim this file makes
+
+Every claim here is **exactness**, and none of it is a bound. A tensor-product space
+answers counting questions about its directions, so the dimension, the per-direction
+degrees, basis counts and interval counts, the two products and the Bézier flag are
+integers and booleans reached by the same integer arithmetic on both sides; those are
+compared with :func:`exact_parity`, and a tolerance on any of them would be hiding
+something.
+
+The two floating-point quantities are compared **bitwise**, and both are claims with
+an argument rather than observations that happened to hold:
+
+- ``domain`` is each direction's own ``domain`` copied unchanged, and a direction's
+  ``domain`` is two indexed reads of its knot vector. No arithmetic is performed on
+  it at either level.
+- ``tolerance`` is ``max`` over the directions' tolerances. A **selection**, not a
+  combination: the result is one of the inputs, bit for bit, so the only thing that
+  could differ is *which* input, which is a verdict rather than a rounding.
+
+Both rest on the directions themselves agreeing bitwise, which
+``tests/parity/test_bspline_space_1d.py`` claims and pins independently. That is the
+whole of the nD derivation: exact integer arithmetic and exact selection over inputs
+that are already equal. ``design/backend_parity.md`` Rule 8 -- a parity claim is only
+defined where the quantity has digits -- is satisfied trivially rather than narrowly,
+because nothing here loses a digit; and ``CLAUDE.md``'s determinism rule licenses
+bit-identity for exactly this case, where finite precision does not bite.
+
+## Why every multi-direction case is asymmetric
+
+This is the file's main structural decision. On a tensor product, two directions that
+agree on their degree, their counts and their domain make a whole family of defects
+invisible at once: a transposition, an off-by-one in the axis index, a ``min`` written
+for a ``max``, and a reduction that quietly returns its first argument all produce the
+right answer. Symmetric cases are how a parity file reads as full coverage and
+measures nothing.
+
+So no case below repeats a direction except the one that exists to exercise repetition
+(``BsplineSpace([s, s])``, which is the common spelling in the suite and which broke a
+first draft of the tolerance reduction), and
+:func:`test_the_sweep_can_see_each_reduction` asserts of the *case table itself* that
+each reduced quantity is distinguished somewhere in it, with the tolerance argmax
+appearing both first and last. It is a test of the test set, and it fails if a later
+case is added that does not carry its weight.
+
+## The independent accuracy check
+
+`design/backend_parity.md` requires more than agreement with the oracle, and agreement
+is all the sweeps establish. The independent check here is a **closed form for a whole
+family**: for a tensor product of clamped uniform directions with degrees ``p_d`` over
+``n_d`` intervals on ``[a_d, b_d]``, hand arithmetic gives ``num_basis[d] == n_d + p_d``,
+``num_intervals[d] == n_d``, the two products, a domain of exactly the requested ends,
+and -- because the ends are chosen as small dyadic rationals -- a tolerance of exactly
+``max_d 8 * eps * max(b_d - a_d, |a_d|, |b_d|)``.
+:func:`test_the_clamped_uniform_closed_form` checks all of them against the formula
+rather than against either backend.
+
+Two cross-checks against the *directions* join it, and they are not mirrors of the
+implementation: they compare the aggregate against the univariate type, which is
+ported and pinned separately, so a reduction that read the wrong axis or dropped a
+direction fails them.
+
+## Rule 12
+
+Every test that says something about the *binding* takes the ``cpp_backend`` fixture,
+whose ``demand_cpp_backend`` is a skip-or-fail rather than a silent skip. The tests
+that state a property of *each* backend take it on the C++ **parameter** instead,
+through ``_BACKENDS`` -- because taking it on the test would skip the Python half too,
+and the Python half is the only thing here that would catch the oracle regressing.
+"""
+
+from __future__ import annotations
+
+import math
+import pickle
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
+
+import numpy as np
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import BsplineSpace, BsplineSpace1D
+from tests._parity_harness import (
+    Field,
+    assert_object_parity,
+    bitwise_parity,
+    demand_cpp_backend,
+    exact_parity,
+)
+
+if TYPE_CHECKING:
+    from numpy import typing as npt
+
+_BACKENDS: Final = (
+    pytest.param(Backend.PYTHON, id="python"),
+    pytest.param(Backend.CPP, id="cpp"),
+)
+"""The two backends, for the tests that state a property of each one separately."""
+
+
+def _demand_the_extension_if_needed(backend: Backend) -> None:
+    """Require the compiled extension, and only for the half that uses it.
+
+    A test parametrized over both backends and *also* taking the ``cpp_backend``
+    fixture skips **both** halves when the extension is absent, which silently drops
+    the Python half -- and the Python half of the closed-form check and the
+    cross-checks is the only thing in this file that would catch the **oracle**
+    regressing. ``tests/parity/test_bspline_space_1d.py`` carries the same guard and
+    the same reason, including why marking the parameter is not available:
+    ``pytest.param`` refuses ``pytest.mark.usefixtures``.
+
+    Args:
+        backend (Backend): The backend this parametrization is about.
+    """
+    if backend is Backend.CPP:
+        demand_cpp_backend()
+
+
+_STATE_WHY: Final = (
+    "a tensor-product space counts things in its directions; the dimension, the "
+    "per-direction degrees, basis counts and interval counts, the two products and "
+    "the Bezier flag are integers and booleans reached by the same integer "
+    "arithmetic on both sides, so a difference is a defect and not a rounding"
+)
+
+_DOMAIN_WHY: Final = (
+    "the domain rows are the directions' own domain ends, copied unchanged; a "
+    "direction's domain is two indexed reads of its knot vector, so no arithmetic "
+    "is performed on these values at either level and the two backends store the "
+    "same bits"
+)
+
+_TOLERANCE_WHY: Final = (
+    "the tolerance is max over the directions' tolerances -- a selection, not a "
+    "combination -- so the result is one of the inputs unmodified. The inputs agree "
+    "bitwise by tests/parity/test_bspline_space_1d.py, and the only thing left that "
+    "could differ is which input wins, which is a verdict rather than a rounding"
+)
+
+
+class _Direction(NamedTuple):
+    """One direction of a tensor-product space.
+
+    Attributes:
+        knots (tuple[float, ...]): The knot vector.
+        degree (int): The polynomial degree.
+        periodic (bool): Whether the direction is periodic.
+    """
+
+    knots: tuple[float, ...]
+    degree: int
+    periodic: bool = False
+
+
+# The named directions the cases are composed from. Each carries the structural
+# feature it contributes and, where it matters, its knot scale -- which is what fixes
+# its tolerance and therefore which direction wins the reduction.
+_QUAD_3: Final = _Direction((0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0), 2)
+"""Clamped quadratic, 3 intervals on [0, 3]: degree 2, 5 basis functions, scale 3."""
+
+_LIN_2: Final = _Direction((10.0, 10.0, 11.0, 12.0, 12.0), 1)
+"""Clamped linear, 2 intervals on [10, 12]: degree 1, 3 basis functions, scale 12."""
+
+_CUBIC_1: Final = _Direction((-2.0, -2.0, -2.0, -2.0, -1.0, -1.0, -1.0, -1.0), 3)
+"""Clamped cubic single span on [-2, -1]: degree 3, 4 basis functions, scale 2."""
+
+_DEG0_4: Final = _Direction((0.0, 1.0, 2.0, 3.0, 4.0), 0)
+"""Degree zero, 4 intervals on [0, 4]: 4 basis functions, scale 4."""
+
+_PERIODIC: Final = _Direction(tuple(float(k) for k in range(10)), 2, True)
+"""Periodic uniform, which is the one direction kind that is never Bezier-like."""
+
+_BEZ_2: Final = _Direction((0.0, 0.0, 0.0, 1.0, 1.0, 1.0), 2)
+"""Clamped quadratic single span: Bezier-like, 3 basis functions, 1 interval."""
+
+_NOTBEZ_2: Final = _Direction((0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0), 2)
+"""The same but with one interior knot: not Bezier-like, 4 basis functions."""
+
+_FAR: Final = _Direction((1e6, 1e6, 1e6, 1e6 + 50.0, 1e6 + 100.0, 1e6 + 100.0, 1e6 + 100.0), 2)
+"""A domain far from the origin, where the scale comes from the coordinates."""
+
+_TINY: Final = _Direction((0.0, 0.0, 0.0, 5e-7, 1e-6, 1e-6, 1e-6), 2)
+"""A domain smaller than one unit, where the scale comes from the span."""
+
+_STRADDLES_ZERO: Final = _Direction((-1e-7, -1e-7, -1e-7, 0.5, 1.0, 1.0, 1.0), 2)
+"""A domain straddling zero, whose ``float32`` tolerance is not a ``float32`` value.
+
+The one direction here whose knot ends are not dyadic, and it is in the table for a
+narrow reason. The tolerance is ``8 * eps * scale`` with ``scale = hi - lo``, and for
+two ``float32`` operands of opposite sign that difference is a *sum*, which can need
+one bit more than ``float32`` has: measured here, the ``float32`` tolerance is
+``9.536744117736828e-07`` while the nearest ``float32`` is ``9.5367436e-07``, a
+relative gap of ``1.9e-08``.
+
+Why that is worth a case of its own: ``pantr/bspline/knots.hpp`` records that the
+tolerance is a ``double`` **at every storage width**, deliberately, and every other
+direction in this table has a dyadic scale -- for which ``8 * eps * scale`` is a
+``float32`` value exactly, since the factor is a power of two. So on the rest of the
+table an implementation that stored the tolerance in ``T`` would agree bit for bit
+with one that stored a ``double``, and the claim would pass while measuring nothing.
+This is the case where the two spellings differ.
+"""
+
+
+class _Case(NamedTuple):
+    """One tensor-product space to build, and what it is in the table for.
+
+    Attributes:
+        label (str): What this case is here to exercise.
+        directions (tuple[_Direction, ...]): The directions, in axis order.
+    """
+
+    label: str
+    directions: tuple[_Direction, ...]
+
+
+_CASES: Final = (
+    # The nD case a reduction can get right by accident, kept because it is what the
+    # `pantr.cad` layer builds for a curve.
+    _Case("one direction", (_QUAD_3,)),
+    # Two directions differing in EVERY reduced quantity: degree 2 against 1, 5 basis
+    # functions against 3, 3 intervals against 2, and scales 3 against 12 so the
+    # tolerances differ too.
+    _Case("two directions, all quantities distinct", (_QUAD_3, _LIN_2)),
+    # The same two, swapped. Present so that a transposition or an axis-index error
+    # cannot pass by agreeing with the other order.
+    _Case("the same two, swapped", (_LIN_2, _QUAD_3)),
+    # Three distinct directions, so the products are over three unequal factors --
+    # which a two-direction case cannot distinguish from a pairwise reduction applied
+    # twice in the wrong order.
+    _Case("three directions, all distinct", (_QUAD_3, _LIN_2, _DEG0_4)),
+    _Case("three directions, another order", (_DEG0_4, _CUBIC_1, _QUAD_3)),
+    # One direction repeated, which is how most of the suite builds a square space and
+    # which broke a first draft of the tolerance reduction: it asked "is this the
+    # first direction?" of the shared handle rather than of the index.
+    _Case("one direction repeated", (_QUAD_3, _QUAD_3)),
+    # A periodic direction beside a clamped one, in both positions. Periodicity moves
+    # the basis count and forces the Bezier flag false whatever the knots say.
+    _Case("periodic first", (_PERIODIC, _LIN_2)),
+    _Case("periodic last", (_LIN_2, _PERIODIC)),
+    # Bezier-likeness needs every direction, so the exception is placed in each
+    # position of a three-direction space in turn. A reduction written as `any`, or as
+    # "ask the first direction", passes exactly one of these three.
+    _Case("all Bezier-like", (_BEZ_2, _BEZ_2, _BEZ_2)),
+    _Case("one non-Bezier direction, first", (_NOTBEZ_2, _BEZ_2, _BEZ_2)),
+    _Case("one non-Bezier direction, middle", (_BEZ_2, _NOTBEZ_2, _BEZ_2)),
+    _Case("one non-Bezier direction, last", (_BEZ_2, _BEZ_2, _NOTBEZ_2)),
+    # Scales six orders apart, with the argmax first and then last, so `max` is
+    # distinguished from `min`, from `first` and from `last` over one set of values.
+    _Case("argmax scale first", (_FAR, _QUAD_3, _TINY)),
+    _Case("argmax scale last", (_TINY, _QUAD_3, _FAR)),
+    # The case where storing the tolerance in the storage format rather than in a
+    # double would show; see `_STRADDLES_ZERO`. It has to be the ARGMAX for that, so
+    # it is paired with a direction of scale 1 rather than with `_QUAD_3`, whose
+    # scale of 3 would win and whose tolerance is dyadic. A first draft did pair it
+    # with `_QUAD_3`, and the narrowing mutation passed the whole suite.
+    _Case("a non-dyadic argmax, first", (_STRADDLES_ZERO, _BEZ_2)),
+    _Case("a non-dyadic argmax, last", (_BEZ_2, _STRADDLES_ZERO)),
+    # The dimensionless space, which the oracle admits and which every reduction has
+    # to answer for: the products are 1, `all(())` is true, and only the tolerance
+    # has nothing to report.
+    _Case("no directions", ()),
+)
+"""The spaces every field-by-field comparison runs over, and what each is here for."""
+
+
+def _build(directions: tuple[_Direction, ...], dtype: npt.DTypeLike) -> BsplineSpace:
+    """Build one tensor-product space under the active backend.
+
+    Args:
+        directions (tuple[_Direction, ...]): The directions, in axis order.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        BsplineSpace: The space.
+    """
+    return BsplineSpace(
+        [
+            BsplineSpace1D(
+                np.asarray(one_d.knots, dtype=dtype), one_d.degree, periodic=one_d.periodic
+            )
+            for one_d in directions
+        ]
+    )
+
+
+def _both_backends(
+    directions: tuple[_Direction, ...],
+    dtype: npt.DTypeLike,
+) -> tuple[BsplineSpace, BsplineSpace]:
+    """Build the same tensor-product space under each backend.
+
+    The directions are built inside each ``use_backend`` block too, and they have to
+    be: a space aggregates its directions' *implementations*, and
+    :func:`pantr.bspline._bspline_space_nd._new_impl` refuses a direction from the
+    other backend rather than reconciling it.
+
+    Args:
+        directions (tuple[_Direction, ...]): The directions, in axis order.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        tuple[BsplineSpace, BsplineSpace]: ``(python, cpp)``, in that order, so that a
+        call site cannot get :func:`assert_object_parity`'s two keyword arguments the
+        wrong way round without saying so.
+    """
+    with use_backend(Backend.PYTHON):
+        python = _build(directions, dtype)
+    with use_backend(Backend.CPP):
+        cpp = _build(directions, dtype)
+    return python, cpp
+
+
+def _fields(dim: int) -> list[Field]:
+    """The state two backends' tensor-product spaces must agree on.
+
+    Args:
+        dim (int): The space's dimension, which decides whether ``domain`` exists to
+            compare: a dimensionless space raises :class:`IndexError` for it, which
+            is the behaviour before the port and is asserted separately.
+
+    Returns:
+        list[Field]: One field per piece of state, each with the claim that governs
+        it.
+    """
+    fields = [
+        Field("dim", exact_parity(why=_STATE_WHY)),
+        Field("degrees", exact_parity(why=_STATE_WHY)),
+        Field("num_basis", exact_parity(why=_STATE_WHY)),
+        Field("num_total_basis", exact_parity(why=_STATE_WHY)),
+        Field("num_intervals", exact_parity(why=_STATE_WHY)),
+        Field("num_total_intervals", exact_parity(why=_STATE_WHY)),
+        Field(
+            "has_Bezier_like_knots",
+            exact_parity(why=_STATE_WHY),
+            read=lambda s: s.has_Bezier_like_knots(),
+        ),
+    ]
+    if dim > 0:
+        fields += [
+            Field("tolerance", bitwise_parity(why=_TOLERANCE_WHY)),
+            Field("domain", bitwise_parity(why=_DOMAIN_WHY)),
+        ]
+    return fields
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64], ids=["float32", "float64"])
+@pytest.mark.parametrize("case", _CASES, ids=[c.label for c in _CASES])
+def test_the_state_agrees_field_by_field(
+    cpp_backend: None,
+    case: _Case,
+    dtype: npt.DTypeLike,
+) -> None:
+    """Every piece of a tensor-product space's state agrees between the two backends.
+
+    Field by field rather than by a single equality, so that a failure names the
+    quantity that moved instead of the object that contains it.
+    """
+    python, cpp = _both_backends(case.directions, dtype)
+    assert_object_parity(
+        py=python,
+        cpp=cpp,
+        fields=_fields(len(case.directions)),
+        context=f"BsplineSpace[{case.label}]",
+    )
+
+
+def test_the_sweep_can_see_each_reduction() -> None:
+    """Every reduced quantity is distinguished somewhere in the case table.
+
+    A test of the case table rather than of the type, and the file's guard against its
+    own worst failure mode: a tensor-product case whose directions agree makes a
+    transposition, an axis-index error and a wrong reduction all invisible, so a table
+    of such cases reads as coverage and measures nothing. Failing here means a case
+    was added or changed in a way that stopped carrying its weight.
+
+    Not gated on the extension and not parametrized: it inspects the table through the
+    default backend, and the property it asserts is a property of the table.
+    """
+    spaces = {
+        case.label: _build(case.directions, np.float64)
+        for case in _CASES
+        if len(case.directions) > 1
+    }
+    assert spaces, "the table must contain multi-direction cases"
+
+    def somewhere(name: str, read: Any) -> bool:
+        return any(len(set(read(space))) > 1 for space in spaces.values())
+
+    assert somewhere("degrees", lambda s: s.degrees), (
+        "no case has directions of differing degree, so an axis-index error in "
+        "`degrees` would be invisible"
+    )
+    assert somewhere("num_basis", lambda s: s.num_basis), (
+        "no case has directions of differing basis count"
+    )
+    assert somewhere("num_intervals", lambda s: s.num_intervals), (
+        "no case has directions of differing interval count"
+    )
+    assert somewhere("tolerance", lambda s: [one.tolerance for one in s.spaces]), (
+        "no case has directions of differing tolerance, so `max` could be `min`, "
+        "`first` or `last` and nothing would notice"
+    )
+    assert somewhere("bezier", lambda s: [one.has_Bezier_like_knots() for one in s.spaces]), (
+        "no case mixes a Bezier-like direction with a non-Bezier one, so `all` could be `any`"
+    )
+    assert somewhere("domain rows", lambda s: [tuple(row) for row in s.domain]), (
+        "no case has directions of differing domain, so a row swap would be invisible"
+    )
+
+    # The tolerance argmax must appear both first and last. One position alone leaves
+    # `max` indistinguishable from whichever of `first` or `last` matches it.
+    argmaxes = set()
+    for space in spaces.values():
+        tolerances = [one.tolerance for one in space.spaces]
+        if len(set(tolerances)) == len(tolerances):
+            argmaxes.add(tolerances.index(max(tolerances)) == 0)
+            argmaxes.add(tolerances.index(max(tolerances)) == len(tolerances) - 1)
+    assert argmaxes == {True, False}, (
+        "the tolerance argmax must be the first direction in some case and the last "
+        "in another, over cases whose direction tolerances are all distinct"
+    )
+
+    # Some case in the table must have a ``float32`` tolerance that is not a
+    # ``float32`` value, and the check has to be on the SPACE rather than on a
+    # direction. `pantr/bspline/knots.hpp` records that the tolerance is a ``double``
+    # at every storage width, deliberately; a space that stored it in ``T`` instead
+    # would agree bit for bit everywhere the winning direction's scale is dyadic,
+    # which is every other case here. So without this the whole file passes on that
+    # mutation -- measured, and it is why the pairing in `_STRADDLES_ZERO`'s two cases
+    # is what it is rather than the more natural one.
+    non_dyadic = [
+        label
+        for label, space in {
+            case.label: _build(case.directions, np.float32) for case in _CASES if case.directions
+        }.items()
+        if float(np.float32(space.tolerance)) != space.tolerance
+    ]
+    assert non_dyadic, (
+        "no case's float32 tolerance is outside float32, so storing the tolerance in "
+        "the storage format rather than in a double would agree bit for bit"
+    )
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_the_clamped_uniform_closed_form(backend: Backend) -> None:
+    """A clamped uniform tensor product matches hand arithmetic, not the other backend.
+
+    The independent accuracy check `design/backend_parity.md` requires. For degrees
+    ``p_d`` over ``n_d`` uniform intervals on ``[a_d, b_d]``, the counts are
+    ``n_d + p_d`` and ``n_d``, the totals are their products, the domain is exactly the
+    requested ends, and the tolerance is ``8 * eps * max_d max(b_d - a_d, |a_d|, |b_d|)``.
+
+    The ends and the interval counts are dyadic, which is what makes the tolerance a
+    closed form rather than an approximation: ``8 * eps`` is a power of two, so the
+    product with an exactly representable scale is exact at both storage widths and the
+    comparison is ``==``.
+    """
+    _demand_the_extension_if_needed(backend)
+    ends = ((0.0, 4.0), (-2.0, 2.0), (0.0, 8.0))
+    with use_backend(backend):
+        for dtype in (np.float32, np.float64):
+            eps = float(np.finfo(dtype).eps)
+            for degrees in ((0, 1), (2, 3), (1, 1), (3, 2, 1)):
+                for counts in ((1, 4), (4, 2), (2, 2), (2, 4, 1)):
+                    if len(degrees) != len(counts):
+                        continue
+                    directions = [
+                        BsplineSpace1D(
+                            np.asarray(
+                                _clamped_uniform_knots(*ends[d], counts[d], degrees[d]),
+                                dtype=dtype,
+                            ),
+                            degrees[d],
+                        )
+                        for d in range(len(degrees))
+                    ]
+                    space = BsplineSpace(directions)
+                    where = f"degrees={degrees} counts={counts} dtype={np.dtype(dtype)}"
+
+                    assert space.dim == len(degrees), where
+                    assert space.degrees == tuple(degrees), where
+                    assert space.num_basis == tuple(
+                        n + p for n, p in zip(counts, degrees, strict=True)
+                    ), where
+                    assert space.num_intervals == tuple(counts), where
+                    assert space.num_total_basis == math.prod(
+                        n + p for n, p in zip(counts, degrees, strict=True)
+                    ), where
+                    assert space.num_total_intervals == math.prod(counts), where
+                    np.testing.assert_array_equal(
+                        space.domain, np.asarray(ends[: len(degrees)], dtype=dtype), err_msg=where
+                    )
+                    expected_tolerance = (
+                        8.0
+                        * eps
+                        * max(max(hi - lo, abs(lo), abs(hi)) for lo, hi in ends[: len(degrees)])
+                    )
+                    assert space.tolerance == expected_tolerance, where
+                    assert space.has_Bezier_like_knots() == all(n == 1 for n in counts), where
+
+
+def _clamped_uniform_knots(lo: float, hi: float, intervals: int, degree: int) -> list[float]:
+    """A clamped uniform knot vector, for the closed-form check.
+
+    Args:
+        lo (float): The domain start.
+        hi (float): The domain end.
+        intervals (int): How many equal intervals to divide the domain into.
+        degree (int): The polynomial degree, which fixes the end multiplicities.
+
+    Returns:
+        list[float]: ``degree + 1`` copies of ``lo``, the interior breakpoints, then
+        ``degree + 1`` copies of ``hi``.
+    """
+    step = (hi - lo) / intervals
+    interior = [lo + k * step for k in range(1, intervals)]
+    return [lo] * (degree + 1) + interior + [hi] * (degree + 1)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("case", _CASES, ids=[c.label for c in _CASES])
+def test_the_aggregate_matches_its_directions(backend: Backend, case: _Case) -> None:
+    """Each reduction agrees with the directions it reduces, within one backend.
+
+    Not a mirror of the implementation: it compares the tensor-product type against the
+    *univariate* type, which is a separate port with its own parity claim
+    (``tests/parity/test_bspline_space_1d.py``). A reduction that read the wrong axis,
+    dropped a direction or transposed the domain rows fails this even where both
+    backends agree with each other, which agreement alone cannot detect.
+    """
+    _demand_the_extension_if_needed(backend)
+    with use_backend(backend):
+        space = _build(case.directions, np.float64)
+    directions = space.spaces
+
+    assert space.dim == len(directions)
+    assert space.degrees == tuple(one.degree for one in directions)
+    assert space.num_basis == tuple(one.num_basis for one in directions)
+    assert space.num_intervals == tuple(one.num_intervals for one in directions)
+    assert space.num_total_basis == math.prod(one.num_basis for one in directions)
+    assert space.num_total_intervals == math.prod(one.num_intervals for one in directions)
+    assert space.has_Bezier_like_knots() == all(one.has_Bezier_like_knots() for one in directions)
+    if directions:
+        # `==` rather than `pytest.approx`: the reduction is a selection, so the
+        # result is one of these values unmodified.
+        assert space.tolerance == max(one.tolerance for one in directions)
+        for d, one in enumerate(directions):
+            assert tuple(space.domain[d]) == tuple(one.domain), f"domain row {d}"
+    else:
+        with pytest.raises(ValueError, match="no directions has no tolerance"):
+            _ = space.tolerance
+        with pytest.raises(IndexError):
+            _ = space.domain
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_permuting_the_directions_permutes_the_per_direction_state(backend: Backend) -> None:
+    """A permutation of the directions permutes exactly the per-direction quantities.
+
+    The structural check a value comparison cannot make. The per-direction sequences
+    and the domain rows must follow the permutation; the two products and the tolerance
+    must not move at all, being symmetric functions of the same multiset.
+    """
+    _demand_the_extension_if_needed(backend)
+    directions = (_QUAD_3, _LIN_2, _DEG0_4)
+    with use_backend(backend):
+        base = _build(directions, np.float64)
+        for permutation in ((1, 2, 0), (2, 1, 0), (0, 2, 1)):
+            permuted = _build(tuple(directions[i] for i in permutation), np.float64)
+            where = f"permutation={permutation}"
+
+            assert permuted.degrees == tuple(base.degrees[i] for i in permutation), where
+            assert permuted.num_basis == tuple(base.num_basis[i] for i in permutation), where
+            assert permuted.num_intervals == tuple(base.num_intervals[i] for i in permutation), (
+                where
+            )
+            np.testing.assert_array_equal(
+                permuted.domain, base.domain[list(permutation)], err_msg=where
+            )
+
+            assert permuted.num_total_basis == base.num_total_basis, where
+            assert permuted.num_total_intervals == base.num_total_intervals, where
+            assert permuted.tolerance == base.tolerance, where
+            assert permuted.has_Bezier_like_knots() == base.has_Bezier_like_knots(), where
+
+
+def test_the_dtype_refusal_agrees_character_for_character(cpp_backend: None) -> None:
+    """Mixed-dtype directions are refused identically under both backends.
+
+    The refusal is the wrapper's, not either implementation's -- ``BsplineSpace<T>``
+    can hold only ``BsplineSpace1D<T>``, so there is nothing in C++ to check -- which
+    is precisely why it is worth asserting under both: a wrapper-level check that
+    moved would be a wrapper-level check that stopped firing.
+    """
+    messages = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            first = BsplineSpace1D(np.asarray(_QUAD_3.knots, dtype=np.float64), 2)
+            second = BsplineSpace1D(np.asarray(_LIN_2.knots, dtype=np.float32), 1)
+            with pytest.raises(ValueError) as caught:
+                BsplineSpace([first, second])
+            messages[backend] = str(caught.value)
+
+    assert messages[Backend.PYTHON] == messages[Backend.CPP]
+    assert messages[Backend.PYTHON] == "All B-spline spaces must have the same data type."
+
+
+def test_the_dimensionless_tolerance_refusal_agrees(cpp_backend: None) -> None:
+    """Both backends refuse a dimensionless space's tolerance with the same message.
+
+    The message is stated in both implementations rather than inherited from
+    ``max()``: CPython's own text for an empty ``max()`` changed between 3.11 and
+    3.12, so leaving it to the builtin would have made the two backends disagree on
+    one leg of the test matrix and agree on the others.
+    """
+    messages = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = BsplineSpace([])
+            with pytest.raises(ValueError) as caught:
+                _ = space.tolerance
+            messages[backend] = str(caught.value)
+
+    assert messages[Backend.PYTHON] == messages[Backend.CPP]
+    assert (
+        messages[Backend.PYTHON]
+        == "tolerance: a B-spline space with no directions has no tolerance"
+    )
+
+
+def test_a_direction_from_the_other_backend_is_refused(cpp_backend: None) -> None:
+    """A tensor-product space cannot be built from a direction of the other backend.
+
+    Both directions of the mismatch, and the reverse one is why this test exists: a
+    C++ direction handed to the oracle would **succeed**, producing a space whose
+    reductions run in Python over C++ values -- a hybrid no parity claim covers and
+    which nothing announces. ``design/cross_backend_types.md`` forbids exactly that
+    shape.
+    """
+    with use_backend(Backend.PYTHON):
+        python_direction = BsplineSpace1D(np.asarray(_QUAD_3.knots), 2)
+    with use_backend(Backend.CPP):
+        cpp_direction = BsplineSpace1D(np.asarray(_QUAD_3.knots), 2)
+
+    with use_backend(Backend.CPP), pytest.raises(ValueError, match="from the active backend"):
+        BsplineSpace([cpp_direction, python_direction])
+    with use_backend(Backend.PYTHON), pytest.raises(ValueError, match="from the active backend"):
+        BsplineSpace([python_direction, cpp_direction])
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64], ids=["float32", "float64"])
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("case", _CASES, ids=[c.label for c in _CASES])
+def test_reduce_round_trips_under_both_backends(
+    backend: Backend, case: _Case, dtype: npt.DTypeLike
+) -> None:
+    """``__reduce__`` restores every piece of state, under each backend on its own."""
+    _demand_the_extension_if_needed(backend)
+    with use_backend(backend):
+        space = _build(case.directions, dtype)
+        restored = pickle.loads(pickle.dumps(space))
+
+        assert type(restored) is BsplineSpace
+        assert restored.dim == space.dim
+        assert restored.degrees == space.degrees
+        assert restored.num_basis == space.num_basis
+        assert restored.num_total_basis == space.num_total_basis
+        assert restored.num_intervals == space.num_intervals
+        assert restored.num_total_intervals == space.num_total_intervals
+        assert restored.has_Bezier_like_knots() == space.has_Bezier_like_knots()
+        if case.directions:
+            np.testing.assert_array_equal(restored.domain, space.domain)
+            assert restored.dtype == space.dtype
+            # `==` and not a bound: `design/bspline_pickle_tolerance.md` derives a
+            # drift for a univariate space whose LAST KNOT CLASS has multiplicity
+            # above one and whose snapping moved it, and no direction in this table
+            # is in that state -- the tolerance is recomputed from the same knots.
+            assert restored.tolerance == space.tolerance
+
+
+@pytest.mark.parametrize("case", _CASES, ids=[c.label for c in _CASES])
+def test_a_pickle_crosses_the_backends(cpp_backend: None, case: _Case) -> None:
+    """A pickle written under one backend loads under the other, and agrees.
+
+    What ``__reduce__`` reducing to the univariate *wrappers* buys: the wire format is
+    the constructor's arguments, so a backend switch cannot become a data-format
+    switch.
+    """
+    for writer, reader in ((Backend.PYTHON, Backend.CPP), (Backend.CPP, Backend.PYTHON)):
+        with use_backend(writer):
+            original = _build(case.directions, np.float64)
+            blob = pickle.dumps(original)
+            expected = (
+                original.degrees,
+                original.num_basis,
+                original.num_total_basis,
+                original.num_intervals,
+                original.num_total_intervals,
+                original.has_Bezier_like_knots(),
+            )
+            domain = None if not case.directions else np.array(original.domain)
+            tolerance = None if not case.directions else original.tolerance
+        with use_backend(reader):
+            restored = pickle.loads(blob)
+            where = f"{case.label}: {writer.name} -> {reader.name}"
+            assert (
+                restored.degrees,
+                restored.num_basis,
+                restored.num_total_basis,
+                restored.num_intervals,
+                restored.num_total_intervals,
+                restored.has_Bezier_like_knots(),
+            ) == expected, where
+            if domain is not None:
+                np.testing.assert_array_equal(restored.domain, domain, err_msg=where)
+                assert restored.tolerance == tolerance, where
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_a_joint_pickle_keeps_the_direction_identity(backend: Backend) -> None:
+    """Pickling a space together with one of its directions restores the sharing.
+
+    ``pickle`` memoises, so the direction is written once and both references restore
+    to one object. That is what makes ``space.spaces[0] is one_d`` survive a round
+    trip, and it is the reason ``__reduce__`` reduces to the wrappers rather than to
+    their implementations. Sharing does **not** survive two independent ``dumps``
+    calls, which is asserted too so the limit is recorded rather than assumed.
+    """
+    _demand_the_extension_if_needed(backend)
+    with use_backend(backend):
+        one_d = BsplineSpace1D(np.asarray(_QUAD_3.knots), 2)
+        other = BsplineSpace1D(np.asarray(_LIN_2.knots), 1)
+        space = BsplineSpace([one_d, other])
+        assert space.spaces[0] is one_d
+
+        restored_space, restored_one_d = pickle.loads(pickle.dumps((space, one_d)))
+        assert restored_space.spaces[0] is restored_one_d
+        assert restored_space.spaces[0] is not one_d
+
+        separate_space = pickle.loads(pickle.dumps(space))
+        separate_one_d = pickle.loads(pickle.dumps(one_d))
+        assert separate_space.spaces[0] is not separate_one_d
+
+
+def _sweep_directions() -> list[tuple[_Direction, ...]]:
+    """A deterministic grid of direction tuples, for the ten-times sweep.
+
+    Every combination of degree and interval count over three domains, at one, two and
+    three directions, with the domains rotated so that no tuple has two directions on
+    the same one. Deterministic rather than random, so a failure is reproducible from
+    the parametrization alone.
+
+    Returns:
+        list[tuple[_Direction, ...]]: The direction tuples to build.
+    """
+    # Dyadic ends of three different scales, so the tolerance argmax varies over the
+    # sweep rather than always being the same direction.
+    domains = ((0.0, 4.0), (-2.0, 2.0), (0.0, 1024.0))
+    tuples: list[tuple[_Direction, ...]] = []
+    for dim in (1, 2, 3):
+        for degrees in _tuples_over((0, 1, 2, 3), dim):
+            for counts in _tuples_over((1, 2, 3), dim):
+                tuples.append(
+                    tuple(
+                        _Direction(
+                            tuple(
+                                _clamped_uniform_knots(
+                                    *domains[(d + counts[d]) % len(domains)],
+                                    counts[d],
+                                    degrees[d],
+                                )
+                            ),
+                            degrees[d],
+                        )
+                        for d in range(dim)
+                    )
+                )
+    return tuples
+
+
+def _tuples_over(values: tuple[int, ...], length: int) -> list[tuple[int, ...]]:
+    """Every tuple of the given length drawn from ``values``.
+
+    Args:
+        values (tuple[int, ...]): The values to draw from.
+        length (int): The tuple length.
+
+    Returns:
+        list[tuple[int, ...]]: All ``len(values) ** length`` tuples, in a fixed order.
+    """
+    if length == 0:
+        return [()]
+    return [(value, *rest) for value in values for rest in _tuples_over(values, length - 1)]
+
+
+def test_the_bitwise_claim_holds_over_a_ten_times_sweep(cpp_backend: None) -> None:
+    """The bitwise claim holds over more than ten times the shipped case count.
+
+    The bound is **zero**: every quantity is an exact integer or an unmodified copy or
+    selection of a value the two backends already agree on bit for bit, so the sweep
+    reports a differing-bit count rather than a margin, and the count must be zero.
+    ``design/backend_parity.md`` Rule 8 is what makes that statable -- the claim is
+    defined because nothing here loses a digit -- and ``CLAUDE.md``'s determinism rule
+    is what licenses bit-identity as the criterion rather than a derived tolerance,
+    since finite precision does not bite on a count, an index or a copied value.
+
+    Two vacuity guards, because a sweep that agrees on nothing interesting agrees
+    trivially: the quantities compared must actually **vary** across the sweep, and the
+    sweep must be at least ten times the shipped parametrization.
+    """
+    shipped = len(_CASES) * 2  # the two dtypes the field-by-field test runs over
+    directions = _sweep_directions()
+    swept = len(directions) * 2
+    assert swept >= 10 * shipped, (
+        f"the sweep is {swept} comparisons against {shipped} shipped, which is under "
+        f"the ten-times floor of {10 * shipped}"
+    )
+
+    seen_tolerances: set[float] = set()
+    seen_totals: set[int] = set()
+    differing = 0
+    for tuple_of_directions in directions:
+        for dtype in (np.float32, np.float64):
+            python, cpp = _both_backends(tuple_of_directions, dtype)
+            seen_tolerances.add(python.tolerance)
+            seen_totals.add(python.num_total_basis)
+            if (
+                python.dim != cpp.dim
+                or python.degrees != cpp.degrees
+                or python.num_basis != cpp.num_basis
+                or python.num_total_basis != cpp.num_total_basis
+                or python.num_intervals != cpp.num_intervals
+                or python.num_total_intervals != cpp.num_total_intervals
+                or python.has_Bezier_like_knots() != cpp.has_Bezier_like_knots()
+                or python.tolerance != cpp.tolerance
+                or not np.array_equal(python.domain, cpp.domain)
+            ):
+                differing += 1
+
+    assert differing == 0, f"{differing} of {swept} comparisons differed"
+    assert len(seen_tolerances) > 1, (
+        "every space in the sweep had the same tolerance, so the reduction was never asked anything"
+    )
+    assert len(seen_totals) > 10, (
+        f"the sweep saw only {len(seen_totals)} distinct basis totals, so the products "
+        f"were barely exercised"
+    )

--- a/tests/test_bspline_space.py
+++ b/tests/test_bspline_space.py
@@ -1375,3 +1375,50 @@ def test_boundary_dofs_rejects_periodic() -> None:
 
     with pytest.raises(ValueError, match="periodic"):
         space.boundary_dofs(0, 0)
+
+
+def test_the_domain_cannot_be_corrupted_through_the_array_it_hands_out() -> None:
+    """A write through ``domain`` reaches the caller's own array and nothing else.
+
+    The regression test for a defect the C++ port retires rather than one it
+    introduced. Until the port, ``domain`` was a ``functools.cached_property``, so
+    every call returned **one** array and that array came back **writeable**: a single
+    ``space.domain[0, 0] = 999.0`` corrupted the value for the object's whole life,
+    and every later read -- including the one inside the out-of-domain message in
+    ``pantr.bspline._bspline_basis_multidim`` -- served the corrupted number. It was
+    the only array-shaped memo in ``src/pantr/bspline/`` that was not frozen
+    read-only, it is the third prohibition of ``design/bspline_derived_caches.md``,
+    and nothing in this suite inspected ``domain.flags``.
+
+    What removed it was not a defensive freeze. ``design/bspline_derived_caches.md``
+    F1 requires the tensor-product space to acquire **no** memos, so there is no
+    cached array left on either side to corrupt, and the wrapper copies out of what
+    the implementation owns. So the array stays writable -- no caller has to change --
+    and the write goes nowhere.
+
+    Deliberately **not** gated on the C++ extension and not parametrised over the
+    backends: the property is the wrapper's and holds under either implementation, and
+    gating it would make it skip in the configuration where it is the only thing
+    checking this. The C++ half of the contract -- that the wrapper does not hand the
+    read-only view straight through -- is in
+    ``tests/parity/test_bspline_binding_contract.py``.
+    """
+    space = BsplineSpace(
+        [
+            BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0], 2),
+            BsplineSpace1D([10.0, 10.0, 11.0, 12.0, 12.0], 1),
+        ]
+    )
+    expected = [[0.0, 3.0], [10.0, 12.0]]
+    np.testing.assert_array_equal(space.domain, expected)
+
+    handed_out = space.domain
+    assert handed_out.flags.writeable, "the domain stopped being writable"
+    assert space.domain is not handed_out, "the domain is cached again"
+    assert not np.shares_memory(space.domain, handed_out), "the domain is a shared buffer"
+
+    handed_out[0, 0] = 999.0
+    handed_out[1, 1] = -999.0
+    np.testing.assert_array_equal(space.domain, expected)
+    assert space.spaces[0].domain[0] == 0.0
+    assert space.spaces[1].domain[1] == 12.0


### PR DESCRIPTION
Slice 4 of FELIGN/pantr#396: the nD tensor-product `BsplineSpace` becomes a value C++ owns, with a nanobind binding and a Python wrapper, following the pattern slices 1 to 3 set for `BsplineSpace1D`. `Closes` does not fire against a base other than `main`, so what it covers and the evidence per criterion are written out below.

## What it covers of #396

**Ported.** `pantr::bspline::BsplineSpace<T>` (`cpp/include/pantr/bspline/space_nd.hpp`) owns the directions and every reduction over them: `dim`, `degrees`, `tolerance`, `num_basis`, `num_total_basis`, `num_intervals`, `num_total_intervals`, `domain`, `has_Bezier_like_knots()`. Bound as `BsplineSpace32` / `BsplineSpace64` in `cpp/bindings/bspline_types.cpp`; wrapped by `pantr.bspline.BsplineSpace`, which keeps its class, its name and its constructor's contract.

**Deliberately not ported, and it is the same line `space_1d.hpp` draws.** `tabulate_basis`, `cell_supports`, `boundary_dofs` and `restrict` are computations *over* a space rather than properties *of* one, so they stay on the wrapper over the existing numba kernels and numpy — as `get_cardinal_intervals` stays off the univariate type. `BsplineSpaceRestriction` stays a Python `NamedTuple`: its `space` field holds a freshly built wrapper, which is class **V** of `design/bspline_ownership_lifetime.md` and has nothing to decide.

**No `_wrap`, and that is a deliberate deferral.** Nothing in the tree produces a `BsplineSpace` from a bare C++ handle today — `restrict` builds one from Python-built directions — so `_spaces` is always seeded from the constructor and the lazy-rebuild half of the seeding rule has no call site. #397 and #398 are where `THBSplineSpace.root_space` and `Bspline.space` need it, and they should add it with their first consumer rather than have it arrive untested here.

## The design rulings this obeys

`design/bspline_ownership_lifetime.md`'s classification, per accessor:

- `spaces` is class **H**. The type stores `std::vector<std::shared_ptr<const BsplineSpace1D<T>>>` and the binding returns a copy of each handle, so the guarantee lives in the *type* rather than in an `rv_policy` — which is what the interpreter-free consumer gets and what a binding scheduled for deletion cannot give. **No `rv_policy` appears anywhere in the file.** The borrowing twin `space_ref(d)` exists in C++ and is not bound.
- `domain` is class **A**: a read-only `(dim, 2)` `nb::ndarray<const T>` over the space's own storage with the space as owner. The wrapper copies it out; see the bug section.
- Everything else is class **V** or a scalar.

`design/bspline_derived_caches.md` F1: **zero memos.** Six eager fields and one three-iteration accessor, exactly as that note's table prescribes — not fourteen `mutable std::optional`s, and not a `LazySlot`.

`design/cross_backend_types.md`: one implementation per concept, no conversion function. The wrapper refuses a direction built under the other backend rather than reconciling it, because the reverse direction — a C++ handle handed to the oracle — *succeeds* and yields a hybrid whose reductions run in Python over C++ values.

`design/backend_parity.md`: see the sweep section, which cites Rule 8 and Rule 12 by number.

## The mutation check

Nine mutations, each applied to a clean tree, rebuilt, run, and reverted. `M-g`'s naive spelling does not compile: dropping the owner argument leaves `self` unused and `-Werror=unused-parameter` catches it, so it was re-run with `self` silenced to reach the runtime consequence.

| | mutation | C++ unit test | Python tests |
|---|---|---|---|
| M-a | `max` → `min` in the tolerance reduction | 7 failures | 38 failed |
| M-b | `has_bezier_like_knots`: `all` → `any` | 4 failures | 58 failed |
| M-c | `domain` row's `lo`/`hi` swapped | 3 failures | 62 failed |
| M-d | `tolerance` stored in `T` instead of `double` | 2 failures | 2 failed |
| M-e | constructor copies its directions instead of sharing | 7 failures | 1 failed (contract) |
| M-f | tensor-product total sums instead of multiplying | 3 failures | 60+ failed |
| M-g | `domain` view handed out with no owner | n/a (binding only) | 1 failed (contract) |
| M-h | the pre-port cached, uncopied `domain` restored | n/a | the regression test red under **both** backends, + 1 contract |
| M-i | `num_basis` reversed on a three-direction space | not reached | 2 failed (the seam test) |

**M-d survived the first draft, and that is the finding worth reporting.** The tolerance is a `double` at every storage width by design (`pantr/bspline/knots.hpp`), and on a knot vector whose scale is dyadic that is *unobservable*: `8 * eps * scale` with a power-of-two factor is a `float32` value exactly, so a space storing the tolerance in `T` agrees bit for bit. The case built to catch it (`_STRADDLES_ZERO`, whose `float32` scale is a sum of two opposite-sign `float32`s and so needs one bit more than `float32` has) was paired with a *wider-scaled* direction, so it never won the `max` and the narrowing was invisible: the whole C++ test and the whole parity suite passed. The fix was to pair it with a scale-1 direction in both orders, and to make the meta-test assert the property of the **space** rather than of a direction. That is exactly the "a claim whose violation only improves the number" failure this milestone keeps paying for, caught by the mutation check rather than by review.

## The sweep, and the bound

| | count |
|---|---|
| shipped | 17 cases × 2 dtypes = **34** field-by-field comparisons |
| 10x floor | 340 |
| swept | 1884 direction tuples × 2 dtypes = **3768** ≈ **110x** |
| differing | **0** |

**The bound is zero, and it is derived rather than observed.** Every quantity compared is either an exact integer reached by the same integer arithmetic on both sides, or an unmodified copy or selection of a value the two backends already agree on bit for bit:

- `domain` rows are each direction's own `domain`, which is two indexed reads of its knot vector. No arithmetic at either level.
- `tolerance` is `max` over the directions' tolerances. A **selection**, not a combination: the result is one of the inputs unmodified, so the only thing that could differ is *which* input wins — a verdict, not a rounding.

Both rest on the directions agreeing bitwise, which `tests/parity/test_bspline_space_1d.py` claims and pins independently.

**`design/backend_parity.md` Rule 8** ("a parity claim is only defined where the quantity has digits") is what licenses stating it at all, and here it is satisfied *trivially rather than narrowly*: nothing in this port loses a digit, so unlike `change_basis` there is no accuracy sub-domain to carve out and no degrees to enumerate as excluded. **`CLAUDE.md`'s determinism rule** is what licenses bit-identity as the *criterion* rather than a derived tolerance — it is the right bar exactly where finite precision does not bite, which is counts, indices, flags and exact arithmetic, and that is all of this.

**Rule 12** governs the gating: no test is parametrized over both backends *and* gated on the extension. Those that state a property of each backend call `_demand_the_extension_if_needed(backend)` from the body instead, so the Python half — the only thing that would catch the *oracle* regressing — survives without the `.so`.

Two vacuity guards on the sweep, because a sweep that agrees on nothing agrees trivially: the tolerances seen must not all be equal (which a bug that always picked domain 0 would violate, since `_knot_tolerance` depends only on the scale), and the basis totals seen must exceed ten distinct values.

## The extension-skip check

`.so` moved aside, same tree:

```
52 passed, 103 skipped
```

Every C++-touching test **skips**, none passes silently, and 52 oracle-side tests still run — the closed-form check, the direction cross-checks, the permutation invariant, the pickle round trip and the case-table meta-test. With `PANTR_REQUIRE_CPP=1` and no extension the skips become hard failures (`51 failed, 52 passed, 52 errors`), which is what stops the CI job that builds the extension from passing by skipping the tests it exists to run.

## The bug the port retires

`BsplineSpace.domain` handed out its **cached array unfrozen**: one `d = space.domain; d[0, 0] = 999.0` corrupted the value for the object's whole life, and every later read served the corrupted number — including the one interpolated into the out-of-domain message in `_bspline_basis_multidim`. It was the only array-shaped memo in `src/pantr/bspline/` not frozen read-only, it is the third prohibition of `design/bspline_derived_caches.md`, and nothing in the suite inspected `domain.flags`. Reproduced on trunk before this change.

**It disappears as a consequence of the design rather than as a fix**: `design/bspline_derived_caches.md` F1 requires this type to acquire zero memos, so there is no cached array left on either side, and the wrapper copies out of what the implementation owns. The array stays **writable**, so no caller has to change, and the write now goes nowhere.

Pinned by `tests/test_bspline_space.py::test_the_domain_cannot_be_corrupted_through_the_array_it_hands_out`, deliberately **ungated** so it runs without the extension, plus the C++-view half in the binding-contract file. `M-h` above is the demonstration: restoring the pre-port cache turns it red under both backends.

`space.domain is space.domain` was `True` and is now `False`. Nothing promised that identity and nothing relied on it; it is the same weakening `BsplineSpace1D.domain` already records, and it is written into the docstring for the same reason.

## The downstream consumer census

Re-run against `~/Dev/tIGArx-future` at `master`, the three categories separately.

**(a) Private pantr symbols: zero.** No `pantr._*` import, no underscore-prefixed name in any `from pantr… import`, no private attribute read on a pantr object. The 25 apparent hits for `._knots`/`._spaces` are all `tests._knots`, the consumer's own test-helper module.

**(b) Public surface, by use sites**: `degrees` 364, `dim` 142, `spaces` 90, `dtype` 75, `num_total_basis` 47, `num_basis` 32, `domain` 18, `num_intervals` 15, `num_total_intervals` 10, `tolerance` 5, `boundary_dofs` 3. Unused: `has_Bezier_like_knots`, `tabulate_basis`, `cell_supports`, `restrict`, `BsplineSpaceRestriction`. Every one of the used names is preserved, verified by importing this branch's `pantr` from the consumer's tree and reading the whole surface.

**(c) Attribute writes on pantr objects: zero.** The two apparent hits are on the consumer's own objects (`record.degrees` in its frozen-record contract test, `self.degrees` in its own class). **Zero writes through a pantr array** — no `.domain[…] =`, no `.knots[…] =` — so making `domain` a copy breaks nothing, and neither would making it read-only.

**The sharpest constraint, and it holds**: `isinstance(pantr_space, BsplineSpace)` at five production sites (`tigarx/core/space.py:705,997`, `core/dofmap.py:485`, `core/partitioner.py:247`, `core/mesh.py:436`). The wrapper *is* the class `pantr.bspline.BsplineSpace`, so all five hold. Checked by execution, not by reading.

The consumer's own canary (`tests/core/test_smoke.py`) pins eight names on this type — `boundary_dofs degrees dim num_basis num_intervals num_total_basis num_total_intervals spaces`. All eight present; checked against this branch.

## Verification

| check | result |
|---|---|
| `ruff check` / `ruff format --check` | clean, 332 files |
| `mypy --strict` (src, tests, scripts) | clean, 307 files |
| `lint-imports` | 2 contracts kept, 0 broken |
| `make doctest` | 82 passed, 7 skipped |
| `pytest` (default backend) | 8849 passed, 44 skipped, 7 xfailed |
| `pytest` under `PANTR_BACKEND=cpp` | 8846 passed, 47 skipped, 7 xfailed |
| `pytest -m slow` | 78 passed, 1 skipped |
| `ctest`, release | 45/45 |
| `ctest`, ASan + UBSan | 51/51 |
| `ctest`, ThreadSanitizer | 51/51 |

The TSan leg is what `design/bspline_derived_caches.md` asks of #396, and its null result is only worth having with the sanitizer confirmed live: a deliberately racy four-thread control in the same toolchain configuration reports 4 races, so the clean run on this type is a measurement rather than an optimised-away accessor. The new `check_concurrent_reads` case is what the leg has to bite on — eight threads over every accessor including the one that copies a handle — because the header claims concurrent safety and nothing checked it before.

### `scripts/ci_local.sh all`

Run **last and alone**, with `.venv` created first so the Python leg cannot skip silently.

```
52 PASS   2 FAIL   0 SKIP
```

The two failures are the **`g++-10` toolchain floor**, pre-existing and not this branch's:

```
FAIL    floor: g++-10 build (-Werror)
FAIL    floor: g++-10 ctest
```

Root-caused rather than assumed. Both are `cpp/include/pantr/core/format.hpp:123,143` calling the **floating-point** overload of `std::to_chars`, which libstdc++ 10 does not provide — which `format.hpp:48-49` documents in its own file comment. Compiling this branch's new header alone under `/usr/bin/g++-10` reproduces exactly those two errors and no others, so nothing in `space_nd.hpp` contributes. `clang++-10` builds and passes over the same tree (`PASS floor: clang++-10 build`, `PASS floor: clang++-10 ctest`), which is the discriminator: it is the standard library, not the C++.

## The docs leg is red, on trunk

`NUMBA_DISABLE_JIT=1 make docs SPHINXOPTS="-W --keep-going"` exits non-zero with **13** nitpicky cross-reference warnings. **This branch adds none**: all 13 are in files it does not touch (`bezier/_bezier.py`, `bspline/_bspline_space_1d.py`, `geometry.py`, `transform.py`, `grid/_bvh.py`, `grid/_tags.py`, `grid/_partition.py`, `quad/__init__.py`), each verified byte-identical to `proto/cpp`.

It started at 20 with this branch's five, and is now 13: the five were removed by following the convention `docs/conf.py` states in its own comment — prose about a private class goes in double backticks, since a role that can never resolve is a broken link rather than a suppressible one — and two more fell to the one `nitpick_ignore` entry added for the `_Impl` annotation that every ported wrapper's `_impl` slot carries. That entry serves three wrappers at once and the next ported type inherits it. The remaining 13 are six earlier slices' and want their own pass; they are not fixed here because a partial fix does not reach green and the files belong to other slices.

## Reviewed

Three review passes over this branch — the C++ region, the Python region, and a vacuity audit of the tests — with the findings fixed in `bb8d04c` (`self-review: …`). One was **Important**: the header still described `tolerance()`'s dimensionless refusal as a deliberate message divergence from the oracle, which stopped being true when the oracle's message was made deliberate instead of inherited from `max()`. Left standing it would have licensed the two texts to drift apart. The rest, and the one coverage gap it closed (a seam test for the four unported operations, whose reach is now measured rather than assumed), are in that commit's message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
