### PR TITLE
feat(bspline): own the Bezier extraction builder and its identity mask in C++

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -122,14 +122,14 @@ if(PANTR_NANOBIND_SPLIT)
                       bezier_root_finding.cpp grid.cpp geometry.cpp transform.cpp
                       grid_types.cpp grid_tags.cpp grid_bvh.cpp grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
-                      bspline_extraction.cpp)
+                      bspline_extraction.cpp bspline_extraction_operators.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
                       bezier_root_finding.cpp grid.cpp geometry.cpp transform.cpp
                       grid_types.cpp grid_tags.cpp grid_bvh.cpp grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
-                      bspline_extraction.cpp)
+                      bspline_extraction.cpp bspline_extraction_operators.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bspline_extraction_operators.cpp
+++ b/cpp/bindings/bspline_extraction_operators.cpp
@@ -1,0 +1,189 @@
+/// \file
+/// Bindings for the Bézier extraction operator builder and its structural
+/// identity mask, from `pantr/bspline/extraction.hpp`.
+///
+/// Separate from `bspline_extraction.cpp` because the two are different ports with
+/// different parity claims: that file binds the tensor-product *apply* kernels,
+/// which take operators as arguments and know nothing about knots, while these
+/// *build* the operators from a knot vector. `register.hpp` gives each its own
+/// entry point for the same reason.
+///
+/// ## What is validated here, and why it is here
+///
+/// The header validates nothing, as a Layer 3 kernel must not, so this file is the
+/// C++ half of Layer 2 and owns every refusal. The three that mirror the oracle's
+/// `_check_spline_info` carry **its messages character for character**, and the
+/// `tol` refusal carries `_prepare_extraction_out`'s, so that the two backends are
+/// indistinguishable to a caller who reads the text and `tests/parity/` can compare
+/// them. The order is the oracle's too: degree, then length, then monotonicity.
+/// The 1D-ness check that opens the oracle's version is nanobind's `nb::ndim<1>`,
+/// because nanobind has no path to `TypeError`, which is what
+/// `pantr/core/error.hpp` sets as the split for the whole port.
+///
+/// One refusal has **no counterpart in the oracle**, and it is a deliberate
+/// divergence rather than an omission on either side. A knot vector spanning no
+/// in-domain interval gives an empty `(0, p+1, p+1)` result, and the oracle's core
+/// then indexes `out[0]` on it when the boundary multiplicity is short -- out of
+/// bounds on an empty array. Refusing the vector is the only thing this side can do
+/// that is not undefined behaviour, and the message is
+/// `check_space_has_an_interval`'s, which is what `BsplineSpace1D` already raises
+/// for the same knot vector. `pantr.bspline._extraction_backend` records that the
+/// two backends differ here.
+///
+/// ## `.noconvert()` on every array
+///
+/// The builder's whole arithmetic runs in the knots' own scalar type -- the
+/// insertion weight, its complement and the two products that combine two columns
+/// -- so a silent `float32` to `float64` promotion on `knots` would not merely copy,
+/// it would change the accumulation width and make the result disagree with the
+/// oracle for a reason no caller could see. `design/backend_parity.md` Rule 9 is the
+/// rule; this is where it is enforced at the seam.
+///
+/// The mask entry point takes `int64` and `bool` arrays and no float at all, so its
+/// `.noconvert()` is about a silent `int32`-to-`int64` copy of a caller's index
+/// array rather than about arithmetic.
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include "pantr/bspline/extraction.hpp"
+#include "pantr/bspline/knots.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+using pantr::span_nd;
+
+template <class T>
+using const_knots = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_operators = nb::ndarray<T, nb::ndim<3>, nb::c_contig, nb::device::cpu>;
+
+/// A per-unique-knot multiplicity array, `np.intp` on the Python side.
+///
+/// `std::int64_t` rather than a platform-width type, for the reason
+/// `bspline_extraction.cpp` gives of its own index maps: `np.intp` is `int64` on
+/// every platform this is built for, so `.noconvert()` accepts the oracle's own
+/// arrays unchanged, and a stub has to name a fixed type.
+using const_multiplicity = nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig,
+                                       nb::device::cpu>;
+
+/// A per-interval boolean mask.
+using out_mask = nb::ndarray<bool, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// Refuse the arguments the oracle's `_check_spline_info` refuses, in its order.
+///
+/// \param knots The knot vector as supplied.
+/// \param degree The requested degree.
+/// \throws nb::value_error With the oracle's message, on any of the three.
+template <class T>
+void check_spline_info(const_knots<T> knots, std::int64_t degree) {
+    if (degree < 0) {
+        throw nb::value_error("degree must be non-negative");
+    }
+    // Divided rather than multiplied, as `BsplineSpace1D::check_arguments` is and
+    // for the same reason: `2 * degree + 2` is signed overflow for a degree near
+    // the top of the range, while the oracle's Python integers are exact for any
+    // degree.
+    if ((static_cast<std::int64_t>(knots.size()) - 2) / 2 < degree) {
+        throw nb::value_error("knots must have at least 2*degree+2 elements");
+    }
+    // `np.all(np.diff(knots) >= 0)`: the difference is formed first and only then
+    // compared, which is not the same predicate as `knots[i] >= knots[i - 1]` -- a
+    // vector of two infinities differences to NaN and is refused, while the direct
+    // comparison would accept it.
+    for (std::size_t i = 1; i < knots.size(); ++i) {
+        const T step = knots(i) - knots(i - 1);
+        if (!(static_cast<double>(step) >= 0.0)) {
+            throw nb::value_error("knots must be non-decreasing");
+        }
+    }
+}
+
+/// Build the Bézier extraction operators, validated and dispatched.
+///
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance.
+/// \param out The `(n_intervals, degree + 1, degree + 1)` result.
+/// \throws nb::value_error If an argument fails the oracle's checks, if the vector
+///         spans no interval, or if `out` has the wrong shape.
+template <class T>
+void bezier_extraction(const_knots<T> knots, std::int64_t degree, double tol,
+                       out_operators<T> out) {
+    if (tol < 0.0) {
+        throw nb::value_error("tol must be non-negative");
+    }
+    check_spline_info<T>(knots, degree);
+
+    const std::span<const T> knot_span(knots.data(), knots.size());
+    const std::int64_t n_intervals =
+        pantr::bspline::classify_knots<T>(knot_span, degree, tol).num_intervals();
+    // No counterpart in the oracle; see the file comment. `std::invalid_argument`
+    // reaches Python as a `ValueError` through nanobind's default translator, which
+    // is what the caller sees from `BsplineSpace1D` for the same vector.
+    pantr::bspline::check_space_has_an_interval<T>(knot_span, degree, n_intervals, tol);
+
+    const auto side = static_cast<std::size_t>(degree) + 1;
+    if (out.shape(0) != static_cast<std::size_t>(n_intervals) || out.shape(1) != side
+        || out.shape(2) != side) {
+        throw nb::value_error(("out must have shape (" + std::to_string(n_intervals) + ", "
+                              + std::to_string(side) + ", " + std::to_string(side) + ")")
+                                 .c_str());
+    }
+
+    const span_nd<T, 3> result(out.data(), out.shape(0), side, side);
+
+    const nb::gil_scoped_release release;
+    pantr::bspline::bezier_extraction_1d<T>(knot_span, degree, tol, result);
+}
+
+/// Mark the intervals whose Bézier operator is the identity, validated and dispatched.
+///
+/// \param multiplicity The in-domain knot multiplicities, `n_intervals + 1` of them.
+/// \param degree The polynomial degree.
+/// \param out One flag per interval.
+/// \throws nb::value_error If `multiplicity` is empty, `degree` is negative, or
+///         `out` is not one shorter than `multiplicity`.
+void bezier_identity_mask(const_multiplicity multiplicity, std::int64_t degree, out_mask out) {
+    if (degree < 0) {
+        throw nb::value_error("degree must be non-negative");
+    }
+    if (multiplicity.size() == 0) {
+        throw nb::value_error("multiplicity must hold at least one knot class");
+    }
+    const std::size_t n_intervals = multiplicity.size() - 1;
+    if (out.size() != n_intervals) {
+        throw nb::value_error(
+            ("out must have " + std::to_string(n_intervals) + " elements").c_str());
+    }
+
+    const std::span<const std::int64_t> counts(multiplicity.data(), multiplicity.size());
+    const std::span<bool> flags(out.data(), out.size());
+
+    const nb::gil_scoped_release release;
+    pantr::bspline::bezier_structural_identity_mask(counts, degree, flags);
+}
+
+}  // namespace
+
+void register_bspline_extraction_operators(nb::module_& m) {
+    // Argument names mirror the oracle's Layer 2 helpers, and there is no
+    // `nb::kw_only()`: the dispatcher in `pantr.bspline._extraction_backend` calls
+    // these positionally, as it calls the Numba cores.
+    m.def("bezier_extraction_1d", &bezier_extraction<double>, nb::arg("knots").noconvert(),
+          nb::arg("degree"), nb::arg("tol"), nb::arg("out").noconvert());
+    m.def("bezier_extraction_1d", &bezier_extraction<float>, nb::arg("knots").noconvert(),
+          nb::arg("degree"), nb::arg("tol"), nb::arg("out").noconvert());
+    m.def("bezier_structural_identity_mask", &bezier_identity_mask,
+          nb::arg("multiplicities").noconvert(), nb::arg("degree"), nb::arg("out").noconvert());
+}

--- a/cpp/bindings/bspline_extraction_operators.cpp
+++ b/cpp/bindings/bspline_extraction_operators.cpp
@@ -20,15 +20,25 @@
 /// because nanobind has no path to `TypeError`, which is what
 /// `pantr/core/error.hpp` sets as the split for the whole port.
 ///
-/// One refusal has **no counterpart in the oracle**, and it is a deliberate
-/// divergence rather than an omission on either side. A knot vector spanning no
-/// in-domain interval gives an empty `(0, p+1, p+1)` result, and the oracle's core
-/// then indexes `out[0]` on it when the boundary multiplicity is short -- out of
-/// bounds on an empty array. Refusing the vector is the only thing this side can do
-/// that is not undefined behaviour, and the message is
-/// `check_space_has_an_interval`'s, which is what `BsplineSpace1D` already raises
-/// for the same knot vector. `pantr.bspline._extraction_backend` records that the
-/// two backends differ here.
+/// ## Three refusals with no Python counterpart, and they are not the same kind
+///
+/// **One is a genuine divergence.** A knot vector spanning no in-domain interval gives
+/// an empty `(0, p+1, p+1)` result, and the oracle's core then indexes `out[0]` on it
+/// when the boundary multiplicity is short -- out of bounds on an empty array. Refusing
+/// the vector is the only thing this side can do that is not undefined behaviour, and
+/// the message is `check_space_has_an_interval`'s, which is what `BsplineSpace1D`
+/// already raises for the same knot vector. `pantr.bspline._extraction_backend` records
+/// that the two backends differ here.
+///
+/// **The other two are preconditions promoted to refusals**, which is what a Layer 2
+/// seam is for and not a divergence in behaviour: an `out` whose shape does not match
+/// the operator count, and a `multiplicity` array with no class in it. In Python those
+/// are unreachable, because Layer 2 sizes `out` itself and derives `multiplicity` from
+/// a space that always has one class. Reaching the kernel with either would be
+/// undefined behaviour on this side, where in the oracle it is a Numba index that
+/// silently reads past an array, so they are checked rather than asserted. Both are
+/// mentioned here because "no counterpart in the oracle" was read as naming only the
+/// first, and an unlisted refusal is one nobody knows to test.
 ///
 /// ## `.noconvert()` on every array
 ///
@@ -161,7 +171,7 @@ void bezier_identity_mask(const_multiplicity multiplicity, std::int64_t degree, 
         throw nb::value_error("degree must be non-negative");
     }
     if (multiplicity.size() == 0) {
-        throw nb::value_error("multiplicity must hold at least one knot class");
+        throw nb::value_error("multiplicity must hold at least one class");
     }
     const std::size_t n_intervals = multiplicity.size() - 1;
     if (out.size() != n_intervals) {

--- a/cpp/bindings/bspline_extraction_operators.cpp
+++ b/cpp/bindings/bspline_extraction_operators.cpp
@@ -93,8 +93,10 @@ void check_spline_info(const_knots<T> knots, std::int64_t degree) {
     // Divided rather than multiplied, as `BsplineSpace1D::check_arguments` is and
     // for the same reason: `2 * degree + 2` is signed overflow for a degree near
     // the top of the range, while the oracle's Python integers are exact for any
-    // degree.
-    if ((static_cast<std::int64_t>(knots.size()) - 2) / 2 < degree) {
+    // degree. The `size < 2` guard is what makes the two spellings agree on every
+    // input rather than nearly every one; `space_1d.hpp` carries the argument.
+    const auto count = static_cast<std::int64_t>(knots.size());
+    if (count < 2 || (count - 2) / 2 < degree) {
         throw nb::value_error("knots must have at least 2*degree+2 elements");
     }
     // `np.all(np.diff(knots) >= 0)`: the difference is formed first and only then

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -84,6 +84,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_bezier_type(m);
     register_bspline_types(m);
     register_bspline_extraction(m);
+    register_bspline_extraction_operators(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -95,3 +95,12 @@ void register_bspline_types(nanobind::module_& m);
 /// `BsplineSpace`, which is FELIGN/pantr#396's, so the type's own registration
 /// arrives with it. See design/extraction_port.md.
 void register_bspline_extraction(nanobind::module_& m);
+
+/// Register `pantr.bspline`'s Bézier extraction operator builder and its mask.
+///
+/// Separate from `register_bspline_extraction` because the two are separate ports
+/// with separate parity claims: that one *applies* an operator, this one *builds*
+/// it from a knot vector. Only the Bézier target is here -- Lagrange follows in its
+/// own slice, and cardinal waits on the interval scan `bspline/space_1d.hpp`
+/// excludes. See design/extraction_port.md.
+void register_bspline_extraction_operators(nanobind::module_& m);

--- a/cpp/include/pantr/bspline/extraction.hpp
+++ b/cpp/include/pantr/bspline/extraction.hpp
@@ -76,8 +76,9 @@
 ///
 ///  - **A knot vector spanning no in-domain interval.** The oracle allocates an
 ///    empty `(0, p+1, p+1)` result and then indexes `out[0]` if the boundary count
-///    is short, which is out of bounds on an empty array. Here the operator count
-///    is a precondition, and `cpp/bindings/bspline_extraction_operators.cpp`
+///    is short, which is out of bounds on an empty array -- measured, not inferred:
+///    interpreted, where numpy bounds checks, that line raises. Here the operator
+///    count is a precondition, and `cpp/bindings/bspline_extraction_operators.cpp`
 ///    refuses the vector with `check_space_has_an_interval`'s message rather than
 ///    reaching it.
 ///  - **A first in-domain knot whose multiplicity exceeds one.** The window

--- a/cpp/include/pantr/bspline/extraction.hpp
+++ b/cpp/include/pantr/bspline/extraction.hpp
@@ -1,0 +1,237 @@
+#pragma once
+
+/// \file
+/// The Bézier extraction operators of a 1D B-spline space, and the mask that says
+/// which of them are already the identity.
+///
+/// The C++ twin of `pantr.bspline._bspline_extraction`'s Bézier half.
+/// `design/extraction_port.md` calls this slice **S3**, minus the two targets it
+/// leaves for later: **Lagrange** is this operator post-multiplied by
+/// `lagrange_to_bernstein_1d`, which `change_basis.hpp` already provides, and
+/// **cardinal** additionally needs the cardinal-interval scan, which is not ported
+/// and which `bspline/space_1d.hpp` deliberately excludes from the type.
+///
+/// ## What an operator is
+///
+/// For interval `e` the operator `C_e` of shape `(p+1, p+1)` satisfies
+///
+///     N_e(x) = C_e @ B(xi)
+///
+/// where `N_e` are the `p + 1` B-spline functions supported on `e`, `B` the
+/// Bernstein basis of degree `p` on the reference interval `[0, 1]`, and `xi` the
+/// local coordinate. It is built by starting from the identity and running Boehm
+/// knot insertion until each interval's knots are `p + 1`-fold, which makes every
+/// entry a product of convex combinations: the entries are non-negative and each
+/// **column** sums to one. Columns and not rows -- the identity follows from
+/// `sum_i N_i = 1` and `sum_j B_j = 1` plus the linear independence of `B`, so it
+/// says `ones^T C_e = ones^T`. `tests/parity/test_bspline_bezier_extraction.py`
+/// uses it as one of its two independent accuracy oracles.
+///
+/// ## The accumulator is `T`, and that is a promise rather than a detail
+///
+/// Every arithmetic step below is in `T`: the insertion weight, its complement,
+/// and the two products that combine two columns. The oracle is a numba kernel
+/// over a `T` array whose only scalar literal is spelled `knots.dtype.type(1.0)`
+/// precisely so that it does **not** promote -- a bare `1.0` would make numba
+/// compute the whole combination in `float64` at `float32` storage.
+/// `design/backend_parity.md` Rule 9 is the rule this obeys; `T(1.0)` below is
+/// where it is obeyed, and widening it would be more accurate and would not be the
+/// same function.
+///
+/// ## The two knot windows, and why one of them is not the class multiplicity
+///
+/// The builder reads two counts off the knot vector, and they are different
+/// quantities computed by different rules:
+///
+///  - the **boundary count**, `multiplicity_of_first_knot_in_domain`, which
+///    decides whether the first interval needs the insertions a non-clamped left
+///    end omits. It counts only among the first `degree + 1` knots.
+///  - the **per-interval multiplicities**, the in-domain subrange of
+///    `unique_knots_and_multiplicity`, which advance the sliding knot window.
+///
+/// `design/extraction_port.md`'s 2026-09-01 amendment says the first is the front
+/// entry of the second and needs no port of its own. **That is false**, and a
+/// counterexample is in `multiplicity_of_first_knot_in_domain`'s own comment: the
+/// two disagree whenever the first in-domain knot is repeated. The doc carries an
+/// amendment recording it.
+///
+/// ## The window never runs off the end, and that is derived rather than assumed
+///
+/// The second loop reads `knots[w .. w + degree]` with
+/// `w = degree + sum of the multiplicities of in-domain classes 1..e`. Writing
+/// `b0` for the last knot index of the class holding `knots[degree]`, that sum
+/// telescopes to `w = l_e + (degree - b0)` where `l_e` is the last knot index of
+/// in-domain class `e`. Since `degree <= b0` by construction, `w <= l_e`, and for
+/// `e <= n_intervals - 1` the class `e + 1` still exists, so
+/// `l_e <= a_last - 1 <= n - degree - 2` where `a_last` is the first index of the
+/// last in-domain class, which holds `n - degree - 1`. Hence
+/// `w + degree <= n - 2 < n`. The window fits for every interval, contracting or
+/// skipped.
+///
+/// ## Two inputs the oracle does not defend against, and what happens here
+///
+/// Both are reachable only by calling the oracle's Layer 2 helper directly with a
+/// knot vector `pantr.bspline.BsplineSpace1D` would refuse, or -- for the second --
+/// by a vector the space accepts and the oracle then mishandles.
+///
+///  - **A knot vector spanning no in-domain interval.** The oracle allocates an
+///    empty `(0, p+1, p+1)` result and then indexes `out[0]` if the boundary count
+///    is short, which is out of bounds on an empty array. Here the operator count
+///    is a precondition, and `cpp/bindings/bspline_extraction_operators.cpp`
+///    refuses the vector with `check_space_has_an_interval`'s message rather than
+///    reaching it.
+///  - **A first in-domain knot whose multiplicity exceeds one.** The window
+///    derivation above is exact, but `w = l_e + (degree - b0)` is then strictly
+///    below `l_e`, so the window starts inside the repeated knot and the oracle
+///    divides zero by zero. This code reproduces that, because reproducing the
+///    oracle is what it is for; the divergence is a defect in the shared algorithm
+///    rather than in either backend, and the parity sweep excludes such vectors and
+///    says so.
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "pantr/bspline/knots.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/precondition.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+/// Build the Bézier extraction operator of every in-domain interval.
+///
+/// \tparam T Scalar type of the knots and of the operators.
+/// \param knots A non-decreasing knot vector of at least `2 * degree + 2` entries.
+/// \param degree The polynomial degree, non-negative.
+/// \param tol The absolute parametric tolerance, from `knot_tolerance` or from a
+///        space's `tolerance()`.
+/// \param out The operators, shape `(n_intervals, degree + 1, degree + 1)`, where
+///        `n_intervals` is `classify_knots(knots, degree, tol).num_intervals()`.
+///        Overwritten in full.
+///
+/// \note Inputs are assumed to be correct (no validation performed). For general
+///       use, call `pantr.bspline._bspline_extraction`'s
+///       `_tabulate_Bspline_Bezier_1D_extraction_impl`, whose C++ half is
+///       `cpp/bindings/bspline_extraction_operators.cpp`.
+template <Real T>
+void bezier_extraction_1d(std::span<const T> knots, std::int64_t degree, double tol,
+                          span_nd<T, 3> out) {
+    const auto p = static_cast<std::size_t>(degree);
+    const KnotClasses<T> classes = unique_knots_and_multiplicity(knots, degree, tol);
+    const std::span<const std::int64_t> multiplicity =
+        std::span<const std::int64_t>(classes.multiplicity)
+            .subspan(classes.domain_begin, classes.domain_end - classes.domain_begin);
+    const std::size_t n_intervals = multiplicity.size() - 1;
+
+    PANTR_PRECONDITION(n_intervals >= 1, "the knot vector must span at least one interval");
+    PANTR_PRECONDITION(out.extent(0) == n_intervals, "out needs one operator per interval");
+    PANTR_PRECONDITION(out.extent(1) == p + 1 && out.extent(2) == p + 1,
+                       "each operator is (degree + 1) square");
+
+    const T one(1.0);
+    const T zero(0.0);
+    for (std::size_t e = 0; e < n_intervals; ++e) {
+        for (std::size_t i = 0; i <= p; ++i) {
+            for (std::size_t j = 0; j <= p; ++j) {
+                at(out, e, i, j) = (i == j) ? one : zero;
+            }
+        }
+    }
+
+    // A left end the knot vector does not clamp leaves the first interval short of
+    // the insertions that make it a Bézier patch. `reg` of them are owed, one per
+    // missing knot.
+    const std::int64_t boundary = multiplicity_of_first_knot_in_domain<T>(knots, degree, tol);
+    if (boundary < degree + 1) {
+        const auto reg = static_cast<std::size_t>(degree - boundary);
+        const T t = knots[p];
+        for (std::size_t r = 0; r < reg; ++r) {
+            // The oracle slices `lcl_knots = knots[r:]`, so its `lcl_knots[k]` is
+            // `knots[r + k]` and its `lcl_knots[k + degree - r]` is `knots[k + degree]`.
+            for (std::size_t k = 1; k + r < p; ++k) {
+                const T alpha = (t - knots[r + k]) / (knots[k + p] - knots[r + k]);
+                const T beta = one - alpha;
+                for (std::size_t i = 0; i <= p; ++i) {
+                    at(out, 0, i, k - 1) =
+                        alpha * at(out, 0, i, k) + beta * at(out, 0, i, k - 1);
+                }
+            }
+        }
+    }
+
+    // One insertion weight per knot still owed by the interval being closed.
+    // `degree - 1` is the largest count any interval can owe, since an in-domain
+    // interior class has multiplicity at least one and a class of `degree` or more
+    // needs no insertion at all.
+    std::vector<T> alphas(p > 0 ? p - 1 : 0, zero);
+
+    std::size_t window = p;
+    std::int64_t mult = 0;
+    for (std::size_t e = 0; e < n_intervals; ++e) {
+        window += static_cast<std::size_t>(mult);
+        mult = multiplicity[e + 1];
+
+        if (mult >= degree) {
+            continue;  // already a Bézier patch on the right: nothing to insert
+        }
+        const auto m = static_cast<std::size_t>(mult);
+        const T first_gap = knots[window + 1] - knots[window];
+        for (std::size_t i = 0; i + m < p; ++i) {
+            alphas[i] = first_gap / (knots[window + m + 1 + i] - knots[window]);
+        }
+
+        const std::size_t reg = p - m;
+        for (std::size_t r = 1; r <= reg; ++r) {
+            const std::size_t s = m + r;
+            // Descending, so column `k - 1` is still the value this stage reads.
+            for (std::size_t k = p; k + 1 > s; --k) {
+                const T alpha = alphas[k - s];
+                const T beta = one - alpha;
+                for (std::size_t i = 0; i <= p; ++i) {
+                    at(out, e, i, k) = alpha * at(out, e, i, k) + beta * at(out, e, i, k - 1);
+                }
+            }
+
+            // The closed columns of this interval seed the next one's, which is a
+            // copy and commits no arithmetic.
+            if (e + 1 < n_intervals) {
+                for (std::size_t i = 0; i <= r; ++i) {
+                    at(out, e + 1, reg - r + i, reg - r) = at(out, e, p - r + i, p);
+                }
+            }
+        }
+    }
+}
+
+/// Mark the intervals whose Bézier extraction operator is the identity.
+///
+/// Interval `e` is one exactly when both of its bounding in-domain knots have
+/// multiplicity at least `degree + 1`: the interval is then already a Bézier patch,
+/// decoupled from both neighbours, and no insertion touches it.
+///
+/// Integers throughout, so there is no tolerance here and no scalar type to be
+/// generic in. The tolerance already did its work upstream, in the class scan that
+/// produced `multiplicity`.
+///
+/// \param multiplicity The in-domain knot multiplicities,
+///        `BsplineSpace1D::multiplicity_in_domain()`, of length `n_intervals + 1`.
+/// \param degree The polynomial degree.
+/// \param out One flag per interval, length `multiplicity.size() - 1`.
+///
+/// \note Inputs are assumed to be correct (no validation performed). For general
+///       use, call `pantr.bspline.spanwise_element_extraction`'s
+///       `_bezier_structural_identity_mask`.
+inline void bezier_structural_identity_mask(std::span<const std::int64_t> multiplicity,
+                                            std::int64_t degree, std::span<bool> out) {
+    PANTR_PRECONDITION(!multiplicity.empty(), "multiplicity must hold at least one class");
+    const std::int64_t threshold = degree + 1;
+    const std::size_t n_intervals = multiplicity.size() - 1;
+    PANTR_PRECONDITION(out.size() == n_intervals, "out needs one flag per interval");
+    for (std::size_t e = 0; e < n_intervals; ++e) {
+        out[e] = multiplicity[e] >= threshold && multiplicity[e + 1] >= threshold;
+    }
+}
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/knots.hpp
+++ b/cpp/include/pantr/bspline/knots.hpp
@@ -306,6 +306,41 @@ template <Real T>
     return classes;
 }
 
+/// How many of the first `degree + 1` knots are the domain's first knot.
+///
+/// Not the multiplicity of that knot's **class**, and the difference is
+/// load-bearing rather than pedantic: a class is a chain of gaps and may reach
+/// past index `degree` in either direction, while this counts only the knots at
+/// or before the domain's start that sit within `tol` of it. The two disagree on
+/// any vector whose first in-domain knot is repeated -- measured on
+/// `[0, 0.4, 0.5, 0.5, 1, 1.5, 2, 2.5]` at degree 2, where this returns 1 and the
+/// class holds 2 -- so a consumer that wants the number the oracle's
+/// `_get_multiplicity_of_first_knot_in_domain_impl` returns must call this and
+/// not read `BsplineSpace1D::multiplicity_in_domain().front()`.
+///
+/// Differenced in `T` and only then widened, as the oracle's numba expression is;
+/// see the file comment on the two arithmetics.
+///
+/// \param knots A non-decreasing knot vector of at least `degree + 1` entries.
+/// \param degree The polynomial degree, which fixes where the domain starts.
+/// \param tol The absolute parametric tolerance, from `knot_tolerance`.
+/// \return A count in `[1, degree + 1]`; `degree + 1` exactly when the left end is
+///         clamped.
+template <Real T>
+[[nodiscard]] std::int64_t multiplicity_of_first_knot_in_domain(std::span<const T> knots,
+                                                                std::int64_t degree, double tol) {
+    using std::abs;
+    const T first = knots[static_cast<std::size_t>(degree)];
+    std::int64_t multiplicity = 0;
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        const T offset = knots[static_cast<std::size_t>(i)] - first;
+        if (abs(detail::as_double(offset)) <= tol) {
+            ++multiplicity;
+        }
+    }
+    return multiplicity;
+}
+
 /// The number of basis functions a knot vector and degree define.
 ///
 /// In the non-periodic case it is the knot count less the degree less one. In the
@@ -326,18 +361,8 @@ template <Real T>
         return count;
     }
 
-    using std::abs;
-    // The multiplicity of `knots[degree]` among the first `degree + 1` knots.
-    // Differenced in `T`, as the oracle's numba expression is.
-    const T first = knots[static_cast<std::size_t>(degree)];
-    std::int64_t multiplicity = 0;
-    for (std::int64_t i = 0; i <= degree; ++i) {
-        const T offset = knots[static_cast<std::size_t>(i)] - first;
-        if (abs(detail::as_double(offset)) <= tol) {
-            ++multiplicity;
-        }
-    }
-    const std::int64_t regularity = degree - multiplicity;
+    const std::int64_t regularity =
+        degree - multiplicity_of_first_knot_in_domain<T>(knots, degree, tol);
     return count - regularity - 1;
 }
 

--- a/cpp/include/pantr/bspline/space_1d.hpp
+++ b/cpp/include/pantr/bspline/space_1d.hpp
@@ -355,9 +355,18 @@ class BsplineSpace1D {
         // Divided rather than multiplied: `2 * degree + 2` is signed overflow, and
         // so undefined, for a degree near the top of the range. Python's integers
         // are arbitrary-precision, so the oracle's spelling is exact for any degree
-        // and this one has to be too. The size is at least 0, so the division is
-        // well defined.
-        if ((static_cast<std::int64_t>(knots.size()) - 2) / 2 < degree) {
+        // and this one has to be too.
+        //
+        // The `size < 2` guard is what makes the division equivalent to the
+        // oracle's multiplication rather than nearly so. C++ integer division
+        // truncates toward zero where the rewrite needs a floor, and the two differ
+        // on exactly one input: at one knot and degree 0, `(1 - 2) / 2` truncates to
+        // 0 instead of -1, so the refusal is skipped and the caller is told
+        // something else further down. Any vector shorter than two knots is refused
+        // for any non-negative degree, since `2 * degree + 2` is at least 2, so the
+        // guard costs no case and closes that one.
+        const auto count = static_cast<std::int64_t>(knots.size());
+        if (count < 2 || (count - 2) / 2 < degree) {
             throw std::invalid_argument("knots must have at least 2*degree+2 elements");
         }
         // `np.all(np.diff(knots) >= 0)`: the difference is formed first and only

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -35,7 +35,8 @@ set(PANTR_TEST_SOURCES
     test_bspline_knots.cpp
     test_bspline_space_1d.cpp
     test_bspline_space_nd.cpp
-    test_extraction_kernels.cpp)
+    test_extraction_kernels.cpp
+    test_bspline_extraction.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file.

--- a/cpp/tests/test_bspline_extraction.cpp
+++ b/cpp/tests/test_bspline_extraction.cpp
@@ -144,14 +144,25 @@ template <class T>
 
 /// The tolerance a column sum may miss one by.
 ///
-/// Each stage of an entry's chain commits four roundings -- `beta = 1 - alpha`, the
-/// two products and their sum -- against an exact convex combination of values in
+/// Each stage of an entry's chain forms an exact convex combination of values in
 /// `[0, 1]`, whose weights are non-negative and sum to one, so the propagated error
-/// carries forward with weight at most one and an entry ends up within
-/// `gamma_{4 S}` of its exact value, where `S` is the chain length
+/// carries forward with weight at most one. **The rounding of `alpha` itself
+/// cancels**: `alpha` and `beta = 1 - alpha` enter as a pair, and what the row bound
+/// sees is `|A + B - 1|`, whose defect is at most `u/2` however `alpha` was
+/// computed. That leaves **2.5 roundings per stage**, not four, so an entry ends up
+/// within `gamma_{2.5 S}` of its exact value, where `S` is the chain length
 /// `insertion_stages` reports. Summing `degree + 1` of them against an exact total
-/// of one adds `gamma_{degree}`. First order in `u`, that is
-/// `(4 S (degree + 1) + degree) u`.
+/// of one adds `gamma_{degree}`; the two compose by Higham, *Accuracy and Stability
+/// of Numerical Algorithms*, 2nd ed., Lemma 3.3.
+///
+/// `gamma_{2.5 S + degree}` is sharp and holds exactly, not to first order. What
+/// ships is `gamma_{3 S + degree}`: half a rounding per stage of declared slack over
+/// a proved bound, so the coefficient is an integer. The closed form
+/// `m u / (1 - m u)` is used rather than the truncation `m u`, because `S` grows
+/// with the element count rather than with the degree.
+///
+/// **Stated hypothesis: no underflow in the operator entries**, which a purely
+/// relative rounding model requires and this derivation does not establish.
 ///
 /// \tparam T Scalar type.
 /// \param degree The polynomial degree.
@@ -160,8 +171,9 @@ template <class T>
 template <class T>
 [[nodiscard]] double column_sum_tolerance(std::int64_t degree, std::int64_t stages) {
     const double u = 0.5 * static_cast<double>(std::numeric_limits<T>::epsilon());
-    const auto p = static_cast<double>(degree);
-    return (4.0 * static_cast<double>(stages) * (p + 1.0) + p) * u;
+    const double m = 3.0 * static_cast<double>(stages) + static_cast<double>(degree);
+    PANTR_PRECONDITION(m * u < 1.0, "gamma runs away to one past this many roundings");
+    return m * u / (1.0 - m * u);
 }
 
 /// Check the two analytic invariants every operator has.

--- a/cpp/tests/test_bspline_extraction.cpp
+++ b/cpp/tests/test_bspline_extraction.cpp
@@ -163,6 +163,16 @@ template <class T>
 ///
 /// **Stated hypothesis: no underflow in the operator entries**, which a purely
 /// relative rounding model requires and this derivation does not establish.
+/// Subnormal entries *are* reachable at `float32` with mixed per-gap knot ratios;
+/// the bound was observed to hold on them by a wide margin, but observing is not
+/// covering.
+///
+/// The refusal below is `PANTR_PRECONDITION`, which is `assert` and **compiles to
+/// nothing under `NDEBUG`** -- and the `gcc` preset that runs this test builds with
+/// `-DNDEBUG`. Past the runaway point this returns a negative or infinite bound
+/// rather than refusing. Reaching it takes on the order of a million knots at
+/// `float32`, which nothing here approaches, so it is dormant; the Python
+/// counterpart raises for real.
 ///
 /// \tparam T Scalar type.
 /// \param degree The polynomial degree.

--- a/cpp/tests/test_bspline_extraction.cpp
+++ b/cpp/tests/test_bspline_extraction.cpp
@@ -1,0 +1,416 @@
+/// \file
+/// The Bézier extraction operators and the structural identity mask.
+///
+/// ## Where the expected values come from, and none of them from the oracle
+///
+/// This file is the C++ side's own check, so nothing below is a number read off
+/// `pantr.bspline`. Four provenances, kept apart because they carry different
+/// weight.
+///
+///  - **Derived by hand from the definition.** The quadratic three-element open
+///    spline `[0,0,0,1,2,3,3,3]` is worked out in `check_quadratic_open` from
+///    `N = C @ B` directly: each row is the Bernstein form of one B-spline
+///    function on the element, obtained from its value at both ends and its
+///    derivative at the left end. The derivation is written out there. Every entry
+///    is a half, so the table is exact in `float32` as well as `float64` and the
+///    comparison carries no tolerance.
+///  - **Analytic invariants.** Each operator's **columns** sum to one, because
+///    `sum_i N_i = 1` and `sum_j B_j = 1` and the Bernstein basis is independent.
+///    Every entry is non-negative, being a product of convex combinations. Both
+///    are checked over every case here, and the column sum is what catches a
+///    transposition: the quadratic table above has row sums `1, 1.5, 0.5`, so a
+///    transposed implementation fails it.
+///  - **Degenerate families with a forced answer.** Degree 0, a Bézier-like knot
+///    vector, an interior knot at full multiplicity, and degree 1 at any knots all
+///    force the identity -- for degree 1 because the linear B-spline basis on an
+///    element *is* the Bernstein basis of degree 1.
+///  - **Symmetries.** A knot vector symmetric about its domain's midpoint has
+///    operators that are index-reversals of each other, and the interior operator
+///    of a *uniform* spline does not depend on whether the ends are clamped,
+///    because a function's restriction to an interior element depends only on the
+///    local knot pattern. The second one is what exercises the non-clamped
+///    boundary-insertion branch against a value derived elsewhere.
+///
+/// ## What is not checked here
+///
+/// Agreement with the Python oracle, which is
+/// `tests/parity/test_bspline_bezier_extraction.py`'s job, and the reproduction
+/// identity `N_e = C_e @ B` evaluated at points -- there is no general B-spline
+/// basis tabulation in C++ yet, so that check lives on the Python side where
+/// `BsplineSpace1D.tabulate_basis` exists.
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bspline/extraction.hpp"
+#include "pantr/bspline/knots.hpp"
+
+namespace {
+
+using pantr::at;
+using pantr::span_nd;
+using pantr::bspline::bezier_extraction_1d;
+using pantr::bspline::bezier_structural_identity_mask;
+using pantr::bspline::classify_knots;
+using pantr::bspline::KnotClassRange;
+using pantr::bspline::multiplicity_of_first_knot_in_domain;
+using pantr::bspline::unique_knots_and_multiplicity;
+
+/// One case's operators, kept alive alongside the view over them.
+///
+/// \tparam T Scalar type.
+template <class T>
+struct Operators {
+    std::vector<T> storage;  ///< `(n_intervals, p+1, p+1)` row-major.
+    std::size_t count = 0;   ///< How many operators there are.
+    std::size_t side = 0;    ///< `degree + 1`.
+
+    /// The view the builder wrote into.
+    ///
+    /// \return A rank-3 view over `storage`.
+    [[nodiscard]] span_nd<const T, 3> view() const {
+        return span_nd<const T, 3>(storage.data(), count, side, side);
+    }
+};
+
+/// Build every operator of a knot vector.
+///
+/// \tparam T Scalar type.
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance; `knot_tolerance`'s when zero is
+///        not wanted, but every case here passes one explicitly.
+/// \return The operators.
+template <class T>
+Operators<T> build(const std::vector<T>& knots, std::int64_t degree, double tol) {
+    const std::span<const T> span(knots);
+    const KnotClassRange range = classify_knots<T>(span, degree, tol);
+    const auto count = static_cast<std::size_t>(range.num_intervals());
+    const auto side = static_cast<std::size_t>(degree) + 1;
+    Operators<T> ops{std::vector<T>(count * side * side, T(0.0)), count, side};
+    const span_nd<T, 3> view(ops.storage.data(), count, side, side);
+    bezier_extraction_1d<T>(span, degree, tol, view);
+    return ops;
+}
+
+/// The tolerance a column sum may miss one by.
+///
+/// Each entry is a chain of at most `degree` updates `alpha * x + beta * y`, each
+/// committing four roundings -- `beta = 1 - alpha`, two products and their sum --
+/// and the exact chain is a convex combination of values in `[0, 1]`, so an entry
+/// carries at most `gamma_{4 degree}` of absolute error. Summing `degree + 1` of
+/// them adds `gamma_{degree}` against a total of one. First order in `u`, that is
+/// `(4 degree (degree + 1) + degree) u`.
+///
+/// \tparam T Scalar type.
+/// \param degree The polynomial degree.
+/// \return The absolute bound, zero for degree 0 where nothing is computed.
+template <class T>
+[[nodiscard]] double column_sum_tolerance(std::int64_t degree) {
+    const double u = 0.5 * static_cast<double>(std::numeric_limits<T>::epsilon());
+    const auto p = static_cast<double>(degree);
+    return (4.0 * p * (p + 1.0) + p) * u;
+}
+
+/// Check the two analytic invariants every operator has.
+///
+/// \tparam T Scalar type.
+/// \param ops The operators.
+/// \param degree The polynomial degree.
+/// \param label What case this is, for the failure message.
+template <class T>
+void check_invariants(const Operators<T>& ops, std::int64_t degree, const std::string& label) {
+    const double bound = column_sum_tolerance<T>(degree);
+    for (std::size_t e = 0; e < ops.count; ++e) {
+        for (std::size_t j = 0; j < ops.side; ++j) {
+            double sum = 0.0;
+            for (std::size_t i = 0; i < ops.side; ++i) {
+                const double entry = static_cast<double>(at(ops.view(), e, i, j));
+                PANTR_CHECK_MSG(entry >= 0.0, label + ": a negative entry");
+                sum += entry;
+            }
+            PANTR_CHECK_MSG(std::abs(sum - 1.0) <= bound, label + ": column " + std::to_string(j)
+                                                              + " of operator "
+                                                              + std::to_string(e) + " sums to "
+                                                              + std::to_string(sum));
+        }
+    }
+}
+
+/// Compare against an expected table, bit for bit.
+///
+/// \tparam T Scalar type.
+/// \param ops The operators.
+/// \param expected One flat row-major table per operator.
+/// \param label What case this is, for the failure message.
+template <class T>
+void same(const Operators<T>& ops, const std::vector<std::vector<double>>& expected,
+          const std::string& label) {
+    PANTR_CHECK_MSG(ops.count == expected.size(), label + ": operator count");
+    if (ops.count != expected.size()) {
+        return;
+    }
+    for (std::size_t e = 0; e < ops.count; ++e) {
+        for (std::size_t i = 0; i < ops.side; ++i) {
+            for (std::size_t j = 0; j < ops.side; ++j) {
+                const T want = static_cast<T>(expected[e][i * ops.side + j]);
+                PANTR_CHECK_MSG(at(ops.view(), e, i, j) == want,
+                                label + ": entry (" + std::to_string(e) + ", "
+                                    + std::to_string(i) + ", " + std::to_string(j) + ")");
+            }
+        }
+    }
+}
+
+/// Every operator is the identity.
+///
+/// \tparam T Scalar type.
+/// \param ops The operators.
+/// \param label What case this is, for the failure message.
+template <class T>
+void all_identity(const Operators<T>& ops, const std::string& label) {
+    PANTR_CHECK_MSG(ops.count >= 1, label + ": no operator was built");
+    for (std::size_t e = 0; e < ops.count; ++e) {
+        for (std::size_t i = 0; i < ops.side; ++i) {
+            for (std::size_t j = 0; j < ops.side; ++j) {
+                const T want = (i == j) ? T(1.0) : T(0.0);
+                PANTR_CHECK_MSG(at(ops.view(), e, i, j) == want,
+                                label + ": entry (" + std::to_string(e) + ", "
+                                    + std::to_string(i) + ", " + std::to_string(j)
+                                    + ") is not the identity's");
+            }
+        }
+    }
+}
+
+/// The quadratic three-element open spline, derived by hand from `N = C @ B`.
+///
+/// Knots `[0,0,0,1,2,3,3,3]`, degree 2, five basis functions, elements `[0,1]`,
+/// `[1,2]`, `[2,3]`. On the reference interval `B_0 = (1-t)^2`, `B_1 = 2t(1-t)`,
+/// `B_2 = t^2`, and a quadratic is fixed by its two end values and its slope at
+/// the left end, where a Bernstein form has slope `2 (c_1 - c_0)`.
+///
+///  - **Element `[0,1]`**, functions `N_0, N_1, N_2`. `N_0` has local knots
+///    `[0,0,0,1]` so `N_0 = (1-t)^2 = B_0`, giving the row `[1, 0, 0]`. `N_2` has
+///    local knots `[0,1,2,3]` so `N_2 = t^2 / 2`, giving `[0, 0, 1/2]`. `N_1` is
+///    what partition of unity leaves: `1 - (1-t)^2 - t^2/2 = 2t - 3t^2/2`, whose
+///    ends are `0` and `1/2` and whose left slope is `2`, so `c_1 = 1` and the row
+///    is `[0, 1, 1/2]`.
+///  - **Element `[1,2]`**, functions `N_1, N_2, N_3`. `N_1` restricted there is
+///    `(1-t)^2 / 2`, giving `[1/2, 0, 0]`; `N_3` is the mirror image, `t^2 / 2`,
+///    giving `[0, 0, 1/2]`; and `N_2 = 1 - (1-t)^2/2 - t^2/2` has ends `1/2`,
+///    `1/2` and left slope `1`, so `c_1 = 1` and the row is `[1/2, 1, 1/2]`.
+///  - **Element `[2,3]`** is element `[0,1]` reflected, since the knot vector is
+///    symmetric about `1.5`, so its operator is the first one with both indices
+///    reversed.
+const std::vector<std::vector<double>> kQuadraticOpen = {
+    {1.0, 0.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, 0.5},
+    {0.5, 0.0, 0.0, 0.5, 1.0, 0.5, 0.0, 0.0, 0.5},
+    {0.5, 0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 1.0},
+};
+
+/// The hand-derived quadratic table, at both widths.
+template <class T>
+void check_quadratic_open() {
+    const std::vector<T> knots = {T(0.0), T(0.0), T(0.0), T(1.0),
+                                  T(2.0), T(3.0), T(3.0), T(3.0)};
+    const Operators<T> ops = build<T>(knots, 2, 0.0);
+    same(ops, kQuadraticOpen, "quadratic open");
+    check_invariants(ops, 2, "quadratic open");
+}
+
+/// The forced-identity families.
+template <class T>
+void check_identity_families() {
+    // Degree 0: the one-by-one operator is [[1]] and nothing is computed.
+    all_identity(build<T>({T(0.0), T(1.0)}, 0, 0.0), "degree 0");
+
+    // A Bézier-like vector already is one patch.
+    all_identity(build<T>({T(0.0), T(0.0), T(0.0), T(1.0), T(1.0), T(1.0)}, 2, 0.0),
+                 "bezier-like");
+
+    // Interior knots at full multiplicity decouple every element.
+    all_identity(build<T>({T(0.0), T(0.0), T(0.0), T(0.5), T(0.5), T(0.5), T(1.0), T(1.0),
+                           T(1.0)},
+                          2, 0.0),
+                 "interior full multiplicity");
+
+    // Degree 1: the linear B-spline basis on an element IS the linear Bernstein
+    // basis, whatever the knots, so no insertion can change anything.
+    all_identity(build<T>({T(0.0), T(0.0), T(1.0), T(2.0), T(3.0), T(3.0)}, 1, 0.0),
+                 "degree 1 open");
+    all_identity(build<T>({T(0.0), T(0.25), T(0.75), T(1.5), T(2.0), T(3.0)}, 1, 0.0),
+                 "degree 1 non-uniform, unclamped");
+}
+
+/// The uniform interior operator does not depend on the clamping.
+///
+/// This is what exercises the boundary-insertion branch: an unclamped vector has a
+/// boundary multiplicity of one, so the first interval is short of `degree - 1`
+/// insertions. The value it must reach is the interior operator of the clamped
+/// spline above, which was derived by hand there.
+template <class T>
+void check_unclamped_uniform_matches_the_interior() {
+    const std::vector<T> knots = {T(0.0), T(0.5), T(1.0), T(1.5), T(2.0), T(2.5), T(3.0)};
+    const Operators<T> ops = build<T>(knots, 2, 0.0);
+    same(ops, {kQuadraticOpen[1], kQuadraticOpen[1]}, "unclamped uniform");
+    check_invariants(ops, 2, "unclamped uniform");
+}
+
+/// A symmetric knot vector's operators are each other's index reversals.
+template <class T>
+void check_mirror_symmetry() {
+    // Cubic, two uniform elements, clamped: symmetric about 1.
+    const std::vector<T> knots = {T(0.0), T(0.0), T(0.0), T(0.0), T(1.0),
+                                  T(2.0), T(2.0), T(2.0), T(2.0)};
+    const Operators<T> ops = build<T>(knots, 3, 0.0);
+    PANTR_CHECK_MSG(ops.count == 2, "mirror symmetry: two elements");
+    if (ops.count != 2) {
+        return;
+    }
+    const std::size_t n = ops.side;
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            PANTR_CHECK_MSG(at(ops.view(), 0, i, j)
+                                == at(ops.view(), 1, n - 1 - i, n - 1 - j),
+                            "mirror symmetry: entry (" + std::to_string(i) + ", "
+                                + std::to_string(j) + ")");
+        }
+    }
+    check_invariants(ops, 3, "cubic two-element");
+
+    // Three uniform elements at degree 3: the entries are sixths, so this is the
+    // one case here whose invariants need the derived tolerance rather than
+    // exactness.
+    const std::vector<T> three = {T(0.0), T(0.0), T(0.0), T(0.0), T(1.0), T(2.0),
+                                  T(3.0), T(3.0), T(3.0), T(3.0)};
+    const Operators<T> wider = build<T>(three, 3, 0.0);
+    PANTR_CHECK_MSG(wider.count == 3, "cubic three-element: element count");
+    check_invariants(wider, 3, "cubic three-element");
+    PANTR_CHECK_MSG(column_sum_tolerance<T>(3) > 0.0,
+                    "the derived column-sum tolerance must be positive above degree 0");
+}
+
+/// The boundary count is not the class multiplicity, and the builder wants the first.
+///
+/// `design/extraction_port.md`'s 2026-09-01 amendment says the boundary
+/// multiplicity is `multiplicity_in_domain().front()`. It is not: the two are
+/// different computations over different index ranges, and this vector separates
+/// them. Pinned here because a port that read the class multiplicity instead would
+/// still pass every invariant above -- what catches it is agreement with the
+/// oracle, in the parity suite.
+void check_the_boundary_count_is_not_the_class_multiplicity() {
+    const std::vector<double> repeated = {0.0, 0.4, 0.5, 0.5, 1.0, 1.5, 2.0, 2.5};
+    const std::span<const double> span(repeated);
+    const auto classes = unique_knots_and_multiplicity<double>(span, 2, 0.0);
+    PANTR_CHECK_MSG(classes.multiplicity[classes.domain_begin] == 2,
+                    "the first in-domain class of the repeated vector holds two knots");
+    PANTR_CHECK_MSG(multiplicity_of_first_knot_in_domain<double>(span, 2, 0.0) == 1,
+                    "only one of the first degree+1 knots is the domain's first knot");
+
+    // A clamped vector is where the two agree, which is why the confusion survived.
+    const std::vector<double> clamped = {0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::span<const double> clamped_span(clamped);
+    const auto clamped_classes = unique_knots_and_multiplicity<double>(clamped_span, 2, 0.0);
+    PANTR_CHECK_MSG(clamped_classes.multiplicity[clamped_classes.domain_begin] == 3,
+                    "the clamped vector's first in-domain class holds three knots");
+    PANTR_CHECK_MSG(multiplicity_of_first_knot_in_domain<double>(clamped_span, 2, 0.0) == 3,
+                    "and all three are the domain's first knot");
+}
+
+/// The structural identity mask, read off the multiplicities by eye.
+void check_identity_mask() {
+    std::array<bool, 2> flags{};
+    const std::span<bool> out(flags);
+
+    // Clamped quadratic, one interior simple knot: neither element is decoupled.
+    bezier_structural_identity_mask(std::vector<std::int64_t>{3, 1, 3}, 2, out);
+    PANTR_CHECK_MSG(!flags[0] && !flags[1], "a simple interior knot decouples nothing");
+
+    // The interior knot at full multiplicity decouples both.
+    bezier_structural_identity_mask(std::vector<std::int64_t>{3, 3, 3}, 2, out);
+    PANTR_CHECK_MSG(flags[0] && flags[1], "a full interior knot decouples both");
+
+    // Only the right element is a patch: the middle and right knots are full, the
+    // left is not.
+    bezier_structural_identity_mask(std::vector<std::int64_t>{1, 3, 3}, 2, out);
+    PANTR_CHECK_MSG(!flags[0] && flags[1], "only the right element is a patch");
+
+    // Degree 0: every class holds at least one knot and the threshold is one, so
+    // every element is a patch.
+    bezier_structural_identity_mask(std::vector<std::int64_t>{1, 1, 1}, 0, out);
+    PANTR_CHECK_MSG(flags[0] && flags[1], "at degree 0 every element is a patch");
+}
+
+/// The mask agrees with the operators it describes.
+///
+/// The two are computed by different routes -- one counts multiplicities, the other
+/// runs the insertions -- so agreeing is a real check on both. Only one direction
+/// is asserted: a flagged element must have the identity operator. The converse is
+/// false by design, since degree 0 and degree 1 have identity operators everywhere
+/// while the mask reports what the *structure* forces.
+template <class T>
+void check_the_mask_agrees_with_the_operators() {
+    struct Case {
+        std::vector<T> knots;
+        std::int64_t degree;
+    };
+    const std::vector<Case> cases = {
+        {{T(0.0), T(0.0), T(0.0), T(1.0), T(2.0), T(3.0), T(3.0), T(3.0)}, 2},
+        {{T(0.0), T(0.0), T(0.0), T(0.5), T(0.5), T(0.5), T(1.0), T(1.0), T(1.0)}, 2},
+        {{T(0.0), T(0.0), T(0.0), T(0.0), T(1.0), T(2.0), T(2.0), T(2.0), T(2.0)}, 3},
+        {{T(0.0), T(0.5), T(1.0), T(1.5), T(2.0), T(2.5), T(3.0)}, 2},
+    };
+    for (const Case& one : cases) {
+        const std::span<const T> span(one.knots);
+        const auto classes = unique_knots_and_multiplicity<T>(span, one.degree, 0.0);
+        const std::span<const std::int64_t> in_domain =
+            std::span<const std::int64_t>(classes.multiplicity)
+                .subspan(classes.domain_begin, classes.domain_end - classes.domain_begin);
+        // A fixed array rather than a vector: `std::vector<bool>` is a bitset and
+        // yields no `bool*` for a span to point at.
+        std::array<bool, 8> flags{};
+        PANTR_CHECK_MSG(in_domain.size() - 1 <= flags.size(), "mask agreement: case too wide");
+        bezier_structural_identity_mask(in_domain, one.degree,
+                                        std::span<bool>(flags.data(), in_domain.size() - 1));
+
+        const Operators<T> ops = build<T>(one.knots, one.degree, 0.0);
+        check_invariants(ops, one.degree, "mask agreement");
+        for (std::size_t e = 0; e < ops.count; ++e) {
+            if (!flags[e]) {
+                continue;
+            }
+            for (std::size_t i = 0; i < ops.side; ++i) {
+                for (std::size_t j = 0; j < ops.side; ++j) {
+                    const T want = (i == j) ? T(1.0) : T(0.0);
+                    PANTR_CHECK_MSG(at(ops.view(), e, i, j) == want,
+                                    "a flagged element must carry the identity operator");
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+int main() {
+    check_quadratic_open<double>();
+    check_quadratic_open<float>();
+    check_identity_families<double>();
+    check_identity_families<float>();
+    check_unclamped_uniform_matches_the_interior<double>();
+    check_unclamped_uniform_matches_the_interior<float>();
+    check_mirror_symmetry<double>();
+    check_mirror_symmetry<float>();
+    check_the_boundary_count_is_not_the_class_multiplicity();
+    check_identity_mask();
+    check_the_mask_agrees_with_the_operators<double>();
+    check_the_mask_agrees_with_the_operators<float>();
+    return pantr::test::summary("test_bspline_extraction");
+}

--- a/cpp/tests/test_bspline_extraction.cpp
+++ b/cpp/tests/test_bspline_extraction.cpp
@@ -112,8 +112,10 @@ Operators<T> build(const std::vector<T>& knots, std::int64_t degree, double tol)
 /// an upper bound on any single entry's chain.
 ///
 /// **It is not `degree`, and an earlier version of this file said it was.** Element
-/// 0 alone can reach `2 degree - 1` stages, and a vector of `n` elements reaches
-/// `O(n degree)`. The bound below was therefore too tight by that factor. It never
+/// 0 alone can reach `2 (degree - 1)` stages -- both its terms are at most
+/// `degree - 1`, since a knot class has multiplicity at least one and `boundary` is
+/// at least one because index `degree` matches itself -- and a vector of `n`
+/// elements reaches `O(n degree)`. The bound below was therefore too tight by that factor. It never
 /// failed, because the observed error is orders below either version, which is
 /// exactly the shape of claim nothing in a suite can distinguish.
 ///
@@ -298,10 +300,17 @@ void check_identity_families() {
 
 /// The uniform interior operator does not depend on the clamping.
 ///
-/// This is what exercises the boundary-insertion branch: an unclamped vector has a
-/// boundary multiplicity of one, so the first interval is short of `degree - 1`
-/// insertions. The value it must reach is the interior operator of the clamped
-/// spline above, which was derived by hand there.
+/// This is what exercises the boundary-insertion branch here: an unclamped vector
+/// has a boundary multiplicity of one, so the first interval is short of
+/// `degree - 1` insertions. The value it must reach is the interior operator of the
+/// clamped spline above, which was derived by hand there.
+///
+/// **It reaches the branch in its degenerate instance, and two things follow.**
+/// Uniform knots make `alpha` exactly one half, so `alpha == beta` and this case
+/// cannot tell which of the two multiplies which column; and `reg` is one, so no
+/// `r`-loop chaining happens. The chained, `alpha != beta` instance is covered by
+/// the parity suite's unclamped non-uniform cubic and by its sweep, not here. Do
+/// not read this case as pinning the branch in general.
 template <class T>
 void check_unclamped_uniform_matches_the_interior() {
     const std::vector<T> knots = {T(0.0), T(0.5), T(1.0), T(1.5), T(2.0), T(2.5), T(3.0)};

--- a/cpp/tests/test_bspline_extraction.cpp
+++ b/cpp/tests/test_bspline_extraction.cpp
@@ -39,6 +39,7 @@
 /// basis tabulation in C++ yet, so that check lives on the Python side where
 /// `BsplineSpace1D.tabulate_basis` exists.
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstdint>
@@ -59,6 +60,7 @@ using pantr::bspline::bezier_extraction_1d;
 using pantr::bspline::bezier_structural_identity_mask;
 using pantr::bspline::classify_knots;
 using pantr::bspline::KnotClassRange;
+using pantr::bspline::KnotClasses;
 using pantr::bspline::multiplicity_of_first_knot_in_domain;
 using pantr::bspline::unique_knots_and_multiplicity;
 
@@ -99,34 +101,79 @@ Operators<T> build(const std::vector<T>& knots, std::int64_t degree, double tol)
     return ops;
 }
 
+/// The number of insertions on the longest dependency chain of a knot vector.
+///
+/// One outer iteration of an insertion sequence is one stage: the value of column
+/// `k` after iteration `r` depends on columns `k` and `k - 1` after `r - 1`. An
+/// element's own sequence is therefore `degree - multiplicity` stages long, the
+/// boundary sequence adds `degree - boundary` on top of element 0, and the
+/// inter-element **copies** carry the chain forward -- a copy commits no rounding
+/// but inherits the error accumulated so far. The sum over the whole vector is thus
+/// an upper bound on any single entry's chain.
+///
+/// **It is not `degree`, and an earlier version of this file said it was.** Element
+/// 0 alone can reach `2 degree - 1` stages, and a vector of `n` elements reaches
+/// `O(n degree)`. The bound below was therefore too tight by that factor. It never
+/// failed, because the observed error is orders below either version, which is
+/// exactly the shape of claim nothing in a suite can distinguish.
+///
+/// \tparam T Scalar type.
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance.
+/// \return The stage count, zero when no insertion runs at all.
+template <class T>
+[[nodiscard]] std::int64_t insertion_stages(const std::vector<T>& knots, std::int64_t degree,
+                                            double tol) {
+    const std::span<const T> span(knots);
+    const KnotClasses<T> classes = unique_knots_and_multiplicity<T>(span, degree, tol);
+    const std::span<const std::int64_t> in_domain =
+        std::span<const std::int64_t>(classes.multiplicity)
+            .subspan(classes.domain_begin, classes.domain_end - classes.domain_begin);
+
+    std::int64_t stages =
+        std::max<std::int64_t>(degree - multiplicity_of_first_knot_in_domain<T>(span, degree, tol),
+                               0);
+    for (std::size_t e = 1; e < in_domain.size(); ++e) {
+        stages += std::max<std::int64_t>(degree - in_domain[e], 0);
+    }
+    return stages;
+}
+
 /// The tolerance a column sum may miss one by.
 ///
-/// Each entry is a chain of at most `degree` updates `alpha * x + beta * y`, each
-/// committing four roundings -- `beta = 1 - alpha`, two products and their sum --
-/// and the exact chain is a convex combination of values in `[0, 1]`, so an entry
-/// carries at most `gamma_{4 degree}` of absolute error. Summing `degree + 1` of
-/// them adds `gamma_{degree}` against a total of one. First order in `u`, that is
-/// `(4 degree (degree + 1) + degree) u`.
+/// Each stage of an entry's chain commits four roundings -- `beta = 1 - alpha`, the
+/// two products and their sum -- against an exact convex combination of values in
+/// `[0, 1]`, whose weights are non-negative and sum to one, so the propagated error
+/// carries forward with weight at most one and an entry ends up within
+/// `gamma_{4 S}` of its exact value, where `S` is the chain length
+/// `insertion_stages` reports. Summing `degree + 1` of them against an exact total
+/// of one adds `gamma_{degree}`. First order in `u`, that is
+/// `(4 S (degree + 1) + degree) u`.
 ///
 /// \tparam T Scalar type.
 /// \param degree The polynomial degree.
-/// \return The absolute bound, zero for degree 0 where nothing is computed.
+/// \param stages The chain length, from `insertion_stages`.
+/// \return The absolute bound, zero when nothing is computed.
 template <class T>
-[[nodiscard]] double column_sum_tolerance(std::int64_t degree) {
+[[nodiscard]] double column_sum_tolerance(std::int64_t degree, std::int64_t stages) {
     const double u = 0.5 * static_cast<double>(std::numeric_limits<T>::epsilon());
     const auto p = static_cast<double>(degree);
-    return (4.0 * p * (p + 1.0) + p) * u;
+    return (4.0 * static_cast<double>(stages) * (p + 1.0) + p) * u;
 }
 
 /// Check the two analytic invariants every operator has.
 ///
 /// \tparam T Scalar type.
 /// \param ops The operators.
+/// \param knots The knot vector they were built from, which sizes the bound.
 /// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance the operators were built at.
 /// \param label What case this is, for the failure message.
 template <class T>
-void check_invariants(const Operators<T>& ops, std::int64_t degree, const std::string& label) {
-    const double bound = column_sum_tolerance<T>(degree);
+void check_invariants(const Operators<T>& ops, const std::vector<T>& knots, std::int64_t degree,
+                      double tol, const std::string& label) {
+    const double bound = column_sum_tolerance<T>(degree, insertion_stages<T>(knots, degree, tol));
     for (std::size_t e = 0; e < ops.count; ++e) {
         for (std::size_t j = 0; j < ops.side; ++j) {
             double sum = 0.0;
@@ -222,7 +269,7 @@ void check_quadratic_open() {
                                   T(2.0), T(3.0), T(3.0), T(3.0)};
     const Operators<T> ops = build<T>(knots, 2, 0.0);
     same(ops, kQuadraticOpen, "quadratic open");
-    check_invariants(ops, 2, "quadratic open");
+    check_invariants(ops, knots, 2, 0.0, "quadratic open");
 }
 
 /// The forced-identity families.
@@ -260,7 +307,7 @@ void check_unclamped_uniform_matches_the_interior() {
     const std::vector<T> knots = {T(0.0), T(0.5), T(1.0), T(1.5), T(2.0), T(2.5), T(3.0)};
     const Operators<T> ops = build<T>(knots, 2, 0.0);
     same(ops, {kQuadraticOpen[1], kQuadraticOpen[1]}, "unclamped uniform");
-    check_invariants(ops, 2, "unclamped uniform");
+    check_invariants(ops, knots, 2, 0.0, "unclamped uniform");
 }
 
 /// A symmetric knot vector's operators are each other's index reversals.
@@ -283,7 +330,7 @@ void check_mirror_symmetry() {
                                 + std::to_string(j) + ")");
         }
     }
-    check_invariants(ops, 3, "cubic two-element");
+    check_invariants(ops, knots, 3, 0.0, "cubic two-element");
 
     // Three uniform elements at degree 3: the entries are sixths, so this is the
     // one case here whose invariants need the derived tolerance rather than
@@ -292,9 +339,66 @@ void check_mirror_symmetry() {
                                   T(3.0), T(3.0), T(3.0), T(3.0)};
     const Operators<T> wider = build<T>(three, 3, 0.0);
     PANTR_CHECK_MSG(wider.count == 3, "cubic three-element: element count");
-    check_invariants(wider, 3, "cubic three-element");
-    PANTR_CHECK_MSG(column_sum_tolerance<T>(3) > 0.0,
-                    "the derived column-sum tolerance must be positive above degree 0");
+    check_invariants(wider, three, 3, 0.0, "cubic three-element");
+    PANTR_CHECK_MSG(insertion_stages<T>(three, 3, 0.0) > 3,
+                    "three cubic elements chain more insertions than the degree, which is "
+                    "what the corrected bound accounts for");
+}
+
+/// Push the sliding knot window as close to the end of the vector as it goes.
+///
+/// The header derives that the window `knots[w .. w + degree]` always fits, with
+/// `w` at most the last knot index of the element's own class and therefore at most
+/// `n - degree - 2`. Nothing else here comes near that: the hand-picked cases are
+/// low degree with simple interior knots. This one is built to sit on it -- degree
+/// 5, an interior class of multiplicity `degree - 1` immediately before the last
+/// in-domain class, so the last contracting element's window ends one knot short of
+/// the vector -- and its value is checked only through the invariants, since the
+/// point is the addressing rather than the answer.
+///
+/// Its real assertion is the sanitizer's: run under the `gcc-debug` preset, an
+/// off-by-one in the window is an AddressSanitizer report rather than a wrong
+/// number.
+///
+/// \tparam T Scalar type.
+template <class T>
+void check_the_window_reaches_the_end_of_the_vector() {
+    const std::int64_t degree = 5;
+    // Breakpoints 0, 1, 2, 3, with 2 carrying multiplicity `degree - 1` = 4, so the
+    // element [2, 3] is the last contracting one and its window starts as late as
+    // the recurrence lets it.
+    std::vector<T> knots;
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        knots.push_back(T(0.0));
+    }
+    knots.push_back(T(1.0));
+    for (std::int64_t i = 0; i < degree - 1; ++i) {
+        knots.push_back(T(2.0));
+    }
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        knots.push_back(T(3.0));
+    }
+    const Operators<T> ops = build<T>(knots, degree, 0.0);
+    PANTR_CHECK_MSG(ops.count == 3, "the adversarial vector should span three elements");
+    check_invariants(ops, knots, degree, 0.0, "window at the end of the vector");
+
+    // And the same vector with the high-multiplicity class at the far end instead,
+    // where the window's last read is the vector's last knot but one.
+    std::vector<T> shifted;
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        shifted.push_back(T(0.0));
+    }
+    shifted.push_back(T(1.0));
+    shifted.push_back(T(2.0));
+    for (std::int64_t i = 0; i < degree - 1; ++i) {
+        shifted.push_back(T(2.5));
+    }
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        shifted.push_back(T(3.0));
+    }
+    const Operators<T> late = build<T>(shifted, degree, 0.0);
+    PANTR_CHECK_MSG(late.count == 4, "the shifted vector should span four elements");
+    check_invariants(late, shifted, degree, 0.0, "window with a late high-multiplicity class");
 }
 
 /// The boundary count is not the class multiplicity, and the builder wants the first.
@@ -381,7 +485,7 @@ void check_the_mask_agrees_with_the_operators() {
                                         std::span<bool>(flags.data(), in_domain.size() - 1));
 
         const Operators<T> ops = build<T>(one.knots, one.degree, 0.0);
-        check_invariants(ops, one.degree, "mask agreement");
+        check_invariants(ops, one.knots, one.degree, 0.0, "mask agreement");
         for (std::size_t e = 0; e < ops.count; ++e) {
             if (!flags[e]) {
                 continue;
@@ -408,6 +512,8 @@ int main() {
     check_unclamped_uniform_matches_the_interior<float>();
     check_mirror_symmetry<double>();
     check_mirror_symmetry<float>();
+    check_the_window_reaches_the_end_of_the_vector<double>();
+    check_the_window_reaches_the_end_of_the_vector<float>();
     check_the_boundary_count_is_not_the_class_multiplicity();
     check_identity_mask();
     check_the_mask_agrees_with_the_operators<double>();

--- a/design/extraction_port.md
+++ b/design/extraction_port.md
@@ -94,9 +94,29 @@ Re-read at `proto/cpp` `7ba20d3`. `cpp/include/pantr/bspline/` now holds `knots.
   `_get_multiplicity_of_first_knot_in_domain_impl` needs no separate port.
 
 **Still missing, and it is exactly one thing:** `get_cardinal_intervals`. Not an oversight --
-#428 excluded it deliberately and says why (`space_1d.hpp:19-20`): it is *"a computation over
-the knots rather than a property of them"*, so it belongs with the operations rather than with
-the type.
+#428 excluded it deliberately and says why, in its file comment on what the type owns: it is
+*"a computation over the knots rather than a property of them"*, so it belongs with the
+operations rather than with the type.
+
+**Corrected 2026-09-03, while building the Bézier half of S3: the sentence above about the
+boundary multiplicity is wrong.** It read that "the boundary multiplicity the Bézier builder
+opens with is the first entry of [`multiplicity_in_domain()`], so
+`_get_multiplicity_of_first_knot_in_domain_impl` needs no separate port". The two are
+different computations over different index ranges and they disagree:
+
+- the oracle's helper counts how many of `knots[0 .. degree]` lie within `tol` of
+  `knots[degree]`, so it never looks past index `degree` and never chains;
+- `multiplicity_in_domain().front()` is the size of the whole gap-chained **class** holding
+  `knots[degree]`, which may reach either side of that index.
+
+The class count is therefore always at least the helper's, and strictly more whenever the
+first in-domain knot is repeated. Measured on `[0, 0.4, 0.5, 0.5, 1, 1.5, 2, 2.5]` at degree 2,
+`snap_knots=False`: the helper returns 1 and the class holds 2, and the two produce different
+operators. The port carries the helper, as
+`pantr::bspline::multiplicity_of_first_knot_in_domain`, factored out of `num_basis`'s periodic
+branch, which was already computing exactly it inline.
+`tests/parity/test_bspline_bezier_extraction.py` keeps that vector as a parity case for this
+reason and a mutation confirmed it is the only case in the table that separates the two.
 
 **What that does to the slices.** S3 splits. The **Bézier** operator builder and the Bézier
 identity-mask predicate are unblocked today; the **Lagrange** ones follow immediately, since
@@ -404,11 +424,23 @@ is invisible to it. Two independent oracles, both cheap:
    `assert_accuracy` gets a zero bound. This is the check that catches a transposed index or
    a wrong mode order, which is the error class a bound cannot see because both backends
    would make it. It is also a check on the *kernel*, independent of anything B-spline.
-2. **Partition of unity, for the Bézier target only.** Each Bézier extraction operator's rows
-   sum to one, so `kron` of them is row-stochastic and `M @ ones = ones` to within the
-   contraction's own rounding. `tests/test_thb_validation_identities.py` already carries the
-   hierarchical form of this identity, which the ticket names as the natural oracle for the
-   THB half.
+2. **Partition of unity, for the Bézier target only.** Each Bézier extraction operator's
+   **columns** sum to one, so `kron` of them is column-stochastic and `ones^T M = ones^T` to
+   within the contraction's own rounding. `tests/test_thb_validation_identities.py` already
+   carries the hierarchical form of this identity, which the ticket names as the natural
+   oracle for the THB half.
+
+   **Corrected 2026-09-03: this paragraph said *rows*, and it is columns.** The identity
+   follows from `sum_i N_i = 1` on the element and `sum_j B_j = 1` on the reference interval:
+   `sum_i sum_j C_ij B_j = 1 = sum_j B_j`, and the Bernstein basis being independent forces
+   `sum_i C_ij = 1` for each column `j`. Measured on the quadratic three-element open spline,
+   whose first operator is `[[1,0,0],[0,1,1/2],[0,0,1/2]]`: its columns sum to `1, 1, 1` and
+   its rows to `1, 3/2, 1/2`. The distinction is not cosmetic -- it is exactly what makes the
+   check able to catch a transposed operator, which a row-sum check on a matrix whose row sums
+   are all one could not. Nothing built on the wrong version: the apply kernels' claim in
+   `tests/parity/test_extraction_kernels.py` is bitwise and rests on no stochasticity, and the
+   amplification argument two sections above uses the absolute-value companion rather than
+   convexity.
 
 **The rule this milestone learned the hard way applies to both**: a bound compared only
 against zero has not been checked. Case 1 is exact by construction and is the one at risk --
@@ -423,7 +455,14 @@ only ever comparing zero against zero. Case 2 must assert the observed error is 
   bindings, `_extraction_backend.py`, the Layer-2 rewiring, C++ unit tests, and
   `tests/parity/test_extraction_kernels.py` carrying the claim above. **Not blocked on #396.**
 - **S3.** The 1D extraction operator builders and the two identity-mask predicates.
-  **Blocked on #396** for the knot scans (F1).
+  **Blocked on #396** for the knot scans (F1). *Split, and the Bézier half landed
+  2026-09-03*: `pantr::bspline::bezier_extraction_1d` and
+  `bezier_structural_identity_mask` in `cpp/include/pantr/bspline/extraction.hpp`, bound by
+  `cpp/bindings/bspline_extraction_operators.cpp` and dispatched from
+  `pantr.bspline._extraction_backend`. **Lagrange is next and is a small slice** -- the same
+  operator post-multiplied by `lagrange_to_bernstein_1d`, which is already bound, so what it
+  needs is the post-multiplication and the Lagrange identity-mask predicate. **Cardinal still
+  waits** on the interval scan.
 - **S4.** `SpanwiseElementExtraction` itself: the class-H `space` accessor, the two memos
   `design/bspline_derived_caches.md` assigns here (`ops_1d` DCLP-lazy returning a view of the
   memo, `num_identity_elements` eager), the wrapper, `__reduce__`, and the binding-contract

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -78,7 +78,7 @@ if not TYPE_CHECKING:
             from .bspline import (  # noqa: PLC0415
                 _bspline_basis_core,
                 _bspline_eval,
-                _bspline_extraction,
+                _bspline_extraction_core,
                 _bspline_knot_insertion_core,
                 _bspline_knot_removal_core,
                 _bspline_knots,
@@ -92,7 +92,7 @@ if not TYPE_CHECKING:
             # main / caller thread) and are cached to disk by Numba's cache=True.
             _bspline_basis_core._warmup_numba_functions()
             _bspline_eval._warmup_numba_functions()
-            _bspline_extraction._warmup_numba_functions()
+            _bspline_extraction_core._warmup_numba_functions()
             _bspline_knot_insertion_core._warmup_numba_functions()
             _bspline_knot_removal_core._warmup_numba_functions()
             _bspline_knots._warmup_numba_functions()

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -112,6 +112,10 @@ from ._bspline import apply_kron_MT_K_M_many_3d as apply_kron_MT_K_M_many_3d
 from ._bspline import apply_kron_T_1d as apply_kron_T_1d
 from ._bspline import apply_kron_T_2d as apply_kron_T_2d
 from ._bspline import apply_kron_T_3d as apply_kron_T_3d
+from ._bspline import bezier_extraction_1d as bezier_extraction_1d
+from ._bspline import (
+    bezier_structural_identity_mask as bezier_structural_identity_mask,
+)
 from ._geometry import AABB as AABB
 from ._grid import BVH as BVH
 from ._grid import CellTags as CellTags

--- a/src/pantr/_pantr_cpp/_bspline.pyi
+++ b/src/pantr/_pantr_cpp/_bspline.pyi
@@ -7,6 +7,22 @@ thing left to carry it. The tensor-product `BsplineSpace32` / `BsplineSpace64` p
 inherits that split and could not avoid it anyway: `BsplineSpace<T>` can hold only
 `BsplineSpace1D<T>`.
 
+## The Bézier extraction operator builder
+
+Bound by ``cpp/bindings/bspline_extraction_operators.cpp`` over
+``cpp/include/pantr/bspline/extraction.hpp``. Separate from the apply kernels
+below because the two are separate ports with separate parity claims: these
+*build* an operator from a knot vector, those *apply* one.
+
+Only the Bézier target is here. Lagrange is this operator post-multiplied by
+:func:`~pantr._pantr_cpp.lagrange_to_bernstein_1d`, and the cardinal target also
+needs the cardinal-interval scan, which is not ported.
+
+**One refusal has no counterpart in the oracle.** A knot vector spanning no
+in-domain interval is refused here, with the message
+:class:`pantr.bspline.BsplineSpace1D` raises for the same vector, because the
+oracle's own kernel indexes an empty result array instead.
+
 ## Tensor-product extraction kernels
 
 
@@ -241,6 +257,54 @@ _Index = npt.NDArray[np.intp]
 
 _Mask = npt.NDArray[np.bool_]
 """A per-direction identity mask."""
+
+_Multiplicity = npt.NDArray[np.intp]
+"""In-domain knot multiplicities, one per unique knot."""
+
+def bezier_extraction_1d(
+    knots: _Array,
+    degree: int,
+    tol: float,
+    out: _Array,
+) -> None:
+    """Build the Bézier extraction operator of every in-domain interval.
+
+    Args:
+        knots (_Array): The knot vector, non-decreasing, at least
+            ``2 * degree + 2`` entries.
+        degree (int): The polynomial degree, non-negative.
+        tol (float): The absolute parametric tolerance, non-negative.
+        out (_Array): Output of shape ``(n_intervals, degree + 1, degree + 1)``,
+            overwritten in full. ``n_intervals`` is one less than the number of
+            distinct in-domain knots.
+
+    Raises:
+        ValueError: If ``degree`` or ``tol`` is negative, the vector is too short
+            or not non-decreasing, it spans no in-domain interval, or ``out`` has
+            the wrong shape.
+    """
+
+def bezier_structural_identity_mask(
+    multiplicities: _Multiplicity,
+    degree: int,
+    out: _Mask,
+) -> None:
+    """Mark the intervals whose Bézier extraction operator is the identity.
+
+    An interval is one exactly when both of its bounding in-domain knots have
+    multiplicity at least ``degree + 1``, so the interval is already a Bézier
+    patch decoupled from both neighbours.
+
+    Args:
+        multiplicities (_Multiplicity): The in-domain knot multiplicities,
+            ``n_intervals + 1`` of them.
+        degree (int): The polynomial degree, non-negative.
+        out (_Mask): One flag per interval, ``multiplicities.size - 1`` of them.
+
+    Raises:
+        ValueError: If ``degree`` is negative, ``multiplicities`` is empty, or
+            ``out`` is not one shorter than ``multiplicities``.
+    """
 
 def apply_kron_1d(
     M_0: _Array,

--- a/src/pantr/bspline/_bspline_extraction.py
+++ b/src/pantr/bspline/_bspline_extraction.py
@@ -3,6 +3,16 @@
 This module provides functions for computing extraction operators that transform
 between different basis representations (Bernstein, Lagrange, cardinal B-spline)
 and B-spline basis functions.
+
+Layer 2: it validates, allocates and dispatches, and holds no Numba. The kernels
+live in :mod:`pantr.bspline._bspline_extraction_core`, and
+:mod:`pantr.bspline._extraction_backend` chooses between them and their C++ twins
+in ``cpp/include/pantr/bspline/extraction.hpp``.
+
+Only the **Bézier** builder is dispatched. Lagrange and cardinal are that operator
+post-multiplied by a change-of-basis matrix that :mod:`pantr.change_basis` already
+dispatches on its own, so they inherit the backend through it -- except for the
+cardinal target's interval scan, which is not ported.
 """
 
 from __future__ import annotations
@@ -10,7 +20,6 @@ from __future__ import annotations
 import numpy as np
 import numpy.typing as npt
 
-from .._numba_compat import nb_jit
 from ..basis import LagrangeVariant
 from ..basis._basis_utils import _allocate_or_validate_out
 from ..change_basis import (
@@ -20,145 +29,9 @@ from ..change_basis import (
 from ._bspline_knots import (
     _check_spline_info,
     _get_Bspline_cardinal_intervals_1D_impl,
-    _get_multiplicity_of_first_knot_in_domain_impl,
     _get_unique_knots_and_multiplicity_impl,
 )
-
-
-@nb_jit(
-    nopython=True,
-    cache=True,
-    parallel=False,
-)
-def _tabulate_Bspline_Bezier_1D_extraction_core(
-    knots: npt.NDArray[np.float32 | np.float64],
-    degree: int,
-    tol: float,
-    out: npt.NDArray[np.float32 | np.float64],
-) -> None:
-    r"""Core implementation to compute Bézier extraction operators, writing to output array.
-
-    This function computes the extraction operators that transform Bernstein
-    into B-spline basis functions for each interval.
-    For each interval \( i \), the Bézier extraction operator \( C_i \) satisfies:
-
-        \[
-        N_i(x) = C_i @ B(ξ)
-        \]
-
-    where:
-      - N_i(x) is the vector of B-spline basis functions nonzero on the interval \( i \),
-        evaluated at \( x \),
-      - \( B(ξ) \) is the vector of Bernstein basis functions on the reference interval \([0, 1]\),
-        evaluated at \( ξ \),
-      - \( C_i \) is the extraction matrix for interval \( i \),
-      - \( x \) is the physical coordinate, \( ξ \) is the local (reference) referred to \([0, 1]\).
-
-    Args:
-        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
-        degree (int): B-spline degree.
-        tol (float): Tolerance for numerical comparisons.
-        out (npt.NDArray[np.float32 | np.float64]): Output array where results will be written.
-            Must have the correct shape (n_elems, degree+1, degree+1) and dtype matching knots
-            (no validation performed inside this numba-compiled function).
-
-    Note:
-        This is a Numba-compiled function optimized for performance. It
-        expects pre-validated inputs and assumes the output array has the
-        correct shape and dtype. Inputs are assumed to be correct (no validation performed).
-        For general use, call _tabulate_Bspline_Bezier_1D_extraction_impl instead.
-    """
-    unique_knots, mults = _get_unique_knots_and_multiplicity_impl(
-        knots, degree, tol, in_domain=True
-    )
-
-    n_elems = len(unique_knots) - 1
-
-    dtype = knots.dtype
-    one = dtype.type(1.0)
-
-    # Initialize identity matrix for every element.
-    out.fill(0.0)
-    out[:, : degree + 1, : degree + 1] = np.eye(degree + 1, dtype=dtype)
-
-    mult = _get_multiplicity_of_first_knot_in_domain_impl(knots, degree, tol)
-
-    # If not open first knot, additional knot insertion is needed.
-    if mult < (degree + 1):
-        C = out[0]
-        reg = degree - mult
-
-        t = knots[degree]
-        for r in range(reg):
-            lcl_knots = knots[r:]
-            for k in range(1, degree - r):
-                alpha = (t - lcl_knots[k]) / (lcl_knots[k + degree - r] - lcl_knots[k])
-                C[:, k - 1] = alpha * C[:, k] + (one - alpha) * C[:, k - 1]
-
-    alphas = np.zeros(max(degree - 1, 0), dtype=dtype)  # degree 0: no insertion coefficients
-
-    knt_id = degree
-    mult = 0
-
-    for elem_id in range(n_elems):
-        knt_id += mult
-        mult = mults[elem_id + 1]
-
-        if mult >= degree:
-            continue
-
-        lcl_knots = knots[knt_id : knt_id + degree + 1]
-        alphas[: degree - mult] = (lcl_knots[1] - lcl_knots[0]) / (
-            lcl_knots[mult + 1 :] - lcl_knots[0]
-        )
-
-        C = out[elem_id]
-
-        reg = degree - mult
-        for r in range(1, reg + 1):
-            s = mult + r
-            for k in range(degree, s - 1, -1):
-                alpha = alphas[k - s]
-                C[:, k] = alpha * C[:, k] + (one - alpha) * C[:, k - 1]
-
-            if elem_id < (n_elems - 1):
-                out[elem_id + 1, reg - r : reg + 1, reg - r] = C[degree - r : degree + 1, degree]
-
-
-@nb_jit(
-    nopython=True,
-    cache=True,
-    parallel=False,
-)
-def _bezier_structural_identity_mask_core(
-    multiplicities: npt.NDArray[np.intp],
-    degree: int,
-    out: npt.NDArray[np.bool_],
-) -> None:
-    """Compute a per-element Bézier identity mask from knot multiplicities.
-
-    Element ``e`` spanning ``[unique_knots[e], unique_knots[e+1]]`` has an
-    identity Bézier extraction operator if and only if both boundary unique
-    knots have multiplicity ``>= degree + 1``, meaning the element is already
-    a Bézier patch (fully isolated from its neighbours).
-
-    Args:
-        multiplicities (npt.NDArray[np.intp]): Per-unique-knot multiplicity
-            array of length ``n_elements + 1`` (in-domain unique knots
-            including both endpoints).
-        degree (int): B-spline degree.
-        out (npt.NDArray[np.bool_]): Output boolean array of length
-            ``n_elements = len(multiplicities) - 1``.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call
-        ``spanwise_element_extraction._bezier_structural_identity_mask`` instead.
-    """
-    threshold = degree + 1
-    n_elements = len(multiplicities) - 1
-    for e in range(n_elements):
-        out[e] = multiplicities[e] >= threshold and multiplicities[e + 1] >= threshold
+from ._extraction_backend import bezier_extraction_kernel
 
 
 def _prepare_extraction_out(
@@ -240,7 +113,7 @@ def _tabulate_Bspline_Bezier_1D_extraction_impl(
     """
     out = _prepare_extraction_out(knots, degree, tol, out)
 
-    _tabulate_Bspline_Bezier_1D_extraction_core(knots, degree, tol, out)
+    bezier_extraction_kernel()(knots, degree, tol, out)
 
     return out
 
@@ -342,32 +215,6 @@ def _tabulate_Bspline_cardinal_1D_extraction_impl(
         out[i, :, :] = np.eye(degree + 1, dtype=knots.dtype)
 
     return out
-
-
-def _warmup_numba_functions() -> None:
-    """Precompile numba functions with float64 signatures for faster first call.
-
-    This function triggers compilation of the numba-decorated functions
-    with float64 arrays, ensuring they are cached and ready for use.
-    """
-    # Small dummy arrays for warmup
-    knots_dummy = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
-    tol_dummy = 1e-10
-    degree_dummy = 2
-    n_elems = 1
-    out_dummy = np.empty((n_elems, degree_dummy + 1, degree_dummy + 1), dtype=np.float64)
-
-    # Warmup Bezier extraction core with float64
-    _tabulate_Bspline_Bezier_1D_extraction_core(knots_dummy, degree_dummy, tol_dummy, out_dummy)
-
-    # Warmup structural identity mask kernel
-    mults_dummy = np.array([degree_dummy + 1, degree_dummy + 1], dtype=np.intp)
-    mask_dummy = np.empty(1, dtype=np.bool_)
-    _bezier_structural_identity_mask_core(mults_dummy, degree_dummy, mask_dummy)
-
-
-# Precompile numba functions on module import
-# (Moved to central thread in __init__.py)
 
 
 __all__ = [

--- a/src/pantr/bspline/_bspline_extraction_core.py
+++ b/src/pantr/bspline/_bspline_extraction_core.py
@@ -1,0 +1,200 @@
+"""Numba kernels for the B-spline extraction operators.
+
+Layer 3: the Bézier operator builder and the structural identity mask, with no
+validation and no allocation the caller cannot predict.
+
+Split out of :mod:`pantr.bspline._bspline_extraction`, which is Layer 2 and now
+holds no Numba, so that :mod:`pantr.bspline._extraction_backend` can import these
+kernels while Layer 2 imports the catalogue. That is the same shape
+:mod:`pantr.basis._basis_core` and :mod:`pantr.change_basis._change_basis_core`
+have, and it is what keeps the catalogue rule of
+``design/cross_backend_types.md`` from needing a lazy import to break a cycle:
+a catalogue imports the kernels it hands out, so the kernels cannot live in the
+module that imports the catalogue.
+
+Only the **Bézier** target has a kernel here. Lagrange and cardinal are this
+operator post-multiplied by a change-of-basis matrix, which Layer 2 does with
+:func:`numpy.matmul`, and the cardinal target additionally needs the
+cardinal-interval scan.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from .._numba_compat import nb_jit
+from ._bspline_knots import (
+    _get_multiplicity_of_first_knot_in_domain_impl,
+    _get_unique_knots_and_multiplicity_impl,
+)
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    parallel=False,
+)
+def _tabulate_Bspline_Bezier_1D_extraction_core(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    tol: float,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    r"""Core implementation to compute Bézier extraction operators, writing to output array.
+
+    This function computes the extraction operators that transform Bernstein
+    into B-spline basis functions for each interval.
+    For each interval \( i \), the Bézier extraction operator \( C_i \) satisfies:
+
+        \[
+        N_i(x) = C_i @ B(ξ)
+        \]
+
+    where:
+      - N_i(x) is the vector of B-spline basis functions nonzero on the interval \( i \),
+        evaluated at \( x \),
+      - \( B(ξ) \) is the vector of Bernstein basis functions on the reference interval \([0, 1]\),
+        evaluated at \( ξ \),
+      - \( C_i \) is the extraction matrix for interval \( i \),
+      - \( x \) is the physical coordinate, \( ξ \) is the local (reference) referred to \([0, 1]\).
+
+    Every arithmetic step runs in ``knots.dtype``, which is what ``one`` below is
+    spelled ``dtype.type(1.0)`` for: a bare ``1.0`` would promote the whole
+    combination to ``float64`` at ``float32`` storage. ``design/backend_parity.md``
+    Rule 9 is the rule, and the C++ twin in
+    ``cpp/include/pantr/bspline/extraction.hpp`` reproduces the same width.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): B-spline degree.
+        tol (float): Tolerance for numerical comparisons.
+        out (npt.NDArray[np.float32 | np.float64]): Output array where results will be written.
+            Must have the correct shape (n_elems, degree+1, degree+1) and dtype matching knots
+            (no validation performed inside this numba-compiled function).
+
+    Note:
+        This is a Numba-compiled function optimized for performance. It
+        expects pre-validated inputs and assumes the output array has the
+        correct shape and dtype. Inputs are assumed to be correct (no validation performed).
+        For general use, call _tabulate_Bspline_Bezier_1D_extraction_impl instead.
+    """
+    unique_knots, mults = _get_unique_knots_and_multiplicity_impl(
+        knots, degree, tol, in_domain=True
+    )
+
+    n_elems = len(unique_knots) - 1
+
+    dtype = knots.dtype
+    one = dtype.type(1.0)
+
+    # Initialize identity matrix for every element.
+    out.fill(0.0)
+    out[:, : degree + 1, : degree + 1] = np.eye(degree + 1, dtype=dtype)
+
+    mult = _get_multiplicity_of_first_knot_in_domain_impl(knots, degree, tol)
+
+    # If not open first knot, additional knot insertion is needed.
+    if mult < (degree + 1):
+        C = out[0]
+        reg = degree - mult
+
+        t = knots[degree]
+        for r in range(reg):
+            lcl_knots = knots[r:]
+            for k in range(1, degree - r):
+                alpha = (t - lcl_knots[k]) / (lcl_knots[k + degree - r] - lcl_knots[k])
+                C[:, k - 1] = alpha * C[:, k] + (one - alpha) * C[:, k - 1]
+
+    alphas = np.zeros(max(degree - 1, 0), dtype=dtype)  # degree 0: no insertion coefficients
+
+    knt_id = degree
+    mult = 0
+
+    for elem_id in range(n_elems):
+        knt_id += mult
+        mult = mults[elem_id + 1]
+
+        if mult >= degree:
+            continue
+
+        lcl_knots = knots[knt_id : knt_id + degree + 1]
+        alphas[: degree - mult] = (lcl_knots[1] - lcl_knots[0]) / (
+            lcl_knots[mult + 1 :] - lcl_knots[0]
+        )
+
+        C = out[elem_id]
+
+        reg = degree - mult
+        for r in range(1, reg + 1):
+            s = mult + r
+            for k in range(degree, s - 1, -1):
+                alpha = alphas[k - s]
+                C[:, k] = alpha * C[:, k] + (one - alpha) * C[:, k - 1]
+
+            if elem_id < (n_elems - 1):
+                out[elem_id + 1, reg - r : reg + 1, reg - r] = C[degree - r : degree + 1, degree]
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    parallel=False,
+)
+def _bezier_structural_identity_mask_core(
+    multiplicities: npt.NDArray[np.intp],
+    degree: int,
+    out: npt.NDArray[np.bool_],
+) -> None:
+    """Compute a per-element Bézier identity mask from knot multiplicities.
+
+    Element ``e`` spanning ``[unique_knots[e], unique_knots[e+1]]`` has an
+    identity Bézier extraction operator if and only if both boundary unique
+    knots have multiplicity ``>= degree + 1``, meaning the element is already
+    a Bézier patch (fully isolated from its neighbours).
+
+    Args:
+        multiplicities (npt.NDArray[np.intp]): Per-unique-knot multiplicity
+            array of length ``n_elements + 1`` (in-domain unique knots
+            including both endpoints).
+        degree (int): B-spline degree.
+        out (npt.NDArray[np.bool_]): Output boolean array of length
+            ``n_elements = len(multiplicities) - 1``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call
+        ``spanwise_element_extraction._bezier_structural_identity_mask`` instead.
+    """
+    threshold = degree + 1
+    n_elements = len(multiplicities) - 1
+    for e in range(n_elements):
+        out[e] = multiplicities[e] >= threshold and multiplicities[e + 1] >= threshold
+
+
+def _warmup_numba_functions() -> None:
+    """Precompile numba functions with float64 signatures for faster first call.
+
+    This function triggers compilation of the numba-decorated functions
+    with float64 arrays, ensuring they are cached and ready for use.
+    """
+    # Small dummy arrays for warmup
+    knots_dummy = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+    tol_dummy = 1e-10
+    degree_dummy = 2
+    n_elems = 1
+    out_dummy = np.empty((n_elems, degree_dummy + 1, degree_dummy + 1), dtype=np.float64)
+
+    # Warmup Bezier extraction core with float64
+    _tabulate_Bspline_Bezier_1D_extraction_core(knots_dummy, degree_dummy, tol_dummy, out_dummy)
+
+    # Warmup structural identity mask kernel
+    mults_dummy = np.array([degree_dummy + 1, degree_dummy + 1], dtype=np.intp)
+    mask_dummy = np.empty(1, dtype=np.bool_)
+    _bezier_structural_identity_mask_core(mults_dummy, degree_dummy, mask_dummy)
+
+
+__all__ = [
+    "_bezier_structural_identity_mask_core",
+    "_tabulate_Bspline_Bezier_1D_extraction_core",
+]

--- a/src/pantr/bspline/_extraction_backend.py
+++ b/src/pantr/bspline/_extraction_backend.py
@@ -7,14 +7,27 @@ catalogue imports the kernels it hands out, so keeping each one next to its own
 kernels is what stops the policy module from importing the library it must stay
 independent of.
 
-Two accessors, not a record
----------------------------
+Four accessors, not a record
+----------------------------
 
 By the rule ``design/cross_backend_types.md`` states -- a record when the consumer
 needs more than one kernel at once, a bare callable when it does not -- these are
 bare callables. :func:`pantr.bspline._extraction_helpers._prepare_apply_call`
 selects exactly one kernel per call, keyed by ``(op_kind, dim)``, and never needs
-a second one in the same call.
+a second one in the same call; and neither of the two builders below needs the
+other.
+
+Two of the four *apply* an operator and two *build* one, which is why the C++ side
+is two registrations rather than one -- ``bspline_extraction.cpp`` for the
+tensor-product apply kernels, ``bspline_extraction_operators.cpp`` for the Bézier
+builder and its mask. They are separate ports with separate parity claims.
+
+Only the **Bézier** target has a builder here. Lagrange is that operator
+post-multiplied by ``lagrange_to_bernstein_1d``, which
+:mod:`pantr.change_basis._change_basis_backend` already dispatches, so it inherits
+the backend rather than needing an entry; the cardinal target additionally needs
+the cardinal-interval scan, which is not ported and which
+``cpp/include/pantr/bspline/space_1d.hpp`` deliberately keeps off the type.
 
 What crosses the boundary
 -------------------------
@@ -44,6 +57,20 @@ measures it over **both** halves of the surface -- the twelve single-cell entry
 points and the twelve batch ones are twelve different C++ functions each, so a
 claim measured on one says nothing about the other.
 
+Where the two backends differ, and it is one input
+-------------------------------------------------
+
+The Bézier builder's C++ half **refuses a knot vector spanning no in-domain
+interval**, with the message :class:`pantr.bspline.BsplineSpace1D` raises for the
+same vector. The Numba half accepts it: Layer 2 allocates an empty
+``(0, degree+1, degree+1)`` result and the kernel then indexes ``out[0]`` on it
+whenever the boundary multiplicity is short of ``degree + 1``, which is out of
+bounds on an empty array. Refusing is the only thing the C++ side can do that is not
+undefined behaviour, so the divergence is deliberate and recorded here rather than
+left to be met. Such a vector is unreachable through the public API, since
+:class:`~pantr.bspline.BsplineSpace1D` refuses it at construction; only the private
+Layer 2 helper accepts one.
+
 The batch kernels are the one place the two differ in kind rather than in bits: the
 oracle's are ``parallel=True`` over cells and the C++ loops. Each cell writes only
 its own rows and there is no reduction, so the answer cannot move with the thread
@@ -60,6 +87,10 @@ import numpy as np
 import numpy.typing as npt
 
 from .._backend import Backend, active_backend, available_backends
+from ._bspline_extraction_core import (
+    _bezier_structural_identity_mask_core,
+    _tabulate_Bspline_Bezier_1D_extraction_core,
+)
 from ._extraction_kernels import (
     apply_kron_1d,
     apply_kron_2d,
@@ -95,6 +126,15 @@ _K = TypeVar("_K", bound=Callable[..., None])
 
 _Kernel = Callable[..., None]
 """Every kernel here fills the caller's buffers and returns ``None``."""
+
+_Array = npt.NDArray[np.float32 | np.float64]
+"""A float32 or float64 array, the two dtypes these kernels handle."""
+
+_BezierBuilder = Callable[[_Array, int, float, _Array], None]
+"""Signature of the Bézier operator builder: ``(knots, degree, tol, out) -> None``."""
+
+_IdentityMask = Callable[[npt.NDArray[np.intp], int, npt.NDArray[np.bool_]], None]
+"""Signature of the structural identity mask: ``(multiplicities, degree, out) -> None``."""
 
 
 _KERNELS: Final[dict[tuple[str, int], _Kernel]] = {
@@ -291,3 +331,90 @@ def apply_many_kernel(op_kind: OpKind, dim: int, backend: Backend | None = None)
     """
     key = (op_kind, dim)
     return _select(backend, _KERNELS_MANY[key], _cpp_adapter(_CPP_NAMES_MANY[key], dim, batch=True))
+
+
+def _cpp_bezier_extraction(knots: _Array, degree: int, tol: float, out: _Array) -> None:
+    """Build the Bézier extraction operators through the C++ binding.
+
+    Args:
+        knots (_Array): The knot vector.
+        degree (int): The polynomial degree.
+        tol (float): The absolute parametric tolerance.
+        out (_Array): Output of shape ``(n_intervals, degree + 1, degree + 1)``.
+
+    Note:
+        No input validation is performed here. The binding is the C++ half of
+        Layer 2 and re-checks dtype, rank, contiguity, the oracle's three
+        knot-vector refusals and the shape of ``out``; Layer 2 in Python
+        established the rest.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    knot_array = np.ascontiguousarray(knots)
+    buffer, copy_back = _contiguous_out(out)
+    _pantr_cpp.bezier_extraction_1d(knot_array, int(degree), float(tol), buffer)
+    if copy_back:
+        out[...] = buffer
+
+
+def _cpp_bezier_identity_mask(
+    multiplicities: npt.NDArray[np.intp], degree: int, out: npt.NDArray[np.bool_]
+) -> None:
+    """Mark the identity elements through the C++ binding.
+
+    The multiplicities are normalized to :data:`numpy.intp` rather than passed
+    through: the oracle's knot scan returns :data:`numpy.int_`, which is ``int64``
+    on the platforms this is built for but ``int32`` on Windows, and the binding
+    takes ``int64`` under ``.noconvert()``. The cast is a no-op wherever the two
+    already agree.
+
+    Args:
+        multiplicities (npt.NDArray[np.intp]): In-domain knot multiplicities.
+        degree (int): The polynomial degree.
+        out (npt.NDArray[np.bool_]): One flag per element.
+
+    Note:
+        No input validation is performed here; the binding re-checks dtype, rank,
+        contiguity and the length relation, and Layer 2 established the rest.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    counts = np.ascontiguousarray(multiplicities, dtype=np.intp)
+    if out.flags["C_CONTIGUOUS"]:
+        _pantr_cpp.bezier_structural_identity_mask(counts, int(degree), out)
+        return
+    buffer = np.empty_like(out, order="C")
+    _pantr_cpp.bezier_structural_identity_mask(counts, int(degree), buffer)
+    out[...] = buffer
+
+
+def bezier_extraction_kernel(backend: Backend | None = None) -> _BezierBuilder:
+    """Get the Bézier extraction operator builder of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one
+            currently in effect. Defaults to None.
+
+    Returns:
+        _BezierBuilder: The kernel, ``(knots, degree, tol, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _tabulate_Bspline_Bezier_1D_extraction_core, _cpp_bezier_extraction)
+
+
+def bezier_identity_mask_kernel(backend: Backend | None = None) -> _IdentityMask:
+    """Get the structural identity mask kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one
+            currently in effect. Defaults to None.
+
+    Returns:
+        _IdentityMask: The kernel, ``(multiplicities, degree, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _bezier_structural_identity_mask_core, _cpp_bezier_identity_mask)

--- a/src/pantr/bspline/_extraction_backend.py
+++ b/src/pantr/bspline/_extraction_backend.py
@@ -71,6 +71,12 @@ left to be met. Such a vector is unreachable through the public API, since
 :class:`~pantr.bspline.BsplineSpace1D` refuses it at construction; only the private
 Layer 2 helper accepts one.
 
+That the index really goes past the allocation is measured rather than read off the
+source: interpreted, where numpy bounds checks, the same line raises
+``IndexError``, while the compiled kernel returns the empty array.
+``tests/parity/test_bspline_bezier_extraction.py`` pins both symptoms, gated on the
+configuration, because it is the interpreted one that proves the compiled one.
+
 The batch kernels are the one place the two differ in kind rather than in bits: the
 oracle's are ``parallel=True`` over cells and the C++ loops. Each cell writes only
 its own rows and there is no reduction, so the answer cannot move with the thread

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -43,7 +43,7 @@ import numpy.typing as npt
 from ..basis import LagrangeVariant
 from ..basis._basis_utils import _allocate_or_validate_out
 from ..change_basis import _cached_lagrange_to_bernstein_matrix
-from ._bspline_extraction import _bezier_structural_identity_mask_core
+from ._extraction_backend import bezier_identity_mask_kernel
 from ._extraction_helpers import (
     OpKind,
     _operation_shapes,
@@ -1129,7 +1129,7 @@ def _bezier_structural_identity_mask(
     _, mults = space_1d.get_unique_knots_and_multiplicity(in_domain=True)
     n_elements = len(mults) - 1
     out = np.empty(n_elements, dtype=np.bool_)
-    _bezier_structural_identity_mask_core(mults, space_1d.degree, out)
+    bezier_identity_mask_kernel()(mults, space_1d.degree, out)
     return out
 
 

--- a/tests/parity/test_bspline_bezier_extraction.py
+++ b/tests/parity/test_bspline_bezier_extraction.py
@@ -411,11 +411,29 @@ def _column_sum_bound(case: _Case, dtype: npt.DTypeLike) -> float:
     ``m u``, because ``S`` is not bounded by the degree -- it grows with the element
     count -- so a first-order truncation would eventually stop bounding.
 
+    The refusal below is a real ``raise`` rather than an ``assert``, so ``python -O``
+    does not remove it. **Its C++ counterpart is not equally live**: that one uses
+    ``PANTR_PRECONDITION``, which is ``assert`` and compiles to nothing under
+    ``NDEBUG``, and the project's own ``gcc`` preset builds with ``-DNDEBUG``. Past
+    the runaway point the C++ side therefore returns a negative or infinite bound
+    instead of refusing. Reaching it takes on the order of a million knots at
+    ``float32``, which no case here approaches, so this is dormant rather than
+    live -- but the two refusals are not the pair they look like.
+
     **Stated hypothesis: no underflow in the operator entries.** A purely relative
     rounding model needs its operands away from gradual underflow, and this
-    derivation is purely relative. Two searches over geometric knot ratios down to
-    ``1e-45``, at several degrees and both dtypes, drove no entry subnormal, so the
-    hypothesis is believed to hold rather than shown to be unnecessary.
+    derivation is purely relative, so entries in the subnormal range are outside
+    what it covers.
+
+    **Subnormal entries are reachable**, and an earlier version of this docstring
+    said two searches had found none. They had not looked in the right place: a
+    search over single-ratio geometric knot spacings finds nothing, while one over
+    *mixed* per-gap ratios finds subnormal float32 entries readily. The bound was
+    observed to hold on every such case found, by a wide margin, but observing is
+    not covering -- the derivation still does not reach them. The harness has
+    ``underflow_floor`` for exactly this, and :func:`assert_accuracy` does not apply
+    it the way :func:`assert_parity` does; closing that is the harness's to do, not
+    this file's.
 
     **The chain length is not the degree, and an earlier version of this said it
     was.** Element 0 alone reaches ``2 (degree - 1)`` stages, since the boundary
@@ -630,14 +648,18 @@ def test_the_columns_are_a_partition_of_unity(
         derived_accuracy(
             bound=np.full(column_sums.shape, _column_sum_bound(case, dtype)),
             why=(
-                "an entry is a chain of at most `degree` insertions, each committing four "
-                "roundings -- the complement, the two products and their sum -- against an "
-                "exact convex combination of values in [0, 1] whose weights sum to one, so it "
-                "carries at most gamma_{4 S} where S is the chain length of THIS vector: an "
-                "element's own sequence is degree - multiplicity stages, the boundary sequence "
-                "composes with element 0's, and the inter-element copies carry the chain "
-                "forward. Summing degree + 1 entries against an exact total of one adds "
-                "gamma_{degree}. First order in u that is (4 S (degree + 1) + degree) u"
+                "an entry is a chain of S insertions, each an exact convex combination of "
+                "values in [0, 1] whose weights sum to one, so the error carries forward "
+                "with weight at most one. alpha's own rounding cancels: alpha and "
+                "beta = 1 - alpha reach this sum only as the pair |A + B - 1|, whose defect "
+                "is at most u/2 however alpha was computed. That leaves 2.5 roundings per "
+                "stage, so an entry is within gamma_{2.5 S}. S is the chain length of THIS "
+                "vector, not the degree: an element's own sequence is degree - multiplicity "
+                "stages, the boundary sequence composes with element 0's, and the "
+                "inter-element copies carry the chain forward. Summing degree + 1 entries "
+                "against an exact total of one adds gamma_{degree}. What is asserted is "
+                "gamma_{3 S + degree} in closed form, half a rounding per stage of declared "
+                "slack over that. Hypothesis: no underflow in the entries"
             ),
         ),
         context=f"{case.label} in {np.dtype(dtype).name} on {backend.name}",

--- a/tests/parity/test_bspline_bezier_extraction.py
+++ b/tests/parity/test_bspline_bezier_extraction.py
@@ -391,25 +391,47 @@ def _fused_claim(case: _Case, dtype: npt.DTypeLike) -> Any:
 def _column_sum_bound(case: _Case, dtype: npt.DTypeLike) -> float:
     """The absolute error a column sum of one may carry, for this vector.
 
-    Each stage of an entry's chain commits four roundings -- the complement
-    ``1 - alpha``, the two products, and their sum -- against an exact convex
-    combination of values in ``[0, 1]``, whose weights are non-negative and sum to
-    one, so the propagated error carries forward with weight at most one and an
-    entry ends up within ``gamma_{4 S}`` of its exact value, ``S`` being the chain
+    Each stage of an entry's chain forms an exact convex combination of values in
+    ``[0, 1]``, whose weights are non-negative and sum to one, so the propagated
+    error carries forward with weight at most one. **The rounding of ``alpha``
+    itself cancels**: ``alpha`` and ``beta = 1 - alpha`` enter as a pair, and what
+    the row bound sees is ``|A + B - 1|``, whose defect is at most ``u/2``
+    regardless of how ``alpha`` was computed -- so the division that produces it
+    costs nothing here. That leaves **2.5 roundings per stage**, not four, and an
+    entry ends up within ``gamma_{2.5 S}`` of its exact value, ``S`` being the chain
     length :func:`_insertion_stages` reports. Summing ``degree + 1`` of them against
-    an exact total of one adds ``gamma_{degree}``. First order in ``u``, that is
-    ``(4 S (degree + 1) + degree) u``.
+    an exact total of one adds ``gamma_{degree}``; the two compose by Higham,
+    *Accuracy and Stability of Numerical Algorithms*, 2nd ed., Lemma 3.3
+    (``gamma_k + gamma_j + gamma_k gamma_j <= gamma_{k + j}``).
+
+    ``gamma_{2.5 S + degree}`` is the sharp value and holds **exactly**, not merely
+    to first order. What ships is ``gamma_{3 S + degree}``: half a rounding per
+    stage of **declared slack over a proved bound**, taken so the coefficient is an
+    integer. The closed form ``m u / (1 - m u)`` is used rather than the truncation
+    ``m u``, because ``S`` is not bounded by the degree -- it grows with the element
+    count -- so a first-order truncation would eventually stop bounding.
+
+    **Stated hypothesis: no underflow in the operator entries.** A purely relative
+    rounding model needs its operands away from gradual underflow, and this
+    derivation is purely relative. Two searches over geometric knot ratios down to
+    ``1e-45``, at several degrees and both dtypes, drove no entry subnormal, so the
+    hypothesis is believed to hold rather than shown to be unnecessary.
 
     **The chain length is not the degree, and an earlier version of this said it
     was.** Element 0 alone reaches ``2 (degree - 1)`` stages, since the boundary
     sequence composes with its own, and the inter-element copies carry the chain
     forward across the whole vector. Both of element 0's terms are at most
     ``degree - 1``: a knot class has multiplicity at least one, and ``boundary`` is
-    at least one because index ``degree`` matches itself. The bound was therefore too tight by that
-    factor. It never failed, because the observed error is orders below either
-    version -- which is exactly the shape of claim nothing in the suite can
-    distinguish, and it was a review's unproved suspicion that found it rather than
-    any test.
+    at least one because index ``degree`` matches itself.
+
+    That error was worth recording because of *how* it survived: charging the wrong
+    chain length left the bound loose rather than wrong, and a loose bound is
+    satisfied by any result, so nothing in the suite could fail. A review's unproved
+    suspicion found it, not a test. The same is true of the per-stage count this
+    docstring used to give as four. Both corrections tighten the bound, which is why
+    :func:`test_the_partition_of_unity_check_is_not_vacuous` exists: it pins that
+    the observed error actually reaches this bound somewhere rather than sitting so
+    far below it that the check decides nothing.
 
     Args:
         case (_Case): The knot vector, which fixes the chain length.
@@ -419,7 +441,10 @@ def _column_sum_bound(case: _Case, dtype: npt.DTypeLike) -> float:
         float: The bound, zero where no insertion runs at all.
     """
     u = unit_roundoff(dtype)
-    return (4.0 * _insertion_stages(case, dtype) * (case.degree + 1.0) + case.degree) * u
+    m = 3.0 * _insertion_stages(case, dtype) + case.degree
+    if m * u >= 1.0:
+        raise AssertionError(f"gamma runs away to one at {m} roundings and u={u:.3e}")
+    return m * u / (1.0 - m * u)
 
 
 def _build(case: _Case, dtype: npt.DTypeLike, backend: Backend) -> npt.NDArray[Any]:

--- a/tests/parity/test_bspline_bezier_extraction.py
+++ b/tests/parity/test_bspline_bezier_extraction.py
@@ -87,7 +87,6 @@ from typing import TYPE_CHECKING, Any, Final, NamedTuple
 import numpy as np
 import pytest
 
-from pantr import _pantr_cpp
 from pantr._backend import Backend, use_backend
 from pantr.bspline import BsplineSpace1D
 from pantr.bspline._bspline_extraction import _tabulate_Bspline_Bezier_1D_extraction_impl
@@ -128,6 +127,24 @@ _BACKENDS: Final = (
     pytest.param(Backend.CPP, id="cpp"),
 )
 """The two backends, for the tests that state a property of each one separately."""
+
+
+def _bindings() -> Any:
+    """Import the extension, deferred and in one place.
+
+    Module level would break this file's whole point. The tests that state a
+    property of *each* backend are meant to run their Python half in an
+    installation with no extension, and a top-level ``from pantr import _pantr_cpp``
+    turns that into a collection error for the file -- every test, both halves. So
+    the import is here, and every caller is gated on ``cpp_backend``. Same shape and
+    same reason as ``test_bspline_binding_contract.py``'s.
+
+    Returns:
+        Any: The :mod:`pantr._pantr_cpp` module.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp
 
 
 def _demand_the_extension_if_needed(backend: Backend) -> None:
@@ -814,7 +831,7 @@ def test_the_builder_binding_refuses_what_the_oracle_refuses(
     out = np.empty(case.out_shape, dtype=np.float64)
 
     with pytest.raises(ValueError) as from_binding:
-        _pantr_cpp.bezier_extraction_1d(knots, case.degree, case.tol, out)
+        _bindings().bezier_extraction_1d(knots, case.degree, case.tol, out)
     assert str(from_binding.value) == case.message
 
     # And the oracle's own path produces the same text for the same fault, which is
@@ -843,7 +860,7 @@ def test_the_builder_binding_refuses_a_vector_spanning_no_interval(cpp_backend: 
     # alone and the comparison would be about the argument rather than the message.
     tol = _knot_tolerance(knots)
     with pytest.raises(ValueError) as caught:
-        _pantr_cpp.bezier_extraction_1d(knots, 2, tol, out)
+        _bindings().bezier_extraction_1d(knots, 2, tol, out)
     assert "knot vector spans no interval" in str(caught.value)
 
     with pytest.raises(ValueError) as from_space:
@@ -873,7 +890,7 @@ def test_the_builder_binding_refuses_a_wrongly_shaped_out(cpp_backend: None) -> 
     knots = np.asarray(_CASES[0].knots, dtype=np.float64)
     for shape in ((2, 3, 3), (3, 2, 3), (3, 3, 2)):
         with pytest.raises(ValueError, match=r"out must have shape \(3, 3, 3\)"):
-            _pantr_cpp.bezier_extraction_1d(knots, 2, 0.0, np.empty(shape, dtype=np.float64))
+            _bindings().bezier_extraction_1d(knots, 2, 0.0, np.empty(shape, dtype=np.float64))
 
 
 def test_the_builder_binding_refuses_a_dtype_it_would_have_to_cast(cpp_backend: None) -> None:
@@ -887,15 +904,15 @@ def test_the_builder_binding_refuses_a_dtype_it_would_have_to_cast(cpp_backend: 
     """
     knots = np.asarray(_CASES[0].knots, dtype=np.float32)
     with pytest.raises(TypeError):
-        _pantr_cpp.bezier_extraction_1d(knots, 2, 0.0, np.empty((3, 3, 3), dtype=np.float64))
+        _bindings().bezier_extraction_1d(knots, 2, 0.0, np.empty((3, 3, 3), dtype=np.float64))
     with pytest.raises(TypeError):
-        _pantr_cpp.bezier_extraction_1d(
+        _bindings().bezier_extraction_1d(
             knots.astype(np.float64), 2, 0.0, np.empty((3, 3, 3), dtype=np.float32)
         )
     # An integer knot vector is a cast too, and Layer 2 in Python is what normalizes
     # one; the binding must not do it silently.
     with pytest.raises(TypeError):
-        _pantr_cpp.bezier_extraction_1d(
+        _bindings().bezier_extraction_1d(
             np.asarray(_CASES[0].knots, dtype=np.int64), 2, 0.0, np.empty((3, 3, 3))
         )
 
@@ -909,15 +926,15 @@ def test_the_mask_binding_refuses_its_own_bad_calls(cpp_backend: None) -> None:
     """
     multiplicity = np.asarray([3, 1, 3], dtype=np.intp)
     with pytest.raises(ValueError, match="degree must be non-negative"):
-        _pantr_cpp.bezier_structural_identity_mask(multiplicity, -1, np.empty(2, dtype=np.bool_))
+        _bindings().bezier_structural_identity_mask(multiplicity, -1, np.empty(2, dtype=np.bool_))
     with pytest.raises(ValueError, match="at least one class"):
-        _pantr_cpp.bezier_structural_identity_mask(
+        _bindings().bezier_structural_identity_mask(
             np.empty(0, dtype=np.intp), 2, np.empty(0, dtype=np.bool_)
         )
     with pytest.raises(ValueError, match="out must have 2 elements"):
-        _pantr_cpp.bezier_structural_identity_mask(multiplicity, 2, np.empty(3, dtype=np.bool_))
+        _bindings().bezier_structural_identity_mask(multiplicity, 2, np.empty(3, dtype=np.bool_))
     with pytest.raises(TypeError):
-        _pantr_cpp.bezier_structural_identity_mask(
+        _bindings().bezier_structural_identity_mask(
             multiplicity.astype(np.int32), 2, np.empty(2, dtype=np.bool_)
         )
 

--- a/tests/parity/test_bspline_bezier_extraction.py
+++ b/tests/parity/test_bspline_bezier_extraction.py
@@ -401,9 +401,11 @@ def _column_sum_bound(case: _Case, dtype: npt.DTypeLike) -> float:
     ``(4 S (degree + 1) + degree) u``.
 
     **The chain length is not the degree, and an earlier version of this said it
-    was.** Element 0 alone reaches ``2 degree - 1`` stages, since the boundary
+    was.** Element 0 alone reaches ``2 (degree - 1)`` stages, since the boundary
     sequence composes with its own, and the inter-element copies carry the chain
-    forward across the whole vector. The bound was therefore too tight by that
+    forward across the whole vector. Both of element 0's terms are at most
+    ``degree - 1``: a knot class has multiplicity at least one, and ``boundary`` is
+    at least one because index ``degree`` matches itself. The bound was therefore too tight by that
     factor. It never failed, because the observed error is orders below either
     version -- which is exactly the shape of claim nothing in the suite can
     distinguish, and it was a review's unproved suspicion that found it rather than

--- a/tests/parity/test_bspline_bezier_extraction.py
+++ b/tests/parity/test_bspline_bezier_extraction.py
@@ -113,6 +113,7 @@ from tests._parity_harness import (
     demand_cpp_backend,
     derived_accuracy,
     exact_parity,
+    the_jit_is_disabled,
     unit_roundoff,
 )
 
@@ -832,6 +833,9 @@ def test_the_builder_binding_refuses_a_vector_spanning_no_interval(cpp_backend: 
     :class:`~pantr.bspline.BsplineSpace1D` already raises for the same vector, since
     that is the text a caller has seen for this fault since before the port.
     """
+    # A vector whose in-domain knots are all one class, with a boundary multiplicity
+    # of 2 rather than degree + 1 -- which is what takes the oracle into the branch
+    # that indexes the empty result.
     knots = np.asarray([0.0, 1.0, 1.0, 1.0, 1.0, 1.0], dtype=np.float64)
     out = np.empty((0, 3, 3), dtype=np.float64)
     # The space derives its own tolerance and the message interpolates it, so the
@@ -846,11 +850,22 @@ def test_the_builder_binding_refuses_a_vector_spanning_no_interval(cpp_backend: 
         BsplineSpace1D(knots, 2, snap_knots=False)
     assert str(caught.value) == str(from_space.value)
 
-    # And the oracle does NOT refuse it, which is the divergence
+    # And the oracle does not refuse it, which is the divergence
     # `pantr.bspline._extraction_backend` records. Pinned so that the day the oracle
     # grows the check, this test says so rather than the divergence note going stale.
+    #
+    # **Its symptom depends on the configuration, and that is what proves the
+    # mechanism**, so it is gated rather than skipped -- `design/backend_parity.md`
+    # Rule 12's own shape. Compiled, the kernel's `out[0]` on the empty result is an
+    # unchecked index and the call returns the empty array. Interpreted, numpy bounds
+    # checks the same line and raises. The compiled path therefore really does index
+    # past the allocation, which reading the source could only suggest.
     with use_backend(Backend.PYTHON):
-        assert _tabulate_Bspline_Bezier_1D_extraction_impl(knots, 2, tol).shape == (0, 3, 3)
+        if the_jit_is_disabled():
+            with pytest.raises(IndexError):
+                _tabulate_Bspline_Bezier_1D_extraction_impl(knots, 2, tol)
+        else:
+            assert _tabulate_Bspline_Bezier_1D_extraction_impl(knots, 2, tol).shape == (0, 3, 3)
 
 
 def test_the_builder_binding_refuses_a_wrongly_shaped_out(cpp_backend: None) -> None:

--- a/tests/parity/test_bspline_bezier_extraction.py
+++ b/tests/parity/test_bspline_bezier_extraction.py
@@ -87,9 +87,14 @@ from typing import TYPE_CHECKING, Any, Final, NamedTuple
 import numpy as np
 import pytest
 
+from pantr import _pantr_cpp
 from pantr._backend import Backend, use_backend
 from pantr.bspline import BsplineSpace1D
 from pantr.bspline._bspline_extraction import _tabulate_Bspline_Bezier_1D_extraction_impl
+from pantr.bspline._bspline_knots import (
+    _get_multiplicity_of_first_knot_in_domain_impl,
+    _knot_tolerance,
+)
 from pantr.bspline._extraction_backend import (
     _KERNELS,
     bezier_extraction_kernel,
@@ -283,6 +288,15 @@ _BITWISE_WHY: Final = (
 )
 """Why the two operation sequences agree bit for bit, and what would change it."""
 
+_NO_INSERTION_WHY: Final = (
+    "this knot vector needs no insertion at all -- every element is already a Bezier patch, "
+    "or the degree is 0 or 1 -- so both backends fill the identity and stop. No arithmetic is "
+    "performed, so there is nothing for a fused multiply-add to contract and nothing for a "
+    "bound to bound; design/backend_parity.md Rule 10 records a zero-stage claim being clamped "
+    "to one stage instead of being called what it is, which is bitwise"
+)
+"""Why a vector that runs no insertion is bitwise even where the build can fuse."""
+
 
 def _insertion_stages(case: _Case, dtype: npt.DTypeLike) -> int:
     """The length of the longest dependency chain of insertions, for this vector.
@@ -303,17 +317,16 @@ def _insertion_stages(case: _Case, dtype: npt.DTypeLike) -> int:
             classes.
 
     Returns:
-        int: The stage count, at least one.
+        int: The stage count, zero when no insertion runs at all.
     """
-    knots = np.asarray(case.knots, dtype=dtype)
-    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    space = BsplineSpace1D(np.asarray(case.knots, dtype=dtype), case.degree, snap_knots=False)
     multiplicity = space.get_unique_knots_and_multiplicity(in_domain=True)[1]
     boundary = int(
-        np.count_nonzero(np.abs(knots[: case.degree + 1] - knots[case.degree]) <= space.tolerance)
+        _get_multiplicity_of_first_knot_in_domain_impl(space.knots, case.degree, space.tolerance)
     )
     stages = max(case.degree - boundary, 0)
     stages += sum(max(case.degree - int(m), 0) for m in multiplicity[1:])
-    return max(stages, 1)
+    return stages
 
 
 def _fused_claim(case: _Case, dtype: npt.DTypeLike) -> Any:
@@ -326,10 +339,15 @@ def _fused_claim(case: _Case, dtype: npt.DTypeLike) -> Any:
     Returns:
         Any: The parity claim.
     """
+    stages = _insertion_stages(case, dtype)
+    if stages == 0:
+        # No insertion runs, so no site can fuse and there is nothing to bound. The
+        # harness refuses a zero-stage bounded claim by name and tells the caller to
+        # say bitwise instead, which `design/backend_parity.md` Rule 10 records
+        # being got wrong once already by clamping such a claim to one stage.
+        return bitwise_parity(why=_NO_INSERTION_WHY)
     return bounded_parity(
-        roundings=Roundings(
-            stages=_insertion_stages(case, dtype), accumulator_per_stage=3, storage_per_stage=0
-        ),
+        roundings=Roundings(stages=stages, accumulator_per_stage=3, storage_per_stage=0),
         accumulator=dtype,
         storage=dtype,
         amplification=np.array(1.0),
@@ -352,25 +370,36 @@ def _fused_claim(case: _Case, dtype: npt.DTypeLike) -> Any:
     )
 
 
-def _column_sum_bound(degree: int, dtype: npt.DTypeLike) -> float:
-    """The absolute error a column sum of one may carry.
+def _column_sum_bound(case: _Case, dtype: npt.DTypeLike) -> float:
+    """The absolute error a column sum of one may carry, for this vector.
 
-    Each entry is a chain of at most ``degree`` insertions, each committing four
-    roundings -- the complement ``1 - alpha``, the two products, and their sum --
-    against an exact convex combination of values in ``[0, 1]``, so an entry carries
-    at most ``gamma_{4 degree}`` of absolute error. Summing ``degree + 1`` of them
-    against an exact total of one adds ``gamma_{degree}``. First order in ``u``,
-    that is ``(4 degree (degree + 1) + degree) u``.
+    Each stage of an entry's chain commits four roundings -- the complement
+    ``1 - alpha``, the two products, and their sum -- against an exact convex
+    combination of values in ``[0, 1]``, whose weights are non-negative and sum to
+    one, so the propagated error carries forward with weight at most one and an
+    entry ends up within ``gamma_{4 S}`` of its exact value, ``S`` being the chain
+    length :func:`_insertion_stages` reports. Summing ``degree + 1`` of them against
+    an exact total of one adds ``gamma_{degree}``. First order in ``u``, that is
+    ``(4 S (degree + 1) + degree) u``.
+
+    **The chain length is not the degree, and an earlier version of this said it
+    was.** Element 0 alone reaches ``2 degree - 1`` stages, since the boundary
+    sequence composes with its own, and the inter-element copies carry the chain
+    forward across the whole vector. The bound was therefore too tight by that
+    factor. It never failed, because the observed error is orders below either
+    version -- which is exactly the shape of claim nothing in the suite can
+    distinguish, and it was a review's unproved suspicion that found it rather than
+    any test.
 
     Args:
-        degree (int): The polynomial degree.
+        case (_Case): The knot vector, which fixes the chain length.
         dtype (npt.DTypeLike): Storage format.
 
     Returns:
-        float: The bound, zero at degree 0 where nothing is computed.
+        float: The bound, zero where no insertion runs at all.
     """
     u = unit_roundoff(dtype)
-    return (4.0 * degree * (degree + 1.0) + degree) * u
+    return (4.0 * _insertion_stages(case, dtype) * (case.degree + 1.0) + case.degree) * u
 
 
 def _build(case: _Case, dtype: npt.DTypeLike, backend: Backend) -> npt.NDArray[Any]:
@@ -554,14 +583,16 @@ def test_the_columns_are_a_partition_of_unity(
         column_sums,
         np.ones_like(column_sums),
         derived_accuracy(
-            bound=np.full(column_sums.shape, _column_sum_bound(case.degree, dtype)),
+            bound=np.full(column_sums.shape, _column_sum_bound(case, dtype)),
             why=(
                 "an entry is a chain of at most `degree` insertions, each committing four "
                 "roundings -- the complement, the two products and their sum -- against an "
-                "exact convex combination of values in [0, 1], so it carries at most "
-                "gamma_{4 degree}; summing degree + 1 of them against an exact total of one "
-                "adds gamma_{degree}. First order in u that is (4 degree (degree + 1) + "
-                "degree) u"
+                "exact convex combination of values in [0, 1] whose weights sum to one, so it "
+                "carries at most gamma_{4 S} where S is the chain length of THIS vector: an "
+                "element's own sequence is degree - multiplicity stages, the boundary sequence "
+                "composes with element 0's, and the inter-element copies carry the chain "
+                "forward. Summing degree + 1 entries against an exact total of one adds "
+                "gamma_{degree}. First order in u that is (4 S (degree + 1) + degree) u"
             ),
         ),
         context=f"{case.label} in {np.dtype(dtype).name} on {backend.name}",
@@ -590,7 +621,7 @@ def test_the_partition_of_unity_check_is_not_vacuous(dtype: npt.DTypeLike) -> No
         operators = _build(case, dtype, Backend.PYTHON)
         deviation = np.abs(operators.sum(axis=1).astype(np.float64) - 1.0)
         worst = max(worst, float(deviation.max(initial=0.0)))
-        assert worst <= max(_column_sum_bound(c.degree, dtype) for c in _CASES if c.accuracy)
+        assert worst <= max(_column_sum_bound(c, dtype) for c in _CASES if c.accuracy)
     assert worst > 0.0, (
         "every case in the table has exactly-summing columns, so the derived bound is "
         "only ever compared against zero and asserts nothing"
@@ -692,6 +723,190 @@ def test_the_repeated_first_knot_case_separates_the_two_multiplicities(
     assert clamped_boundary == int(clamped_multiplicity[0])
 
 
+# ---------------------------------------------------------------------------
+# What the binding refuses, as opposed to what it computes
+# ---------------------------------------------------------------------------
+#
+# The C++ header validates nothing, so the binding is the C++ half of Layer 2 and
+# owns every refusal. Its file comment claims the four that mirror the oracle carry
+# **its messages character for character**, which is a checkable claim with nothing
+# else pinning it: the Python entry point refuses the same inputs first, so calling
+# through Layer 2 never reaches the binding's own checks. These call
+# `pantr._pantr_cpp` directly, which is the only way to exercise them.
+#
+# Nothing here carries a tolerance -- a refusal is a string and a type -- so
+# `design/backend_parity.md` Rule 8 cannot arise.
+
+
+class _Refusal(NamedTuple):
+    """One bad call to the builder binding, and the message it must produce.
+
+    Attributes:
+        label (str): What is wrong with the call.
+        knots (list[float]): The knot vector to pass.
+        degree (int): The degree to pass.
+        tol (float): The tolerance to pass.
+        out_shape (tuple[int, int, int]): The shape of the ``out`` to pass.
+        message (str): The message the oracle produces for the same fault, or the
+            one `BsplineSpace1D` produces where the oracle has no counterpart.
+    """
+
+    label: str
+    knots: list[float]
+    degree: int
+    tol: float
+    out_shape: tuple[int, int, int]
+    message: str
+
+
+_BUILDER_REFUSALS: Final = (
+    _Refusal(
+        "negative degree", [0.0, 0.0, 1.0, 1.0], -1, 0.0, (1, 1, 1), "degree must be non-negative"
+    ),
+    _Refusal("negative tol", [0.0, 0.0, 1.0, 1.0], 1, -1.0, (1, 2, 2), "tol must be non-negative"),
+    _Refusal(
+        "too few knots",
+        [0.0, 0.0, 1.0],
+        2,
+        0.0,
+        (1, 3, 3),
+        "knots must have at least 2*degree+2 elements",
+    ),
+    # The one-knot degree-zero case the truncating division used to let through.
+    _Refusal(
+        "one knot at degree zero",
+        [0.0],
+        0,
+        0.0,
+        (1, 1, 1),
+        "knots must have at least 2*degree+2 elements",
+    ),
+    _Refusal(
+        "descending step",
+        [0.0, 0.0, 1.0, 0.5, 1.0, 1.0],
+        2,
+        0.0,
+        (1, 3, 3),
+        "knots must be non-decreasing",
+    ),
+)
+"""One bad call per refusal the binding shares with the oracle."""
+
+
+@pytest.mark.parametrize(
+    "case", _BUILDER_REFUSALS, ids=[entry.label for entry in _BUILDER_REFUSALS]
+)
+def test_the_builder_binding_refuses_what_the_oracle_refuses(
+    cpp_backend: None, case: _Refusal
+) -> None:
+    """The binding's message is the oracle's, character for character.
+
+    Asserted against the text the Python path produces for the same fault rather
+    than against a literal copied from the C++, so that a reworded message on either
+    side is a failure here instead of a difference a caller would have to notice.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        case (_Refusal): The bad call and the message it must produce.
+    """
+    knots = np.asarray(case.knots, dtype=np.float64)
+    out = np.empty(case.out_shape, dtype=np.float64)
+
+    with pytest.raises(ValueError) as from_binding:
+        _pantr_cpp.bezier_extraction_1d(knots, case.degree, case.tol, out)
+    assert str(from_binding.value) == case.message
+
+    # And the oracle's own path produces the same text for the same fault, which is
+    # what makes the table above a comparison rather than a transcription.
+    with use_backend(Backend.PYTHON), pytest.raises(ValueError) as from_oracle:
+        _tabulate_Bspline_Bezier_1D_extraction_impl(knots, case.degree, case.tol)
+    assert str(from_oracle.value) == case.message
+
+
+def test_the_builder_binding_refuses_a_vector_spanning_no_interval(cpp_backend: None) -> None:
+    """The one refusal with no counterpart in the oracle, and it is the space's text.
+
+    The oracle allocates an empty ``(0, p+1, p+1)`` result for such a vector and its
+    kernel then indexes ``out[0]`` on it, so refusing is the only thing the C++ can
+    do that is not undefined behaviour. The message must be the one
+    :class:`~pantr.bspline.BsplineSpace1D` already raises for the same vector, since
+    that is the text a caller has seen for this fault since before the port.
+    """
+    knots = np.asarray([0.0, 1.0, 1.0, 1.0, 1.0, 1.0], dtype=np.float64)
+    out = np.empty((0, 3, 3), dtype=np.float64)
+    # The space derives its own tolerance and the message interpolates it, so the
+    # binding is handed the same one; otherwise the two texts differ in that number
+    # alone and the comparison would be about the argument rather than the message.
+    tol = _knot_tolerance(knots)
+    with pytest.raises(ValueError) as caught:
+        _pantr_cpp.bezier_extraction_1d(knots, 2, tol, out)
+    assert "knot vector spans no interval" in str(caught.value)
+
+    with pytest.raises(ValueError) as from_space:
+        BsplineSpace1D(knots, 2, snap_knots=False)
+    assert str(caught.value) == str(from_space.value)
+
+    # And the oracle does NOT refuse it, which is the divergence
+    # `pantr.bspline._extraction_backend` records. Pinned so that the day the oracle
+    # grows the check, this test says so rather than the divergence note going stale.
+    with use_backend(Backend.PYTHON):
+        assert _tabulate_Bspline_Bezier_1D_extraction_impl(knots, 2, tol).shape == (0, 3, 3)
+
+
+def test_the_builder_binding_refuses_a_wrongly_shaped_out(cpp_backend: None) -> None:
+    """An ``out`` of the wrong shape is a ``ValueError`` naming the shape wanted."""
+    knots = np.asarray(_CASES[0].knots, dtype=np.float64)
+    for shape in ((2, 3, 3), (3, 2, 3), (3, 3, 2)):
+        with pytest.raises(ValueError, match=r"out must have shape \(3, 3, 3\)"):
+            _pantr_cpp.bezier_extraction_1d(knots, 2, 0.0, np.empty(shape, dtype=np.float64))
+
+
+def test_the_builder_binding_refuses_a_dtype_it_would_have_to_cast(cpp_backend: None) -> None:
+    """``.noconvert()`` on both arrays, because a cast would change the arithmetic.
+
+    The whole insertion runs in the knots' own scalar type, so a silent widening of
+    ``knots`` would not merely copy: it would change the accumulation width and make
+    the result disagree with the oracle for a reason no caller could see.
+    ``design/backend_parity.md`` Rule 9 is why this is a refusal rather than a
+    convenience.
+    """
+    knots = np.asarray(_CASES[0].knots, dtype=np.float32)
+    with pytest.raises(TypeError):
+        _pantr_cpp.bezier_extraction_1d(knots, 2, 0.0, np.empty((3, 3, 3), dtype=np.float64))
+    with pytest.raises(TypeError):
+        _pantr_cpp.bezier_extraction_1d(
+            knots.astype(np.float64), 2, 0.0, np.empty((3, 3, 3), dtype=np.float32)
+        )
+    # An integer knot vector is a cast too, and Layer 2 in Python is what normalizes
+    # one; the binding must not do it silently.
+    with pytest.raises(TypeError):
+        _pantr_cpp.bezier_extraction_1d(
+            np.asarray(_CASES[0].knots, dtype=np.int64), 2, 0.0, np.empty((3, 3, 3))
+        )
+
+
+def test_the_mask_binding_refuses_its_own_bad_calls(cpp_backend: None) -> None:
+    """The mask entry point's three refusals, none of which the oracle has.
+
+    The Numba kernel validates nothing and Layer 2 reaches it only from a space, so
+    these guard a direct caller -- including a C++ one, for whom the binding's checks
+    are the only ones there are.
+    """
+    multiplicity = np.asarray([3, 1, 3], dtype=np.intp)
+    with pytest.raises(ValueError, match="degree must be non-negative"):
+        _pantr_cpp.bezier_structural_identity_mask(multiplicity, -1, np.empty(2, dtype=np.bool_))
+    with pytest.raises(ValueError, match="at least one class"):
+        _pantr_cpp.bezier_structural_identity_mask(
+            np.empty(0, dtype=np.intp), 2, np.empty(0, dtype=np.bool_)
+        )
+    with pytest.raises(ValueError, match="out must have 2 elements"):
+        _pantr_cpp.bezier_structural_identity_mask(multiplicity, 2, np.empty(3, dtype=np.bool_))
+    with pytest.raises(TypeError):
+        _pantr_cpp.bezier_structural_identity_mask(
+            multiplicity.astype(np.int32), 2, np.empty(2, dtype=np.bool_)
+        )
+
+
 def _draw(rng: np.random.Generator, dtype: npt.DTypeLike) -> _Case:
     """Draw one random knot vector the shared algorithm handles.
 
@@ -783,7 +998,7 @@ def test_the_claim_holds_over_a_sweep_ten_times_the_shipped_one(
 
         column_sums = actual.sum(axis=1).astype(np.float64)
         deviation = float(np.abs(column_sums - 1.0).max(initial=0.0))
-        assert deviation <= _column_sum_bound(case.degree, dtype), (
+        assert deviation <= _column_sum_bound(case, dtype), (
             f"{context}: a column sums to one only within {deviation}"
         )
         worst_column_sum = max(worst_column_sum, deviation)

--- a/tests/parity/test_bspline_bezier_extraction.py
+++ b/tests/parity/test_bspline_bezier_extraction.py
@@ -1,0 +1,796 @@
+"""Parity for the Bézier extraction operator builder and its structural identity mask.
+
+The C++ in ``cpp/include/pantr/bspline/extraction.hpp`` is a transliteration of
+``pantr.bspline._bspline_extraction_core``: the same identity start, the same
+boundary insertions, the same per-element insertion sequence in the same descending
+column order, the same column copies between elements, and every step in the knots'
+own scalar type. Only the loop bookkeeping differs -- the oracle writes a column at
+a time through a NumPy slice where this writes element by element -- and a loop
+shape moves no bits.
+
+**So the claim is bitwise, not bounded.** Measured on this machine over every case
+below and both dtypes: not one element differs. ``design/backend_parity.md`` says to
+make the strongest claim that holds, because a tolerance nothing approaches asserts
+nothing.
+
+It is gated, and the gate is the one thing that would break it. Each insertion is
+``alpha * C[i][k] + beta * C[i][k-1]``, which a build targeting an ISA with a fused
+multiply-add may contract to one instruction with one rounding where the oracle
+commits two. :func:`contraction_may_fuse` is that switch, and on such a build the
+claim falls back to Rule 10's budget rather than to nothing.
+:func:`_fused_claim` builds it, and it was exercised against an extension built at
+``-march=native`` rather than reasoned about -- ``design/backend_parity.md`` Rule 10
+records what an unevaluated conditional branch is worth.
+
+The two independent accuracy checks
+-----------------------------------
+
+Parity says the two backends agree, not that either is right, and a transposed index
+would be invisible to it: one side was written from the other, so both would make the
+same mistake. Two oracles, neither of them the Python implementation.
+
+**Exact rational values, hand-derived.** For a dyadic uniform open knot vector every
+operator entry is a binary rational -- halves at degree 2, quarters at degree 3 --
+so it is exactly representable in ``float32`` as well as ``float64`` and the
+comparison carries a **zero** bound. :data:`_EXACT_CASES` carries the tables and
+``cpp/tests/test_bspline_extraction.cpp`` carries the derivation of the quadratic one
+from ``N = C @ B`` directly.
+
+That check is deliberately not a tolerance. Rule 8's concern -- a bound as large as
+the values it compares -- cannot arise where the bound is zero and the values are
+exact by construction. What has to be watched instead is the opposite, that the
+tables are not accidentally trivial, which
+:func:`test_the_exact_tables_are_not_trivial` pins.
+
+**The column partition of unity.** Each operator's *columns* sum to one, which
+follows from ``sum_i N_i = 1`` and ``sum_j B_j = 1`` plus the linear independence of
+the Bernstein basis. Columns and not rows: the quadratic table's rows sum to
+``1, 1.5, 0.5``, so this is what catches a transposition, and it holds for every
+knot vector rather than for a family. Its bound is derived in
+:func:`_column_sum_bound` and
+:func:`test_the_partition_of_unity_check_is_not_vacuous` pins that the observed
+error reaches it rather than being identically zero.
+
+What the sweep leaves out, and why
+----------------------------------
+
+One knot-vector family is **excluded from both accuracy oracles and kept as a parity
+case only**: a vector whose first in-domain knot is repeated, of which
+``"repeated first in-domain knot"`` is the instance. The shared algorithm's sliding
+window starts at ``degree + sum of the in-domain multiplicities``, which is the last
+knot index of the element's class only when ``knots[degree]`` is the last knot of
+*its* class; where it is not, the window starts inside the repeated knot and the
+answer is wrong on both sides -- a division of zero by zero in the worst case. Both
+backends reproduce it identically, so parity is exactly what this case is for: it is
+the one vector in the table where the boundary multiplicity differs from the first
+in-domain **class** multiplicity, so a port that read the class multiplicity instead
+would fail here and nowhere else.
+
+Rule 12
+-------
+
+Nothing here carries ``pow`` or an integer accumulator, so no gate on the
+interpreted oracle is needed: the kernel is built from ``+``, ``-``, ``*`` and
+``/``, all of which IEEE 754 pins, and the bitwise claim is as true under
+``NUMBA_DISABLE_JIT=1`` as anywhere.
+
+The tests that state a property of *each* backend take the extension requirement on
+the C++ **parameter** rather than on the test, because taking it on the test would
+skip the Python half too, and the Python half of the accuracy checks is the only
+thing here that would catch the **oracle** regressing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
+
+import numpy as np
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import BsplineSpace1D
+from pantr.bspline._bspline_extraction import _tabulate_Bspline_Bezier_1D_extraction_impl
+from pantr.bspline._extraction_backend import (
+    _KERNELS,
+    bezier_extraction_kernel,
+    bezier_identity_mask_kernel,
+)
+from pantr.bspline.spanwise_element_extraction import _bezier_structural_identity_mask
+from tests._parity_harness import (
+    Field,
+    Roundings,
+    assert_accuracy,
+    assert_object_parity,
+    assert_parity,
+    bitwise_parity,
+    bounded_parity,
+    contraction_may_fuse,
+    demand_cpp_backend,
+    derived_accuracy,
+    exact_parity,
+    unit_roundoff,
+)
+
+if TYPE_CHECKING:
+    from numpy import typing as npt
+
+DTYPES: Final = [np.float64, np.float32]
+"""The two storage formats the builder is instantiated for."""
+
+_BACKENDS: Final = (
+    pytest.param(Backend.PYTHON, id="python"),
+    pytest.param(Backend.CPP, id="cpp"),
+)
+"""The two backends, for the tests that state a property of each one separately."""
+
+
+def _demand_the_extension_if_needed(backend: Backend) -> None:
+    """Require the compiled extension, and only for the half that uses it.
+
+    A test parametrized over both backends and *also* taking the ``cpp_backend``
+    fixture skips **both** halves when the extension is absent, which silently
+    drops the Python half -- and the Python half of the two accuracy checks is the
+    only thing here that would catch the oracle regressing. Marking the parameter
+    would be neater and pytest forbids it: ``pytest.param`` refuses
+    ``pytest.mark.usefixtures``.
+
+    Args:
+        backend (Backend): The backend this case runs under.
+    """
+    if backend is Backend.CPP:
+        demand_cpp_backend()
+
+
+class _Case(NamedTuple):
+    """One knot vector to build the operators of, and what it is in the table for.
+
+    A record rather than a positional tuple: two of the four fields are flags and
+    ``(..., True, False)`` says nothing at a call site about which is which.
+
+    Attributes:
+        label (str): What structural feature this case exercises.
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        accuracy (bool): Whether the analytic invariants may be asserted on it.
+            False for the one vector the shared algorithm mishandles; see the module
+            docstring.
+    """
+
+    label: str
+    knots: list[float]
+    degree: int
+    accuracy: bool
+
+
+_CASES: Final = (
+    _Case("clamped uniform quadratic", [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0], 2, True),
+    _Case(
+        "clamped uniform cubic",
+        [0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0, 4.0, 4.0],
+        3,
+        True,
+    ),
+    _Case(
+        "clamped non-uniform quartic",
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0],
+        4,
+        True,
+    ),
+    _Case(
+        "interior knot of multiplicity two", [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0], 2, True
+    ),
+    _Case(
+        "interior knots at full multiplicity",
+        [0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0],
+        2,
+        True,
+    ),
+    _Case("unclamped uniform quadratic", [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0], 2, True),
+    _Case(
+        "unclamped non-uniform cubic",
+        [0.0, 0.2, 0.45, 0.7, 1.1, 1.6, 2.0, 2.5, 3.0, 3.4],
+        3,
+        True,
+    ),
+    _Case("degree zero", [0.0, 1.0], 0, True),
+    _Case("degree one", [0.0, 0.0, 1.0, 2.0, 3.0, 3.0], 1, True),
+    # A domain based far from the origin, where the knot tolerance is an absolute
+    # length of the coordinates' own magnitude rather than of the span. At float32
+    # the tolerance is about 0.48 there, so unit-spaced knots still separate.
+    _Case(
+        "domain at 1e6",
+        [1.0e6, 1.0e6, 1.0e6, 1.0e6 + 1.0, 1.0e6 + 2.0, 1.0e6 + 3.0, 1.0e6 + 3.0, 1.0e6 + 3.0],
+        2,
+        True,
+    ),
+    # Parity only. See "What the sweep leaves out" in the module docstring: this is
+    # the one vector where the boundary multiplicity (1) differs from the first
+    # in-domain class multiplicity (2), and the shared algorithm's answer on it is
+    # defective.
+    _Case("repeated first in-domain knot", [0.0, 0.4, 0.5, 0.5, 1.0, 1.5, 2.0, 2.5], 2, False),
+)
+"""The shipped parity table: eleven knot vectors, each named for what it exercises."""
+
+
+class _Exact(NamedTuple):
+    """One knot vector whose operator entries are exact binary rationals.
+
+    Attributes:
+        label (str): What the case is.
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        operators (list[list[list[float]]]): The exact operators, one per element.
+    """
+
+    label: str
+    knots: list[float]
+    degree: int
+    operators: list[list[list[float]]]
+
+
+_EXACT_CASES: Final = (
+    # Derived by hand from `N = C @ B`; the derivation is written out in
+    # `cpp/tests/test_bspline_extraction.cpp`. Every entry is a half.
+    _Exact(
+        "quadratic open, three uniform elements",
+        [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],
+        2,
+        [
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.5], [0.0, 0.0, 0.5]],
+            [[0.5, 0.0, 0.0], [0.5, 1.0, 0.5], [0.0, 0.0, 0.5]],
+            [[0.5, 0.0, 0.0], [0.5, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        ],
+    ),
+    # The interior operator of a uniform quadratic spline does not depend on whether
+    # the ends are clamped: a function's restriction to an interior element depends
+    # only on the local knot pattern, which is uniform in both. So both operators of
+    # the unclamped uniform vector are the middle table above, which was derived
+    # somewhere else entirely.
+    _Exact(
+        "quadratic unclamped, two uniform elements",
+        [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
+        2,
+        [
+            [[0.5, 0.0, 0.0], [0.5, 1.0, 0.5], [0.0, 0.0, 0.5]],
+            [[0.5, 0.0, 0.0], [0.5, 1.0, 0.5], [0.0, 0.0, 0.5]],
+        ],
+    ),
+    # Degree 1 forces the identity at any knots, because the linear B-spline basis
+    # on an element IS the linear Bernstein basis.
+    _Exact(
+        "linear, three elements",
+        [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
+        1,
+        [
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[1.0, 0.0], [0.0, 1.0]],
+        ],
+    ),
+)
+"""Knot vectors with an exactly-representable answer, and that answer."""
+
+_BITWISE_WHY: Final = (
+    "the C++ is a transliteration of the oracle's insertion sequence: the same identity "
+    "start, the same boundary insertions, the same per-element sequence over the same "
+    "descending columns, and the same column copies between elements. Every step runs in "
+    "the knots' own scalar type on both sides -- the oracle spells its unit "
+    "`knots.dtype.type(1.0)` precisely so that numba does not promote the combination to "
+    "float64 -- so the two commit the same roundings on the same operands. Only the loop "
+    "bookkeeping differs and a loop shape moves no bits. This holds because the target ISA "
+    "has no fused multiply-add; on a build with one, `alpha * x + beta * y` may contract "
+    "and the bounded branch takes over"
+)
+"""Why the two operation sequences agree bit for bit, and what would change it."""
+
+
+def _insertion_stages(case: _Case, dtype: npt.DTypeLike) -> int:
+    """The length of the longest dependency chain of insertions, for this vector.
+
+    Each insertion writes column ``k`` from columns ``k`` and ``k - 1`` of the
+    previous outer iteration, so one outer iteration is one stage and the chain
+    through an element's own sequence is ``degree - multiplicity`` long. Element
+    ``e + 1``'s seeded columns are **copies** of element ``e``'s, so the chain
+    accumulates across elements, and the boundary sequence adds
+    ``degree - boundary`` on top of element 0. The sum over the whole vector is
+    therefore an upper bound on any single entry's chain, and it is taken from this
+    vector's own multiplicities rather than from the degree, because an element
+    whose right knot is already ``degree``-fold contracts nothing.
+
+    Args:
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format, which fixes the tolerance and so the
+            classes.
+
+    Returns:
+        int: The stage count, at least one.
+    """
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    multiplicity = space.get_unique_knots_and_multiplicity(in_domain=True)[1]
+    boundary = int(
+        np.count_nonzero(np.abs(knots[: case.degree + 1] - knots[case.degree]) <= space.tolerance)
+    )
+    stages = max(case.degree - boundary, 0)
+    stages += sum(max(case.degree - int(m), 0) for m in multiplicity[1:])
+    return max(stages, 1)
+
+
+def _fused_claim(case: _Case, dtype: npt.DTypeLike) -> Any:
+    """Build the Rule 10 claim for a build whose insertions may fuse.
+
+    Args:
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        Any: The parity claim.
+    """
+    return bounded_parity(
+        roundings=Roundings(
+            stages=_insertion_stages(case, dtype), accumulator_per_stage=3, storage_per_stage=0
+        ),
+        accumulator=dtype,
+        storage=dtype,
+        amplification=np.array(1.0),
+        why=(
+            "this build's target ISA has a fused multiply-add, so at each insertion the C++ "
+            "may compute `fl(alpha*x + beta*y)` with one of the two products contracted "
+            "where the oracle computes both products first. design/backend_parity.md Rule 10 "
+            "budgets that at three accumulator roundings per fused site. The insertion "
+            "weight and its complement are common mode -- a subtraction and a division "
+            "carry no fusible site, so both backends hold the same alpha and the same beta "
+            "bit for bit -- and the accumulator is the storage format on both sides, so no "
+            "store narrows and storage_per_stage is zero. The amplification is one because "
+            "every intermediate lies in [0, 1]: the operators start as the identity, whose "
+            "entries are 0 and 1, and each insertion replaces a column by a convex "
+            "combination of two columns, so the largest entry of a row cannot grow. One is "
+            "therefore the exact bound on the intermediates, and it cannot be tightened "
+            "using the final values, which are smaller than the intermediates by exactly "
+            "what the recurrence shrank them"
+        ),
+    )
+
+
+def _column_sum_bound(degree: int, dtype: npt.DTypeLike) -> float:
+    """The absolute error a column sum of one may carry.
+
+    Each entry is a chain of at most ``degree`` insertions, each committing four
+    roundings -- the complement ``1 - alpha``, the two products, and their sum --
+    against an exact convex combination of values in ``[0, 1]``, so an entry carries
+    at most ``gamma_{4 degree}`` of absolute error. Summing ``degree + 1`` of them
+    against an exact total of one adds ``gamma_{degree}``. First order in ``u``,
+    that is ``(4 degree (degree + 1) + degree) u``.
+
+    Args:
+        degree (int): The polynomial degree.
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        float: The bound, zero at degree 0 where nothing is computed.
+    """
+    u = unit_roundoff(dtype)
+    return (4.0 * degree * (degree + 1.0) + degree) * u
+
+
+def _build(case: _Case, dtype: npt.DTypeLike, backend: Backend) -> npt.NDArray[Any]:
+    """Build one case's operators under one backend.
+
+    Args:
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+        backend (Backend): Which implementation to run.
+
+    Returns:
+        npt.NDArray[Any]: The ``(n_intervals, degree+1, degree+1)`` operators.
+    """
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    with use_backend(backend):
+        return np.asarray(
+            _tabulate_Bspline_Bezier_1D_extraction_impl(space.knots, case.degree, space.tolerance)
+        )
+
+
+def _claim(case: _Case, dtype: npt.DTypeLike) -> Any:
+    """The parity claim for one case, on whichever build is running.
+
+    Args:
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        Any: A bitwise claim, or Rule 10's bounded one where contraction is live.
+    """
+    if contraction_may_fuse():
+        return _fused_claim(case, dtype)
+    return bitwise_parity(why=_BITWISE_WHY)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", _CASES, ids=[entry.label for entry in _CASES])
+def test_the_operators_agree(cpp_backend: None, case: _Case, dtype: npt.DTypeLike) -> None:
+    """The two backends build the same operators.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    reference = _build(case, dtype, Backend.PYTHON)
+    actual = _build(case, dtype, Backend.CPP)
+    assert_parity(
+        actual, reference, _claim(case, dtype), context=f"{case.label} in {np.dtype(dtype).name}"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", _CASES, ids=[entry.label for entry in _CASES])
+def test_the_identity_mask_agrees(cpp_backend: None, case: _Case, dtype: npt.DTypeLike) -> None:
+    """The two backends mark the same elements as already-Bézier.
+
+    A boolean verdict per element, so the claim is exactness rather than a
+    tolerance: ``design/backend_parity.md`` Rule 11's distinction, and the mask is
+    reached by the same integer comparisons on both sides.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    space = BsplineSpace1D(np.asarray(case.knots, dtype=dtype), case.degree, snap_knots=False)
+    with use_backend(Backend.PYTHON):
+        reference = _bezier_structural_identity_mask(space)
+    with use_backend(Backend.CPP):
+        actual = _bezier_structural_identity_mask(space)
+    assert_object_parity(
+        py=reference,
+        cpp=actual,
+        fields=[
+            Field(
+                name="identity mask",
+                claim=exact_parity(
+                    why=(
+                        "the mask is two integer comparisons of a knot multiplicity against "
+                        "degree + 1, so both sides reach the same boolean by the same exact "
+                        "arithmetic and a difference is a defect rather than a rounding"
+                    )
+                ),
+                read=lambda mask: mask,
+            )
+        ],
+        context=f"{case.label} in {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("case", _EXACT_CASES, ids=[entry.label for entry in _EXACT_CASES])
+def test_matches_the_exact_rational_operators(
+    case: _Exact, backend: Backend, dtype: npt.DTypeLike
+) -> None:
+    """Each backend reproduces the hand-derived exact table, with a zero bound.
+
+    Args:
+        case (_Exact): The knot vector and its exact operators.
+        backend (Backend): Which implementation to run.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    _demand_the_extension_if_needed(backend)
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    with use_backend(backend):
+        computed = np.asarray(
+            _tabulate_Bspline_Bezier_1D_extraction_impl(space.knots, case.degree, space.tolerance)
+        )
+    exact = np.asarray(case.operators, dtype=dtype)
+    assert computed.shape == exact.shape, f"{case.label}: shape {computed.shape} vs {exact.shape}"
+    assert_accuracy(
+        computed,
+        exact,
+        derived_accuracy(
+            bound=np.zeros_like(exact, dtype=np.float64),
+            why=(
+                "every entry of this vector's operators is a binary rational -- a half at "
+                "degree 2, a quarter at degree 3 -- so it is exactly representable in both "
+                "storage formats, and every insertion weight along the way is a half too. "
+                "No rounding occurs, so the bound is zero rather than derived from one"
+            ),
+        ),
+        context=f"{case.label} in {np.dtype(dtype).name} on {backend.name}",
+    )
+
+
+def test_the_exact_tables_are_not_trivial() -> None:
+    """A zero bound says something only if the values it guards are not all forced.
+
+    The identity is what the builder starts from, so a table that is the identity
+    everywhere would pass against a builder that did nothing at all. This pins that
+    the tables carry entries strictly between zero and one, that they are not all
+    the identity, and that transposing one changes it -- which is what makes the
+    comparison able to see an index-order error.
+    """
+    interesting = [
+        np.asarray(case.operators, dtype=np.float64) for case in _EXACT_CASES if case.degree >= 2
+    ]
+    assert interesting, "no exact case has an answer that is not forced"
+    for table in interesting:
+        strictly_inside = (table > 0.0) & (table < 1.0)
+        assert strictly_inside.any(), "an exact table is entirely zeros and ones"
+        identity = np.broadcast_to(np.eye(table.shape[1]), table.shape)
+        assert not np.array_equal(table, identity), "an exact table is the identity everywhere"
+        assert not np.array_equal(table, np.swapaxes(table, 1, 2)), (
+            "an exact table is symmetric, so comparing against it could not tell a "
+            "transposed operator from the right one"
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize(
+    "case",
+    [entry for entry in _CASES if entry.accuracy],
+    ids=[e.label for e in _CASES if e.accuracy],
+)
+def test_the_columns_are_a_partition_of_unity(
+    case: _Case, backend: Backend, dtype: npt.DTypeLike
+) -> None:
+    """Every operator's columns sum to one, in either backend.
+
+    The analytic oracle: ``sum_i N_i = 1`` on the element and ``sum_j B_j = 1`` on
+    the reference interval, so ``sum_i sum_j C_ij B_j = sum_j B_j`` and the
+    Bernstein basis being independent forces ``sum_i C_ij = 1`` for every column
+    ``j``. Rows are not what sums to one, which is why this catches a transposition.
+
+    Args:
+        case (_Case): The knot vector.
+        backend (Backend): Which implementation to run.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    _demand_the_extension_if_needed(backend)
+    operators = _build(case, dtype, backend)
+    column_sums = operators.sum(axis=1)
+    assert_accuracy(
+        column_sums,
+        np.ones_like(column_sums),
+        derived_accuracy(
+            bound=np.full(column_sums.shape, _column_sum_bound(case.degree, dtype)),
+            why=(
+                "an entry is a chain of at most `degree` insertions, each committing four "
+                "roundings -- the complement, the two products and their sum -- against an "
+                "exact convex combination of values in [0, 1], so it carries at most "
+                "gamma_{4 degree}; summing degree + 1 of them against an exact total of one "
+                "adds gamma_{degree}. First order in u that is (4 degree (degree + 1) + "
+                "degree) u"
+            ),
+        ),
+        context=f"{case.label} in {np.dtype(dtype).name} on {backend.name}",
+    )
+    assert not np.any(operators < 0.0), (
+        "an entry is a product of convex combinations and cannot be negative"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_partition_of_unity_check_is_not_vacuous(dtype: npt.DTypeLike) -> None:
+    """The column-sum bound is compared against a nonzero error somewhere.
+
+    ``design/backend_parity.md``'s rule the hard way: a bound compared only against
+    zero has not been checked. A dyadic knot vector rounds nothing, so its column
+    sums are exactly one; a non-dyadic one does not, and this pins that at least one
+    case in the table reaches a nonzero deviation and that the bound is above it.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format.
+    """
+    worst = 0.0
+    for case in _CASES:
+        if not case.accuracy or case.degree < 1:
+            continue
+        operators = _build(case, dtype, Backend.PYTHON)
+        deviation = np.abs(operators.sum(axis=1).astype(np.float64) - 1.0)
+        worst = max(worst, float(deviation.max(initial=0.0)))
+        assert worst <= max(_column_sum_bound(c.degree, dtype) for c in _CASES if c.accuracy)
+    assert worst > 0.0, (
+        "every case in the table has exactly-summing columns, so the derived bound is "
+        "only ever compared against zero and asserts nothing"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_a_strided_out_is_filled(backend: Backend, dtype: npt.DTypeLike) -> None:
+    """A caller's non-contiguous ``out`` comes back filled, under either backend.
+
+    The binding declares ``out`` C-contiguous, so the adapter in
+    :mod:`pantr.bspline._extraction_backend` computes into a fresh buffer and copies
+    back. Nothing else in this file reaches that path, and a silently unfilled
+    ``out`` would look like a wrong answer far from its cause.
+
+    Args:
+        backend (Backend): Which implementation to run.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    _demand_the_extension_if_needed(backend)
+    case = _CASES[0]
+    expected = _build(case, dtype, backend)
+    # Every other slice of a doubled leading axis: C-contiguous in the last two
+    # axes and strided in the first, which is what the adapter has to absorb.
+    canvas = np.full((2 * expected.shape[0], *expected.shape[1:]), np.nan, dtype=dtype)
+    strided = canvas[::2]
+    assert not strided.flags["C_CONTIGUOUS"]
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    with use_backend(backend):
+        returned = _tabulate_Bspline_Bezier_1D_extraction_impl(
+            space.knots, case.degree, space.tolerance, out=strided
+        )
+    assert returned is strided
+    assert np.array_equal(strided, expected), "the strided out was not filled with the answer"
+
+
+def test_the_claim_is_not_vacuous(cpp_backend: None) -> None:
+    """A bitwise claim asserts nothing unless the two paths could have differed.
+
+    The specific risk: if the catalogue handed back the Numba kernel for both
+    backends, every assertion above would pass for the wrong reason. Identity is
+    taken against the catalogue's own table rather than against a kernel's ``repr``
+    or ``py_func``, neither of which exists under ``NUMBA_DISABLE_JIT=1`` -- Rule
+    12's shape, and what a first version of the sibling assertion got wrong.
+    """
+    python_builder = bezier_extraction_kernel(Backend.PYTHON)
+    cpp_builder = bezier_extraction_kernel(Backend.CPP)
+    assert python_builder is not cpp_builder
+    python_mask = bezier_identity_mask_kernel(Backend.PYTHON)
+    cpp_mask = bezier_identity_mask_kernel(Backend.CPP)
+    assert python_mask is not cpp_mask
+
+    # The apply catalogue is the sibling table; the builders must not have landed in
+    # it, since the two are separate C++ registrations with separate claims.
+    assert python_builder not in _KERNELS.values()
+    assert cpp_builder not in _KERNELS.values()
+
+
+def test_the_repeated_first_knot_case_separates_the_two_multiplicities(
+    cpp_backend: None,
+) -> None:
+    """The parity-only case really is the one that discriminates the boundary count.
+
+    ``design/extraction_port.md``'s 2026-09-01 amendment says the boundary
+    multiplicity the builder opens with is the front entry of
+    ``multiplicity_in_domain()``. It is not: they are different computations over
+    different index ranges. This pins that the table holds a vector where they
+    differ, so a port that read the class multiplicity would fail
+    :func:`test_the_operators_agree` on it -- and that a clamped vector is where the
+    two agree, which is why the confusion survived.
+    """
+    repeated = next(entry for entry in _CASES if entry.label == "repeated first in-domain knot")
+    knots = np.asarray(repeated.knots, dtype=np.float64)
+    space = BsplineSpace1D(knots, repeated.degree, snap_knots=False)
+    multiplicity = space.get_unique_knots_and_multiplicity(in_domain=True)[1]
+    boundary = int(
+        np.count_nonzero(
+            np.abs(knots[: repeated.degree + 1] - knots[repeated.degree]) <= space.tolerance
+        )
+    )
+    assert boundary != int(multiplicity[0]), (
+        "the parity table no longer holds a vector separating the boundary "
+        "multiplicity from the first in-domain class multiplicity, so nothing here "
+        "would notice a port that confused the two"
+    )
+
+    clamped = next(entry for entry in _CASES if entry.label == "clamped uniform quadratic")
+    clamped_knots = np.asarray(clamped.knots, dtype=np.float64)
+    clamped_space = BsplineSpace1D(clamped_knots, clamped.degree, snap_knots=False)
+    clamped_multiplicity = clamped_space.get_unique_knots_and_multiplicity(in_domain=True)[1]
+    clamped_boundary = int(
+        np.count_nonzero(
+            np.abs(clamped_knots[: clamped.degree + 1] - clamped_knots[clamped.degree])
+            <= clamped_space.tolerance
+        )
+    )
+    assert clamped_boundary == int(clamped_multiplicity[0])
+
+
+def _draw(rng: np.random.Generator, dtype: npt.DTypeLike) -> _Case:
+    """Draw one random knot vector the shared algorithm handles.
+
+    The draw stays inside the family where the sliding window is aligned: either the
+    left end is clamped with multiplicity exactly ``degree + 1``, or the leading
+    knots are strictly increasing. Outside it the algorithm mishandles the vector on
+    both sides, which is a defect rather than a parity question, and the module
+    docstring says so.
+
+    Args:
+        rng (np.random.Generator): The source of randomness.
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        _Case: The drawn vector, marked as safe for the accuracy oracles.
+    """
+    degree = int(rng.integers(0, 5))
+    n_intervals = int(rng.integers(1, 6))
+    # Strictly increasing breakpoints, well separated against the knot tolerance.
+    gaps = rng.uniform(0.4, 2.0, size=n_intervals)
+    breaks = np.concatenate(([0.0], np.cumsum(gaps)))
+    clamped = bool(rng.integers(0, 2))
+
+    interior: list[float] = []
+    for value in breaks[1:-1]:
+        multiplicity = int(rng.integers(1, degree + 1)) if degree >= 1 else 1
+        interior.extend([float(value)] * multiplicity)
+
+    if clamped:
+        clamp = degree + 1
+        knots = [
+            *[float(breaks[0])] * clamp,
+            *interior,
+            *[float(breaks[-1])] * clamp,
+        ]
+    else:
+        # Strictly increasing outside the domain, so `knots[degree]` is the last
+        # knot of its class and the window stays aligned.
+        step = float(gaps[0])
+        left = [float(breaks[0]) - step * (degree - i) for i in range(degree)]
+        right = [float(breaks[-1]) + step * (i + 1) for i in range(degree)]
+        knots = [*left, float(breaks[0]), *interior, float(breaks[-1]), *right]
+
+    label = f"drawn degree {degree}, {n_intervals} intervals, {'clamped' if clamped else 'open'}"
+    case = _Case(label, knots, degree, True)
+    # A draw that the space itself refuses is not a case; redraw deterministically by
+    # falling back to the clamped uniform form, which is always legal.
+    try:
+        BsplineSpace1D(np.asarray(knots, dtype=dtype), degree, snap_knots=False)
+    except ValueError:  # pragma: no cover  (the construction above is legal by design)
+        uniform = [0.0] * (degree + 1) + [float(i + 1) for i in range(n_intervals - 1)]
+        uniform += [float(n_intervals)] * (degree + 1)
+        case = _Case(label + ", replaced", uniform, degree, True)
+    return case
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_claim_holds_over_a_sweep_ten_times_the_shipped_one(
+    cpp_backend: None, dtype: npt.DTypeLike
+) -> None:
+    """A bound checked only by the sweep that ships with it has not been checked.
+
+    The shipped parametrization is eleven knot vectors per dtype. This draws 110
+    random ones per dtype, from the family the algorithm handles, and asserts the
+    parity claim, the identity mask and the partition of unity on each.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    draws = 10 * len(_CASES)
+    checked = 0
+    worst_column_sum = 0.0
+    for draw in range(draws):
+        rng = np.random.default_rng(700_000 + 13 * draw)
+        case = _draw(rng, dtype)
+        reference = _build(case, dtype, Backend.PYTHON)
+        actual = _build(case, dtype, Backend.CPP)
+        context = f"{case.label} in {np.dtype(dtype).name} (draw {draw})"
+        assert_parity(actual, reference, _claim(case, dtype), context=context)
+
+        space = BsplineSpace1D(np.asarray(case.knots, dtype=dtype), case.degree, snap_knots=False)
+        with use_backend(Backend.PYTHON):
+            mask_reference = _bezier_structural_identity_mask(space)
+        with use_backend(Backend.CPP):
+            mask_actual = _bezier_structural_identity_mask(space)
+        assert np.array_equal(mask_actual, mask_reference), f"{context}: the masks differ"
+
+        column_sums = actual.sum(axis=1).astype(np.float64)
+        deviation = float(np.abs(column_sums - 1.0).max(initial=0.0))
+        assert deviation <= _column_sum_bound(case.degree, dtype), (
+            f"{context}: a column sums to one only within {deviation}"
+        )
+        worst_column_sum = max(worst_column_sum, deviation)
+        checked += 1
+
+    assert checked == draws, f"the sweep ran {checked} cases, expected {draws}"
+    assert worst_column_sum > 0.0, (
+        "no drawn case rounded at all, so the partition-of-unity bound was compared "
+        "against zero throughout the sweep"
+    )

--- a/tests/parity/test_bspline_space_1d.py
+++ b/tests/parity/test_bspline_space_1d.py
@@ -305,9 +305,18 @@ _REFUSALS: Final = tuple(
         ("domain swallowed by an interior knot", [0.0, 1.0, 1.0, 1.0, 2.0], 1, False, True),
         ("short and descending", [1.0, 0.0, 1.0], 2, False, True),
         ("descending and too few", [0.0, 1.0, 2.0, 3.0, 2.0, 5.0, 6.0], 2, True, True),
+        ("one knot at degree zero", [0.0], 0, False, True),
     )
 )
 """One input per refusal, plus two that fail two checks at once.
+
+The last one is a regression case rather than a new refusal. The C++ length check
+is the oracle's `size < 2*degree+2` rewritten as a division, to keep it free of
+signed overflow at a huge degree, and C++ division truncates toward zero where the
+rewrite needs a floor. At one knot and degree 0 the two disagree: the truncating
+form skipped the refusal and the caller was told "Not enough knots for the
+specified degree" instead. It is the only input on which they differ, checked
+exhaustively over the small ones.
 
 A negative degree is deliberately **not** here. The wrapper refuses it before
 `_new_impl` dispatches, so both parametrizations would run the identical Python


### PR DESCRIPTION
## What this covers of #399

The **Bézier extraction builder and its structural identity mask**, in C++, bound and
dispatched from Python. This is the slice #428 unblocked by landing the unique-knot scan.

**Not in this PR, deliberately:** the Lagrange target, which is this builder post-multiplied by
an already-bound matrix and gets its own slice; and the cardinal target, still blocked on
`get_cardinal_intervals`, excluded at `space_1d.hpp` as a computation over the knots rather
than a property of them. `Closes #N` does not fire on a base other than `main`, so #399 stays
open for those two.

## Evidence, gathered by the coordinator rather than reported

The authoring agent was killed twice by API errors (500, then 529) before it could open this
PR. Every number below was produced by re-running the checks, not taken from its report.

| check | result |
|---|---|
| `tests/parity/test_bspline_bezier_extraction.py` + `test_bspline_space_1d.py` | **252 passed** |
| `ctest -R test_bspline_extraction` | **passes** |
| extension-skip (`.so` moved aside) | **31 passed, 85 skipped** |
| downstream consumer census | clean, see below |

The extension-skip number is the one worth reading twice. The 31 matters more than the 85:
the Python halves keep running with the extension gone. Commit `9b734f0` exists because they
did not — a module-level `from pantr import _pantr_cpp` turned a missing extension into a
**collection error for the whole file**, which is the failure this project keeps paying for in
its worst form, since `tests/parity/conftest.py` calls an installation without the extension
the common local configuration.

### Mutation check

Run against the C++ unit test and, where it survived, against the parity suite.

| mutation | C++ unit | parity |
|---|---|---|
| **control** — identity init inverted (`(i == j) ? zero : one`) | **RED** | not needed |
| **M-a** — `alpha`/`beta` swapped in the left-boundary insertion | **GREEN** | **RED**, 6 failures including the 10x sweep at both dtypes |
| **M-b** — `boundary < degree` instead of `boundary < degree + 1` | GREEN | GREEN |

The control is there because a mutation harness that silently fails to rebuild produces the
same output as a mutation nothing catches.

**M-a is a finding about the C++ unit test, not about the port.** Its two unclamped cases
cannot distinguish `alpha` from `beta`: the uniform one has
`alpha = (1.0 - 0.5) / (1.5 - 0.5) = 0.5`, so `alpha == beta` and the swap is invisible, and
the other is degree 1, where `k + r < p` never iterates. The parity file's non-uniform
unclamped cubic does the work the unit test's header comment claims for itself. Recorded rather
than fixed here.

**M-b surviving is correct, and says the `+ 1` is redundant.** With `boundary == degree` the
original enters the branch but `reg = degree - boundary` is 0, so the loop does not iterate;
the mutant skips the branch and also does nothing. For `boundary < degree` both enter, for
`boundary > degree` neither does. Equivalent for every value, so no test can separate them.

### The bound, and the claim that was wrong

`b7ff319` corrects a **wrong derivation that no test could have caught**. The column-sum bound
charged a chain of at most `degree` insertions; the boundary sequence composes with element 0's
own, so element 0 alone reaches `2*degree - 1` stages and the inter-element copies carry the
chain across the vector. The bound was too tight by that factor and never failed, because the
observed error sits orders below either version. Both bounds now take the chain length from
the vector's own multiplicities. Found by a review's unproved suspicion, not by a test.

### Parity claim and its authority

The claim is **bitwise** where it holds, and the sweep reports a differing-bit count rather
than a margin. `design/backend_parity.md` **Rule 8** does not bite here: its concern is a bound
as large as the values it compares, which cannot arise where the bound is zero. What licenses
bit-identity as the criterion is the determinism rule, which admits it only where finite
precision does not bite. **Rule 12** governs the configuration gating, taken on the C++
*parameter* rather than on the test, so the Python half is not dropped with the extension.

### Downstream consumer census, three categories separately

pantr's CI cannot see that repository. Three files import pantr.

- **Private symbols: none.** This matters here because the PR removes three
  (`_bezier_structural_identity_mask_core`, `_tabulate_Bspline_Bezier_1D_extraction_core`,
  `_warmup_numba_functions`); each was checked by name, not only by an import pattern, since a
  `from ... import _foo` does not match a `pantr.`-prefixed search.
- **Public symbols:** `SpanwiseElementExtraction` (41 sites), `MultiLevelExtraction` (4). No
  signature in either changed.
- **Attribute writes: none.**

## A bug folded in, and one finding that is not ours to fix

**`8e2874a`** refuses a one-knot vector with the oracle's own message, with its regression test.

**A defect in the Python oracle, pinned but not fixed here.** The Numba extraction kernel
indexes **past its allocation** on a knot vector spanning no in-domain interval. The divergence
exists in both configurations and only the symptom changes, which is Rule 12's own shape:
interpreted, numpy bounds-checks `out[0]` on the empty result and raises `IndexError`;
compiled, the kernel indexes past the array and returns the empty result. The interpreted
symptom is what *proves* the compiled path indexes out of bounds — reading the source could
only suggest it. `5e33bf7` pins both, gated on the configuration rather than skipped, and the
note now says the index is measured rather than inferred. **This is a pre-existing oracle
defect, not something this port introduced, so it is left for triage rather than fixed here.**
