### PR TITLE
feat(bspline): own the Lagrange extraction target in C++

### DIFF
--- a/cpp/bindings/bspline_extraction_operators.cpp
+++ b/cpp/bindings/bspline_extraction_operators.cpp
@@ -187,8 +187,12 @@ span_nd<T, 3> prepare_operators(const_knots<T> knots, std::int64_t degree, doubl
 /// behaviour on this side, so it is a refusal rather than an assertion -- the same
 /// kind as the `out` and `multiplicity` checks the file comment lists.
 ///
+/// **Both callers refuse a negative `degree` before reaching this**, which they must:
+/// `degree + 1` is cast to `std::size_t` here, so a negative degree would wrap to an
+/// enormous side and the message would name it.
+///
 /// \param matrix The matrix as supplied.
-/// \param degree The polynomial degree.
+/// \param degree The polynomial degree, already known to be non-negative.
 /// \return A view over the matrix.
 /// \throws nb::value_error If the matrix is not `(degree + 1, degree + 1)`.
 template <class T>

--- a/cpp/bindings/bspline_extraction_operators.cpp
+++ b/cpp/bindings/bspline_extraction_operators.cpp
@@ -1,6 +1,6 @@
 /// \file
-/// Bindings for the Bézier extraction operator builder and its structural
-/// identity mask, from `pantr/bspline/extraction.hpp`.
+/// Bindings for the Bézier and Lagrange extraction operator builders and their
+/// structural identity masks, from `pantr/bspline/extraction.hpp`.
 ///
 /// Separate from `bspline_extraction.cpp` because the two are different ports with
 /// different parity claims: that file binds the tensor-product *apply* kernels,
@@ -49,9 +49,24 @@
 /// oracle for a reason no caller could see. `design/backend_parity.md` Rule 9 is the
 /// rule; this is where it is enforced at the seam.
 ///
-/// The mask entry point takes `int64` and `bool` arrays and no float at all, so its
-/// `.noconvert()` is about a silent `int32`-to-`int64` copy of a caller's index
-/// array rather than about arithmetic.
+/// The Bézier mask entry point takes `int64` and `bool` arrays and no float at all,
+/// so its `.noconvert()` is about a silent `int32`-to-`int64` copy of a caller's
+/// index array rather than about arithmetic. The Lagrange mask does carry a float
+/// matrix, and there `.noconvert()` is load-bearing again: the predicate compares
+/// that matrix against the identity **exactly**, and a `float32` matrix widened to
+/// `float64` on the way in would compare against a different set of bits than the
+/// caller holds.
+///
+/// ## The Lagrange pair takes the change-of-basis matrix, and does not build it
+///
+/// `change_basis.hpp` owns `lagrange_to_bernstein_1d`, the variant that picks its
+/// nodes is resolved on the Python side (`design/cross_backend_types.md`), and
+/// `pantr.change_basis` caches the finished matrix per `(degree, variant, dtype)`.
+/// Taking the matrix keeps all three: one implementation of the tabulation, no enum
+/// at the seam, and the cache still in front of it. It also makes the matrix common
+/// mode between the backends, so `tests/parity/test_bspline_lagrange_extraction.py`
+/// claims about the *extraction* rather than about the change of basis, whose own
+/// parity is `tests/parity/test_change_basis.py`'s.
 
 #include <cstddef>
 #include <cstdint>
@@ -70,6 +85,7 @@ namespace nb = nanobind;
 
 namespace {
 
+using pantr::span2d;
 using pantr::span_nd;
 
 template <class T>
@@ -89,6 +105,10 @@ using const_multiplicity = nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_co
 
 /// A per-interval boolean mask.
 using out_mask = nb::ndarray<bool, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// The `(degree + 1, degree + 1)` Lagrange-to-Bernstein change-of-basis matrix.
+template <class T>
+using const_matrix = nb::ndarray<const T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
 
 /// Refuse the arguments the oracle's `_check_spline_info` refuses, in its order.
 ///
@@ -121,17 +141,21 @@ void check_spline_info(const_knots<T> knots, std::int64_t degree) {
     }
 }
 
-/// Build the Bézier extraction operators, validated and dispatched.
+/// Run every refusal a builder owes, and return the view it writes into.
+///
+/// Shared by both builders, so the two cannot drift on which inputs they accept or
+/// on the text they refuse them with.
 ///
 /// \param knots The knot vector.
 /// \param degree The polynomial degree.
 /// \param tol The absolute parametric tolerance.
-/// \param out The `(n_intervals, degree + 1, degree + 1)` result.
+/// \param out The `(n_intervals, degree + 1, degree + 1)` result array.
+/// \return The rank-3 view over `out`.
 /// \throws nb::value_error If an argument fails the oracle's checks, if the vector
 ///         spans no interval, or if `out` has the wrong shape.
 template <class T>
-void bezier_extraction(const_knots<T> knots, std::int64_t degree, double tol,
-                       out_operators<T> out) {
+span_nd<T, 3> prepare_operators(const_knots<T> knots, std::int64_t degree, double tol,
+                                out_operators<T> out) {
     if (tol < 0.0) {
         throw nb::value_error("tol must be non-negative");
     }
@@ -152,11 +176,70 @@ void bezier_extraction(const_knots<T> knots, std::int64_t degree, double tol,
                               + std::to_string(side) + ", " + std::to_string(side) + ")")
                                  .c_str());
     }
+    return span_nd<T, 3>(out.data(), out.shape(0), side, side);
+}
 
-    const span_nd<T, 3> result(out.data(), out.shape(0), side, side);
+/// Refuse a change-of-basis matrix that is not `(degree + 1)` square.
+///
+/// No counterpart in the oracle: Layer 2 in Python takes the matrix from
+/// `pantr.change_basis`'s cache, which builds it at the degree it is asked for, so a
+/// wrong shape is unreachable there. Reaching the header with one would be undefined
+/// behaviour on this side, so it is a refusal rather than an assertion -- the same
+/// kind as the `out` and `multiplicity` checks the file comment lists.
+///
+/// \param matrix The matrix as supplied.
+/// \param degree The polynomial degree.
+/// \return A view over the matrix.
+/// \throws nb::value_error If the matrix is not `(degree + 1, degree + 1)`.
+template <class T>
+span2d<const T> checked_matrix(const_matrix<T> matrix, std::int64_t degree) {
+    const auto side = static_cast<std::size_t>(degree) + 1;
+    if (matrix.shape(0) != side || matrix.shape(1) != side) {
+        throw nb::value_error(("lagrange_to_bernstein must have shape ("
+                               + std::to_string(side) + ", " + std::to_string(side) + ")")
+                                  .c_str());
+    }
+    return span2d<const T>(matrix.data(), side, side);
+}
+
+/// Build the Bézier extraction operators, validated and dispatched.
+///
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance.
+/// \param out The `(n_intervals, degree + 1, degree + 1)` result.
+/// \throws nb::value_error If an argument fails the oracle's checks, if the vector
+///         spans no interval, or if `out` has the wrong shape.
+template <class T>
+void bezier_extraction(const_knots<T> knots, std::int64_t degree, double tol,
+                       out_operators<T> out) {
+    const std::span<const T> knot_span(knots.data(), knots.size());
+    const span_nd<T, 3> result = prepare_operators<T>(knots, degree, tol, out);
 
     const nb::gil_scoped_release release;
     pantr::bspline::bezier_extraction_1d<T>(knot_span, degree, tol, result);
+}
+
+/// Build the Lagrange extraction operators, validated and dispatched.
+///
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance.
+/// \param lagrange_to_bernstein The `(degree + 1, degree + 1)` change-of-basis matrix.
+/// \param out The `(n_intervals, degree + 1, degree + 1)` result.
+/// \throws nb::value_error If an argument fails the oracle's checks, if the vector
+///         spans no interval, or if either array has the wrong shape.
+template <class T>
+void lagrange_extraction(const_knots<T> knots, std::int64_t degree, double tol,
+                         const_matrix<T> lagrange_to_bernstein, out_operators<T> out) {
+    const std::span<const T> knot_span(knots.data(), knots.size());
+    const span_nd<T, 3> result = prepare_operators<T>(knots, degree, tol, out);
+    // After `prepare_operators`, so a negative degree is refused with the oracle's
+    // message rather than with a shape complaint about a matrix nobody could size.
+    const span2d<const T> matrix = checked_matrix<T>(lagrange_to_bernstein, degree);
+
+    const nb::gil_scoped_release release;
+    pantr::bspline::lagrange_extraction_1d<T>(knot_span, degree, tol, matrix, result);
 }
 
 /// Mark the intervals whose Bézier operator is the identity, validated and dispatched.
@@ -186,6 +269,37 @@ void bezier_identity_mask(const_multiplicity multiplicity, std::int64_t degree, 
     pantr::bspline::bezier_structural_identity_mask(counts, degree, flags);
 }
 
+/// Mark the intervals whose Lagrange operator is the identity, validated and dispatched.
+///
+/// \param multiplicity The in-domain knot multiplicities, `n_intervals + 1` of them.
+/// \param degree The polynomial degree.
+/// \param lagrange_to_bernstein The `(degree + 1, degree + 1)` change-of-basis matrix.
+/// \param out One flag per interval.
+/// \throws nb::value_error If `multiplicity` is empty, `degree` is negative, `out` is
+///         not one shorter than `multiplicity`, or the matrix has the wrong shape.
+template <class T>
+void lagrange_identity_mask(const_multiplicity multiplicity, std::int64_t degree,
+                            const_matrix<T> lagrange_to_bernstein, out_mask out) {
+    if (degree < 0) {
+        throw nb::value_error("degree must be non-negative");
+    }
+    if (multiplicity.size() == 0) {
+        throw nb::value_error("multiplicity must hold at least one class");
+    }
+    const std::size_t n_intervals = multiplicity.size() - 1;
+    if (out.size() != n_intervals) {
+        throw nb::value_error(
+            ("out must have " + std::to_string(n_intervals) + " elements").c_str());
+    }
+    const span2d<const T> matrix = checked_matrix<T>(lagrange_to_bernstein, degree);
+
+    const std::span<const std::int64_t> counts(multiplicity.data(), multiplicity.size());
+    const std::span<bool> flags(out.data(), out.size());
+
+    const nb::gil_scoped_release release;
+    pantr::bspline::lagrange_structural_identity_mask<T>(counts, degree, matrix, flags);
+}
+
 }  // namespace
 
 void register_bspline_extraction_operators(nb::module_& m) {
@@ -198,4 +312,16 @@ void register_bspline_extraction_operators(nb::module_& m) {
           nb::arg("degree"), nb::arg("tol"), nb::arg("out").noconvert());
     m.def("bezier_structural_identity_mask", &bezier_identity_mask,
           nb::arg("multiplicities").noconvert(), nb::arg("degree"), nb::arg("out").noconvert());
+    m.def("lagrange_extraction_1d", &lagrange_extraction<double>, nb::arg("knots").noconvert(),
+          nb::arg("degree"), nb::arg("tol"), nb::arg("lagrange_to_bernstein").noconvert(),
+          nb::arg("out").noconvert());
+    m.def("lagrange_extraction_1d", &lagrange_extraction<float>, nb::arg("knots").noconvert(),
+          nb::arg("degree"), nb::arg("tol"), nb::arg("lagrange_to_bernstein").noconvert(),
+          nb::arg("out").noconvert());
+    m.def("lagrange_structural_identity_mask", &lagrange_identity_mask<double>,
+          nb::arg("multiplicities").noconvert(), nb::arg("degree"),
+          nb::arg("lagrange_to_bernstein").noconvert(), nb::arg("out").noconvert());
+    m.def("lagrange_structural_identity_mask", &lagrange_identity_mask<float>,
+          nb::arg("multiplicities").noconvert(), nb::arg("degree"),
+          nb::arg("lagrange_to_bernstein").noconvert(), nb::arg("out").noconvert());
 }

--- a/cpp/include/pantr/bspline/extraction.hpp
+++ b/cpp/include/pantr/bspline/extraction.hpp
@@ -4,12 +4,19 @@
 /// The Bézier extraction operators of a 1D B-spline space, and the mask that says
 /// which of them are already the identity.
 ///
-/// The C++ twin of `pantr.bspline._bspline_extraction`'s Bézier half.
-/// `design/extraction_port.md` calls this slice **S3**, minus the two targets it
-/// leaves for later: **Lagrange** is this operator post-multiplied by
-/// `lagrange_to_bernstein_1d`, which `change_basis.hpp` already provides, and
-/// **cardinal** additionally needs the cardinal-interval scan, which is not ported
-/// and which `bspline/space_1d.hpp` deliberately excludes from the type.
+/// The C++ twin of `pantr.bspline._bspline_extraction`'s Bézier and Lagrange
+/// halves. `design/extraction_port.md` calls this slice **S3**, minus the one
+/// target it still leaves for later: **cardinal** needs the cardinal-interval scan,
+/// which is not ported and which `bspline/space_1d.hpp` deliberately excludes from
+/// the type.
+///
+/// The Lagrange operator is the Bézier one post-multiplied by the
+/// Lagrange-to-Bernstein matrix. That matrix is an **argument** here rather than
+/// something this file builds: `change_basis.hpp` already owns it, the variant that
+/// selects its nodes is resolved on the Python side and never crosses the seam
+/// (`design/cross_backend_types.md`), and passing the finished matrix is what makes
+/// it common mode between the two backends so its own parity is
+/// `tests/parity/test_change_basis.py`'s question and not this file's.
 ///
 /// ## What an operator is
 ///
@@ -26,6 +33,17 @@
 /// `sum_i N_i = 1` and `sum_j B_j = 1` plus the linear independence of `B`, so it
 /// says `ones^T C_e = ones^T`. `tests/parity/test_bspline_bezier_extraction.py`
 /// uses it as one of its two independent accuracy oracles.
+///
+/// The **Lagrange** operator `A_e = C_e L` satisfies `N_e(x) = A_e @ Lag(xi)` for
+/// the Lagrange basis of the same degree on the reference interval, `L` being
+/// `L[j, k] = B_j(x_k)`. Two properties follow and both are used as oracles:
+/// because the Lagrange basis is cardinal at its own nodes, **column `k` of `A_e`
+/// is the vector of B-spline functions evaluated at node `k`** mapped into the
+/// interval; and because every node lies in `[0, 1]` where the Bernstein basis is
+/// non-negative and sums to one, `L` is column-stochastic, so `A_e` is a product of
+/// two column-stochastic matrices and is itself column-stochastic. The second one
+/// contradicts `design/extraction_port.md`, which said the Lagrange-to-Bernstein
+/// matrix has negative entries; it does not, and the doc carries the correction.
 ///
 /// ## The accumulator is `T`, and that is a promise rather than a detail
 ///
@@ -206,6 +224,62 @@ void bezier_extraction_1d(std::span<const T> knots, std::int64_t degree, double 
     }
 }
 
+/// Build the Lagrange extraction operator of every in-domain interval.
+///
+/// `A_e = C_e L`, with `C_e` the Bézier operator of interval `e` and `L` the
+/// Lagrange-to-Bernstein matrix of the same degree, so that `N_e(x) = A_e @ Lag(xi)`.
+/// The product is formed in place, one row at a time, over a scratch copy of the
+/// row being overwritten.
+///
+/// **The accumulator is `T`.** The oracle contracts this product with
+/// :func:`numpy.matmul`, whose BLAS reaches `sgemm` at `float32` and accumulates in
+/// the storage format, and `design/backend_parity.md` Rule 9 makes reproducing that
+/// width part of the contract rather than an implementation detail. The *summation
+/// order* is not part of it: numpy's is unspecified and blocked, so the two backends
+/// are bounded rather than bitwise here, which is the one place the Lagrange target
+/// differs in kind from the Bézier one.
+///
+/// \tparam T Scalar type of the knots, of the matrix and of the operators.
+/// \param knots A non-decreasing knot vector of at least `2 * degree + 2` entries.
+/// \param degree The polynomial degree, non-negative.
+/// \param tol The absolute parametric tolerance, from `knot_tolerance` or from a
+///        space's `tolerance()`.
+/// \param lagrange_to_bernstein The `(degree + 1, degree + 1)` matrix
+///        `L[j, k] = B_j(x_k)`, from `pantr::lagrange_to_bernstein_1d`.
+/// \param out The operators, shape `(n_intervals, degree + 1, degree + 1)`.
+///        Overwritten in full.
+///
+/// \note Inputs are assumed to be correct (no validation performed). For general
+///       use, call `pantr.bspline._bspline_extraction`'s
+///       `_tabulate_Bspline_Lagrange_1D_extraction_impl`, whose C++ half is
+///       `cpp/bindings/bspline_extraction_operators.cpp`.
+template <Real T>
+void lagrange_extraction_1d(std::span<const T> knots, std::int64_t degree, double tol,
+                            span2d<const T> lagrange_to_bernstein, span_nd<T, 3> out) {
+    const auto p = static_cast<std::size_t>(degree);
+    PANTR_PRECONDITION(lagrange_to_bernstein.extent(0) == p + 1
+                           && lagrange_to_bernstein.extent(1) == p + 1,
+                       "the change-of-basis matrix is (degree + 1) square");
+
+    bezier_extraction_1d<T>(knots, degree, tol, out);
+
+    std::vector<T> row(p + 1, T(0.0));
+    for (std::size_t e = 0; e < out.extent(0); ++e) {
+        for (std::size_t i = 0; i <= p; ++i) {
+            for (std::size_t k = 0; k <= p; ++k) {
+                row[k] = at(out, e, i, k);
+            }
+            for (std::size_t j = 0; j <= p; ++j) {
+                T acc(0.0);
+                for (std::size_t k = 0; k <= p; ++k) {
+                    acc += row[k] * at(lagrange_to_bernstein, k, j);
+                }
+                at(out, e, i, j) = acc;
+            }
+        }
+    }
+}
+
 /// Mark the intervals whose Bézier extraction operator is the identity.
 ///
 /// Interval `e` is one exactly when both of its bounding in-domain knots have
@@ -232,6 +306,76 @@ inline void bezier_structural_identity_mask(std::span<const std::int64_t> multip
     PANTR_PRECONDITION(out.size() == n_intervals, "out needs one flag per interval");
     for (std::size_t e = 0; e < n_intervals; ++e) {
         out[e] = multiplicity[e] >= threshold && multiplicity[e + 1] >= threshold;
+    }
+}
+
+
+/// Mark the intervals whose Lagrange extraction operator is the identity.
+///
+/// The predicate is the Bézier mask when `L` is the identity, and all-false
+/// otherwise, which is the oracle's rule. **The all-false half is a claim and it is
+/// provable.** `A_e = C_e L = I` needs `C_e = L^{-1}`; `C_e` is entrywise
+/// non-negative, so `L^{-1}` would have to be too, and a non-negative matrix with a
+/// non-negative inverse is monomial. Both `C_e` and `L` are column-stochastic, so
+/// the monomial matrix is a permutation. `L[j, k] = B_j(x_k)` is a permutation only
+/// if every node makes one Bernstein function `1` and the rest `0`, which on `[0, 1]`
+/// only `x = 0` and `x = 1` do; so `degree <= 1`, and with the ascending nodes every
+/// variant here produces, that permutation is the identity. Hence `A_e = I` forces
+/// `L = I`, and the else-branch is sound. Measured, `L` is the identity for the
+/// equispaced, Gauss-Lobatto-Legendre and second-kind Chebyshev families at degree 1
+/// and for no other family or degree tried.
+///
+/// The comparison against the identity is **exact**: `L`'s entries are the ones the
+/// caller holds, the identity's are `0` and `1`, and a matrix that misses the
+/// identity by an ulp yields a non-identity operator, which is what the mask is
+/// asked about. `design/backend_parity.md` Rule 11's distinction -- a verdict is not
+/// a displaced value, and there is no tolerance to apply to it.
+///
+/// **Degree 0 does not reach here.** `compute_lagrange_to_bernstein_1d` refuses a
+/// degree below 1, so there is no matrix to pass and the oracle's Layer 2 answers
+/// all-true without one; this function is therefore never called at `degree == 0`,
+/// and reproducing that short-circuit here would be inventing a matrix nobody built.
+///
+/// \tparam T Scalar type of the change-of-basis matrix.
+/// \param multiplicity The in-domain knot multiplicities,
+///        `BsplineSpace1D::multiplicity_in_domain()`, of length `n_intervals + 1`.
+/// \param degree The polynomial degree.
+/// \param lagrange_to_bernstein The `(degree + 1, degree + 1)` matrix.
+/// \param out One flag per interval, length `multiplicity.size() - 1`.
+///
+/// \note Inputs are assumed to be correct (no validation performed). For general
+///       use, call `pantr.bspline.spanwise_element_extraction`'s
+///       `_lagrange_structural_identity_mask`.
+template <Real T>
+void lagrange_structural_identity_mask(std::span<const std::int64_t> multiplicity,
+                                       std::int64_t degree,
+                                       span2d<const T> lagrange_to_bernstein,
+                                       std::span<bool> out) {
+    const auto p = static_cast<std::size_t>(degree);
+    PANTR_PRECONDITION(lagrange_to_bernstein.extent(0) == p + 1
+                           && lagrange_to_bernstein.extent(1) == p + 1,
+                       "the change-of-basis matrix is (degree + 1) square");
+    PANTR_PRECONDITION(!multiplicity.empty(), "multiplicity must hold at least one class");
+    PANTR_PRECONDITION(out.size() == multiplicity.size() - 1,
+                       "out needs one flag per interval");
+
+    bool is_identity = true;
+    for (std::size_t j = 0; j <= p && is_identity; ++j) {
+        for (std::size_t k = 0; k <= p; ++k) {
+            const T want = (j == k) ? T(1.0) : T(0.0);
+            if (at(lagrange_to_bernstein, j, k) != want) {
+                is_identity = false;
+                break;
+            }
+        }
+    }
+
+    if (is_identity) {
+        bezier_structural_identity_mask(multiplicity, degree, out);
+        return;
+    }
+    for (std::size_t e = 0; e < out.size(); ++e) {
+        out[e] = false;
     }
 }
 

--- a/cpp/include/pantr/bspline/extraction.hpp
+++ b/cpp/include/pantr/bspline/extraction.hpp
@@ -239,6 +239,15 @@ void bezier_extraction_1d(std::span<const T> knots, std::int64_t degree, double 
 /// are bounded rather than bitwise here, which is the one place the Lagrange target
 /// differs in kind from the Bézier one.
 ///
+/// **The width is checked here rather than by the parity suite**, and that is forced.
+/// A bounded claim must admit the two summation orders' own disagreement, which at
+/// `float32` is one unit in the last place -- the same size as the narrow-versus-wide
+/// gap, and not separable from it, since a contraction of non-negative terms has no
+/// cancellation to make the width gap dominate. Measured by mutating this line to a
+/// `double` accumulator: the whole Python parity file still passes.
+/// `cpp/tests/test_bspline_extraction.cpp`'s `check_the_accumulator_is_the_storage_type`
+/// is the test that fails instead.
+///
 /// \tparam T Scalar type of the knots, of the matrix and of the operators.
 /// \param knots A non-decreasing knot vector of at least `2 * degree + 2` entries.
 /// \param degree The polynomial degree, non-negative.

--- a/cpp/include/pantr/bspline/extraction.hpp
+++ b/cpp/include/pantr/bspline/extraction.hpp
@@ -239,14 +239,17 @@ void bezier_extraction_1d(std::span<const T> knots, std::int64_t degree, double 
 /// are bounded rather than bitwise here, which is the one place the Lagrange target
 /// differs in kind from the Bézier one.
 ///
-/// **The width is checked here rather than by the parity suite**, and that is forced.
-/// A bounded claim must admit the two summation orders' own disagreement, which at
-/// `float32` is one unit in the last place -- the same size as the narrow-versus-wide
-/// gap, and not separable from it, since a contraction of non-negative terms has no
-/// cancellation to make the width gap dominate. Measured by mutating this line to a
-/// `double` accumulator: the whole Python parity file still passes.
-/// `cpp/tests/test_bspline_extraction.cpp`'s `check_the_accumulator_is_the_storage_type`
-/// is the test that fails instead.
+/// **The width is checked here rather than by the parity suite, and no bound could do
+/// it.** The parity bound is derived from each backend's forward error against the exact
+/// product. A `double` accumulator has a *smaller* forward error than a `T` one, so it
+/// sits inside the same bound by construction: any claim built that way admits a more
+/// accurate backend, which is what `design/backend_parity.md` Rule 8 records as
+/// something a bound deliberately does not license. Nothing about the constant would
+/// change it. Measured alongside the argument, so the two agree: mutating this line to a
+/// `double` accumulator leaves the whole Python parity file green, and the gap it opens
+/// at `float32` is one unit in the last place, the same size as the two backends' own
+/// disagreement. `cpp/tests/test_bspline_extraction.cpp`'s
+/// `check_the_accumulator_is_the_storage_type` is the test that fails instead.
 ///
 /// \tparam T Scalar type of the knots, of the matrix and of the operators.
 /// \param knots A non-decreasing knot vector of at least `2 * degree + 2` entries.
@@ -254,7 +257,10 @@ void bezier_extraction_1d(std::span<const T> knots, std::int64_t degree, double 
 /// \param tol The absolute parametric tolerance, from `knot_tolerance` or from a
 ///        space's `tolerance()`.
 /// \param lagrange_to_bernstein The `(degree + 1, degree + 1)` matrix
-///        `L[j, k] = B_j(x_k)`, from `pantr::lagrange_to_bernstein_1d`.
+///        `L[j, k] = B_j(x_k)`, from `pantr::lagrange_to_bernstein_1d`. Must not
+///        overlap `out`: the product is formed in place over a scratch copy of the
+///        row being overwritten, which makes `out` safe against itself and nothing
+///        else. Both callers pass a cached matrix that owns its own storage.
 /// \param out The operators, shape `(n_intervals, degree + 1, degree + 1)`.
 ///        Overwritten in full.
 ///

--- a/cpp/tests/test_bspline_extraction.cpp
+++ b/cpp/tests/test_bspline_extraction.cpp
@@ -62,6 +62,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <utility>
 #include <cstdint>
 #include <limits>
 #include <span>
@@ -749,6 +750,58 @@ void check_lagrange_identity_mask() {
     }
 }
 
+/// The contraction accumulates in `T`, not in `double`.
+///
+/// **This is the one contract the Python parity suite cannot check**, and it is worth
+/// saying why rather than assuming the suite covers it. That suite's Lagrange claim is
+/// *bounded* -- the oracle sums the contraction with a BLAS `gemm` whose order is
+/// unspecified, so bit-identity is not available -- and the bound has to admit the two
+/// summation orders' own disagreement. Measured over the shipped table at `float32`,
+/// that disagreement and the narrow-versus-wide gap are **both exactly one unit in the
+/// last place**, and they cannot be separated by any bound: the contraction sums
+/// non-negative terms, so there is no cancellation to make the width gap dominate.
+/// `design/backend_parity.md` Rule 9 says the width is part of the contract; this is
+/// where it is enforced.
+///
+/// The construction. The unclamped uniform quadratic vector's Bézier operators are both
+/// `[[1/2, 0, 0], [1/2, 1, 1/2], [0, 0, 1/2]]`, so row 1 contracts with weights
+/// `(1/2, 1, 1/2)`. Against a matrix column `(2^-23, 1, 2^-23)` at `float32`, each
+/// outer term is `2^-24`, exactly half an ulp of one, so a `float32` accumulator rounds
+/// both to even and returns exactly `1`, while a `double` accumulator reaches
+/// `1 + 2^-23` and stores it exactly. One ulp apart, and only one of the two is what
+/// the oracle computes.
+///
+/// The matrix is not a Lagrange-to-Bernstein matrix and does not have to be: it is an
+/// argument, and what is under test is the contraction.
+void check_the_accumulator_is_the_storage_type() {
+    const std::vector<float> knots = {0.0F, 0.5F, 1.0F, 1.5F, 2.0F, 2.5F, 3.0F};
+    const float tiny = std::ldexp(1.0F, -23);
+    // Column-major reading: every column is (tiny, 1, tiny), so every entry of row 1
+    // exercises the same cancellation-free half-ulp sum.
+    const std::vector<float> matrix = {tiny, tiny, tiny, 1.0F, 1.0F, 1.0F, tiny, tiny, tiny};
+
+    const Operators<float> ops = build_lagrange<float>(knots, 2, 0.0, matrix);
+    PANTR_CHECK_MSG(ops.count == 2, "the unclamped uniform quadratic vector has two elements");
+    for (std::size_t e = 0; e < ops.count; ++e) {
+        for (std::size_t j = 0; j < ops.side; ++j) {
+            PANTR_CHECK_MSG(at(ops.view(), e, 1, j) == 1.0F,
+                            "the contraction accumulated wider than float, so a pair of "
+                            "half-ulp terms survived where the oracle rounds them away");
+        }
+    }
+
+    // And the construction really does separate the two widths, so the assertion above
+    // is not passing because both give the same answer.
+    double wide = 0.0;
+    for (const auto& [weight, entry] :
+         std::array<std::pair<float, float>, 3>{{{0.5F, tiny}, {1.0F, 1.0F}, {0.5F, tiny}}}) {
+        wide += static_cast<double>(weight) * static_cast<double>(entry);
+    }
+    PANTR_CHECK_MSG(static_cast<float>(wide) != 1.0F,
+                    "the width probe no longer separates a float accumulator from a double "
+                    "one, so the check above asserts nothing");
+}
+
 }  // namespace
 
 int main() {
@@ -774,5 +827,6 @@ int main() {
     check_lagrange_columns_are_a_partition_of_unity<float>();
     check_lagrange_identity_mask<double>();
     check_lagrange_identity_mask<float>();
+    check_the_accumulator_is_the_storage_type();
     return pantr::test::summary("test_bspline_extraction");
 }

--- a/cpp/tests/test_bspline_extraction.cpp
+++ b/cpp/tests/test_bspline_extraction.cpp
@@ -1,5 +1,5 @@
 /// \file
-/// The Bézier extraction operators and the structural identity mask.
+/// The Bézier and Lagrange extraction operators and the structural identity masks.
 ///
 /// ## Where the expected values come from, and none of them from the oracle
 ///
@@ -31,6 +31,26 @@
 ///    local knot pattern. The second one is what exercises the non-clamped
 ///    boundary-insertion branch against a value derived elsewhere.
 ///
+/// ## The Lagrange half
+///
+/// `A_e = C_e L`, and the change-of-basis matrix is an argument rather than something
+/// this file builds, so the checks are about the product:
+///
+///  - **`L = I` reproduces the Bézier operator exactly.** Every term of the
+///    contraction is `C[i,k] * 0` or `C[i,j] * 1`, so nothing rounds and the two
+///    builders must agree bit for bit. That is what pins the index order: a
+///    transposed product would give `C^T` here.
+///  - **A hand-derived exact table.** At degree 2 with equispaced nodes,
+///    `L = [[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]]` from `L[j,k] = B_j(x_k)` at
+///    `x = 0, 1/2, 1`, and the quadratic three-element open spline's Bézier table is
+///    halves, so every entry of the product is a binary rational and the comparison
+///    carries no tolerance. Written out in `check_lagrange_quadratic_open`.
+///  - **The columns still sum to one.** `L` is column-stochastic -- its columns are
+///    the Bernstein basis at a node, non-negative and summing to one -- so a product
+///    of two column-stochastic matrices is column-stochastic. This also says the
+///    Lagrange operator is entrywise non-negative, which
+///    `design/extraction_port.md` denied and which is checked here.
+///
 /// ## What is not checked here
 ///
 /// Agreement with the Python oracle, which is
@@ -55,9 +75,12 @@
 namespace {
 
 using pantr::at;
+using pantr::span2d;
 using pantr::span_nd;
 using pantr::bspline::bezier_extraction_1d;
 using pantr::bspline::bezier_structural_identity_mask;
+using pantr::bspline::lagrange_extraction_1d;
+using pantr::bspline::lagrange_structural_identity_mask;
 using pantr::bspline::classify_knots;
 using pantr::bspline::KnotClassRange;
 using pantr::bspline::KnotClasses;
@@ -532,6 +555,200 @@ void check_the_mask_agrees_with_the_operators() {
     }
 }
 
+/// Build every Lagrange operator of a knot vector.
+///
+/// \tparam T Scalar type.
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance.
+/// \param matrix The `(degree + 1, degree + 1)` change-of-basis matrix, row-major.
+/// \return The operators.
+template <class T>
+Operators<T> build_lagrange(const std::vector<T>& knots, std::int64_t degree, double tol,
+                            const std::vector<T>& matrix) {
+    const std::span<const T> span(knots);
+    const KnotClassRange range = classify_knots<T>(span, degree, tol);
+    const auto count = static_cast<std::size_t>(range.num_intervals());
+    const auto side = static_cast<std::size_t>(degree) + 1;
+    Operators<T> ops{std::vector<T>(count * side * side, T(0.0)), count, side};
+    const span_nd<T, 3> view(ops.storage.data(), count, side, side);
+    lagrange_extraction_1d<T>(span, degree, tol, span2d<const T>(matrix.data(), side, side),
+                              view);
+    return ops;
+}
+
+/// The identity matrix of a given side, row-major.
+///
+/// \tparam T Scalar type.
+/// \param side The number of rows and columns.
+/// \return The matrix.
+template <class T>
+std::vector<T> identity_matrix(std::size_t side) {
+    std::vector<T> matrix(side * side, T(0.0));
+    for (std::size_t i = 0; i < side; ++i) {
+        matrix[i * side + i] = T(1.0);
+    }
+    return matrix;
+}
+
+/// With the identity change of basis, the Lagrange builder is the Bézier one.
+///
+/// Bitwise, not within a tolerance: every term of the contraction is `C[i,k] * 0` or
+/// `C[i,j] * 1`, and a sum of exact zeros with one exact term rounds nothing. That
+/// is what makes this able to catch a transposed product, which would return `C^T`.
+template <class T>
+void check_lagrange_with_the_identity_reproduces_bezier() {
+    const std::vector<std::vector<T>> vectors = {
+        {T(0.0), T(0.0), T(0.0), T(1.0), T(2.0), T(3.0), T(3.0), T(3.0)},
+        {T(0.0), T(0.5), T(1.0), T(1.5), T(2.0), T(2.5), T(3.0)},
+        {T(0.0), T(0.0), T(0.0), T(0.0), T(1.0), T(2.0), T(3.0), T(4.0), T(4.0), T(4.0), T(4.0)},
+    };
+    const std::vector<std::int64_t> degrees = {2, 2, 3};
+    for (std::size_t c = 0; c < vectors.size(); ++c) {
+        const std::size_t side = static_cast<std::size_t>(degrees[c]) + 1;
+        const Operators<T> bezier = build<T>(vectors[c], degrees[c], 0.0);
+        const Operators<T> lagrange =
+            build_lagrange<T>(vectors[c], degrees[c], 0.0, identity_matrix<T>(side));
+        PANTR_CHECK_MSG(bezier.storage.size() == lagrange.storage.size(),
+                        "the two builders disagree on how many operators there are");
+        for (std::size_t n = 0; n < bezier.storage.size(); ++n) {
+            PANTR_CHECK_MSG(bezier.storage[n] == lagrange.storage[n],
+                            "the identity change of basis moved a bit");
+        }
+    }
+}
+
+/// The quadratic three-element open spline against a hand-derived exact table.
+///
+/// The Bézier table is `check_quadratic_open`'s. The equispaced degree-2
+/// Lagrange-to-Bernstein matrix is `L[j,k] = B_j(x_k)` at `x = 0, 1/2, 1`, i.e.
+/// `[[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]]`. Multiplying out gives, per element,
+///
+///     e = 0: [[1, 1/4, 0], [0, 5/8, 1/2], [0, 1/8, 1/2]]
+///     e = 1: [[1/2, 1/8, 0], [1/2, 3/4, 1/2], [0, 1/8, 1/2]]
+///     e = 2: [[1/2, 1/8, 0], [1/2, 5/8, 0], [0, 1/4, 1]]
+///
+/// Every entry is a binary rational, and so is every partial sum of the contraction,
+/// so the comparison is exact in `float32` as well as `float64`.
+template <class T>
+void check_lagrange_quadratic_open() {
+    const std::vector<T> knots = {T(0.0), T(0.0), T(0.0), T(1.0),
+                                  T(2.0), T(3.0), T(3.0), T(3.0)};
+    const std::vector<T> matrix = {T(1.0), T(0.25), T(0.0), T(0.0), T(0.5),
+                                   T(0.0), T(0.0),  T(0.25), T(1.0)};
+    const std::vector<T> expected = {
+        T(1.0),  T(0.25),  T(0.0), T(0.0), T(0.625), T(0.5), T(0.0), T(0.125), T(0.5),
+        T(0.5),  T(0.125), T(0.0), T(0.5), T(0.75),  T(0.5), T(0.0), T(0.125), T(0.5),
+        T(0.5),  T(0.125), T(0.0), T(0.5), T(0.625), T(0.0), T(0.0), T(0.25),  T(1.0),
+    };
+    const Operators<T> ops = build_lagrange<T>(knots, 2, 0.0, matrix);
+    PANTR_CHECK_MSG(ops.storage.size() == expected.size(),
+                    "the quadratic open spline should have three 3x3 operators");
+    for (std::size_t n = 0; n < expected.size(); ++n) {
+        PANTR_CHECK_MSG(ops.storage[n] == expected[n],
+                        "a Lagrange operator entry misses its exact binary rational");
+    }
+}
+
+/// Each Lagrange operator's column sums reproduce the matrix's own, and none is negative.
+///
+/// The invariant is `sum_i A[i,j] = sum_k (sum_i C[i,k]) L[k,j] = sum_k L[k,j]`, using
+/// the Bézier column sums. It is compared against `sum_k L[k,j]` **as the supplied
+/// matrix actually sums**, not against one: `L`'s columns sum to one in exact
+/// arithmetic, being the Bernstein basis at a node, but the thirds of the cubic case
+/// below do not sum to one in binary, and folding that defect in exactly is better
+/// than bounding it. The bound then covers only the Bézier chain plus the
+/// contraction's own `gamma_{degree + 1}`, and the amplification is one because every
+/// entry stays in `[0, 1]`.
+///
+/// Non-negativity comes with it: `L` is entrywise non-negative because every Lagrange
+/// node lies in `[0, 1]` where the Bernstein basis is, and `C_e` is a product of
+/// convex combinations, so the product cannot be negative.
+template <class T>
+void check_lagrange_columns_are_a_partition_of_unity() {
+    // Equispaced degree 2 and degree 3, `L[j,k] = B_j(x_k)`. Degree 3's nodes are
+    // 0, 1/3, 2/3, 1, so its entries are ninths and twenty-sevenths.
+    const std::vector<T> matrix2 = {T(1.0), T(0.25), T(0.0), T(0.0), T(0.5),
+                                    T(0.0), T(0.0),  T(0.25), T(1.0)};
+    const std::vector<T> matrix3 = {
+        T(1.0), T(8.0 / 27.0), T(1.0 / 27.0), T(0.0), T(0.0), T(12.0 / 27.0), T(6.0 / 27.0),
+        T(0.0), T(0.0),        T(6.0 / 27.0), T(12.0 / 27.0), T(0.0), T(0.0), T(1.0 / 27.0),
+        T(8.0 / 27.0), T(1.0),
+    };
+    struct Case {
+        std::vector<T> knots;
+        std::int64_t degree;
+        const std::vector<T>* matrix;
+    };
+    const std::vector<Case> cases = {
+        {{T(0.0), T(0.0), T(0.0), T(1.0), T(2.0), T(3.0), T(3.0), T(3.0)}, 2, &matrix2},
+        {{T(0.0), T(0.0), T(0.0), T(1.0), T(1.0), T(2.0), T(3.0), T(3.0), T(3.0)}, 2, &matrix2},
+        {{T(0.0), T(0.5), T(1.0), T(1.5), T(2.0), T(2.5), T(3.0)}, 2, &matrix2},
+        {{T(0.0), T(0.0), T(0.0), T(0.0), T(0.3), T(0.7), T(1.0), T(1.0), T(1.0), T(1.0)}, 3,
+         &matrix3},
+    };
+    for (const Case& one : cases) {
+        const Operators<T> ops = build_lagrange<T>(one.knots, one.degree, 0.0, *one.matrix);
+        // The Bézier chain, plus `degree + 1` roundings for the contraction, plus the
+        // `degree` additions of the column sum itself. `column_sum_tolerance` already
+        // charges the last of those, so only the contraction is added here.
+        const std::int64_t stages = insertion_stages<T>(one.knots, one.degree, 0.0);
+        const double bound =
+            column_sum_tolerance<T>(one.degree, stages + one.degree + 1);
+        for (std::size_t j = 0; j < ops.side; ++j) {
+            double target = 0.0;
+            for (std::size_t k = 0; k < ops.side; ++k) {
+                target += static_cast<double>((*one.matrix)[k * ops.side + j]);
+            }
+            PANTR_CHECK_MSG(std::abs(target - 1.0) <= bound,
+                            "the supplied change-of-basis matrix is not column-stochastic");
+            for (std::size_t e = 0; e < ops.count; ++e) {
+                double total = 0.0;
+                for (std::size_t i = 0; i < ops.side; ++i) {
+                    const double entry = static_cast<double>(at(ops.view(), e, i, j));
+                    PANTR_CHECK_MSG(entry >= 0.0,
+                                    "a Lagrange operator entry is negative, so neither factor "
+                                    "of the product is column-stochastic after all");
+                    total += entry;
+                }
+                PANTR_CHECK_MSG(std::abs(total - target) <= bound,
+                                "a Lagrange operator column does not sum to the matrix's");
+            }
+        }
+    }
+}
+
+/// The Lagrange mask is the Bézier mask under the identity and all-false otherwise.
+template <class T>
+void check_lagrange_identity_mask() {
+    const std::vector<std::int64_t> multiplicity = {3, 1, 3, 3};
+    std::array<bool, 3> lagrange{};
+    std::array<bool, 3> bezier{};
+    const std::span<bool> lagrange_flags(lagrange.data(), lagrange.size());
+    const std::span<bool> bezier_flags(bezier.data(), bezier.size());
+
+    const std::vector<T> identity = identity_matrix<T>(3);
+    bezier_structural_identity_mask(multiplicity, 2, bezier_flags);
+    lagrange_structural_identity_mask<T>(multiplicity, 2,
+                                         span2d<const T>(identity.data(), 3, 3), lagrange_flags);
+    PANTR_CHECK_MSG(bezier[2] && !bezier[0] && !bezier[1],
+                    "the Bézier mask should flag only the element between two full knots");
+    for (std::size_t e = 0; e < bezier.size(); ++e) {
+        PANTR_CHECK_MSG(lagrange[e] == bezier[e],
+                        "under the identity change of basis the two masks must agree");
+    }
+
+    // One entry off the identity, by the smallest amount there is: the predicate is
+    // exact, so this must flip every flag to false.
+    std::vector<T> nudged = identity;
+    nudged[1] = std::numeric_limits<T>::denorm_min();
+    lagrange_structural_identity_mask<T>(multiplicity, 2,
+                                         span2d<const T>(nudged.data(), 3, 3), lagrange_flags);
+    for (const bool flag : lagrange) {
+        PANTR_CHECK_MSG(!flag, "a change of basis that is not the identity forbids every flag");
+    }
+}
+
 }  // namespace
 
 int main() {
@@ -549,5 +766,13 @@ int main() {
     check_identity_mask();
     check_the_mask_agrees_with_the_operators<double>();
     check_the_mask_agrees_with_the_operators<float>();
+    check_lagrange_with_the_identity_reproduces_bezier<double>();
+    check_lagrange_with_the_identity_reproduces_bezier<float>();
+    check_lagrange_quadratic_open<double>();
+    check_lagrange_quadratic_open<float>();
+    check_lagrange_columns_are_a_partition_of_unity<double>();
+    check_lagrange_columns_are_a_partition_of_unity<float>();
+    check_lagrange_identity_mask<double>();
+    check_lagrange_identity_mask<float>();
     return pantr::test::summary("test_bspline_extraction");
 }

--- a/design/extraction_port.md
+++ b/design/extraction_port.md
@@ -595,6 +595,17 @@ CPython refuses it outright (`too many data types for 'Both': {<class 'str'>, <c
   change-of-basis matrices themselves differ only at `float32` for the second-kind Chebyshev
   family, whose nodes dispatch. The last one is why the end-to-end parity test measures the
   matrix gap instead of assuming it away.
+- **Found by mutating the port, and it generalises past this slice:** a *bounded* parity
+  claim cannot enforce Rule 9's accumulation width where the kernel's own backend
+  disagreement is the same size as the narrow-versus-wide gap. For the Lagrange
+  contraction both are one unit in the last place at `float32`, and they are not separable
+  by a tighter bound, because a sum of non-negative terms has no cancellation to make the
+  width gap dominate. Widening the C++ accumulator to `double` leaves the whole Python
+  parity file green. The width is therefore pinned on the C++ side instead, by a case whose
+  terms are each exactly half an ulp of the running total. **The same gap applies to every
+  bounded claim in the port** -- `change_basis`'s five solving builders above all -- and
+  nothing there pins a width either; F3's warning that a width change "would surface as a
+  `float32` parity failure" holds only for a *bitwise* claim.
 - **Deliberately not claimed:** an accuracy bound for the Lagrange operator against the
   B-spline basis tabulated at the nodes, above degree 2. That identity is the target's defining
   property and it is checked, but only on the dyadic family where both routes are exact.

--- a/design/extraction_port.md
+++ b/design/extraction_port.md
@@ -505,6 +505,16 @@ only ever comparing zero against zero. Case 2 must assert the observed error is 
     second-kind Chebyshev nodes -- is the exception and falls back to the Bézier claim.
 
   **Cardinal still waits** on the interval scan.
+
+  The fused branch of the Lagrange claim was **run, not reasoned about**, against an
+  extension built at `-march=x86-64-v3` -- the target `design/simd.md` schedules, and the
+  smallest one that defines `__FP_FAST_FMA`; `-march=native` does not build here, because
+  it turns on AVX512 and Eigen's AVX512 TRSM kernel trips `-Wmaybe-uninitialized` under
+  `PANTR_WERROR`. On that build the extraction files pass in full, including the 10x
+  sweep, and the observed disagreement reaches a few percent of the fused bound. **Twenty-seven
+  parity cases in five other files do fail there** -- basis tabulations, three Bézier
+  files and quad -- which is the pre-existing state that flipping the SIMD target is
+  expected to expose and is not this slice's to fix.
 - **S4.** `SpanwiseElementExtraction` itself: the class-H `space` accessor, the two memos
   `design/bspline_derived_caches.md` assigns here (`ops_1d` DCLP-lazy returning a view of the
   memo, `num_identity_elements` eager), the wrapper, `__reduce__`, and the binding-contract
@@ -596,12 +606,14 @@ CPython refuses it outright (`too many data types for 'Both': {<class 'str'>, <c
   family, whose nodes dispatch. The last one is why the end-to-end parity test measures the
   matrix gap instead of assuming it away.
 - **Found by mutating the port, and it generalises past this slice:** a *bounded* parity
-  claim cannot enforce Rule 9's accumulation width where the kernel's own backend
-  disagreement is the same size as the narrow-versus-wide gap. For the Lagrange
-  contraction both are one unit in the last place at `float32`, and they are not separable
-  by a tighter bound, because a sum of non-negative terms has no cancellation to make the
-  width gap dominate. Widening the C++ accumulator to `double` leaves the whole Python
-  parity file green. The width is therefore pinned on the C++ side instead, by a case whose
+  claim cannot enforce Rule 9's accumulation width **at all**, and the reason is structural
+  rather than a matter of the constant. Such a bound is derived from each backend's forward
+  error against the exact answer; a wider accumulator has a smaller forward error, so it
+  lies inside the bound by construction. That is Rule 8's "a different but valid algorithm
+  passing is not a failure of the bound", read from the other side. Measured to agree with
+  the argument: widening the C++ accumulator to `double` leaves the whole Python parity
+  file green, and the gap it opens at `float32` is one unit in the last place, the same
+  size as the two backends' own disagreement. The width is therefore pinned on the C++ side instead, by a case whose
   terms are each exactly half an ulp of the running total. **The same gap applies to every
   bounded claim in the port** -- `change_basis`'s five solving builders above all -- and
   nothing there pins a width either; F3's warning that a width change "would surface as a

--- a/design/extraction_port.md
+++ b/design/extraction_port.md
@@ -241,6 +241,14 @@ So nothing is wrong now. What is wrong is that nothing *stops* it: the first aut
 `LagrangeVariant` into a kernel and branch on a member gets a silently dead branch. Flagged
 below rather than fixed here.
 
+**Re-checked 2026-09-03, by the slice that passes closest to this edge.** S3's Lagrange half is
+the first dispatched code path that has a `LagrangeVariant` in scope *and* a kernel to call, so
+it is where the containment would have broken. It did not: the variant is resolved to a matrix
+in Layer 2 and the **matrix** crosses the seam, never the tag. That was a deliberate choice and
+not an accident of the shape -- building the matrix inside the kernel would have needed the
+variant there -- so the containment is now one decision wide rather than zero, and it is still
+a fact about the call graph rather than a guard.
+
 ### F6 (recommended). `OpKind` is the same rule's second instance, in the same cluster, and is deliberately left alone
 
 `OpKind = Literal["apply", "apply_T", "MT_K_M", "M_K_MT"]`
@@ -405,13 +413,30 @@ non-convex entry in its own table (`|R| @ |c|`, "since `R` has negative entries"
 
 It has to be the companion here rather than `max|M| * max|v|`, and the reason is specific to
 this cluster: **the operators are not all convex.** A Bézier extraction operator is, being a
-product of knot-insertion convex combinations -- its rows sum to one, which is the
+product of knot-insertion convex combinations -- its **columns** sum to one, which is the
 partition-of-unity invariant below. The Lagrange and cardinal operators are that matrix
-post-multiplied by a Lagrange-to-Bernstein or cardinal-to-Bernstein matrix
-(`_bspline_extraction.py:290`, `:337`), and those have negative entries. So a bound that
-assumed non-negative weights summing to one would be false for two of the three targets, and
-the failure would be a `float32` parity failure at high degree rather than anything that
-names the assumption.
+post-multiplied by a Lagrange-to-Bernstein or cardinal-to-Bernstein matrix, in
+`_tabulate_Bspline_Lagrange_1D_extraction_impl` and its cardinal sibling.
+
+**Corrected 2026-09-03, while building the Lagrange half of S3: this said "those have negative
+entries ... false for two of the three targets", and it is one of the three.** The
+Lagrange-to-Bernstein matrix is `L[j, k] = B_j(x_k)`, the Bernstein basis tabulated at the
+Lagrange nodes, and every node of every family here lies in `[0, 1]` where the Bernstein basis
+is non-negative and sums to one. So `L` is column-stochastic, and the Lagrange extraction
+operator is a product of two column-stochastic matrices: entrywise non-negative, columns
+summing to one, exactly like its Bézier parent. Measured over all five node families at
+degrees 1, 2, 3, 5, 8 and 12: the smallest entry is never negative and the largest column-sum
+deviation from one is 1.2e-15. Only **cardinal-to-Bernstein** has negative entries.
+
+That does not change what the code does -- the absolute-value companion is correct either way,
+and is what both parity files use -- but it does change what the amplification is worth: for
+the Lagrange target the companion is the answer's own magnitude, bounded by one, so the bound
+is tight rather than merely valid. `tests/parity/test_bspline_lagrange_extraction.py` asserts
+the non-negativity rather than assuming it, so a family whose nodes left `[0, 1]` would be a
+failure here rather than a silently loose bound.
+
+The sentence above also said the Bézier operator's *rows* sum to one. They do not; its columns
+do, which the 2026-09-03 correction further down already records for the same reason.
 
 ### The independent accuracy check
 
@@ -459,10 +484,27 @@ only ever comparing zero against zero. Case 2 must assert the observed error is 
   2026-09-03*: `pantr::bspline::bezier_extraction_1d` and
   `bezier_structural_identity_mask` in `cpp/include/pantr/bspline/extraction.hpp`, bound by
   `cpp/bindings/bspline_extraction_operators.cpp` and dispatched from
-  `pantr.bspline._extraction_backend`. **Lagrange is next and is a small slice** -- the same
-  operator post-multiplied by `lagrange_to_bernstein_1d`, which is already bound, so what it
-  needs is the post-multiplication and the Lagrange identity-mask predicate. **Cardinal still
-  waits** on the interval scan.
+  `pantr.bspline._extraction_backend`. *The **Lagrange** half landed 2026-09-03*:
+  `pantr::bspline::lagrange_extraction_1d` and `lagrange_structural_identity_mask` in the same
+  header, bound in the same file and dispatched from the same catalogue. It was the small slice
+  this note predicted, with two things it did not:
+
+  - **The change-of-basis matrix is an argument, not something the C++ builds.**
+    `change_basis.hpp` already owns `lagrange_to_bernstein_1d`, `pantr.change_basis` caches the
+    finished matrix per `(degree, variant, dtype)`, and `LagrangeVariant` must not approach a
+    kernel (F5). Passing the matrix keeps one implementation, keeps the cache, keeps the enum
+    off the seam, and makes the matrix **common mode** between the backends, so the parity
+    claim is about the extraction and `test_change_basis.py`'s is about the change of basis.
+  - **The claim is bounded rather than bitwise, and it is the first builder in this cluster
+    that is.** The oracle's post-multiplication is `numpy.matmul`, a BLAS `gemm` whose
+    summation order is unspecified and blocked; the C++ runs an ascending loop. Both accumulate
+    in the storage format, so the budget is `Roundings(degree + 1, 1, 0)` with the
+    absolute-value companion as amplification. Measured: the two differ by one unit of roundoff
+    at degree 3 and above and not at all below, so the bound is live rather than nominal. The
+    identity change of basis -- degree 1 with equispaced, Gauss-Lobatto-Legendre or
+    second-kind Chebyshev nodes -- is the exception and falls back to the Bézier claim.
+
+  **Cardinal still waits** on the interval scan.
 - **S4.** `SpanwiseElementExtraction` itself: the class-H `space` accessor, the two memos
   `design/bspline_derived_caches.md` assigns here (`ops_1d` DCLP-lazy returning a view of the
   memo, `num_identity_elements` eager), the wrapper, `__reduce__`, and the binding-contract
@@ -545,6 +587,22 @@ CPython refuses it outright (`too many data types for 'Both': {<class 'str'>, <c
   hash/equality consistency. The two scripts are throwaway and are not committed -- what they
   establish is a property of numba and CPython at the versions named, not of this repository,
   and the durable half is the `IntEnum` test that ships.
+- **Measured 2026-09-03, by the Lagrange half of S3**, and each figure is reproduced by a test
+  rather than quoted here: that `compute_lagrange_to_bernstein_1d` is entrywise non-negative
+  and column-stochastic for every node family and every degree tried, which refutes the
+  sentence this note used to carry; that the two backends' Lagrange operators differ by one
+  unit of roundoff at degree 3 and above and agree exactly below; that the two backends'
+  change-of-basis matrices themselves differ only at `float32` for the second-kind Chebyshev
+  family, whose nodes dispatch. The last one is why the end-to-end parity test measures the
+  matrix gap instead of assuming it away.
+- **Deliberately not claimed:** an accuracy bound for the Lagrange operator against the
+  B-spline basis tabulated at the nodes, above degree 2. That identity is the target's defining
+  property and it is checked, but only on the dyadic family where both routes are exact.
+  Composing a bound above it needs the Cox-de Boor evaluation error, the error of the
+  `pow`-seeded Bernstein ratio recurrence inside the matrix, and the affine map's rounding
+  amplified by `max|N'|` -- and `design/backend_parity.md`'s open question 2 records the
+  transcendental category as having no vocabulary in the harness and no source consulted. Three
+  unsharp terms would give a bound satisfied by any result, which Rule 3 refuses.
 - **Derived, not measured:** the rounding budget in "The parity claim". It is the standard
   inner-product bound composed over stages, in the vocabulary
   `tests/_parity_harness.py` already uses; nothing has been built to compare it against, and

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -116,6 +116,10 @@ from ._bspline import bezier_extraction_1d as bezier_extraction_1d
 from ._bspline import (
     bezier_structural_identity_mask as bezier_structural_identity_mask,
 )
+from ._bspline import lagrange_extraction_1d as lagrange_extraction_1d
+from ._bspline import (
+    lagrange_structural_identity_mask as lagrange_structural_identity_mask,
+)
 from ._geometry import AABB as AABB
 from ._grid import BVH as BVH
 from ._grid import CellTags as CellTags

--- a/src/pantr/_pantr_cpp/_bspline.pyi
+++ b/src/pantr/_pantr_cpp/_bspline.pyi
@@ -306,6 +306,59 @@ def bezier_structural_identity_mask(
             ``out`` is not one shorter than ``multiplicities``.
     """
 
+def lagrange_extraction_1d(
+    knots: _Array,
+    degree: int,
+    tol: float,
+    lagrange_to_bernstein: _Array,
+    out: _Array,
+) -> None:
+    """Build the Lagrange extraction operator of every in-domain interval.
+
+    ``A_e = C_e @ lagrange_to_bernstein``, with ``C_e`` the Bézier operator of
+    interval ``e``.
+
+    Args:
+        knots (_Array): The knot vector, non-decreasing, at least
+            ``2 * degree + 2`` entries.
+        degree (int): The polynomial degree, non-negative.
+        tol (float): The absolute parametric tolerance, non-negative.
+        lagrange_to_bernstein (_Array): The ``(degree + 1, degree + 1)``
+            change-of-basis matrix ``L[j, k] = B_j(x_k)``, in ``knots``' dtype.
+        out (_Array): Output of shape ``(n_intervals, degree + 1, degree + 1)``,
+            overwritten in full.
+
+    Raises:
+        ValueError: If ``degree`` or ``tol`` is negative, the vector is too short
+            or not non-decreasing, it spans no in-domain interval, or either
+            matrix has the wrong shape.
+    """
+
+def lagrange_structural_identity_mask(
+    multiplicities: _Multiplicity,
+    degree: int,
+    lagrange_to_bernstein: _Array,
+    out: _Mask,
+) -> None:
+    """Mark the intervals whose Lagrange extraction operator is the identity.
+
+    The Bézier mask when ``lagrange_to_bernstein`` is exactly the identity, and
+    all-false otherwise.
+
+    Args:
+        multiplicities (_Multiplicity): The in-domain knot multiplicities,
+            ``n_intervals + 1`` of them.
+        degree (int): The polynomial degree, non-negative.
+        lagrange_to_bernstein (_Array): The ``(degree + 1, degree + 1)``
+            change-of-basis matrix.
+        out (_Mask): One flag per interval, ``multiplicities.size - 1`` of them.
+
+    Raises:
+        ValueError: If ``degree`` is negative, ``multiplicities`` is empty,
+            ``out`` is not one shorter than ``multiplicities``, or the matrix has
+            the wrong shape.
+    """
+
 def apply_kron_1d(
     M_0: _Array,
     is_id_0: bool,

--- a/src/pantr/bspline/_bspline_extraction.py
+++ b/src/pantr/bspline/_bspline_extraction.py
@@ -9,10 +9,9 @@ live in :mod:`pantr.bspline._bspline_extraction_core`, and
 :mod:`pantr.bspline._extraction_backend` chooses between them and their C++ twins
 in ``cpp/include/pantr/bspline/extraction.hpp``.
 
-Only the **Bézier** builder is dispatched. Lagrange and cardinal are that operator
-post-multiplied by a change-of-basis matrix that :mod:`pantr.change_basis` already
-dispatches on its own, so they inherit the backend through it -- except for the
-cardinal target's interval scan, which is not ported.
+The **Bézier** and **Lagrange** builders are dispatched. The cardinal one is not:
+it needs the cardinal-interval scan on top of a change-of-basis matrix, and that
+scan is not ported, so it still runs the Bézier builder and post-multiplies here.
 """
 
 from __future__ import annotations
@@ -31,7 +30,7 @@ from ._bspline_knots import (
     _get_Bspline_cardinal_intervals_1D_impl,
     _get_unique_knots_and_multiplicity_impl,
 )
-from ._extraction_backend import bezier_extraction_kernel
+from ._extraction_backend import bezier_extraction_kernel, lagrange_extraction_kernel
 
 
 def _prepare_extraction_out(
@@ -153,14 +152,14 @@ def _tabulate_Bspline_Lagrange_1D_extraction_impl(
     """
     out = _prepare_extraction_out(knots, degree, tol, out)
 
-    # Compute Bezier extraction into out
-    _tabulate_Bspline_Bezier_1D_extraction_impl(knots, degree, tol, out=out)
-
-    # Transform Bezier -> Lagrange extraction in-place: out[i] = out[i] @ lagr_to_bzr
-    # for every interval, as a single batched matmul (np.matmul broadcasts the
-    # (p+1, p+1) matrix over the leading interval axis), mirroring the cardinal path.
+    # The matrix is resolved here rather than inside the kernel: it depends only on
+    # (degree, variant, dtype), `pantr.change_basis` caches it on exactly that key
+    # and dispatches its own backend, and `lagrange_variant` is a `StrEnum`, which
+    # must not reach a kernel. It also refuses `degree == 0`, which is why this
+    # target has no degree-0 case and its sibling mask short-circuits before asking.
     lagr_to_bzr = _cached_lagrange_to_bernstein_matrix(degree, lagrange_variant, knots.dtype)
-    np.matmul(out, lagr_to_bzr, out=out)
+
+    lagrange_extraction_kernel()(knots, degree, tol, lagr_to_bzr, out)
 
     return out
 

--- a/src/pantr/bspline/_bspline_extraction_core.py
+++ b/src/pantr/bspline/_bspline_extraction_core.py
@@ -12,10 +12,17 @@ have, and it is what keeps the catalogue rule of
 a catalogue imports the kernels it hands out, so the kernels cannot live in the
 module that imports the catalogue.
 
-Only the **Bézier** target has a kernel here. Lagrange and cardinal are this
-operator post-multiplied by a change-of-basis matrix, which Layer 2 does with
-:func:`numpy.matmul`, and the cardinal target additionally needs the
-cardinal-interval scan.
+The **Bézier** and **Lagrange** targets have kernels here; the cardinal one does
+not, because it additionally needs the cardinal-interval scan, which is not ported.
+
+Two of the four are Numba and two are not, and the split is deliberate. The Lagrange
+pair is the Bézier operator post-multiplied by a change-of-basis matrix, and that
+product is :func:`numpy.matmul` -- a BLAS ``gemm``, already compiled, and the thing
+the C++ twin has to agree with. Rewriting it as a ``nopython`` loop would not speed
+it up and would change the oracle's summation order, which is the one property
+``design/backend_parity.md`` Rule 9 says a port must reproduce rather than improve.
+``numpy.matmul`` is in any case unsupported for a rank-3 operand inside ``nopython``,
+so the loop would have to be written out by hand.
 """
 
 from __future__ import annotations
@@ -172,6 +179,91 @@ def _bezier_structural_identity_mask_core(
         out[e] = multiplicities[e] >= threshold and multiplicities[e + 1] >= threshold
 
 
+def _tabulate_Bspline_Lagrange_1D_extraction_core(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    tol: float,
+    lagrange_to_bernstein: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    r"""Compute the Lagrange extraction operators, writing to the output array.
+
+    ``A_e = C_e @ L``, with ``C_e`` the Bézier operator of interval ``e`` and ``L``
+    the Lagrange-to-Bernstein matrix ``L[j, k] = B_j(x_k)`` of the same degree, so
+    that \( N_e(x) = A_e @ Lag(ξ) \) for the Lagrange basis on the reference
+    interval. :func:`numpy.matmul` broadcasts the ``(degree+1, degree+1)`` matrix
+    over the leading interval axis, so the whole stack is one call.
+
+    The matrix is an argument rather than something this builds: it depends only on
+    ``(degree, lagrange_variant, dtype)``, :mod:`pantr.change_basis` caches it on
+    exactly that key, and the variant is a :class:`~enum.StrEnum` that must not
+    reach a kernel.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): B-spline degree.
+        tol (float): Tolerance for numerical comparisons.
+        lagrange_to_bernstein (npt.NDArray[np.float32 | np.float64]): The
+            ``(degree+1, degree+1)`` change-of-basis matrix, in ``knots``' dtype.
+        out (npt.NDArray[np.float32 | np.float64]): Output array of shape
+            ``(n_elems, degree+1, degree+1)``, overwritten in full.
+
+    Note:
+        Not a Numba kernel, and the module docstring says why. Inputs are assumed to
+        be correct (no validation performed). For general use, call
+        ``_tabulate_Bspline_Lagrange_1D_extraction_impl`` instead.
+    """
+    _tabulate_Bspline_Bezier_1D_extraction_core(knots, degree, tol, out)
+    # In place, and legally so: `numpy.matmul` detects the overlap between `out` and
+    # its own first operand and buffers, which is what the shipped Layer 2 has always
+    # relied on. The C++ twin does the same product over a private copy of the row it
+    # is overwriting.
+    np.matmul(out, lagrange_to_bernstein, out=out)
+
+
+def _lagrange_structural_identity_mask_core(
+    multiplicities: npt.NDArray[np.intp],
+    degree: int,
+    lagrange_to_bernstein: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.bool_],
+) -> None:
+    """Compute a per-element Lagrange identity mask.
+
+    ``A_e = C_e @ L`` is the identity exactly when ``L`` is and ``C_e`` is, so the
+    mask is the Bézier one when ``L`` is the identity and all-false otherwise. The
+    comparison against the identity is exact, because the question is a verdict
+    rather than a value: a matrix that misses the identity by an ulp produces an
+    operator that is not the identity.
+
+    ``L`` is the identity when every Lagrange node coincides with the Bernstein
+    abscissa of the same index, which happens at degree 1 for the equispaced,
+    Gauss-Lobatto-Legendre and second-kind Chebyshev families.
+
+    Args:
+        multiplicities (npt.NDArray[np.intp]): Per-unique-knot multiplicity array of
+            length ``n_elements + 1``.
+        degree (int): B-spline degree, at least 1.
+        lagrange_to_bernstein (npt.NDArray[np.float32 | np.float64]): The
+            ``(degree+1, degree+1)`` change-of-basis matrix.
+        out (npt.NDArray[np.bool_]): Output boolean array of length
+            ``n_elements = len(multiplicities) - 1``.
+
+    Note:
+        Not a Numba kernel, for the reason the module docstring gives of its sibling:
+        it is the Python half of a pair whose C++ twin it must agree with, and the
+        work is a whole-array comparison rather than a loop. Inputs are assumed to be
+        correct (no validation performed). Degree 0 does not reach here, since
+        :func:`pantr.change_basis.compute_lagrange_to_bernstein_1d` refuses it and
+        there is no matrix to pass. For general use, call
+        ``spanwise_element_extraction._lagrange_structural_identity_mask`` instead.
+    """
+    identity = np.eye(degree + 1, dtype=lagrange_to_bernstein.dtype)
+    if np.array_equal(lagrange_to_bernstein, identity):
+        _bezier_structural_identity_mask_core(multiplicities, degree, out)
+        return
+    out.fill(False)
+
+
 def _warmup_numba_functions() -> None:
     """Precompile numba functions with float64 signatures for faster first call.
 
@@ -196,5 +288,7 @@ def _warmup_numba_functions() -> None:
 
 __all__ = [
     "_bezier_structural_identity_mask_core",
+    "_lagrange_structural_identity_mask_core",
     "_tabulate_Bspline_Bezier_1D_extraction_core",
+    "_tabulate_Bspline_Lagrange_1D_extraction_core",
 ]

--- a/src/pantr/bspline/_bspline_extraction_core.py
+++ b/src/pantr/bspline/_bspline_extraction_core.py
@@ -214,9 +214,13 @@ def _tabulate_Bspline_Lagrange_1D_extraction_core(
         ``_tabulate_Bspline_Lagrange_1D_extraction_impl`` instead.
     """
     _tabulate_Bspline_Bezier_1D_extraction_core(knots, degree, tol, out)
-    # In place, and legally so: `numpy.matmul` detects the overlap between `out` and
-    # its own first operand and buffers, which is what the shipped Layer 2 has always
-    # relied on. The C++ twin does the same product over a private copy of the row it
+    # In place, and this relies on `numpy.matmul` buffering the overlap between `out`
+    # and its own first operand rather than reading rows it has already written. That
+    # is a claim about numpy, not about this module, so it is checked rather than
+    # assumed: `tests/parity/test_bspline_lagrange_extraction.py` asserts the in-place
+    # answer equals a non-aliased one, bit for bit. The shipped Layer 2 has always
+    # relied on it; the port relocated the call, it did not introduce the reliance. The
+    # C++ twin needs no such reliance -- it contracts over a private copy of the row it
     # is overwriting.
     np.matmul(out, lagrange_to_bernstein, out=out)
 

--- a/src/pantr/bspline/_extraction_backend.py
+++ b/src/pantr/bspline/_extraction_backend.py
@@ -22,12 +22,20 @@ is two registrations rather than one -- ``bspline_extraction.cpp`` for the
 tensor-product apply kernels, ``bspline_extraction_operators.cpp`` for the Bézier
 builder and its mask. They are separate ports with separate parity claims.
 
-Only the **Bézier** target has a builder here. Lagrange is that operator
-post-multiplied by ``lagrange_to_bernstein_1d``, which
-:mod:`pantr.change_basis._change_basis_backend` already dispatches, so it inherits
-the backend rather than needing an entry; the cardinal target additionally needs
-the cardinal-interval scan, which is not ported and which
-``cpp/include/pantr/bspline/space_1d.hpp`` deliberately keeps off the type.
+The **Bézier** and **Lagrange** targets have builders here; the cardinal one does
+not, because it additionally needs the cardinal-interval scan, which is not ported
+and which ``cpp/include/pantr/bspline/space_1d.hpp`` deliberately keeps off the
+type.
+
+The Lagrange pair takes the ``lagrange_to_bernstein`` matrix as an **argument**.
+:mod:`pantr.change_basis` builds it, caches it per ``(degree, variant, dtype)`` and
+dispatches it on its own, so passing the finished matrix keeps one implementation of
+the tabulation, keeps the cache in front of it, and keeps
+:class:`pantr.basis.LagrangeVariant` -- a :class:`~enum.StrEnum`, which numba would
+accept and then silently mis-compare -- off the seam entirely. It also makes the
+matrix common mode between the two backends, so
+``tests/parity/test_bspline_lagrange_extraction.py`` claims about the extraction and
+``tests/parity/test_change_basis.py`` about the change of basis.
 
 What crosses the boundary
 -------------------------
@@ -47,6 +55,13 @@ The twelve per-cell Numba kernels are specialised per dimension because a
 side is four dimension-generic functions behind twenty-four flat entry points with
 the same names, arities and argument order, so this catalogue selects between two
 functions with one signature rather than between two conventions.
+
+The **Lagrange** builder is the one exception to that pattern, and its claim is
+weaker in kind rather than in degree: the post-multiplication is
+:func:`numpy.matmul` on one side, whose BLAS sums a contraction in an unspecified
+blocked order, and a plain loop on the other. So the two are **bounded**, not
+bitwise, wherever the degree exceeds zero; the identity change of basis is the
+exception, since a sum of exact zeros with one exact term rounds nothing.
 
 Measured, and it is stronger than the port needed: on a build whose target ISA has
 no fused multiply-add the two agree **bit for bit**, because the C++ reproduces the
@@ -95,7 +110,9 @@ import numpy.typing as npt
 from .._backend import Backend, active_backend, available_backends
 from ._bspline_extraction_core import (
     _bezier_structural_identity_mask_core,
+    _lagrange_structural_identity_mask_core,
     _tabulate_Bspline_Bezier_1D_extraction_core,
+    _tabulate_Bspline_Lagrange_1D_extraction_core,
 )
 from ._extraction_kernels import (
     apply_kron_1d,
@@ -141,6 +158,12 @@ _BezierBuilder = Callable[[_Array, int, float, _Array], None]
 
 _IdentityMask = Callable[[npt.NDArray[np.intp], int, npt.NDArray[np.bool_]], None]
 """Signature of the structural identity mask: ``(multiplicities, degree, out) -> None``."""
+
+_LagrangeBuilder = Callable[[_Array, int, float, _Array, _Array], None]
+"""Signature of the Lagrange builder: ``(knots, degree, tol, lagr_to_bzr, out) -> None``."""
+
+_LagrangeIdentityMask = Callable[[npt.NDArray[np.intp], int, _Array, npt.NDArray[np.bool_]], None]
+"""Signature of the Lagrange mask: ``(multiplicities, degree, lagr_to_bzr, out) -> None``."""
 
 
 _KERNELS: Final[dict[tuple[str, int], _Kernel]] = {
@@ -394,6 +417,69 @@ def _cpp_bezier_identity_mask(
     out[...] = buffer
 
 
+def _cpp_lagrange_extraction(
+    knots: _Array, degree: int, tol: float, lagrange_to_bernstein: _Array, out: _Array
+) -> None:
+    """Build the Lagrange extraction operators through the C++ binding.
+
+    Args:
+        knots (_Array): The knot vector.
+        degree (int): The polynomial degree.
+        tol (float): The absolute parametric tolerance.
+        lagrange_to_bernstein (_Array): The ``(degree + 1, degree + 1)``
+            change-of-basis matrix, in ``knots``' dtype.
+        out (_Array): Output of shape ``(n_intervals, degree + 1, degree + 1)``.
+
+    Note:
+        No input validation is performed here. The binding is the C++ half of
+        Layer 2 and re-checks dtype, rank, contiguity, the oracle's three
+        knot-vector refusals and the shapes of both matrices; Layer 2 in Python
+        established the rest.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    knot_array = np.ascontiguousarray(knots)
+    matrix = np.ascontiguousarray(lagrange_to_bernstein)
+    buffer, copy_back = _contiguous_out(out)
+    _pantr_cpp.lagrange_extraction_1d(knot_array, int(degree), float(tol), matrix, buffer)
+    if copy_back:
+        out[...] = buffer
+
+
+def _cpp_lagrange_identity_mask(
+    multiplicities: npt.NDArray[np.intp],
+    degree: int,
+    lagrange_to_bernstein: _Array,
+    out: npt.NDArray[np.bool_],
+) -> None:
+    """Mark the identity elements of the Lagrange target through the C++ binding.
+
+    The multiplicities are normalized to :data:`numpy.intp` for the reason
+    :func:`_cpp_bezier_identity_mask` gives.
+
+    Args:
+        multiplicities (npt.NDArray[np.intp]): In-domain knot multiplicities.
+        degree (int): The polynomial degree.
+        lagrange_to_bernstein (_Array): The ``(degree + 1, degree + 1)``
+            change-of-basis matrix.
+        out (npt.NDArray[np.bool_]): One flag per element.
+
+    Note:
+        No input validation is performed here; the binding re-checks dtype, rank,
+        contiguity and the two length relations, and Layer 2 established the rest.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    counts = np.ascontiguousarray(multiplicities, dtype=np.intp)
+    matrix = np.ascontiguousarray(lagrange_to_bernstein)
+    if out.flags["C_CONTIGUOUS"]:
+        _pantr_cpp.lagrange_structural_identity_mask(counts, int(degree), matrix, out)
+        return
+    buffer = np.empty_like(out, order="C")
+    _pantr_cpp.lagrange_structural_identity_mask(counts, int(degree), matrix, buffer)
+    out[...] = buffer
+
+
 def bezier_extraction_kernel(backend: Backend | None = None) -> _BezierBuilder:
     """Get the Bézier extraction operator builder of the requested backend.
 
@@ -424,3 +510,37 @@ def bezier_identity_mask_kernel(backend: Backend | None = None) -> _IdentityMask
         RuntimeError: If ``backend`` is given and is not available.
     """
     return _select(backend, _bezier_structural_identity_mask_core, _cpp_bezier_identity_mask)
+
+
+def lagrange_extraction_kernel(backend: Backend | None = None) -> _LagrangeBuilder:
+    """Get the Lagrange extraction operator builder of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one
+            currently in effect. Defaults to None.
+
+    Returns:
+        _LagrangeBuilder: The kernel,
+        ``(knots, degree, tol, lagrange_to_bernstein, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _tabulate_Bspline_Lagrange_1D_extraction_core, _cpp_lagrange_extraction)
+
+
+def lagrange_identity_mask_kernel(backend: Backend | None = None) -> _LagrangeIdentityMask:
+    """Get the Lagrange structural identity mask kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one
+            currently in effect. Defaults to None.
+
+    Returns:
+        _LagrangeIdentityMask: The kernel,
+        ``(multiplicities, degree, lagrange_to_bernstein, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _lagrange_structural_identity_mask_core, _cpp_lagrange_identity_mask)

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -43,7 +43,7 @@ import numpy.typing as npt
 from ..basis import LagrangeVariant
 from ..basis._basis_utils import _allocate_or_validate_out
 from ..change_basis import _cached_lagrange_to_bernstein_matrix
-from ._extraction_backend import bezier_identity_mask_kernel
+from ._extraction_backend import bezier_identity_mask_kernel, lagrange_identity_mask_kernel
 from ._extraction_helpers import (
     OpKind,
     _operation_shapes,
@@ -1148,6 +1148,11 @@ def _lagrange_structural_identity_mask(
     equispaced, GLL, or Chebyshev-2nd nodes.  For all other cases no element
     can have an identity Lagrange extraction operator.
 
+    The ``degree == 0`` branch stays here rather than moving into the dispatched
+    kernel, and it is not a special case that could be folded away:
+    :func:`pantr.change_basis.compute_lagrange_to_bernstein_1d` refuses a degree
+    below 1, so there is no matrix to pass and no kernel call to make.
+
     Args:
         space_1d (BsplineSpace1D): A 1D B-spline space.
         lagrange_variant (LagrangeVariant): Lagrange node distribution.
@@ -1155,14 +1160,14 @@ def _lagrange_structural_identity_mask(
     Returns:
         npt.NDArray[np.bool_]: Boolean array of shape ``(n_elements,)``.
     """
-    n_elements = space_1d.num_intervals
     if space_1d.degree == 0:
-        return np.ones(n_elements, dtype=np.bool_)
+        return np.ones(space_1d.num_intervals, dtype=np.bool_)
     dtype = space_1d.knots.dtype
     lagr_to_bzr = _cached_lagrange_to_bernstein_matrix(space_1d.degree, lagrange_variant, dtype)
-    if np.array_equal(lagr_to_bzr, np.eye(space_1d.degree + 1, dtype=dtype)):
-        return _bezier_structural_identity_mask(space_1d)
-    return np.zeros(n_elements, dtype=np.bool_)
+    _, mults = space_1d.get_unique_knots_and_multiplicity(in_domain=True)
+    out = np.empty(len(mults) - 1, dtype=np.bool_)
+    lagrange_identity_mask_kernel()(mults, space_1d.degree, lagr_to_bzr, out)
+    return out
 
 
 # The op_kind shape helper is kept import-local so downstream callers can build

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -1146,7 +1146,10 @@ def _lagrange_structural_identity_mask(
     ``lagr_to_bzr`` equals ``I`` when the Lagrange nodes coincide with the
     Bernstein abscissae ``i / degree`` — e.g. for ``degree == 1`` with
     equispaced, GLL, or Chebyshev-2nd nodes.  For all other cases no element
-    can have an identity Lagrange extraction operator.
+    can have an identity Lagrange extraction operator; the argument for that
+    half, which is a claim rather than a definition, is written out beside
+    ``lagrange_structural_identity_mask`` in
+    ``cpp/include/pantr/bspline/extraction.hpp``.
 
     The ``degree == 0`` branch stays here rather than moving into the dispatched
     kernel, and it is not a special case that could be folded away:

--- a/tests/parity/test_bspline_lagrange_extraction.py
+++ b/tests/parity/test_bspline_lagrange_extraction.py
@@ -1,0 +1,1324 @@
+"""Parity for the Lagrange extraction operator builder and its identity mask.
+
+``A_e = C_e @ L``: the Bézier operator of interval ``e``, post-multiplied by the
+Lagrange-to-Bernstein matrix ``L[j, k] = B_j(x_k)`` of the same degree. The Bézier
+half is ``tests/parity/test_bspline_bezier_extraction.py``'s and is reused from
+there rather than restated -- the case table, the chain length and the Bézier column
+bound are imported, so the two files cannot drift on them.
+
+**The claim is bounded, not bitwise, and that is the one way this target differs in
+kind from its Bézier parent.** The oracle contracts the product with
+:func:`numpy.matmul`, which reaches a BLAS ``gemm`` and sums the ``degree + 1`` terms
+in an unspecified, possibly blocked order; the C++ runs a plain ascending loop. Both
+accumulate in the storage format -- ``sgemm`` at ``float32`` on one side and
+``design/backend_parity.md`` Rule 9's "the accumulator is `T`" on the other -- so the
+budget is a rounding per term with no narrowing store, and the amplification is the
+absolute-value companion Rule 10 prescribes. Measured on this machine, the two
+backends do differ, by one unit of roundoff at degree 3 and above and not at all
+below; :func:`test_the_two_backends_still_differ_somewhere` is the guard that keeps
+the bound from silently becoming a comparison against zero.
+
+The exception is an **identity** change of basis, which happens at degree 1 for the
+equispaced, Gauss-Lobatto-Legendre and second-kind Chebyshev families. Every term is
+then ``C[i,k] * 0`` or ``C[i,j] * 1``, so nothing rounds in either summation order
+and the claim falls back to the Bézier one, bit for bit or Rule 10's fused budget
+according to the build.
+
+Why the matrix is an argument, and what that buys the claim
+----------------------------------------------------------
+
+Both kernels take ``L`` rather than building it. :mod:`pantr.change_basis` owns the
+tabulation and caches it per ``(degree, variant, dtype)``, and
+:class:`pantr.basis.LagrangeVariant` is a :class:`~enum.StrEnum`, which numba types
+as ``unicode_type`` and then silently mis-compares against a captured member -- so
+the variant must not approach a kernel at all.
+
+For the claim the consequence is that ``L`` is **common mode**:
+:func:`test_the_operators_agree` hands the same array to both backends, so what it
+measures is the extraction. ``L``'s own parity is
+``tests/parity/test_change_basis.py::test_lagrange_to_bernstein_is_bitwise``, and it
+is bitwise except where the node family itself dispatches.
+:func:`test_the_layer_2_path_agrees` is the end-to-end companion that does not hold
+it fixed: it measures the gap between the two backends' matrices and carries it
+through the product, exactly as that file measures its node gap.
+
+The three independent accuracy oracles
+--------------------------------------
+
+Parity says the two backends agree, not that either is right, and a transposed index
+would be invisible to it. None of the three below is the Python implementation.
+
+**Exact rational values, hand-derived.** At degree 2 with equispaced nodes,
+``L = [[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]]`` follows from ``L[j,k] = B_j(x_k)`` at
+``x = 0, 1/2, 1``, and the dyadic uniform Bézier tables are halves, so every entry of
+the product and every partial sum of the contraction is a binary rational. The
+comparison carries a **zero** bound in both storage formats.
+``cpp/tests/test_bspline_extraction.cpp`` carries the same tables.
+
+**The column sums reproduce the matrix's own.** ``sum_i A[i,j] = sum_k (sum_i
+C[i,k]) L[k,j] = sum_k L[k,j]``, using the Bézier column sums. Compared against
+``sum_k L[k,j]`` **as the matrix actually sums**, not against one, so ``L``'s own
+tabulation error is folded in exactly rather than bounded. Columns and not rows: the
+quadratic table's rows sum to ``1.25, 1.75, 0.625``, so this is what catches a
+transposition.
+
+It also pins that no entry is negative, which is a correction rather than a
+restatement: ``design/extraction_port.md`` says the Lagrange-to-Bernstein matrix has
+negative entries and that a bound assuming convexity would be false for it. It does
+not. Its columns are the Bernstein basis evaluated at a node in ``[0, 1]``, so they
+are non-negative and sum to one, and ``A_e`` is a product of two column-stochastic
+matrices.
+
+**The columns are the B-spline basis at the nodes.** The defining property: the
+Lagrange basis is cardinal at its own nodes, so ``A_e[:, k] = N_e(x_k)`` with ``x_k``
+the ``k``-th node mapped into the interval. Checked against
+:meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis`, which is Cox-de Boor and shares
+no code with the extraction path.
+
+**It is checked on a dyadic family only, and the restriction is deliberate.** At
+degree 1 and 2 with equispaced nodes on dyadic knots, every node, every mapped point
+and every intermediate of both routes is a binary rational of a few bits, so nothing
+rounds and the bound is **zero**. Above degree 2 the equispaced nodes become thirds
+and both routes round, and the bound would have to compose the Cox-de Boor
+evaluation error, the error of the ``pow``-seeded ratio recurrence inside ``L``, and
+the affine map's rounding amplified by ``max|N'|``. Two of those three are foreign
+derivations and one of them is the transcendental category
+``design/backend_parity.md``'s open question 2 records as having no vocabulary in the
+harness and no source consulted. A bound composed of three unsharp terms would be
+satisfied by any result, which is the failure Rule 3 refuses; so the check keeps the
+degrees where it is exact and says why it stops.
+
+What the table leaves out
+-------------------------
+
+**Degree 0.** :func:`pantr.change_basis.compute_lagrange_to_bernstein_1d` refuses a
+degree below 1, so the Lagrange target has no degree-0 case at all. That is
+pre-existing behaviour rather than anything this port introduced, and
+:func:`test_degree_zero_is_refused_by_both_backends` pins it so the omission is a
+recorded fact rather than a gap.
+
+**The vector whose first in-domain knot is repeated.** Kept as a parity case and
+excluded from the accuracy oracles, for the reason the Bézier file gives: the shared
+algorithm's sliding window misaligns there and both backends are wrong together.
+
+Rule 12
+-------
+
+The Bézier half is built from ``+``, ``-``, ``*`` and ``/``, all of which IEEE 754
+pins, and the product is :func:`numpy.matmul` on the Python side whatever the JIT
+setting. So nothing here needs a gate on the interpreted oracle, and the bitwise
+branch is as true under ``NUMBA_DISABLE_JIT=1`` as anywhere.
+
+The tests that state a property of *each* backend take the extension requirement on
+the C++ **parameter** rather than on the test, because taking it on the test would
+skip the Python half too, and the Python half of the accuracy checks is the only
+thing here that would catch the **oracle** regressing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, cast
+
+import numpy as np
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.basis import LagrangeVariant
+from pantr.bspline import BsplineSpace1D
+from pantr.bspline._bspline_extraction import (
+    _tabulate_Bspline_Bezier_1D_extraction_impl,
+    _tabulate_Bspline_Lagrange_1D_extraction_impl,
+)
+from pantr.bspline._extraction_backend import (
+    _KERNELS,
+    lagrange_extraction_kernel,
+    lagrange_identity_mask_kernel,
+)
+from pantr.bspline.spanwise_element_extraction import _lagrange_structural_identity_mask
+from pantr.change_basis import _cached_lagrange_to_bernstein_matrix
+from tests._parity_harness import (
+    Field,
+    Roundings,
+    assert_accuracy,
+    assert_object_parity,
+    assert_parity,
+    bounded_parity,
+    contraction_may_fuse,
+    demand_cpp_backend,
+    demand_the_reference_host,
+    derived_accuracy,
+    exact_parity,
+    unit_roundoff,
+)
+from tests.parity.test_bspline_bezier_extraction import (
+    _CASES as _BEZIER_CASES,
+)
+from tests.parity.test_bspline_bezier_extraction import (
+    _Case,
+    _claim,
+    _column_sum_bound,
+    _draw,
+    _insertion_stages,
+)
+
+if TYPE_CHECKING:
+    from numpy import typing as npt
+
+DTYPES: Final = [np.float64, np.float32]
+"""The two storage formats the builder is instantiated for."""
+
+_BACKENDS: Final = (
+    pytest.param(Backend.PYTHON, id="python"),
+    pytest.param(Backend.CPP, id="cpp"),
+)
+"""The two backends, for the tests that state a property of each one separately."""
+
+_VARIANTS: Final = list(LagrangeVariant)
+"""Every node family, because which of them makes ``L`` the identity is the branch."""
+
+_CASES: Final = tuple(entry for entry in _BEZIER_CASES if entry.degree >= 1)
+"""The Bézier table minus its degree-0 vector, which this target refuses.
+
+Imported rather than restated: the two builders are the same builder up to one
+matrix product, so a vector worth exercising on one is worth exercising on the other,
+and two copies of the table would drift.
+"""
+
+
+def _bindings() -> Any:
+    """Import the extension, deferred and in one place.
+
+    Module level would break the extension-skip property: the tests parametrized
+    over both backends are meant to run their Python half in an installation with no
+    extension, and a top-level ``from pantr import _pantr_cpp`` turns that into a
+    collection error for the file -- every test, both halves. Same shape and same
+    reason as the Bézier file's.
+
+    Returns:
+        Any: The :mod:`pantr._pantr_cpp` module.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp
+
+
+def _demand_the_extension_if_needed(backend: Backend) -> None:
+    """Require the compiled extension, and only for the half that uses it.
+
+    Args:
+        backend (Backend): The backend this case runs under.
+    """
+    if backend is Backend.CPP:
+        demand_cpp_backend()
+
+
+def _matrix_under(
+    backend: Backend, degree: int, variant: LagrangeVariant, dtype: npt.DTypeLike
+) -> npt.NDArray[Any]:
+    """The Lagrange-to-Bernstein matrix one backend builds.
+
+    The one place ``dtype`` is narrowed for the cache's signature. Every caller here
+    passes a member of :data:`DTYPES`, so the cast restates what the parametrization
+    already guarantees and does not widen anything; it exists because
+    :data:`numpy.typing.DTypeLike` is what a pytest parameter can carry.
+
+    Args:
+        backend (Backend): Which backend builds it.
+        degree (int): Polynomial degree, at least 1.
+        variant (LagrangeVariant): The node family.
+        dtype (npt.DTypeLike): Storage format, ``float32`` or ``float64``.
+
+    Returns:
+        npt.NDArray[Any]: The read-only ``(degree+1, degree+1)`` matrix.
+    """
+    resolved = cast("np.dtype[np.float32 | np.float64]", np.dtype(dtype))
+    with use_backend(backend):
+        return np.asarray(_cached_lagrange_to_bernstein_matrix(degree, variant, resolved))
+
+
+def _matrix(degree: int, variant: LagrangeVariant, dtype: npt.DTypeLike) -> npt.NDArray[Any]:
+    """The matrix both backends are handed, so the change of basis is common mode.
+
+    :func:`pantr.change_basis._cached_lagrange_to_bernstein_matrix` is keyed on the
+    active backend, so calling it inside each half of a parity comparison would hand
+    the two sides different matrices and fold the change of basis into a claim about
+    the extraction. Taken once, under Python, and passed to both.
+
+    Args:
+        degree (int): Polynomial degree, at least 1.
+        variant (LagrangeVariant): The node family.
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        npt.NDArray[Any]: The read-only ``(degree+1, degree+1)`` matrix.
+    """
+    return _matrix_under(Backend.PYTHON, degree, variant, dtype)
+
+
+def _bezier(case: _Case, dtype: npt.DTypeLike) -> npt.NDArray[Any]:
+    """The Bézier operators of one case, under the Python backend.
+
+    Used only to build the amplification: the absolute-value companion of the product
+    is ``|C| @ |L|``, and ``C`` is what the contraction actually reads.
+
+    Args:
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        npt.NDArray[Any]: The ``(n_intervals, degree+1, degree+1)`` Bézier operators.
+    """
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    with use_backend(Backend.PYTHON):
+        return np.asarray(
+            _tabulate_Bspline_Bezier_1D_extraction_impl(space.knots, case.degree, space.tolerance)
+        )
+
+
+def _build_kernel(
+    case: _Case, dtype: npt.DTypeLike, matrix: npt.NDArray[Any], backend: Backend
+) -> npt.NDArray[Any]:
+    """Run one backend's Lagrange kernel on a matrix both are given.
+
+    The catalogue accessor rather than the Layer 2 entry point, so the matrix stays
+    fixed across the comparison.
+
+    Args:
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+        matrix (npt.NDArray[Any]): The change-of-basis matrix.
+        backend (Backend): Which implementation to run.
+
+    Returns:
+        npt.NDArray[Any]: The ``(n_intervals, degree+1, degree+1)`` operators.
+    """
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    out = np.empty((space.num_intervals, case.degree + 1, case.degree + 1), dtype=dtype)
+    lagrange_extraction_kernel(backend)(space.knots, case.degree, space.tolerance, matrix, out)
+    return out
+
+
+def _build_layer_2(
+    case: _Case, dtype: npt.DTypeLike, variant: LagrangeVariant, backend: Backend
+) -> npt.NDArray[Any]:
+    """Run one backend's whole Layer 2 path, matrix and all.
+
+    Args:
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+        variant (LagrangeVariant): The node family.
+        backend (Backend): Which implementation to run.
+
+    Returns:
+        npt.NDArray[Any]: The operators.
+    """
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    with use_backend(backend):
+        return np.asarray(
+            _tabulate_Bspline_Lagrange_1D_extraction_impl(
+                space.knots, case.degree, space.tolerance, lagrange_variant=variant
+            )
+        )
+
+
+def _is_the_identity(matrix: npt.NDArray[Any]) -> bool:
+    """Whether a change-of-basis matrix is exactly the identity.
+
+    The same predicate both kernels apply, and the branch the claim turns on.
+
+    Args:
+        matrix (npt.NDArray[Any]): The matrix.
+
+    Returns:
+        bool: True when every entry matches the identity's bit for bit.
+    """
+    return bool(np.array_equal(matrix, np.eye(matrix.shape[0], dtype=matrix.dtype)))
+
+
+def _companion(bezier: npt.NDArray[Any], matrix: npt.NDArray[Any]) -> npt.NDArray[np.float64]:
+    """The absolute-value companion of the product, elementwise.
+
+    ``design/backend_parity.md`` Rule 10 prescribes running the kernel on absolute
+    values rather than taking ``max|M| max|v|``, and this is that: the magnitude
+    reachable at each output element of ``C @ L``. Both factors happen to be
+    non-negative here, so it coincides with the answer, but it is formed from
+    absolute values so that a future non-negative-losing change does not silently
+    invalidate it.
+
+    Args:
+        bezier (npt.NDArray[Any]): The Bézier operators.
+        matrix (npt.NDArray[Any]): The change-of-basis matrix.
+
+    Returns:
+        npt.NDArray[np.float64]: The companion, shaped like the operators.
+    """
+    return np.asarray(
+        np.matmul(
+            np.abs(bezier.astype(np.float64)),
+            np.abs(matrix.astype(np.float64)),
+        ),
+        dtype=np.float64,
+    )
+
+
+def _gamma(roundings: int, dtype: npt.DTypeLike) -> float:
+    """Higham's ``gamma_m = m u / (1 - m u)`` for a given rounding count.
+
+    The closed form rather than the truncation ``m u``, and the same one
+    :func:`tests._parity_harness.absolute_tolerance` applies internally. Recomputed
+    here only where an **absolute** term has to be converted into the amplification
+    the harness multiplies by ``gamma``; ``tests/parity/test_change_basis.py`` does
+    the same conversion for the same reason.
+
+    Args:
+        roundings (int): The accumulated rounding count ``m``.
+        dtype (npt.DTypeLike): The format the roundings happen in.
+
+    Returns:
+        float: ``gamma_m``.
+
+    Raises:
+        AssertionError: If the budget runs away to one, where gamma bounds nothing.
+    """
+    u = unit_roundoff(dtype)
+    total = roundings * u
+    if total >= 1.0:
+        raise AssertionError(f"gamma runs away to one at {roundings} roundings and u={u:.3e}")
+    return total / (1.0 - total)
+
+
+def _product_claim(
+    case: _Case,
+    dtype: npt.DTypeLike,
+    matrix: npt.NDArray[Any],
+    bezier: npt.NDArray[Any],
+    extra_absolute: npt.NDArray[np.float64] | None = None,
+) -> Any:
+    """The parity claim for the Lagrange operators of one case.
+
+    Three branches, in order of strength.
+
+    **An identity change of basis** contracts ``C[i,k] * 0`` and ``C[i,j] * 1`` only.
+    Every product is exact, every partial sum adds an exact zero to an exact value,
+    and no summation order can separate the two backends. So the claim is the Bézier
+    one, imported unchanged from that file: bitwise, or Rule 10's fused budget on a
+    build whose insertions may contract.
+
+    **Otherwise, on a build with no fused multiply-add**, the Bézier halves agree bit
+    for bit, so both contractions read the *same* ``C`` and the whole difference is
+    the summation order of a length-``degree + 1`` dot product. Higham, *Accuracy and
+    Stability of Numerical Algorithms*, 2nd ed., SIAM 2002, section 3.1: for any
+    summation order ``|fl(x^T y) - x^T y| <= gamma_n |x|^T |y|`` with ``n`` the
+    length, and pp. 62-64 note that blocking only tightens it. So the budget is
+    ``Roundings(degree + 1, 1, 0)`` -- one accumulator rounding per term, and no
+    storage rounding because the accumulator **is** the storage format on both sides
+    (``design/backend_parity.md`` Rule 9, and ``sgemm`` accumulates in ``float32``).
+    The harness doubles it, which is the step that turns each side's one-sided
+    forward-error bound into a bound on their difference.
+
+    **On a fusing build** the Bézier halves may differ too, by Rule 10's budget of
+    three accumulator roundings over the insertion chain, amplified by one since
+    every Bézier entry lies in ``[0, 1]``. That difference reaches an output element
+    weighted by ``sum_k |L[k,j]|``, and the contraction itself may fuse, so its own
+    budget rises from one rounding per term to three. Both terms are folded into a
+    single claim by monotonicity of ``gamma``: charging the longer chain to both and
+    adding the two amplifications is an upper bound on charging each its own.
+
+    Args:
+        case (_Case): The knot vector.
+        dtype (npt.DTypeLike): Storage format.
+        matrix (npt.NDArray[Any]): The change-of-basis matrix both backends read.
+        bezier (npt.NDArray[Any]): The Bézier operators, for the companion.
+        extra_absolute (npt.NDArray[np.float64] | None): An absolute term to add,
+            for the end-to-end case where the two backends' matrices differ.
+            Defaults to None.
+
+    Returns:
+        Any: The parity claim.
+    """
+    if _is_the_identity(matrix) and extra_absolute is None:
+        return _claim(case, dtype)
+
+    terms = case.degree + 1
+    per_stage = 1
+    amplification = _companion(bezier, matrix)
+    why_head = (
+        "the contraction is a dot product of degree + 1 terms, summed by a BLAS gemm on the "
+        "oracle's side and by an ascending loop on the C++ side. Higham, Accuracy and "
+        "Stability of Numerical Algorithms, 2nd ed., section 3.1: any summation order is "
+        "within gamma_n |x|^T |y| of the exact product, and blocking only tightens it "
+        "(pp. 62-64). The accumulator is the storage format on both sides -- Rule 9, and "
+        "sgemm accumulates in float32 -- so nothing narrows on the store and "
+        "storage_per_stage is zero. The amplification is the absolute-value companion "
+        "|C| @ |L|, elementwise, which Rule 10 prescribes over max|M| max|v|"
+    )
+    why_tail = ""
+
+    if contraction_may_fuse():
+        insertion = _insertion_stages(case, dtype)
+        terms += insertion
+        per_stage = 3
+        column = np.abs(matrix.astype(np.float64)).sum(axis=0)
+        amplification = amplification + np.broadcast_to(column, amplification.shape)
+        why_tail += (
+            ". This build's target ISA has a fused multiply-add, so both stages may "
+            "contract and Rule 10's three accumulator roundings per fused site apply to "
+            "each. The Bezier halves may then differ by gamma over the insertion chain, "
+            "amplified by one since every Bezier entry lies in [0, 1], and that reaches an "
+            "output element weighted by sum_k |L[k,j]|, which is the second amplification "
+            "term. The two stages are folded into one claim by charging the longer chain to "
+            "both, which is an upper bound because gamma is monotone"
+        )
+
+    if extra_absolute is not None:
+        amplification = amplification + extra_absolute / (2.0 * _gamma(terms * per_stage, dtype))
+        why_tail += (
+            ". The two backends are handed different change-of-basis matrices here, and the "
+            "measured gap between them propagates as sum_k |C[i,k]| |dL[k,j]| <= gap times "
+            "the row sum of C. That is an absolute term, so it is divided by the claim's own "
+            "gamma and by the harness's factor of two before being added to the "
+            "amplification, which is what turns it back into the tolerance it started as"
+        )
+
+    return bounded_parity(
+        roundings=Roundings(stages=terms, accumulator_per_stage=per_stage, storage_per_stage=0),
+        accumulator=dtype,
+        storage=dtype,
+        amplification=amplification,
+        why=why_head + why_tail,
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("variant", _VARIANTS, ids=[v.name for v in _VARIANTS])
+@pytest.mark.parametrize("case", _CASES, ids=[entry.label for entry in _CASES])
+def test_the_operators_agree(
+    cpp_backend: None, case: _Case, variant: LagrangeVariant, dtype: npt.DTypeLike
+) -> None:
+    """The two backends build the same operators from the same matrix.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        case (_Case): The knot vector.
+        variant (LagrangeVariant): The node family.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    matrix = _matrix(case.degree, variant, dtype)
+    reference = _build_kernel(case, dtype, matrix, Backend.PYTHON)
+    actual = _build_kernel(case, dtype, matrix, Backend.CPP)
+    assert_parity(
+        actual,
+        reference,
+        _product_claim(case, dtype, matrix, _bezier(case, dtype)),
+        context=f"{case.label} {variant.name} in {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("variant", _VARIANTS, ids=[v.name for v in _VARIANTS])
+@pytest.mark.parametrize("case", _CASES, ids=[entry.label for entry in _CASES])
+def test_the_layer_2_path_agrees(
+    cpp_backend: None, case: _Case, variant: LagrangeVariant, dtype: npt.DTypeLike
+) -> None:
+    """End to end, where each backend also builds its own change-of-basis matrix.
+
+    The companion to :func:`test_the_operators_agree`, which holds the matrix fixed.
+    Here the matrix is whatever :mod:`pantr.change_basis` hands each backend, so the
+    difference between the two matrices is measured and carried through the product
+    rather than assumed away. Measured on this machine it is zero everywhere except
+    ``float32`` at the second-kind Chebyshev family, whose nodes dispatch.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        case (_Case): The knot vector.
+        variant (LagrangeVariant): The node family.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    matrix_py = _matrix_under(Backend.PYTHON, case.degree, variant, dtype)
+    matrix_cpp = _matrix_under(Backend.CPP, case.degree, variant, dtype)
+    gap = float(
+        np.abs(matrix_cpp.astype(np.float64) - matrix_py.astype(np.float64)).max(initial=0.0)
+    )
+
+    bezier = _bezier(case, dtype)
+    extra = None
+    if gap > 0.0:
+        # |dA[i,j]| = |sum_k C[i,k] dL[k,j]| <= gap * sum_k |C[i,k]|, broadcast over j.
+        row_sums = np.abs(bezier.astype(np.float64)).sum(axis=2)
+        extra = np.broadcast_to(gap * row_sums[:, :, None], bezier.shape).copy()
+
+    reference = _build_layer_2(case, dtype, variant, Backend.PYTHON)
+    actual = _build_layer_2(case, dtype, variant, Backend.CPP)
+    assert_parity(
+        actual,
+        reference,
+        _product_claim(case, dtype, matrix_py, bezier, extra_absolute=extra),
+        context=f"{case.label} {variant.name} in {np.dtype(dtype).name} (matrix gap {gap:.3e})",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("variant", _VARIANTS, ids=[v.name for v in _VARIANTS])
+@pytest.mark.parametrize("case", _CASES, ids=[entry.label for entry in _CASES])
+def test_the_identity_mask_agrees(
+    cpp_backend: None, case: _Case, variant: LagrangeVariant, dtype: npt.DTypeLike
+) -> None:
+    """The two backends mark the same elements as already-Lagrange.
+
+    A boolean verdict per element, so the claim is exactness rather than a tolerance:
+    ``design/backend_parity.md`` Rule 11's distinction. Both sides reach it by the
+    same exact comparison of the matrix against the identity followed by the same
+    integer comparisons of the multiplicities.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        case (_Case): The knot vector.
+        variant (LagrangeVariant): The node family.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    space = BsplineSpace1D(np.asarray(case.knots, dtype=dtype), case.degree, snap_knots=False)
+    with use_backend(Backend.PYTHON):
+        reference = _lagrange_structural_identity_mask(space, variant)
+    with use_backend(Backend.CPP):
+        actual = _lagrange_structural_identity_mask(space, variant)
+    assert_object_parity(
+        py=reference,
+        cpp=actual,
+        fields=[
+            Field(
+                name="identity mask",
+                claim=exact_parity(
+                    why=(
+                        "the mask is an exact comparison of the change-of-basis matrix "
+                        "against the identity, and then two integer comparisons of a knot "
+                        "multiplicity against degree + 1. Both sides reach the same boolean "
+                        "by the same exact arithmetic, so a difference is a defect rather "
+                        "than a rounding"
+                    )
+                ),
+                read=lambda mask: mask,
+            )
+        ],
+        context=f"{case.label} {variant.name} in {np.dtype(dtype).name}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The three independent accuracy oracles
+# ---------------------------------------------------------------------------
+
+
+class _Exact(NamedTuple):
+    """One knot vector whose Lagrange operator entries are exact binary rationals.
+
+    Attributes:
+        label (str): What the case is.
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        operators (list[list[list[float]]]): The exact operators, one per element.
+    """
+
+    label: str
+    knots: list[float]
+    degree: int
+    operators: list[list[list[float]]]
+
+
+_EXACT_CASES: Final = (
+    # `C @ L` with the Bézier tables of `test_bspline_bezier_extraction._EXACT_CASES`
+    # and `L = [[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]]`, the equispaced degree-2
+    # Lagrange-to-Bernstein matrix. Worked out entry by entry; the C++ file carries
+    # the same tables and derives the Bézier half from `N = C @ B`.
+    _Exact(
+        "quadratic open, three uniform elements",
+        [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0],
+        2,
+        [
+            [[1.0, 0.25, 0.0], [0.0, 0.625, 0.5], [0.0, 0.125, 0.5]],
+            [[0.5, 0.125, 0.0], [0.5, 0.75, 0.5], [0.0, 0.125, 0.5]],
+            [[0.5, 0.125, 0.0], [0.5, 0.625, 0.0], [0.0, 0.25, 1.0]],
+        ],
+    ),
+    # Both operators of the unclamped uniform vector are the clamped case's middle
+    # one, because an interior element's operator depends only on the local knot
+    # pattern. Post-multiplying by the same matrix preserves that.
+    _Exact(
+        "quadratic unclamped, two uniform elements",
+        [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
+        2,
+        [
+            [[0.5, 0.125, 0.0], [0.5, 0.75, 0.5], [0.0, 0.125, 0.5]],
+            [[0.5, 0.125, 0.0], [0.5, 0.75, 0.5], [0.0, 0.125, 0.5]],
+        ],
+    ),
+    # Degree 1: the Bézier operator is the identity at any knots, and the equispaced
+    # degree-1 matrix is the identity too, so the product is.
+    _Exact(
+        "linear, three elements",
+        [0.0, 0.0, 1.0, 2.0, 3.0, 3.0],
+        1,
+        [
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[1.0, 0.0], [0.0, 1.0]],
+        ],
+    ),
+)
+"""Knot vectors whose equispaced Lagrange operators are exactly representable."""
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("case", _EXACT_CASES, ids=[entry.label for entry in _EXACT_CASES])
+def test_matches_the_exact_rational_operators(
+    case: _Exact, backend: Backend, dtype: npt.DTypeLike
+) -> None:
+    """Each backend reproduces the hand-derived exact table, with a zero bound.
+
+    Args:
+        case (_Exact): The knot vector and its exact operators.
+        backend (Backend): Which implementation to run.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    _demand_the_extension_if_needed(backend)
+    computed = _build_layer_2(
+        _Case(case.label, case.knots, case.degree, True),
+        dtype,
+        LagrangeVariant.EQUISPACES,
+        backend,
+    )
+    exact = np.asarray(case.operators, dtype=dtype)
+    assert computed.shape == exact.shape, f"{case.label}: shape {computed.shape} vs {exact.shape}"
+    assert_accuracy(
+        computed,
+        exact,
+        derived_accuracy(
+            bound=np.zeros_like(exact, dtype=np.float64),
+            why=(
+                "the Bezier entries of this vector are halves and the equispaced degree-2 "
+                "Lagrange-to-Bernstein matrix is [[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]], so "
+                "every product and every partial sum of the contraction is a binary rational "
+                "of a few bits, exactly representable in both storage formats. No rounding "
+                "occurs, so the bound is zero rather than derived from one"
+            ),
+        ),
+        context=f"{case.label} in {np.dtype(dtype).name} on {backend.name}",
+    )
+
+
+def test_the_exact_tables_are_not_trivial() -> None:
+    """A zero bound says something only if the values it guards are not all forced.
+
+    The Bézier builder starts from the identity, so a table that is the identity
+    everywhere would pass against a builder that did nothing at all and then
+    multiplied by nothing. This pins that the tables carry entries strictly between
+    zero and one, that they are not all the identity, that transposing one changes
+    it, and -- what separates them from the Bézier file's -- that they are not the
+    Bézier tables either, so an implementation that skipped the product would fail.
+    """
+    interesting = [
+        np.asarray(case.operators, dtype=np.float64) for case in _EXACT_CASES if case.degree >= 2
+    ]
+    assert interesting, "no exact case has an answer that is not forced"
+    for table in interesting:
+        strictly_inside = (table > 0.0) & (table < 1.0)
+        assert strictly_inside.any(), "an exact table is entirely zeros and ones"
+        identity = np.broadcast_to(np.eye(table.shape[1]), table.shape)
+        assert not np.array_equal(table, identity), "an exact table is the identity everywhere"
+        assert not np.array_equal(table, np.swapaxes(table, 1, 2)), (
+            "an exact table is symmetric, so comparing against it could not tell a "
+            "transposed operator from the right one"
+        )
+
+    quadratic = next(case for case in _EXACT_CASES if case.degree == 2 and "open" in case.label)
+    bezier = _bezier(_Case(quadratic.label, quadratic.knots, 2, True), np.float64)
+    assert not np.allclose(np.asarray(quadratic.operators), bezier), (
+        "the exact Lagrange table equals the Bezier one, so a builder that forgot the "
+        "change of basis entirely would pass against it"
+    )
+
+
+def _column_sum_tolerance(
+    case: _Case, dtype: npt.DTypeLike, matrix: npt.NDArray[Any], companion: npt.NDArray[Any]
+) -> npt.NDArray[np.float64]:
+    """How far a Lagrange operator's column sum may sit from the matrix's own.
+
+    The invariant is ``sum_i A[i,j] = sum_k (sum_i C[i,k]) L[k,j] = sum_k L[k,j]``.
+    Four terms, each named because each is a different mechanism:
+
+    * **The Bézier column defect.** ``|sum_i C[i,k] - 1|`` is what the Bézier file's
+      :func:`~tests.parity.test_bspline_bezier_extraction._column_sum_bound` bounds,
+      and it is imported rather than re-derived. It reaches column ``j`` weighted by
+      ``sum_k |L[k,j]|``. Using it here is a slight over-estimate, since it also
+      charges the ``degree`` roundings of a summation this term does not perform.
+    * **The contraction.** Each ``A[i,j]`` is within ``gamma_{degree+1}`` of the exact
+      product of the stored operands, times the companion; summed over ``i`` that is
+      ``gamma_{degree+1}`` times the companion's own column sum.
+    * **The two sums this test forms**, both in ``float64`` over ``degree + 1``
+      values: one over ``A[:, j]`` and one over ``L[:, j]``, each costing
+      ``gamma^{float64}_{degree}`` times its own absolute column sum.
+
+    No term is a fitted constant and none is a truncation: ``gamma`` is the closed
+    form throughout, because the Bézier chain grows with the element count.
+
+    **Stated hypothesis: no underflow in the entries.** The rounding model is purely
+    relative, and the Bézier file records that subnormal ``float32`` entries are
+    reachable with mixed per-gap knot ratios. The bound was observed to hold there by
+    a wide margin; observing is not covering.
+
+    Args:
+        case (_Case): The knot vector, which fixes the Bézier chain length.
+        dtype (npt.DTypeLike): Storage format.
+        matrix (npt.NDArray[Any]): The change-of-basis matrix.
+        companion (npt.NDArray[Any]): ``|C| @ |L|``, elementwise.
+
+    Returns:
+        npt.NDArray[np.float64]: One bound per ``(interval, column)``.
+    """
+    column_of_matrix = np.abs(matrix.astype(np.float64)).sum(axis=0)
+    column_of_companion = companion.sum(axis=1)
+
+    bezier_defect = _column_sum_bound(case, dtype) * column_of_matrix
+    contraction = _gamma(case.degree + 1, dtype) * column_of_companion
+    outer = _gamma(max(case.degree, 1), np.float64) * (column_of_companion + column_of_matrix)
+    return np.asarray(bezier_defect + contraction + outer, dtype=np.float64)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("variant", _VARIANTS, ids=[v.name for v in _VARIANTS])
+@pytest.mark.parametrize(
+    "case",
+    [entry for entry in _CASES if entry.accuracy],
+    ids=[e.label for e in _CASES if e.accuracy],
+)
+def test_the_columns_sum_to_the_matrix_columns(
+    case: _Case, variant: LagrangeVariant, backend: Backend, dtype: npt.DTypeLike
+) -> None:
+    """Every operator's columns sum to the change-of-basis matrix's, in either backend.
+
+    The analytic oracle, and the one that catches a transposition: the Bézier column
+    sums are one, so ``sum_i A[i,j] = sum_k L[k,j]``, while the row sums are not one
+    on either factor.
+
+    It also pins non-negativity, which ``design/extraction_port.md`` denied for this
+    target: every Lagrange node lies in ``[0, 1]`` where the Bernstein basis is
+    non-negative, so ``L`` is entrywise non-negative and so is the product.
+
+    Args:
+        case (_Case): The knot vector.
+        variant (LagrangeVariant): The node family.
+        backend (Backend): Which implementation to run.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    _demand_the_extension_if_needed(backend)
+    matrix = _matrix(case.degree, variant, dtype)
+    operators = _build_kernel(case, dtype, matrix, backend)
+    companion = _companion(_bezier(case, dtype), matrix)
+
+    assert matrix.min() >= 0.0, (
+        f"{variant.name} degree {case.degree}: the change-of-basis matrix has a negative "
+        "entry, so the columns of the product are not a convex combination and the "
+        "non-negativity claim below does not follow"
+    )
+    assert operators.min() >= 0.0, (
+        "a Lagrange operator entry is negative, though both factors are non-negative"
+    )
+
+    column_sums = operators.sum(axis=1).astype(np.float64)
+    target = np.broadcast_to(np.abs(matrix.astype(np.float64)).sum(axis=0), column_sums.shape)
+    assert_accuracy(
+        column_sums,
+        target,
+        derived_accuracy(
+            bound=np.broadcast_to(
+                _column_sum_tolerance(case, dtype, matrix, companion), column_sums.shape
+            ).copy(),
+            why=(
+                "sum_i A[i,j] = sum_k (sum_i C[i,k]) L[k,j] = sum_k L[k,j], using the Bezier "
+                "column sums. Compared against the matrix's own column sum rather than "
+                "against one, so its tabulation error is folded in exactly instead of "
+                "bounded. Four terms: the Bezier column defect weighted by sum_k |L[k,j]|, "
+                "the contraction's gamma_{degree+1} times the companion's column sum, and "
+                "the two float64 sums this test forms. Hypothesis: no underflow in the "
+                "entries"
+            ),
+        ),
+        context=f"{case.label} {variant.name} in {np.dtype(dtype).name} on {backend.name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_column_sum_check_is_not_vacuous(dtype: npt.DTypeLike) -> None:
+    """The column-sum bound is compared against a nonzero error somewhere.
+
+    ``design/backend_parity.md``'s rule the hard way: a bound compared only against
+    zero has not been checked. A dyadic vector with an equispaced matrix rounds
+    nothing; a Gauss-Legendre matrix at a non-uniform vector does.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format.
+    """
+    worst_ratio = 0.0
+    worst = 0.0
+    for case in _CASES:
+        if not case.accuracy:
+            continue
+        for variant in _VARIANTS:
+            matrix = _matrix(case.degree, variant, dtype)
+            operators = _build_kernel(case, dtype, matrix, Backend.PYTHON)
+            companion = _companion(_bezier(case, dtype), matrix)
+            target = np.abs(matrix.astype(np.float64)).sum(axis=0)
+            deviation = np.abs(operators.sum(axis=1).astype(np.float64) - target)
+            bound = _column_sum_tolerance(case, dtype, matrix, companion)
+            assert np.all(deviation <= bound), f"{case.label} {variant.name}: bound exceeded"
+            worst = max(worst, float(deviation.max(initial=0.0)))
+            worst_ratio = max(worst_ratio, float((deviation / bound).max(initial=0.0)))
+    assert worst > 0.0, (
+        "every case in the table has exactly-summing columns, so the derived bound is "
+        "only ever compared against zero and asserts nothing"
+    )
+    assert worst_ratio > 1e-3, (
+        f"the worst observed deviation reaches only {worst_ratio:.2e} of the bound, which "
+        "is far enough below it that the check would pass against a materially wrong answer"
+    )
+
+
+class _Dyadic(NamedTuple):
+    """A knot vector on which the node-tabulation check is exact.
+
+    Attributes:
+        label (str): What the case is.
+        knots (list[float]): The knot vector, dyadic throughout.
+        degree (int): The polynomial degree, 1 or 2, so the equispaced nodes are
+            dyadic too.
+    """
+
+    label: str
+    knots: list[float]
+    degree: int
+
+
+_DYADIC_CASES: Final = (
+    _Dyadic("quadratic uniform open", [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0], 2),
+    _Dyadic("quadratic unclamped uniform", [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0], 2),
+    _Dyadic("interior knot of multiplicity two", [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0], 2),
+    _Dyadic("linear, three elements", [0.0, 0.0, 1.0, 2.0, 3.0, 3.0], 1),
+)
+"""Vectors where every node, mapped point and intermediate is a short binary rational."""
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("case", _DYADIC_CASES, ids=[entry.label for entry in _DYADIC_CASES])
+def test_the_columns_are_the_basis_at_the_nodes(
+    case: _Dyadic, backend: Backend, dtype: npt.DTypeLike
+) -> None:
+    """Column ``k`` of an operator is the B-spline basis at the ``k``-th node.
+
+    The defining property of the target, checked against Cox-de Boor, which shares no
+    code with the extraction path. The right endpoint of each interval is skipped:
+    :meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis` resolves a point on a knot to
+    the interval starting there, so at ``xi = 1`` it reports the *next* interval's
+    window and the two vectors index different basis functions. The alignment of every
+    point that is checked is asserted rather than assumed.
+
+    The bound is zero, and the module docstring says why this family and no larger one.
+
+    Args:
+        case (_Dyadic): The knot vector.
+        backend (Backend): Which implementation to run.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    _demand_the_extension_if_needed(backend)
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    operators = _build_layer_2(
+        _Case(case.label, case.knots, case.degree, True),
+        dtype,
+        LagrangeVariant.EQUISPACES,
+        backend,
+    )
+    breaks = space.get_unique_knots_and_multiplicity(in_domain=True)[0]
+    first = space.first_basis_per_interval()
+    nodes = np.arange(case.degree + 1, dtype=dtype) / np.dtype(dtype).type(case.degree)
+
+    checked = 0
+    for interval in range(space.num_intervals):
+        left, right = breaks[interval], breaks[interval + 1]
+        for k in range(case.degree + 1):
+            if float(nodes[k]) >= 1.0:
+                continue
+            point = left + nodes[k] * (right - left)
+            values, window = space.tabulate_basis(np.asarray([point], dtype=dtype))
+            assert int(window[0]) == int(first[interval]), (
+                f"{case.label}: the point at node {k} of interval {interval} landed in "
+                f"another interval's basis window, so the comparison would be misaligned"
+            )
+            assert_accuracy(
+                np.asarray(values[0]),
+                np.asarray(operators[interval, :, k]),
+                derived_accuracy(
+                    bound=np.zeros(case.degree + 1, dtype=np.float64),
+                    why=(
+                        "every knot, every equispaced node at degree 1 or 2, the mapped "
+                        "point and every intermediate of both routes is a binary rational "
+                        "of a few bits, so neither the Cox-de Boor recurrence nor the "
+                        "extraction rounds and the two agree exactly. Above degree 2 the "
+                        "nodes become thirds and this stops holding, which is why the "
+                        "family is what it is"
+                    ),
+                ),
+                context=(
+                    f"{case.label} interval {interval} node {k} in "
+                    f"{np.dtype(dtype).name} on {backend.name}"
+                ),
+            )
+            checked += 1
+    assert checked >= case.degree * space.num_intervals, (
+        f"{case.label}: only {checked} node comparisons ran, so the check is thinner than "
+        "the table implies"
+    )
+
+
+def test_the_node_tabulation_check_is_not_trivial() -> None:
+    """The vectors it compares are not forced to agree by being all zeros and ones.
+
+    A degree-1 operator is the identity, so its columns are unit vectors and the
+    comparison would hold against almost anything. This pins that the quadratic cases
+    put values strictly inside ``(0, 1)`` in front of it, and that the columns of one
+    operator are not all equal -- which is what makes a permuted node order visible.
+    """
+    interesting = 0
+    for case in _DYADIC_CASES:
+        if case.degree < 2:
+            continue
+        operators = _build_layer_2(
+            _Case(case.label, case.knots, case.degree, True),
+            np.float64,
+            LagrangeVariant.EQUISPACES,
+            Backend.PYTHON,
+        )
+        assert ((operators > 0.0) & (operators < 1.0)).any(), (
+            f"{case.label}: every entry is a zero or a one"
+        )
+        distinct = {tuple(operators[0, :, k]) for k in range(case.degree + 1)}
+        assert len(distinct) == case.degree + 1, (
+            f"{case.label}: two columns of the first operator are equal, so a permuted "
+            "node order would be invisible here"
+        )
+        interesting += 1
+    assert interesting > 0, "no dyadic case has an answer that is not forced"
+
+
+# ---------------------------------------------------------------------------
+# What the port does not do, and what the binding refuses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_degree_zero_is_refused_by_both_backends(backend: Backend) -> None:
+    """The Lagrange target has no degree-0 case, and that predates this port.
+
+    :func:`pantr.change_basis.compute_lagrange_to_bernstein_1d` refuses a degree
+    below 1, and Layer 2 asks it for the matrix before reaching either kernel. Pinned
+    so that the absence of a degree-0 row in every table above is a recorded fact
+    rather than an untested gap, and so that a change to that refusal shows up here.
+
+    Args:
+        backend (Backend): Which implementation to run.
+    """
+    _demand_the_extension_if_needed(backend)
+    knots = np.asarray([0.0, 1.0], dtype=np.float64)
+    space = BsplineSpace1D(knots, 0, snap_knots=False)
+    with use_backend(backend), pytest.raises(ValueError, match="[Dd]egree must at least 1"):
+        space.tabulate_Lagrange_extraction_operators()
+
+    # The mask does have a degree-0 answer, because Layer 2 short-circuits before
+    # asking for a matrix. Both backends take that branch, so it never reaches a
+    # kernel and there is nothing to dispatch.
+    with use_backend(backend):
+        mask = _lagrange_structural_identity_mask(space, LagrangeVariant.EQUISPACES)
+    assert mask.tolist() == [True]
+
+
+def test_the_claim_is_not_vacuous(cpp_backend: None) -> None:
+    """A parity claim asserts nothing unless the two paths could have differed.
+
+    The specific risk: if the catalogue handed back the same callable for both
+    backends, every assertion above would pass for the wrong reason. Identity is
+    taken against the catalogue rather than against a kernel's ``repr`` or
+    ``py_func``, neither of which exists under ``NUMBA_DISABLE_JIT=1``.
+    """
+    python_builder = lagrange_extraction_kernel(Backend.PYTHON)
+    cpp_builder = lagrange_extraction_kernel(Backend.CPP)
+    assert python_builder is not cpp_builder
+    python_mask = lagrange_identity_mask_kernel(Backend.PYTHON)
+    cpp_mask = lagrange_identity_mask_kernel(Backend.CPP)
+    assert python_mask is not cpp_mask
+
+    # The apply catalogue is the sibling table; the builders must not have landed in
+    # it, since the two are separate C++ registrations with separate claims.
+    assert python_builder not in _KERNELS.values()
+    assert cpp_builder not in _KERNELS.values()
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_two_backends_still_differ_somewhere(cpp_backend: None, dtype: npt.DTypeLike) -> None:
+    """The bounded claim is compared against a nonzero difference somewhere.
+
+    ``design/backend_parity.md`` Rule 7: a bound nothing approaches can rot without a
+    test noticing, so the guard asserts the opposite of the bound -- but it is a fact
+    about the *host*, not about this library, since which summation order the BLAS
+    picks depends on the build and the processor. Enforced only where it was
+    measured, and reported with a reason anywhere else.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    worst = 0.0
+    for case in _CASES:
+        for variant in _VARIANTS:
+            matrix = _matrix(case.degree, variant, dtype)
+            reference = _build_kernel(case, dtype, matrix, Backend.PYTHON)
+            actual = _build_kernel(case, dtype, matrix, Backend.CPP)
+            worst = max(
+                worst,
+                float(
+                    np.abs(actual.astype(np.float64) - reference.astype(np.float64)).max(
+                        initial=0.0
+                    )
+                ),
+            )
+    demand_the_reference_host(
+        guard="the two backends still disagree on at least one Lagrange operator",
+        measured=(
+            "one unit of roundoff at degree 3 and above, in both storage formats, and "
+            "exactly zero below. Which arguments a BLAS gemm and an ascending loop round "
+            "differently is a property of the build and the processor, so this is not "
+            "enforced off the machine it was measured on"
+        ),
+    )
+    assert worst > 0.0, (
+        "the two backends agree bit for bit on every case in the table, so the bounded "
+        "claim is only ever compared against zero. Either the dispatch collapsed onto one "
+        "implementation or the bound should be strengthened to bitwise"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_a_strided_out_is_filled(backend: Backend, dtype: npt.DTypeLike) -> None:
+    """A caller's non-contiguous ``out`` comes back filled, under either backend.
+
+    The binding declares ``out`` C-contiguous, so the adapter in
+    :mod:`pantr.bspline._extraction_backend` computes into a fresh buffer and copies
+    back. Nothing else in this file reaches that path, and a silently unfilled ``out``
+    would look like a wrong answer far from its cause.
+
+    Args:
+        backend (Backend): Which implementation to run.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    _demand_the_extension_if_needed(backend)
+    case = _CASES[0]
+    expected = _build_layer_2(case, dtype, LagrangeVariant.EQUISPACES, backend)
+    canvas = np.full((2 * expected.shape[0], *expected.shape[1:]), np.nan, dtype=dtype)
+    strided = canvas[::2]
+    assert not strided.flags["C_CONTIGUOUS"]
+    knots = np.asarray(case.knots, dtype=dtype)
+    space = BsplineSpace1D(knots, case.degree, snap_knots=False)
+    with use_backend(backend):
+        returned = _tabulate_Bspline_Lagrange_1D_extraction_impl(
+            space.knots, case.degree, space.tolerance, out=strided
+        )
+    assert returned is strided
+    assert np.array_equal(strided, expected), "the strided out was not filled with the answer"
+
+
+def test_the_builder_binding_refuses_a_wrongly_shaped_matrix(cpp_backend: None) -> None:
+    """A change-of-basis matrix that is not ``(degree + 1)`` square is a ``ValueError``.
+
+    No counterpart in the oracle, where Layer 2 takes the matrix from a cache keyed on
+    the degree. Reaching the header with a wrong shape would be undefined behaviour,
+    so the binding refuses instead of asserting.
+    """
+    knots = np.asarray(_CASES[0].knots, dtype=np.float64)
+    out = np.empty((3, 3, 3), dtype=np.float64)
+    for shape in ((2, 3), (3, 2), (4, 4)):
+        with pytest.raises(ValueError, match=r"lagrange_to_bernstein must have shape \(3, 3\)"):
+            _bindings().lagrange_extraction_1d(knots, 2, 0.0, np.eye(*shape, dtype=np.float64), out)
+    with pytest.raises(ValueError, match=r"lagrange_to_bernstein must have shape \(3, 3\)"):
+        _bindings().lagrange_structural_identity_mask(
+            np.asarray([3, 1, 3], dtype=np.intp),
+            2,
+            np.eye(2, dtype=np.float64),
+            np.empty(2, dtype=np.bool_),
+        )
+
+
+def test_the_builder_binding_refuses_the_knot_vectors_the_oracle_refuses(
+    cpp_backend: None,
+) -> None:
+    """The Lagrange entry point runs the same refusals as its Bézier sibling.
+
+    Shared code on the C++ side, so what this pins is that the Lagrange binding calls
+    it, and that it does so **before** the matrix check -- otherwise a negative degree
+    would be reported as a shape complaint about a matrix nobody could have sized.
+    """
+    matrix = np.eye(3, dtype=np.float64)
+    out = np.empty((1, 3, 3), dtype=np.float64)
+    with pytest.raises(ValueError, match="knots must be non-decreasing"):
+        _bindings().lagrange_extraction_1d(
+            np.asarray([0.0, 0.0, 1.0, 0.5, 1.0, 1.0]), 2, 0.0, matrix, out
+        )
+    with pytest.raises(ValueError, match=r"knots must have at least 2\*degree\+2 elements"):
+        _bindings().lagrange_extraction_1d(np.asarray([0.0, 0.0, 1.0]), 2, 0.0, matrix, out)
+    with pytest.raises(ValueError, match="tol must be non-negative"):
+        _bindings().lagrange_extraction_1d(
+            np.asarray(_CASES[0].knots, dtype=np.float64), 2, -1.0, matrix, out
+        )
+    # Degree first, matrix second: a negative degree cannot size a matrix, so the
+    # message must be the oracle's rather than the shape one.
+    with pytest.raises(ValueError, match="degree must be non-negative"):
+        _bindings().lagrange_extraction_1d(
+            np.asarray([0.0, 0.0, 1.0, 1.0]), -1, 0.0, np.eye(1, dtype=np.float64), out
+        )
+
+
+def test_the_lagrange_bindings_refuse_a_dtype_they_would_have_to_cast(cpp_backend: None) -> None:
+    """``.noconvert()`` on every array, and on the matrix for two separate reasons.
+
+    In the builder a widened matrix would change the accumulation width of the
+    contraction, which ``design/backend_parity.md`` Rule 9 makes part of the contract,
+    so ``knots``, the matrix and ``out`` must all be the same format and a mixed call
+    matches no overload.
+
+    **The mask is the deliberate exception, and it is not a gap.** Its matrix is the
+    only float it takes, so both overloads are legal and a ``float32`` matrix selects
+    the ``float`` one rather than being cast. What ``.noconvert()`` still buys there
+    is that an integer matrix is refused instead of being widened into a comparison
+    against bits the caller never held.
+    """
+    knots = np.asarray(_CASES[0].knots, dtype=np.float64)
+    out = np.empty((3, 3, 3), dtype=np.float64)
+    with pytest.raises(TypeError):
+        _bindings().lagrange_extraction_1d(knots, 2, 0.0, np.eye(3, dtype=np.float32), out)
+    with pytest.raises(TypeError):
+        _bindings().lagrange_extraction_1d(
+            knots.astype(np.float32), 2, 0.0, np.eye(3, dtype=np.float64), out
+        )
+    with pytest.raises(TypeError):
+        _bindings().lagrange_extraction_1d(
+            np.asarray(_CASES[0].knots, dtype=np.int64), 2, 0.0, np.eye(3), out
+        )
+
+    multiplicity = np.asarray([3, 1, 3], dtype=np.intp)
+    narrow = np.empty(2, dtype=np.bool_)
+    wide = np.empty(2, dtype=np.bool_)
+    _bindings().lagrange_structural_identity_mask(
+        multiplicity, 2, np.eye(3, dtype=np.float32), narrow
+    )
+    _bindings().lagrange_structural_identity_mask(
+        multiplicity, 2, np.eye(3, dtype=np.float64), wide
+    )
+    assert narrow.tolist() == wide.tolist(), (
+        "the two matrix overloads of the mask disagree on the identity"
+    )
+    with pytest.raises(TypeError):
+        _bindings().lagrange_structural_identity_mask(
+            multiplicity, 2, np.eye(3, dtype=np.int64), narrow
+        )
+    with pytest.raises(TypeError):
+        _bindings().lagrange_structural_identity_mask(
+            np.asarray([3, 1, 3], dtype=np.int32),
+            2,
+            np.eye(3, dtype=np.float64),
+            narrow,
+        )
+
+
+def test_the_mask_binding_refuses_its_own_bad_calls(cpp_backend: None) -> None:
+    """The Lagrange mask entry point's three non-matrix refusals.
+
+    The Numba kernel validates nothing and Layer 2 reaches it only from a space, so
+    these guard a direct caller -- including a C++ one, for whom the binding's checks
+    are the only ones there are.
+    """
+    multiplicity = np.asarray([3, 1, 3], dtype=np.intp)
+    matrix = np.eye(3, dtype=np.float64)
+    with pytest.raises(ValueError, match="degree must be non-negative"):
+        _bindings().lagrange_structural_identity_mask(
+            multiplicity, -1, matrix, np.empty(2, dtype=np.bool_)
+        )
+    with pytest.raises(ValueError, match="at least one class"):
+        _bindings().lagrange_structural_identity_mask(
+            np.empty(0, dtype=np.intp), 2, matrix, np.empty(0, dtype=np.bool_)
+        )
+    with pytest.raises(ValueError, match="out must have 2 elements"):
+        _bindings().lagrange_structural_identity_mask(
+            multiplicity, 2, matrix, np.empty(3, dtype=np.bool_)
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_claim_holds_over_a_sweep_ten_times_the_shipped_one(
+    cpp_backend: None, dtype: npt.DTypeLike
+) -> None:
+    """A bound checked only by the sweep that ships with it has not been checked.
+
+    The shipped parametrization is ``len(_CASES)`` knot vectors per (dtype, variant).
+    This draws ten times that many per dtype, cycling the variant, from the family the
+    Bézier algorithm handles, and asserts the parity claim, the identity mask and the
+    column-sum invariant on each. Degree-0 draws are discarded, since this target
+    refuses them.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    wanted = 10 * len(_CASES) * len(_VARIANTS)
+    checked = 0
+    worst_column = 0.0
+    draw = 0
+    while checked < wanted:
+        rng = np.random.default_rng(910_000 + 13 * draw)
+        case = _draw(rng, dtype)
+        draw += 1
+        if case.degree < 1:
+            continue
+        variant = _VARIANTS[checked % len(_VARIANTS)]
+        matrix = _matrix(case.degree, variant, dtype)
+        bezier = _bezier(case, dtype)
+        reference = _build_kernel(case, dtype, matrix, Backend.PYTHON)
+        actual = _build_kernel(case, dtype, matrix, Backend.CPP)
+        context = f"{case.label} {variant.name} in {np.dtype(dtype).name} (draw {draw})"
+        assert_parity(
+            actual, reference, _product_claim(case, dtype, matrix, bezier), context=context
+        )
+
+        space = BsplineSpace1D(np.asarray(case.knots, dtype=dtype), case.degree, snap_knots=False)
+        with use_backend(Backend.PYTHON):
+            mask_reference = _lagrange_structural_identity_mask(space, variant)
+        with use_backend(Backend.CPP):
+            mask_actual = _lagrange_structural_identity_mask(space, variant)
+        assert np.array_equal(mask_actual, mask_reference), f"{context}: the masks differ"
+
+        companion = _companion(bezier, matrix)
+        target = np.abs(matrix.astype(np.float64)).sum(axis=0)
+        deviation = np.abs(actual.sum(axis=1).astype(np.float64) - target)
+        bound = _column_sum_tolerance(case, dtype, matrix, companion)
+        assert np.all(deviation <= bound), f"{context}: a column sum missed the bound"
+        worst_column = max(worst_column, float(deviation.max(initial=0.0)))
+        checked += 1
+
+    assert checked == wanted, f"the sweep ran {checked} cases, expected {wanted}"
+    assert worst_column > 0.0, (
+        "no drawn case rounded at all, so the column-sum bound was compared against zero "
+        "throughout the sweep"
+    )

--- a/tests/parity/test_bspline_lagrange_extraction.py
+++ b/tests/parity/test_bspline_lagrange_extraction.py
@@ -18,17 +18,18 @@ backends do differ, by one unit of roundoff at degree 3 and above and not at all
 below; :func:`test_the_two_backends_still_differ_somewhere` is the guard that keeps
 the bound from silently becoming a comparison against zero.
 
-**What a bounded claim cannot see here, and where it is checked instead.** The bound
-has to admit the two summation orders' own disagreement, and measured over the shipped
-table at ``float32`` that disagreement is **exactly one unit in the last place** -- the
-same size as the gap between accumulating the contraction in ``float32`` and in
-``float64``. The two are not separable by any bound, and not for want of a tighter one:
-the contraction sums non-negative terms, so no cancellation can make the width gap
-dominate. So nothing in this file would fail if the C++ accumulated in ``double``, which
-``design/backend_parity.md`` Rule 9 forbids. Verified by mutation, not assumed.
-``cpp/tests/test_bspline_extraction.cpp``'s ``check_the_accumulator_is_the_storage_type``
-is where the width is pinned, on the C++ side where there is no BLAS and both operands
-can be chosen.
+**What a bounded claim cannot see here, and where it is checked instead.** Nothing in
+this file would fail if the C++ accumulated the contraction in ``double``, which
+``design/backend_parity.md`` Rule 9 forbids. That is not a hole in the bound and no
+constant would close it: the bound is derived from each backend's forward error against
+the exact product, and a wider accumulator has a **smaller** forward error, so it lies
+inside the same bound by construction. Rule 8 records the general form -- "a different
+but valid algorithm passing is not a failure of the bound". Measured alongside the
+argument: mutating the accumulator leaves all cases green, and the gap it opens at
+``float32`` is one unit in the last place, the same size as the two backends' own
+disagreement. ``cpp/tests/test_bspline_extraction.cpp``'s
+``check_the_accumulator_is_the_storage_type`` is where the width is pinned, on the C++
+side where there is no BLAS and both operands can be chosen.
 
 The exception is an **identity** change of basis, which happens at degree 1 for the
 equispaced, Gauss-Lobatto-Legendre and second-kind Chebyshev families. Every term is
@@ -136,6 +137,7 @@ import pytest
 
 from pantr._backend import Backend, use_backend
 from pantr.basis import LagrangeVariant
+from pantr.basis._basis_lagrange import _get_lagrange_points
 from pantr.bspline import BsplineSpace1D
 from pantr.bspline._bspline_extraction import (
     _tabulate_Bspline_Bezier_1D_extraction_impl,
@@ -376,6 +378,29 @@ def _companion(bezier: npt.NDArray[Any], matrix: npt.NDArray[Any]) -> npt.NDArra
     )
 
 
+def _column_sums(operators: npt.NDArray[Any]) -> npt.NDArray[np.float64]:
+    """Sum each operator's columns, in ``float64`` whatever the operators are.
+
+    The cast comes **before** the sum, and that is the whole point: ``ndarray.sum``
+    accumulates in the array's own dtype, so summing a ``float32`` operator and then
+    casting would put ``gamma^{float32}_{degree}`` of this test's own arithmetic into
+    a quantity meant to measure the operator's. Casting first is exact and leaves only
+    ``gamma^{float64}_{degree}``, which is what :func:`_column_sum_tolerance` charges.
+
+    One spelling for all three call sites, so the bound and the measurement cannot
+    disagree about which arithmetic the sum lives in -- ``design/backend_parity.md``
+    Rule 5's "name the arithmetic", applied to a test rather than to a kernel.
+
+    Args:
+        operators (npt.NDArray[Any]): The ``(n_intervals, degree+1, degree+1)``
+            operators.
+
+    Returns:
+        npt.NDArray[np.float64]: One column sum per ``(interval, column)``.
+    """
+    return np.asarray(operators.astype(np.float64).sum(axis=1), dtype=np.float64)
+
+
 def _gamma(roundings: int, dtype: npt.DTypeLike) -> float:
     """Higham's ``gamma_m = m u / (1 - m u)`` for a given rounding count.
 
@@ -436,8 +461,17 @@ def _product_claim(
     every Bézier entry lies in ``[0, 1]``. That difference reaches an output element
     weighted by ``sum_k |L[k,j]|``, and the contraction itself may fuse, so its own
     budget rises from one rounding per term to three. Both terms are folded into a
-    single claim by monotonicity of ``gamma``: charging the longer chain to both and
-    adding the two amplifications is an upper bound on charging each its own.
+    single claim by monotonicity of ``gamma``: charging the **longer** of the two
+    chains to both and adding the two amplifications is an upper bound on charging
+    each its own. The max rather than the sum, because the max is already enough and
+    is the tighter of the two.
+
+    **This branch is not reasoned about, it is run.** ``design/backend_parity.md``
+    Rule 11 records the sibling Bézier port shipping a fused branch that called
+    :func:`bounded_parity` with an argument it does not take, green over 133 tests
+    because nothing reached it. So this one was exercised against an extension built
+    at ``-march=native``, where ``contraction_may_fuse()`` is true, and the result is
+    recorded in the PR that added it rather than assumed here.
 
     Args:
         case (_Case): The knot vector.
@@ -465,13 +499,19 @@ def _product_claim(
         "(pp. 62-64). The accumulator is the storage format on both sides -- Rule 9, and "
         "sgemm accumulates in float32 -- so nothing narrows on the store and "
         "storage_per_stage is zero. The amplification is the absolute-value companion "
-        "|C| @ |L|, elementwise, which Rule 10 prescribes over max|M| max|v|"
+        "|C| @ |L|, elementwise, which Rule 10 prescribes over max|M| max|v|. The "
+        "hypothesis this rests on: the Bezier halves agree bit for bit, which "
+        "tests/parity/test_bspline_bezier_extraction.py claims and which "
+        "contraction_may_fuse() is the one condition known to break, so the whole "
+        "difference here is the contraction's"
     )
     why_tail = ""
 
     if contraction_may_fuse():
-        insertion = _insertion_stages(case, dtype)
-        terms += insertion
+        # The longer of the two chains, charged to both, rather than their sum: gamma is
+        # monotone, so gamma_{3S} and gamma_{3n} are each at most gamma_{3 max(S, n)},
+        # and the max is the tighter of the two valid choices.
+        terms = max(terms, _insertion_stages(case, dtype))
         per_stage = 3
         column = np.abs(matrix.astype(np.float64)).sum(axis=0)
         amplification = amplification + np.broadcast_to(column, amplification.shape)
@@ -481,8 +521,11 @@ def _product_claim(
             "each. The Bezier halves may then differ by gamma over the insertion chain, "
             "amplified by one since every Bezier entry lies in [0, 1], and that reaches an "
             "output element weighted by sum_k |L[k,j]|, which is the second amplification "
-            "term. The two stages are folded into one claim by charging the longer chain to "
-            "both, which is an upper bound because gamma is monotone"
+            "term. The two stages are folded into one claim by charging the longer of the "
+            "two chains to both and adding their amplifications, which is an upper bound "
+            "because gamma is monotone. The companion is formed from the oracle's Bezier "
+            "operator rather than the exact one; the difference is second order in u and "
+            "is absorbed by the budget"
         )
 
     if extra_absolute is not None:
@@ -710,11 +753,13 @@ def test_matches_the_exact_rational_operators(
         derived_accuracy(
             bound=np.zeros_like(exact, dtype=np.float64),
             why=(
-                "the Bezier entries of this vector are halves and the equispaced degree-2 "
-                "Lagrange-to-Bernstein matrix is [[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]], so "
-                "every product and every partial sum of the contraction is a binary rational "
-                "of a few bits, exactly representable in both storage formats. No rounding "
-                "occurs, so the bound is zero rather than derived from one"
+                "the Bezier entries of this vector are halves at degree 2 and zeros and "
+                "ones at degree 1, and the equispaced Lagrange-to-Bernstein matrix is "
+                "[[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]] at degree 2 and the identity at "
+                "degree 1. So every product and every partial sum of the contraction is a "
+                "binary rational of a few bits, exactly representable in both storage "
+                "formats. No rounding occurs, so the bound is zero rather than derived "
+                "from one"
             ),
         ),
         context=f"{case.label} in {np.dtype(dtype).name} on {backend.name}",
@@ -769,9 +814,15 @@ def _column_sum_tolerance(
     * **The contraction.** Each ``A[i,j]`` is within ``gamma_{degree+1}`` of the exact
       product of the stored operands, times the companion; summed over ``i`` that is
       ``gamma_{degree+1}`` times the companion's own column sum.
-    * **The two sums this test forms**, both in ``float64`` over ``degree + 1``
-      values: one over ``A[:, j]`` and one over ``L[:, j]``, each costing
-      ``gamma^{float64}_{degree}`` times its own absolute column sum.
+    * **The two sums this test forms.** Both run in ``float64`` over ``degree + 1``
+      values and each costs ``gamma^{float64}_{degree}`` times its own absolute column
+      sum. That both are ``float64`` is a property of :func:`_column_sums` and of the
+      ``astype`` in front of the matrix's sum, not something to assume:
+      :meth:`numpy.ndarray.sum` accumulates in the array's own dtype, so a cast placed
+      *after* the sum would leave a ``float32`` accumulation charged at ``float64``
+      rates and understate this term by eight orders of magnitude. The contraction
+      term above happens to dominate the shortfall for every degree, by monotonicity
+      of ``gamma``, which is exactly what would have kept the error invisible.
 
     No term is a fitted constant and none is a truncation: ``gamma`` is the closed
     form throughout, because the Bézier chain grows with the element count.
@@ -795,7 +846,7 @@ def _column_sum_tolerance(
 
     bezier_defect = _column_sum_bound(case, dtype) * column_of_matrix
     contraction = _gamma(case.degree + 1, dtype) * column_of_companion
-    outer = _gamma(max(case.degree, 1), np.float64) * (column_of_companion + column_of_matrix)
+    outer = _gamma(case.degree, np.float64) * (column_of_companion + column_of_matrix)
     return np.asarray(bezier_defect + contraction + outer, dtype=np.float64)
 
 
@@ -840,7 +891,7 @@ def test_the_columns_sum_to_the_matrix_columns(
         "a Lagrange operator entry is negative, though both factors are non-negative"
     )
 
-    column_sums = operators.sum(axis=1).astype(np.float64)
+    column_sums = _column_sums(operators)
     target = np.broadcast_to(np.abs(matrix.astype(np.float64)).sum(axis=0), column_sums.shape)
     assert_accuracy(
         column_sums,
@@ -884,7 +935,7 @@ def test_the_column_sum_check_is_not_vacuous(dtype: npt.DTypeLike) -> None:
             operators = _build_kernel(case, dtype, matrix, Backend.PYTHON)
             companion = _companion(_bezier(case, dtype), matrix)
             target = np.abs(matrix.astype(np.float64)).sum(axis=0)
-            deviation = np.abs(operators.sum(axis=1).astype(np.float64) - target)
+            deviation = np.abs(_column_sums(operators) - target)
             bound = _column_sum_tolerance(case, dtype, matrix, companion)
             assert np.all(deviation <= bound), f"{case.label} {variant.name}: bound exceeded"
             worst = max(worst, float(deviation.max(initial=0.0)))
@@ -1055,6 +1106,77 @@ def test_degree_zero_is_refused_by_both_backends(backend: Backend) -> None:
     with use_backend(backend):
         mask = _lagrange_structural_identity_mask(space, LagrangeVariant.EQUISPACES)
     assert mask.tolist() == [True]
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("variant", _VARIANTS, ids=[v.name for v in _VARIANTS])
+def test_the_oracles_in_place_product_matches_a_non_aliased_one(
+    variant: LagrangeVariant, dtype: npt.DTypeLike
+) -> None:
+    """The Python kernel's ``np.matmul(out, L, out=out)`` is not corrupted by aliasing.
+
+    The oracle forms the product in place, with ``out`` as both the first operand and
+    the destination. That is safe only because :func:`numpy.matmul` detects the overlap
+    and buffers -- a claim about a third party, across a numpy range this project's own
+    ``CLAUDE.md`` records as behaving differently between local and CI. So it is checked
+    rather than asserted in a comment: the in-place answer must equal the one computed
+    into a fresh array, bit for bit. A numpy that stopped buffering would corrupt the
+    later rows from the earlier ones and fail here.
+
+    The call is pre-existing -- the port relocated it, it did not introduce it -- so this
+    also guards the oracle rather than only the port.
+
+    Args:
+        variant (LagrangeVariant): The node family.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    for case in _CASES:
+        matrix = _matrix(case.degree, variant, dtype)
+        bezier = _bezier(case, dtype)
+        aliased = bezier.copy()
+        np.matmul(aliased, matrix, out=aliased)
+        separate = np.matmul(bezier, matrix)
+        assert aliased.tobytes() == separate.tobytes(), (
+            f"{case.label} {variant.name} in {np.dtype(dtype).name}: the in-place matmul "
+            "differs from the non-aliased one, so numpy is no longer buffering the "
+            "overlap the oracle relies on"
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("variant", _VARIANTS, ids=[v.name for v in _VARIANTS])
+def test_every_node_family_is_ascending_inside_the_unit_interval(
+    variant: LagrangeVariant, dtype: npt.DTypeLike
+) -> None:
+    """The hypothesis both structural claims rest on, checked rather than reasoned.
+
+    Two claims in this port need it and neither could survive without it. That the
+    Lagrange-to-Bernstein matrix is entrywise non-negative and column-stochastic follows
+    from the nodes lying in ``[0, 1]``, where the Bernstein basis is; that is what makes
+    the Lagrange operator column-stochastic and the amplification tight. And the
+    soundness of the mask's all-false branch -- written out beside
+    ``lagrange_structural_identity_mask`` in ``cpp/include/pantr/bspline/extraction.hpp``
+    -- ends by ruling out the reversal permutation, which needs the nodes to be
+    **ascending** rather than merely inside the interval.
+
+    Swept past the degrees any table here uses, since a family that reordered or
+    overshot at high degree would break both claims silently.
+
+    Args:
+        variant (LagrangeVariant): The node family.
+        dtype (npt.DTypeLike): Storage format.
+    """
+    for n_pts in range(2, 40):
+        nodes = _get_lagrange_points(variant, n_pts, np.dtype(dtype))
+        assert np.all(np.diff(nodes) > 0), (
+            f"{variant.name} at {n_pts} nodes is not strictly ascending, so the mask's "
+            "all-false branch is no longer sound"
+        )
+        assert nodes.min() >= 0.0 and nodes.max() <= 1.0, (
+            f"{variant.name} at {n_pts} nodes leaves [0, 1], so the Bernstein basis is "
+            "not non-negative there and neither the amplification nor the "
+            "column-stochasticity claim follows"
+        )
 
 
 def test_the_claim_is_not_vacuous(cpp_backend: None) -> None:
@@ -1323,7 +1445,7 @@ def test_the_claim_holds_over_a_sweep_ten_times_the_shipped_one(
 
         companion = _companion(bezier, matrix)
         target = np.abs(matrix.astype(np.float64)).sum(axis=0)
-        deviation = np.abs(actual.sum(axis=1).astype(np.float64) - target)
+        deviation = np.abs(_column_sums(actual) - target)
         bound = _column_sum_tolerance(case, dtype, matrix, companion)
         assert np.all(deviation <= bound), f"{context}: a column sum missed the bound"
         worst_column = max(worst_column, float(deviation.max(initial=0.0)))

--- a/tests/parity/test_bspline_lagrange_extraction.py
+++ b/tests/parity/test_bspline_lagrange_extraction.py
@@ -55,11 +55,23 @@ is bitwise except where the node family itself dispatches.
 it fixed: it measures the gap between the two backends' matrices and carries it
 through the product, exactly as that file measures its node gap.
 
-The three independent accuracy oracles
---------------------------------------
+The three accuracy oracles, and how far apart they really stand
+---------------------------------------------------------------
 
 Parity says the two backends agree, not that either is right, and a transposed index
 would be invisible to it. None of the three below is the Python implementation.
+
+**They are not three independent checks, and an earlier version of this heading said
+they were.** Over the inputs they share -- equispaced nodes, degree at most two --
+the first and the third assert *bit-identical* reference values, because both are
+asking whether an entry of ``A_e`` equals the mathematically correct B-spline value
+at that node. What separates them is **provenance, not arithmetic**: the first's
+reference is derived by hand outside pantr, so it alone can catch a defect shared
+between the extraction path and Cox-de Boor, while the third's comes from pantr's
+own Cox-de Boor and cannot. The third's extra reach over the first is one case with
+an interior knot of multiplicity two, plus the window-alignment assertion. **Only the
+second is a genuinely different question**: a different algebraic invariant, bounded
+rather than zero, swept over the whole case and variant table.
 
 **Exact rational values, hand-derived.** At degree 2 with equispaced nodes,
 ``L = [[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]]`` follows from ``L[j,k] = B_j(x_k)`` at
@@ -75,12 +87,13 @@ tabulation error is folded in exactly rather than bounded. Columns and not rows:
 quadratic table's rows sum to ``1.25, 1.75, 0.625``, so this is what catches a
 transposition.
 
-It also pins that no entry is negative, which is a correction rather than a
-restatement: ``design/extraction_port.md`` says the Lagrange-to-Bernstein matrix has
-negative entries and that a bound assuming convexity would be false for it. It does
-not. Its columns are the Bernstein basis evaluated at a node in ``[0, 1]``, so they
-are non-negative and sum to one, and ``A_e`` is a product of two column-stochastic
-matrices.
+It also pins that no entry is negative. ``design/extraction_port.md`` used to say
+the Lagrange-to-Bernstein matrix has negative entries, and that a bound assuming
+convexity would be false for it; that claim was wrong and this branch corrected it,
+so the document no longer says so. Only the *cardinal*-to-Bernstein matrix has
+negative entries. The Lagrange one does not: its columns are the Bernstein basis
+evaluated at a node in ``[0, 1]``, so they are non-negative and sum to one, and
+``A_e`` is a product of two column-stochastic matrices.
 
 **The columns are the B-spline basis at the nodes.** The defining property: the
 Lagrange basis is cardinal at its own nodes, so ``A_e[:, k] = N_e(x_k)`` with ``x_k``
@@ -470,8 +483,18 @@ def _product_claim(
     Rule 11 records the sibling Bézier port shipping a fused branch that called
     :func:`bounded_parity` with an argument it does not take, green over 133 tests
     because nothing reached it. So this one was exercised against an extension built
-    at ``-march=native``, where ``contraction_may_fuse()`` is true, and the result is
-    recorded in the PR that added it rather than assumed here.
+    at ``-march=x86-64-v3`` -- the smallest target that defines ``__FP_FAST_FMA``,
+    and the one ``design/simd.md`` schedules -- where ``contraction_may_fuse()`` is
+    true, and the result is recorded in the PR that added it rather than assumed
+    here. **Not** ``-march=native``, which does not build in this repository; an
+    earlier version of this line said it did, and the recipe it gave could not have
+    reproduced the check.
+
+    **This branch is dead in every build the repository itself runs.**
+    ``contraction_may_fuse()`` reads the built binary's own provenance and is false
+    at baseline ``x86-64``, so neither CI nor a local run reaches the code below.
+    Its only evidence is a one-off manual build, and this comment is the whole
+    record of it -- which is why the target above has to be right.
 
     Args:
         case (_Case): The knot vector.
@@ -1091,6 +1114,13 @@ def test_degree_zero_is_refused_by_both_backends(backend: Backend) -> None:
     so that the absence of a degree-0 row in every table above is a recorded fact
     rather than an untested gap, and so that a change to that refusal shows up here.
 
+    **The order matters and is asserted, not just described.** Layer 2 resolves the
+    matrix *before* it writes anything, so a caller's ``out`` is untouched when the
+    refusal fires. Swapping the two lines back would leave a caller holding a
+    half-written array after an exception, and an earlier version of this test could
+    not have seen that: it checked only that the ``ValueError`` was raised, never
+    passing an ``out`` for the refusal to spare.
+
     Args:
         backend (Backend): Which implementation to run.
     """
@@ -1099,6 +1129,15 @@ def test_degree_zero_is_refused_by_both_backends(backend: Backend) -> None:
     space = BsplineSpace1D(knots, 0, snap_knots=False)
     with use_backend(backend), pytest.raises(ValueError, match="[Dd]egree must at least 1"):
         space.tabulate_Lagrange_extraction_operators()
+
+    sentinel = np.full((1, 1, 1), -7.0, dtype=np.float64)
+    caller_array = sentinel.copy()
+    with use_backend(backend), pytest.raises(ValueError, match="[Dd]egree must at least 1"):
+        space.tabulate_Lagrange_extraction_operators(out=caller_array)
+    assert np.array_equal(caller_array, sentinel), (
+        "the refusal wrote into the caller's out before raising, so the matrix was "
+        "resolved after the operators were built rather than before"
+    )
 
     # The mask does have a degree-0 answer, because Layer 2 short-circuits before
     # asking for a matrix. Both backends take that branch, so it never reaches a

--- a/tests/parity/test_bspline_lagrange_extraction.py
+++ b/tests/parity/test_bspline_lagrange_extraction.py
@@ -18,6 +18,18 @@ backends do differ, by one unit of roundoff at degree 3 and above and not at all
 below; :func:`test_the_two_backends_still_differ_somewhere` is the guard that keeps
 the bound from silently becoming a comparison against zero.
 
+**What a bounded claim cannot see here, and where it is checked instead.** The bound
+has to admit the two summation orders' own disagreement, and measured over the shipped
+table at ``float32`` that disagreement is **exactly one unit in the last place** -- the
+same size as the gap between accumulating the contraction in ``float32`` and in
+``float64``. The two are not separable by any bound, and not for want of a tighter one:
+the contraction sums non-negative terms, so no cancellation can make the width gap
+dominate. So nothing in this file would fail if the C++ accumulated in ``double``, which
+``design/backend_parity.md`` Rule 9 forbids. Verified by mutation, not assumed.
+``cpp/tests/test_bspline_extraction.cpp``'s ``check_the_accumulator_is_the_storage_type``
+is where the width is pinned, on the C++ side where there is no BLAS and both operands
+can be chosen.
+
 The exception is an **identity** change of basis, which happens at degree 1 for the
 equispaced, Gauss-Lobatto-Legendre and second-kind Chebyshev families. Every term is
 then ``C[i,k] * 0`` or ``C[i,j] * 1``, so nothing rounds in either summation order


### PR DESCRIPTION
Covers the **Lagrange** slice of #399's S3, in `design/extraction_port.md`'s numbering. The
**Bézier** half landed already; **cardinal** is what is left of S3, and it still waits on the
cardinal-interval scan, which `cpp/include/pantr/bspline/space_1d.hpp` deliberately keeps off
the type as "a computation over the knots rather than a property of them". S4
(`SpanwiseElementExtraction` itself) is untouched.

`Closes` does not fire against a base other than `main`, so this closes nothing; #399 stays
open.

## What landed

`A_e = C_e @ L`: the Bézier extraction operator post-multiplied by the Lagrange-to-Bernstein
matrix `L[j, k] = B_j(x_k)`.

- `pantr::bspline::lagrange_extraction_1d` and `lagrange_structural_identity_mask` in
  `cpp/include/pantr/bspline/extraction.hpp`, bound in
  `cpp/bindings/bspline_extraction_operators.cpp` and dispatched from
  `pantr.bspline._extraction_backend` through `lagrange_extraction_kernel()` and
  `lagrange_identity_mask_kernel()`.
- Layer 2 (`_tabulate_Bspline_Lagrange_1D_extraction_impl`) and the mask helper in
  `spanwise_element_extraction.py` now dispatch instead of running `numpy.matmul` themselves.
- `tests/parity/test_bspline_lagrange_extraction.py`, 547 cases.

**The change-of-basis matrix crosses as an argument, not as a variant.** `change_basis.hpp`
already owns the tabulation, `pantr.change_basis` caches the finished matrix per
`(degree, variant, dtype)`, and `pantr.basis.LagrangeVariant` is a `StrEnum` — which numba
types as `unicode_type` and then silently resolves a comparison against a captured member to
`False`, deleting the branch. Passing the matrix keeps one implementation of the tabulation,
keeps the cache in front of it, keeps the enum off the seam, and makes the matrix **common
mode** between the backends. `design/extraction_port.md`'s F5 containment therefore survives
the slice that passes closest to it, and now by decision rather than by accident.

**The claim is bounded, not bitwise, and it is the first builder in this cluster that is.**
The oracle contracts the product with `numpy.matmul`, a BLAS `gemm` whose summation order is
unspecified and blocked; the C++ runs an ascending loop. Both accumulate in the storage format
(Rule 9; `sgemm` accumulates in `float32`), so the budget is
`Roundings(degree + 1, 1, 0)` — Higham, *Accuracy and Stability of Numerical Algorithms*,
2nd ed., §3.1 — with the absolute-value companion `|C| @ |L|` as amplification (Rule 10). An
identity change of basis is the exception and falls back to the Bézier claim.

## Mutation check, with a control

Each mutation is applied to `cpp/include/pantr/bspline/extraction.hpp`, the extension is
rebuilt, `tests/parity/test_bspline_lagrange_extraction.py` is run (525 cases, `-m "not slow"`),
and the source is reverted. Failure counts are per parametrized case.

| mutation | failures | which tests went red |
|---|---|---|
| **control** — every product doubled | 304 | `operators_agree` 100 · `layer_2_path_agrees` 100 · `columns_sum_to_the_matrix_columns` 90 · `columns_are_the_basis_at_the_nodes` 8 · `matches_the_exact_rational_operators` 6 |
| the product is transposed, `L[j,k]` for `L[k,j]` | 270 | `operators_agree` 90 · `layer_2` 90 · `column_sums` 80 · `basis_at_nodes` 6 · `exact_rational` 4 |
| the product is skipped entirely (return after the Bézier build) | 198 | `operators_agree` 94 · `layer_2` 94 · `basis_at_nodes` 6 · `exact_rational` 4 |
| the contraction drops its last term | 302 | `operators_agree` 100 · `layer_2` 100 · `column_sums` 90 · `basis_at_nodes` 6 · `exact_rational` 6 |
| the mask's identity branch is inverted | 10 | `identity_mask_agrees` 10 |

**The control is the point of the table**: it is a mutation that must be caught, and its 304
failures prove the harness really rebuilds the extension between runs. A harness that silently
skipped the rebuild would report the same green as a mutation nobody catches.

Two things the table shows that are worth stating rather than leaving to be read off:

- **Skipping the product is invisible to the column-sum oracle.** Both the Bézier operator and
  the Lagrange one have column sums of one, so that invariant cannot see a missing change of
  basis. The exact-rational table and the node-tabulation check are what catch it, which is why
  `test_the_exact_tables_are_not_trivial` asserts the exact table is *not* the Bézier table.
- **A sixth mutation is NOT caught, and it is the interesting one.** Widening the C++
  accumulator to `double` — a `design/backend_parity.md` Rule 9 violation — leaves every case
  green. **That is not a hole in the bound and no constant would close it.** The bound is
  derived from each backend's forward error against the exact product, and a wider accumulator
  has a *smaller* forward error, so it lies inside the same bound by construction — Rule 8's
  "a different but valid algorithm passing is not a failure of the bound", read from the other
  side. Measured to agree with the argument: the gap it opens at `float32` is one unit in the
  last place, the same size as the two backends' own disagreement.

  **So the width is pinned on the C++ side instead**, by
  `check_the_accumulator_is_the_storage_type` in `cpp/tests/test_bspline_extraction.cpp`: the
  unclamped uniform quadratic vector's Bézier row contracts with weights `(1/2, 1, 1/2)`, and
  against a matrix column `(2^-23, 1, 2^-23)` at `float32` each outer term is exactly half an
  ulp of one, so a `float` accumulator rounds both to even and a `double` one does not. Verified
  by re-running the same mutation against it: 6 failures. **The gap generalises past this
  slice** — every bounded claim in the port has it, `change_basis`'s five solving builders
  included, and nothing there pins a width either. `design/extraction_port.md` now records it.

## The bound over a sweep 10x the shipped one

Shipped parametrization: 10 knot vectors x 5 node families = 50 per dtype. The sweep draws
**500 per dtype** from the family the shared Bézier algorithm handles, cycling the node family,
and asserts the parity claim, the identity mask and the column-sum invariant on each
(`test_the_claim_holds_over_a_sweep_ten_times_the_shipped_one`, `slow`-marked). It also asserts
the worst column-sum deviation is nonzero, so the bound is not compared against zero throughout.

**The bound and its derivation.** For a single element, `A[i,j] = sum_k C[i,k] L[k,j]`, a dot
product of `n = degree + 1` terms.

- Each backend is within `gamma_n |C|.|L|` of the exact product of the stored operands, for any
  summation order (Higham §3.1; blocking only tightens it, pp. 62-64). Their difference is
  bounded by the sum of the two, which is the harness's own factor of two.
- `accumulator_per_stage = 1`: one rounding per term. `storage_per_stage = 0`: the accumulator
  **is** the storage format on both sides, so no store narrows.
- `amplification = |C| @ |L|`, elementwise — Rule 10's absolute-value companion rather than
  `max|M| max|v|`. Here it is tight rather than merely valid, because both factors are
  non-negative (see the correction below), so it is the answer's own magnitude, bounded by one.
- On a fusing build both stages may contract, so Rule 10's three roundings per site apply to
  each, the Bézier chain is added to the term count, and `sum_k |L[k,j]|` is added to the
  amplification for the Bézier difference reaching the output. Folding the two stages into one
  claim by charging the longer chain to both is an upper bound, since `gamma` is monotone.
- `gamma` is the closed form `m u / (1 - m u)` throughout, never truncated to `m u`, because the
  Bézier chain length grows with the element count rather than with the degree.

**Measured**: the two backends differ by one unit of roundoff at degree 3 and above and agree
exactly below, in both storage formats. `test_the_two_backends_still_differ_somewhere` is the
Rule 7 guard that keeps the bound from silently becoming a comparison against zero; it is gated
on `PANTR_REFERENCE_HOST`, because which arguments a BLAS `gemm` and an ascending loop round
differently is a property of the build and the processor.

## The independent accuracy checks

Three, none of them the Python implementation.

1. **Exact rational operators, hand-derived.** At degree 2 with equispaced nodes,
   `L = [[1, 1/4, 0], [0, 1/2, 0], [0, 1/4, 1]]`, and the dyadic uniform Bézier tables are
   halves, so every entry and every partial sum is a binary rational — a **zero** bound in both
   storage formats. `cpp/tests/test_bspline_extraction.cpp` carries the same tables.
2. **The column sums reproduce the matrix's own.** `sum_i A[i,j] = sum_k L[k,j]`, from the
   Bézier column sums. Compared against `sum_k L[k,j]` **as the matrix actually sums**, so its
   tabulation error is folded in exactly rather than bounded. Columns and not rows, which is
   what catches a transposition.
3. **The columns are the B-spline basis at the nodes.** The defining property, checked against
   `BsplineSpace1D.tabulate_basis` (Cox-de Boor, no shared code). Checked **only on a dyadic
   family** (degree 1 and 2, equispaced nodes, dyadic knots) where both routes are exact and the
   bound is zero. Above degree 2 the nodes become thirds and a bound would have to compose the
   Cox-de Boor error, the error of the `pow`-seeded Bernstein ratio recurrence inside `L`, and
   the affine map's rounding amplified by `max|N'|`; two are foreign derivations and one is the
   transcendental category `design/backend_parity.md`'s open question 2 records as having no
   vocabulary in the harness. Three unsharp terms would give a bound satisfied by any result.

## Extension-skip

`.so` moved aside inside the worktree's own venv, nothing else touched:

| | result |
|---|---|
| extension present | **545 passed, 2 skipped** (the 2 are the reference-host guard) |
| extension absent | **131 passed, 416 skipped, 0 failed** |

The file still **collects** — the extension is imported through a deferred `_bindings()` helper
rather than at module level, so its absence is a skip and not a collection error for the whole
file. The gate is taken on the C++ **parameter** (`_demand_the_extension_if_needed`), not on the
test, so the 111 that keep running are the Python halves of the three accuracy oracles, the
non-vacuity guards, the Python half of the degree-0 refusal, the `numpy.matmul` aliasing check
and the node-family sweep — which is the only part of this file that would catch the **oracle**
regressing.

## Downstream-consumer census

Measured against `tIGArx-future` at `bfb8e18`, 201 Python files, in three separate categories.

**Private pantr symbols: none.** No `from pantr… import _name`, no `pantr.<module>._name`
attribute access, no import of any private module. Searched both by import pattern and **by
name** for every symbol this PR touches, since `from pantr.bspline._foo import _bar` does not
appear in a `pantr.`-prefixed search: `_tabulate_Bspline_Lagrange_1D_extraction_impl`,
`_tabulate_Bspline_Bezier_1D_extraction_impl`, `_lagrange_structural_identity_mask`,
`_bezier_structural_identity_mask`, `_extraction_backend`, `_bspline_extraction_core`,
`_bspline_extraction`, `_cached_lagrange_to_bernstein_matrix`, `_extraction_kernels`,
`_extraction_helpers`, `ExtractionStructView`, `ExtractionTarget` — **0 hits each**.

**Public pantr symbols in the blast radius:** `SpanwiseElementExtraction` (41 sites, **always**
constructed with the `"cardinal"` target, never Lagrange), `BsplineSpace1D`, `BsplineSpace`.
Nothing calls `tabulate_Lagrange_extraction_operators` or
`tabulate_Bezier_extraction_operators`. `pantr.basis.LagrangeVariant`: **0 hits** — the three
`LagrangeVariant` matches are `basix.LagrangeVariant`. `get_cardinal_intervals` appears once, in
a name list inside a smoke test.

**Attribute writes onto pantr-owned objects: none.** The `spline.maxIters` / `relativeTolerance`
writes are on legacy tIGAr objects; every `monkeypatch.setattr` targets tigarx's own modules.

Nothing is deleted or reshaped by this PR in any case — it only adds — so the census is
confirmation rather than a gate.

## `__reduce__` round-trip

**Not applicable, and checked rather than assumed.** This slice introduces no type. The one type
in the area, `SpanwiseElementExtraction`, has no `__reduce__`, no `__getstate__` and no pickle
test in the suite today, so there is nothing to round-trip. It gets one when S4 makes it
C++-owned.

## One design-note correction, with its evidence

`design/extraction_port.md` said the Lagrange-to-Bernstein and cardinal-to-Bernstein matrices
both have negative entries, so a bound assuming convexity "would be false for two of the three
targets". **It is one of the three.** `L[j, k] = B_j(x_k)` is the Bernstein basis tabulated at
the Lagrange nodes; every node of every family lies in `[0, 1]`, where the Bernstein basis is
non-negative and sums to one. So `L` is column-stochastic and the Lagrange extraction operator
is a product of two column-stochastic matrices: entrywise non-negative with columns summing to
one, exactly like its Bézier parent. Only cardinal-to-Bernstein has negative entries. The same
sentence also said the Bézier operator's *rows* sum to one; the note already corrects that to
columns further down.

Nothing was built on the wrong version — the absolute-value companion is correct either way —
but it changes what the amplification is worth here, and the parity file **asserts** the
non-negativity rather than assuming it, so a family whose nodes left `[0, 1]` would be a failure
rather than a silently loose bound.

## Behaviour of the existing Python, checked differentially

- `_tabulate_Bspline_Lagrange_1D_extraction_impl` under the Python backend is **bit-identical**
  to the pre-change Layer 2 expression over 2435 (random vector, dtype, node family)
  combinations. The oracle did not move.
- `_lagrange_structural_identity_mask` agrees with the pre-change implementation in value, dtype
  and shape over 8000 combinations, under both backends.
- One deliberate ordering change: the change-of-basis matrix is now fetched **before** the
  operators are built, so a `degree == 0` call raises `ValueError: Degree must at least 1`
  without first writing the Bézier operators into a caller's `out`. Same exception, same
  message, one fewer partial write. `test_degree_zero_is_refused_by_both_backends` pins the
  refusal so the absence of a degree-0 row in every table is a recorded fact rather than a gap.

## The fused branch was run, not reasoned about

`contraction_may_fuse()` is false on every build in this repository, so the bounded claim's
fused branch would otherwise ship unexecuted — which `design/backend_parity.md` Rule 11 records
going wrong once already, the Bézier port's fused branch calling `bounded_parity` with an
argument it does not take and staying green over 133 tests because nothing reached it.

Built at **`-march=x86-64-v3`**, the target `design/simd.md` schedules and the smallest that
defines `__FP_FAST_FMA`. `-march=native` does **not** build here: it turns on AVX512 and
Eigen's AVX512 TRSM kernel trips `-Wmaybe-uninitialized` under `PANTR_WERROR`.

On that build `__fp_contract__` is `available`, the branch is taken (`BOUNDED` claims are
constructed where the baseline build makes `BITWISE` ones), and both extraction parity files
pass in full including the 10x sweep. The observed disagreement reaches **2.5% of the fused
bound** at `float64` and 2.6% at `float32` — a factor-40 margin, which is what composing two
worst-case fused stages costs.

**Twenty-seven parity cases in five unrelated files do fail on that target** —
`test_basis_tabulations` (5), `test_bezier_shape` (10), `test_bezier_degree` (3),
`test_bezier_evaluate` (3), `test_quad_*` (6). Those are pre-existing bitwise claims that
flipping the SIMD target is expected to expose; none is in the extraction cluster and none is
this slice's to fix. Recorded here because a later attempt at `-march=x86-64-v3` should not
have to rediscover it.

## Review round

A reviewer pass over the whole diff. Two Important findings, both fixed here; two suspicions,
both converted into tests rather than argued away. All in commit
`test(bspline): close the review round on the Lagrange slice`.

- **I — the column-sum bound charged arithmetic the test did not perform.** The derivation said
  both sums run in `float64`, but `operators.sum(axis=1)` accumulates in the array's own dtype
  and only then cast, so the operators' half was a `float32` accumulation charged at `float64`
  rates: eight orders of magnitude short. It never failed, and would not have — the correctly
  derived contraction term is larger than the missing one at every degree by monotonicity of
  `gamma`, so a redundancy nobody had stated was holding it up. Fixed by casting before the sum,
  through one helper all three call sites share. The bound is now approached to within a factor
  of 8 at `float64` and 16 at `float32`.
- **I — the fused branch had never been run.** Fixed as described above.
- **U — `numpy.matmul` buffers when `out` aliases its own first operand.** A claim about a third
  party, in a project whose `CLAUDE.md` records numpy behaving differently between local and the
  CI matrix. *Confirmed* and now pinned: a test asserts the in-place answer equals a non-aliased
  one bit for bit, over every case and node family. The call is pre-existing — the port
  relocated it, it did not introduce it — so this guards the oracle too.
- **U — every Lagrange node family is ascending inside `[0, 1]`.** The hypothesis under both the
  non-negativity claim and the mask's all-false branch, reasoned from the definitions rather than
  read. *Confirmed* and now swept to 39 nodes per family in both dtypes.

Two smaller things came out of my own pass and are in the same commit: the fused fold now charges
the **longer** of the two chains rather than their sum (both are valid; the max is tighter and is
what the docstring already claimed), and two relied-on preconditions are written down — that both
binding callers refuse a negative degree before the matrix shape is checked, and that the
change-of-basis matrix must not overlap `out`.

## Checks run

`ruff check` · `ruff format --check` · `mypy --strict` (310 files) · `lint-imports` (2 contracts
kept) · full `pytest` (9589 passed, 47 skipped, 7 xfailed) · `ctest --preset gcc` (46/46) ·
`ctest --preset gcc-debug`, ASan+UBSan (52/52) · doctests with and without
`NUMBA_DISABLE_JIT=1` (82 passed) · docs build with `-W --keep-going`.

`scripts/ci_local.sh` deliberately not run.
