### PR TITLE
feat(bspline): own THBSplineSpace's construction and query core in C++ (#397, cut 1)

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -123,7 +123,8 @@ if(PANTR_NANOBIND_SPLIT)
                       grid_types.cpp grid_hierarchical.cpp grid_tags.cpp grid_bvh.cpp
                       grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
-                      bspline_extraction.cpp bspline_extraction_operators.cpp)
+                      bspline_extraction.cpp bspline_extraction_operators.cpp
+                      bspline_thb_space.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
@@ -131,7 +132,8 @@ else()
                       grid_types.cpp grid_hierarchical.cpp grid_tags.cpp grid_bvh.cpp
                       grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
-                      bspline_extraction.cpp bspline_extraction_operators.cpp)
+                      bspline_extraction.cpp bspline_extraction_operators.cpp
+                      bspline_thb_space.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bspline_thb_space.cpp
+++ b/cpp/bindings/bspline_thb_space.cpp
@@ -1,0 +1,293 @@
+/// \file
+/// nanobind bindings for `pantr::bspline::THBSplineSpace`.
+///
+/// ## Two registrations, and one grid under both
+///
+/// `THBSplineSpace32` and `THBSplineSpace64` are separate classes for the reason
+/// `bspline_types.cpp` gives: the root space's storage format is part of its value,
+/// `float32` root spaces are exercised in the suite, and a single Python name would
+/// have nothing left to carry the width.
+///
+/// The **grid is `double` under both**, which is not an oversight and is not the
+/// dtype axis leaking. `pantr.grid` is `float64`-only by its own port's ruling and
+/// `cpp/bindings/grid_hierarchical.cpp` registers no `float`, while a root B-spline
+/// space stores whatever it was handed;
+/// `tests/test_thb_spline_space.py::TestCellMembershipTolerance` ships a `float32`
+/// root over a `float64` grid and pins that the grading stays `float64`. So the two
+/// scalars are genuinely independent and the type says so.
+///
+/// ## What this file validates: nothing
+///
+/// The type validates its own arguments and throws `std::invalid_argument`, which
+/// nanobind maps to `ValueError` preserving `what()`, and the messages are the
+/// oracle's. What the wrapper still owes is Python's calling convention rather than
+/// validation, and there are three pieces of it:
+///
+///  - coercing an `ArrayLike` `cell_ids` into a contiguous `int64` array, and the
+///    `TypeError` for a non-integer one, for which `pantr/core/error.hpp` records
+///    there is no `std::exception` nanobind turns into one;
+///  - broadcasting a scalar `regularity` to one entry per direction, and refusing a
+///    non-integer entry;
+///  - the `IndexError` the oracle raises for an out-of-range cell id. It is
+///    `std::out_of_range` here, which nanobind maps to `IndexError`, so this one is
+///    already the right *kind* -- what the wrapper owes is the message's wording,
+///    which lists every offending id where this names the first.
+///
+/// ## Arrays out: views, never copies
+///
+/// Every array below is storage the space owns and computed once -- the per-level
+/// active sets at construction, the contribution table behind the memo in
+/// `pantr/core/lazy.hpp`, a truncated function's coefficient box. They go out as
+/// `nb::ndarray` views with the space as the array's owner, which is
+/// `bspline_types.cpp`'s idiom and for its reasons: the owner keeps the storage alive
+/// when the array outlives the handle it came from, and `const T` is what nanobind
+/// turns into the read-only flag.
+///
+/// That is a **deliberate difference from the oracle**, which copies:
+/// `active_function_indices` ends in `.copy()` and `active_basis` builds a fresh
+/// array. `design/bspline_derived_caches.md` asks for exactly this change for the
+/// contribution table -- a `span`-returning accessor retiring the oracle's unenforced
+/// *"callers must not mutate it"* convention -- and the same argument reaches the
+/// active sets. The wrapper is what reconciles the two: it copies on the way out under
+/// both backends, so a caller that mutates the result of `active_function_indices`
+/// keeps working and cannot corrupt a C++-owned array.
+///
+/// ## `_ref` accessors are not bound
+///
+/// `design/bspline_ownership_lifetime.md` requires that no borrowing accessor reaches
+/// Python. This type has three -- `root_space_ref`, `grid_ref`, `level_space_ref` --
+/// and none is below.
+/// `tests/parity/test_bspline_binding_contract.py` asserts over the bound surface that
+/// no method name ends in `_ref`, which is the only available check.
+///
+/// ## `grid` is the one handle that is not `const`
+///
+/// `design/bspline_ownership_lifetime.md`'s single exception, and `pantr/grid/tags.hpp`
+/// carries the argument: a grid holds tag registries that are the reasoned
+/// accumulating-container exception to construct-then-freeze, and a `const` handle
+/// would reach only the `const` overload of `cell_tags()`, silently removing the
+/// ability to tag cells through a THB space's grid.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "pantr/bspline/space_nd.hpp"
+#include "pantr/bspline/thb_space.hpp"
+#include "pantr/grid/hierarchical_grid.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+using Grid = pantr::grid::HierarchicalGrid<double>;
+
+/// A read-only, contiguous 1D `int64` array as nanobind sees it.
+using const_ids = nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// A never-dereferenced address for a zero-length array.
+///
+/// An empty `std::vector`'s `data()` may be null and nanobind reads a null pointer as
+/// "no array" rather than as an empty one. A cell with no active function and a
+/// dimensionless space both produce empty results here, so a valid address stands in;
+/// `bspline_types.cpp` and `grid_types.cpp` carry the same sentinel.
+///
+/// \tparam T The element type.
+template <class T>
+T kEmptyStorage{};
+
+/// Hand out a span of the owner's storage as a read-only 1D numpy view.
+///
+/// \tparam T The element type.
+/// \param self The Python object that owns the storage, kept alive by the array.
+/// \param data The span; may be empty.
+/// \return A read-only 1D `numpy` array viewing `data`.
+template <class T>
+nb::object view_of(nb::handle self, std::span<const T> data) {
+    const T* base = data.empty() ? &kEmptyStorage<T> : data.data();
+    return nb::cast(nb::ndarray<nb::numpy, const T, nb::ndim<1>>(base, {data.size()}, self));
+}
+
+/// A tuple of integers, as the oracle's per-direction properties are.
+///
+/// A near-copy of `bspline_types.cpp`'s, and deliberately so: `register.hpp`'s
+/// reserved slots exist precisely so a ticket touches one `.cpp`, and hoisting a
+/// six-line helper would put two tickets back in one file.
+///
+/// \param counts The values.
+/// \return A Python tuple of them.
+nb::tuple counts_tuple(std::span<const std::int64_t> counts) {
+    nb::list values;
+    for (const std::int64_t count : counts) {
+        values.append(count);
+    }
+    return nb::tuple(values);
+}
+
+/// A `std::span` over a 1D nanobind array of ids.
+///
+/// \param ids The array.
+/// \return A view of its elements.
+std::span<const std::int64_t> ids_span(const const_ids& ids) {
+    return {ids.data(), ids.size()};
+}
+
+/// Register one scalar type's `THBSplineSpace`.
+///
+/// \tparam T The root space's scalar type.
+/// \param m The extension module.
+/// \param name The Python-visible class name, `THBSplineSpace32` or `THBSplineSpace64`.
+template <class T>
+void bind_thb_space(nb::module_& m, const char* name) {
+    using Space = pantr::bspline::THBSplineSpace<T>;
+    using Root = pantr::bspline::BsplineSpace<T>;
+
+    nb::class_<Space>(m, name)
+        // Takes both nested objects as handles, which is what makes the space SHARE
+        // them rather than copy them; `level_space(0)` then hands back the very handle
+        // it was built from, which is the oracle's own identity contract.
+        .def(
+            "__init__",
+            [](Space* self, std::shared_ptr<const Root> root_space, std::shared_ptr<Grid> grid,
+               bool truncate, std::vector<std::optional<std::int64_t>> regularity) {
+                new (self) Space(std::move(root_space), std::move(grid), truncate,
+                                 std::move(regularity));
+            },
+            nb::arg("root_space"), nb::arg("grid"), nb::arg("truncate"),
+            nb::arg("regularity"))
+        // Class H throughout: the value is a `shared_ptr`, so ownership travels in the
+        // return value and no policy is needed.
+        .def_prop_ro("root_space", &Space::root_space)
+        .def_prop_ro("grid", &Space::grid)
+        .def_prop_ro("dim", [](const Space& s) { return s.dim(); })
+        .def_prop_ro("degrees",
+                     [](const Space& s) { return counts_tuple(s.degrees()); })
+        .def_prop_ro("num_levels", [](const Space& s) { return s.num_levels(); })
+        .def_prop_ro("truncate", &Space::truncate)
+        .def_prop_ro("regularity",
+                     [](const Space& s) {
+                         nb::list values;
+                         for (const std::optional<std::int64_t>& r : s.regularity()) {
+                             values.append(r.has_value() ? nb::cast(*r) : nb::none());
+                         }
+                         return nb::tuple(values);
+                     })
+        .def_prop_ro("num_total_basis", [](const Space& s) { return s.num_total_basis(); })
+        .def_prop_ro("num_basis_per_level",
+                     [](const Space& s) { return counts_tuple(s.num_basis_per_level()); })
+        .def_prop_ro("level_offsets",
+                     [](nb::handle self) {
+                         const Space& s = nb::cast<const Space&>(self);
+                         return view_of<std::int64_t>(self, s.level_offsets());
+                     })
+        // Class A: a read-only `(dim, 2)` view of the root space's storage, with THIS
+        // space as the array's owner -- which is correct because the root space is
+        // shared and outlives it either way.
+        .def_prop_ro("domain",
+                     [](nb::handle self) {
+                         const Space& s = nb::cast<const Space&>(self);
+                         const std::span<const T> flat = s.domain();
+                         const T* base = flat.empty() ? &kEmptyStorage<T> : flat.data();
+                         return nb::cast(nb::ndarray<nb::numpy, const T, nb::ndim<2>>(
+                             base, {static_cast<std::size_t>(s.dim()), std::size_t{2}}, self));
+                     })
+        .def_prop_ro("tolerance", &Space::tolerance)
+        .def_prop_ro("num_truncated", [](const Space& s) { return s.num_truncated(); })
+        .def("level_space", &Space::level_space, nb::arg("level"))
+        .def("active_function_indices",
+             [](nb::handle self, std::int64_t level) {
+                 const Space& s = nb::cast<const Space&>(self);
+                 return view_of<std::int64_t>(self, s.active_function_indices(level));
+             },
+             nb::arg("level"))
+        .def("active_basis",
+             [](nb::handle self, std::int64_t cid) {
+                 const Space& s = nb::cast<const Space&>(self);
+                 return view_of<std::int64_t>(self, s.active_basis(cid));
+             },
+             nb::arg("cid"))
+        // The three parallel views of one cell's slice of the contribution table.
+        // A tuple rather than three calls, because a caller wanting the multi-indices
+        // wants the dofs beside them and a second lookup would re-check the cid.
+        .def("contributions",
+             [](nb::handle self, std::int64_t cid) {
+                 const Space& s = nb::cast<const Space&>(self);
+                 const pantr::bspline::CellContributions c = s.contributions(cid);
+                 const std::size_t rows = c.multi_indices.size() == 0
+                                              ? 0
+                                              : static_cast<std::size_t>(c.size());
+                 const std::int64_t* multi_base = c.multi_indices.empty()
+                                                      ? &kEmptyStorage<std::int64_t>
+                                                      : c.multi_indices.data();
+                 return nb::make_tuple(
+                     view_of<std::int64_t>(self, c.dofs),
+                     view_of<std::int64_t>(self, c.levels),
+                     nb::cast(nb::ndarray<nb::numpy, const std::int64_t, nb::ndim<2>>(
+                         multi_base, {rows, static_cast<std::size_t>(s.dim())}, self)));
+             },
+             nb::arg("cid"))
+        .def("max_active_per_cell", &Space::max_active_per_cell)
+        .def("dof_level", &Space::dof_level, nb::arg("dof"))
+        // `None` for a function the truncation left alone, which is what the oracle's
+        // `_trunc.get(dof)` gives and what distinguishes a plain tensor-product
+        // B-spline from a truncated one carrying an all-ones box.
+        .def("truncated",
+             [](nb::handle self, std::int64_t dof) -> nb::object {
+                 const Space& s = nb::cast<const Space&>(self);
+                 const std::optional<pantr::bspline::TruncatedView> view = s.truncated(dof);
+                 if (!view.has_value()) {
+                     return nb::none();
+                 }
+                 std::vector<std::size_t> shape;
+                 shape.reserve(view->shape.size());
+                 for (const std::int64_t n : view->shape) {
+                     shape.push_back(static_cast<std::size_t>(n));
+                 }
+                 const double* base =
+                     view->coeffs.empty() ? &kEmptyStorage<double> : view->coeffs.data();
+                 nb::object coeffs = nb::cast(nb::ndarray<nb::numpy, const double>(
+                     base, shape.size(), shape.data(), self));
+                 return nb::make_tuple(view->rep_level, counts_tuple(view->box_lo), coeffs);
+             },
+             nb::arg("dof"))
+        .def("refine",
+             [](const Space& s, const_ids cell_ids,
+                std::optional<std::int64_t> admissible_class) {
+                 return s.refine(ids_span(cell_ids), admissible_class);
+             },
+             nb::arg("cell_ids").noconvert(), nb::arg("admissible_class"))
+        .def("refine_region",
+             [](const Space& s, std::int64_t level, const_ids lo, const_ids hi,
+                std::optional<std::int64_t> admissible_class) {
+                 return s.refine_region(level, ids_span(lo), ids_span(hi), admissible_class);
+             },
+             nb::arg("level"), nb::arg("lo").noconvert(), nb::arg("hi").noconvert(),
+             nb::arg("admissible_class"))
+        .def("coarsen",
+             [](const Space& s, const_ids cell_ids,
+                std::optional<std::int64_t> admissible_class) {
+                 return s.coarsen(ids_span(cell_ids), admissible_class);
+             },
+             nb::arg("cell_ids").noconvert(), nb::arg("admissible_class"))
+        .def("__repr__", &Space::to_string);
+}
+
+}  // namespace
+
+void register_bspline_thb_space(nb::module_& m) {
+    bind_thb_space<float>(m, "THBSplineSpace32");
+    bind_thb_space<double>(m, "THBSplineSpace64");
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -86,6 +86,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_bspline_types(m);
     register_bspline_extraction(m);
     register_bspline_extraction_operators(m);
+    register_bspline_thb_space(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -110,6 +110,15 @@ void register_bspline_types(nanobind::module_& m);
 /// arrives with it. See design/extraction_port.md.
 void register_bspline_extraction(nanobind::module_& m);
 
+/// Register `pantr.bspline.THBSplineSpace`.
+///
+/// Its own entry point rather than a second type inside `register_bspline_types`, for
+/// the reason `register_grid_hierarchical` is separate from `register_grid_types`: the
+/// two are separate ports with separate parity claims, and the comments justifying this
+/// one's checks -- the one non-`const` handle in `pantr.bspline`, the views that replace
+/// the oracle's copies -- argue from somewhere else entirely.
+void register_bspline_thb_space(nanobind::module_& m);
+
 /// Register `pantr.bspline`'s Bézier extraction operator builder and its mask.
 ///
 /// Separate from `register_bspline_extraction` because the two are separate ports

--- a/cpp/include/pantr/bspline/knot_insertion.hpp
+++ b/cpp/include/pantr/bspline/knot_insertion.hpp
@@ -1,0 +1,453 @@
+#pragma once
+
+/// \file
+/// Knot insertion and the two-scale (Oslo) refinement matrix.
+///
+/// Ports `src/pantr/bspline/_bspline_knot_insertion_core.py` and the two Layer 2
+/// helpers a *space* needs from `_bspline_knot_insertion.py`, which stay as the
+/// parity oracle. The control-point half of knot insertion is not here: a space
+/// carries no control points, and `Bspline` is FELIGN/pantr#398.
+///
+/// ## Why this file exists ahead of its own ticket
+///
+/// `THBSplineSpace`'s *state* is defined by two operations this tree did not have.
+/// Its per-level spaces are the root space subdivided (`_thb_spline_space.py`'s
+/// `_build_level_spaces`), and its truncated coefficients are built by pushing a
+/// function through the two-scale matrix level by level (`_compute_truncated_coeffs`).
+/// FELIGN/pantr#396 moved only *state and what it determines* and left every
+/// operation in Python, which was right for a tensor-product space; a THB space is
+/// the first type whose state is the output of an operation, so the operation has to
+/// come with it. `design/cross_backend_types.md` forbids the alternative of computing
+/// the level spaces in Python and handing them to a C++ constructor -- that is the
+/// conversion function the ownership rule exists to prevent.
+///
+/// ## Free functions, not methods
+///
+/// `pantr/bspline/space_1d.hpp` keeps operations off the type on purpose, and
+/// `pantr/bspline/space_nd.hpp` restates the line: a space owns its value and the
+/// quantities that value fixes, and nothing else. Subdivision *constructs a new
+/// space* from an old one, so it is a computation over a space rather than a
+/// property of one, and it lives here as a free function taking a
+/// `const BsplineSpace1D<T>&`.
+///
+/// ## The floating-point discipline, quantity by quantity
+///
+/// **The Oslo recurrence is transcribed operation for operation**, in the oracle's
+/// own order: the quotient is formed first and multiplied by the carried band value
+/// second (`(t[j+k] - x) / denom * band[l]`), the guard is `denom > 0` and not a
+/// tolerance, and the two terms sharing a denominator are computed from one test.
+/// Writing it as `band[l] * (t[j+k] - x) / denom` is the same real number and a
+/// different floating-point one, and `design/backend_parity.md` Rule 10 is what makes
+/// that the difference between a bitwise claim and a bound. Under this build --
+/// `-ffp-contract=on`, no `-march`, so baseline x86-64 with no FMA to fuse into,
+/// `cpp/README.md` -- the two backends execute the same IEEE-754 operations in the
+/// same order and the result is bit-identical. That is a property of the *host*, not
+/// of the code, which is Rule 7; a target with FMA fuses `saved + to_left` and the
+/// claim becomes a bound. `pantr._pantr_cpp.__fp_contract__` is the gate that tells
+/// them apart.
+///
+/// **The subdivision points are computed in `double` whatever the knots are stored
+/// in**, and cast once at the end. That is not a widening for accuracy: the oracle
+/// forms them with `float(unique[k])` and `numpy.linspace(..., dtype=float64)` and
+/// casts the result to the knot dtype, so `double` *is* the arithmetic on both sides
+/// and computing a `float` space's new knots in `float` would be the divergence.
+/// `design/cross_backend_types.md` states the same rule for `pantr.quad`: compute in
+/// `double`, template only the store type.
+///
+/// **`linspace`'s own expression is reproduced rather than simplified.** numpy forms
+/// `j * step + start` with `step = (hi - lo) / n`, so that is what this computes.
+/// `lo + j * (hi - lo) / n` and `lo + (hi - lo) * j / n` are both better-looking and
+/// both differ in the last bit.
+///
+/// **The merge is a stable sort.** `numpy.sort`'s default is introsort, which is not
+/// stable, but the input is a concatenation of two exact arrays and equal `double`s
+/// are indistinguishable -- except for a `-0.0` next to a `+0.0`, where the two
+/// differ in a bit pattern that compares equal. `std::stable_sort` keeps the
+/// concatenation order for that pair, which is the order `numpy.sort` also happens to
+/// produce here, and `CLAUDE.md` records that the sign of such a tie is exactly what
+/// must never be asserted. Stability costs nothing at these sizes and removes the
+/// question.
+///
+/// ## Validation
+///
+/// This is the C++ counterpart of Layer 2, so it validates and throws in a release
+/// build as much as in a debug one, with the oracle's messages. `pantr/core/error.hpp`
+/// sets the split: value and range checks here, type-kind checks in the Python
+/// wrapper.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "pantr/bspline/knots.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/core/format.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+/// The two-scale refinement matrix, in the banded form the recurrence produces.
+///
+/// Row `i` of the refinement matrix is a discrete B-spline supported on the columns
+/// `[first_col[i], first_col[i] + degree]`, so `num_rows * (degree + 1)` values
+/// describe a matrix with `num_rows * (n + 1)` entries. `oslo_matrix_1d` scatters
+/// this into the dense form; nothing else needs the dense one.
+///
+/// \tparam T The scalar type the knots are stored in.
+template <Real T>
+struct OsloBands {
+    /// `num_rows * (degree + 1)` coefficients, row-major. Entry `(i, l)` multiplies
+    /// old control point `first_col[i] + l`.
+    std::vector<T> alphas;
+
+    /// `num_rows` column offsets, one per row.
+    ///
+    /// Negative when the span sits inside the first `degree` knots, which happens on
+    /// a non-clamped vector. The leading entries of such a row are meaningless and a
+    /// consumer must skip columns outside `[0, num_cols)`; `oslo_matrix_1d` does.
+    std::vector<std::int64_t> first_col;
+
+    /// The number of rows, which is the refined space's basis count.
+    std::int64_t num_rows = 0;
+
+    /// The band width, `degree + 1`.
+    std::int64_t width = 0;
+};
+
+/// Build the two-scale refinement matrix one banded row at a time.
+///
+/// Row `i` holds the discrete B-splines `alpha_{j,p+1}(i)`, which vanish outside
+/// `j` in `[mu(i) - degree, mu(i)]` where `mu(i)` is the old-knot span containing
+/// `new_knots[i]`. Only that window is computed, by the recurrence of Cohen, Lyche
+/// and Riesenfeld (1980) run for `k = 1 .. degree` from the seed `alpha_mu = 1`; see
+/// the oracle's docstring for the recurrence in full. A term whose denominator
+/// vanishes is dropped, and the two terms consuming `alpha_j^{(k)}` share that
+/// denominator, so one test settles both -- which is what lets a level run in place
+/// with a single carried value.
+///
+/// Costs `O(num_rows * degree^2)` against the `O(num_rows * num_cols)` of a dense
+/// sweep, and reproduces it entry for entry: outside the band the dense sweep
+/// computes exact zeros.
+///
+/// \param degree The polynomial degree, non-negative.
+/// \param old_knots The original knot vector, `n + degree + 2` entries.
+/// \param new_knots The refined knot vector, `m + degree + 2` entries. Must be a
+///        superset of `old_knots`; this is not checked.
+/// \return The bands, with `num_rows = m + 1`.
+/// \throws std::invalid_argument If the degree is negative or either vector is too
+///         short to describe a space of that degree.
+///
+/// \note No check that `new_knots` refines `old_knots` is performed; a caller that
+///       has not established it gets a matrix that does not reproduce the geometry.
+///       `inserted_knot_vector` is how the guarantee is obtained.
+template <Real T>
+[[nodiscard]] OsloBands<T> oslo_bands_1d(std::int64_t degree, std::span<const T> old_knots,
+                                         std::span<const T> new_knots) {
+    if (degree < 0) {
+        throw std::invalid_argument("degree must be non-negative; got "
+                                    + std::to_string(degree) + ".");
+    }
+    const std::int64_t need = degree + 2;
+    if (static_cast<std::int64_t>(old_knots.size()) < need
+        || static_cast<std::int64_t>(new_knots.size()) < need) {
+        throw std::invalid_argument("a knot vector of degree " + std::to_string(degree)
+                                    + " needs at least " + std::to_string(need)
+                                    + " entries to describe one basis function.");
+    }
+
+    const std::int64_t p = degree;
+    // The oracle's `n` and `m`: the LAST index of the old and new control points,
+    // not their counts. Kept in that spelling so the recurrence below reads against
+    // the source it was transcribed from.
+    const std::int64_t n = static_cast<std::int64_t>(old_knots.size()) - p - 2;
+    const std::int64_t m = static_cast<std::int64_t>(new_knots.size()) - p - 2;
+
+    OsloBands<T> out;
+    out.num_rows = m + 1;
+    out.width = p + 1;
+    out.alphas.assign(static_cast<std::size_t>(out.num_rows * out.width), T(0));
+    out.first_col.resize(static_cast<std::size_t>(out.num_rows));
+
+    // The two vectors are read through pointers rather than through `operator[]`.
+    // The recurrence indexes them with signed offsets throughout -- `j + k`, `mu - p`
+    // -- and `std::span::operator[]` takes a `size_type`, so every one of those
+    // becomes a `static_cast<std::size_t>` under `-Wsign-conversion` and the
+    // transcription stops being readable against the source it came from.
+    const T* const t = old_knots.data();
+    const T* const tau = new_knots.data();
+
+    for (std::int64_t i = 0; i <= m; ++i) {
+        // The span of the old knot vector containing `new_knots[i]`. The right
+        // endpoint lands past the last span and is clamped back onto it.
+        const auto upper = std::upper_bound(old_knots.begin(), old_knots.end(), tau[i]);
+        std::int64_t mu = static_cast<std::int64_t>(upper - old_knots.begin()) - 1;
+        mu = std::min(mu, n);
+        mu = std::max(mu, std::int64_t{0});
+        out.first_col[static_cast<std::size_t>(i)] = mu - p;
+
+        T* band = out.alphas.data() + i * out.width;
+        band[p] = T(1);
+
+        for (std::int64_t k = 1; k <= p; ++k) {
+            const T x = tau[i + k];
+            T saved = T(0);
+            // The band grows one entry to the left per level; entries left of column
+            // 0 only ever feed columns further left, so they are skipped.
+            const std::int64_t l_start = std::max(p - k + 1, p - mu);
+            for (std::int64_t l = l_start; l <= p; ++l) {
+                const std::int64_t j = mu - p + l;
+                const T denom = t[j + k] - t[j];
+                T to_left = T(0);
+                T to_right = T(0);
+                if (denom > T(0)) {
+                    // Quotient first, then the carried value: the oracle's order, and
+                    // the file comment says why reordering it costs the bitwise claim.
+                    to_left = (t[j + k] - x) / denom * band[l];
+                    to_right = (x - t[j]) / denom * band[l];
+                }
+                band[l - 1] = saved + to_left;
+                saved = to_right;
+            }
+            band[p] = saved;
+        }
+    }
+    return out;
+}
+
+/// Build the dense two-scale refinement matrix.
+///
+/// The matrix `alpha` of shape `(m + 1, n + 1)`, row-major, such that new control
+/// points `Q = alpha @ P` reproduce the original geometry exactly, and such that an
+/// old basis function `B_i` equals `sum_j alpha[j, i] B_j` in the refined basis.
+/// Assembled by scattering `oslo_bands_1d`'s rows; every entry outside a band is an
+/// exact zero.
+///
+/// \param degree The polynomial degree, non-negative.
+/// \param old_knots The original knot vector, `n + degree + 2` entries.
+/// \param new_knots The refined knot vector, `m + degree + 2` entries.
+/// \return `(m + 1) * (n + 1)` values in row-major order.
+/// \throws std::invalid_argument If `oslo_bands_1d` refuses its arguments.
+template <Real T>
+[[nodiscard]] std::vector<T> oslo_matrix_1d(std::int64_t degree, std::span<const T> old_knots,
+                                            std::span<const T> new_knots) {
+    const OsloBands<T> bands = oslo_bands_1d<T>(degree, old_knots, new_knots);
+    const std::int64_t num_cols = static_cast<std::int64_t>(old_knots.size()) - degree - 1;
+
+    std::vector<T> dense(static_cast<std::size_t>(bands.num_rows)
+                             * static_cast<std::size_t>(num_cols),
+                         T(0));
+    for (std::int64_t i = 0; i < bands.num_rows; ++i) {
+        const std::int64_t base = bands.first_col[static_cast<std::size_t>(i)];
+        for (std::int64_t l = 0; l < bands.width; ++l) {
+            const std::int64_t col = base + l;
+            if (col >= 0 && col < num_cols) {
+                dense[static_cast<std::size_t>(i * num_cols + col)] =
+                    bands.alphas[static_cast<std::size_t>(i * bands.width + l)];
+            }
+        }
+    }
+    return dense;
+}
+
+/// The knots that subdivide every non-empty span into `n_subdivisions` equal parts.
+///
+/// For each in-domain span `[u_k, u_{k+1})`, `n_subdivisions - 1` equally spaced
+/// interior values, each repeated `degree - regularity` times so the refined space is
+/// `C^regularity` at every inserted knot. Empty when the domain holds a single span
+/// and `n_subdivisions` is 1 -- which is not an error, it is what a direction whose
+/// refinement factor is 1 asks for.
+///
+/// \param knots The knot vector to subdivide.
+/// \param degree The polynomial degree.
+/// \param tol The tolerance that decides which knots are the same knot; the space's
+///        own `tolerance()`.
+/// \param n_subdivisions Equal sub-spans per existing span, at least 1.
+/// \param regularity The continuity at each inserted knot, in `[-1, degree - 1]`.
+/// \return The values to insert, non-decreasing, in `T`.
+/// \throws std::invalid_argument If `n_subdivisions < 1` or `regularity` is out of
+///         range.
+///
+/// \note The arithmetic is `double` whatever `T` is, and the result is cast once at
+///       the end; see the file comment.
+template <Real T>
+[[nodiscard]] std::vector<T> uniform_subdivision_knots(std::span<const T> knots,
+                                                       std::int64_t degree, double tol,
+                                                       std::int64_t n_subdivisions,
+                                                       std::int64_t regularity) {
+    if (n_subdivisions < 1) {
+        throw std::invalid_argument("n_subdivisions must be >= 1, got "
+                                    + std::to_string(n_subdivisions));
+    }
+    if (regularity < -1 || regularity > degree - 1) {
+        throw std::invalid_argument("regularity must be in [-1, degree - 1] = [-1, "
+                                    + std::to_string(degree - 1) + "], got "
+                                    + std::to_string(regularity));
+    }
+
+    std::vector<T> out;
+    if (n_subdivisions == 1) {
+        return out;
+    }
+
+    const KnotClasses<T> classes = unique_knots_and_multiplicity<T>(knots, degree, tol);
+    const std::size_t begin = classes.domain_begin;
+    const std::size_t end = classes.domain_end;
+    if (end <= begin + 1) {
+        return out;
+    }
+
+    const std::int64_t repeat = degree - regularity;
+    const std::int64_t per_span = n_subdivisions - 1;
+    out.reserve(static_cast<std::size_t>(static_cast<std::int64_t>(end - begin - 1) * per_span
+                                         * repeat));
+
+    for (std::size_t k = begin; k + 1 < end; ++k) {
+        const double lo = static_cast<double>(classes.unique[k]);
+        const double hi = static_cast<double>(classes.unique[k + 1]);
+        // numpy's own expression, not a tidier equivalent; see the file comment.
+        const double step = (hi - lo) / static_cast<double>(n_subdivisions);
+        for (std::int64_t j = 1; j <= per_span; ++j) {
+            const double value = static_cast<double>(j) * step + lo;
+            for (std::int64_t r = 0; r < repeat; ++r) {
+                out.push_back(static_cast<T>(value));
+            }
+        }
+    }
+    return out;
+}
+
+/// Merge knots into a knot vector, refusing the insertions a space cannot take.
+///
+/// \param knots The original knot vector.
+/// \param degree The polynomial degree.
+/// \param to_insert The values to insert; repeats raise the multiplicity by that
+///        many. Must not be empty.
+/// \param tol The tolerance that decides which knots are the same knot.
+/// \return The merged vector, non-decreasing.
+/// \throws std::invalid_argument If `to_insert` is empty, any value lies outside the
+///         domain `[knots[degree], knots[size - degree - 1]]` by more than `tol`, or
+///         the merge would give some knot a multiplicity above `degree + 1`.
+template <Real T>
+[[nodiscard]] std::vector<T> inserted_knot_vector(std::span<const T> knots, std::int64_t degree,
+                                                  std::span<const T> to_insert, double tol) {
+    if (to_insert.empty()) {
+        throw std::invalid_argument("new_knots_to_insert must not be empty.");
+    }
+
+    // The domain check forms the difference and compares it against `tol`, rather
+    // than shifting the bound: `value <= hi + tol` reads more directly and rounds the
+    // sum, so once `tol` drops below `ulp(hi)` the effective tolerance becomes
+    // `ulp(hi)`. That is the oracle's own argument, transcribed with its predicate --
+    // strict inequality first, then the absolute difference -- rather than with the
+    // one-sided equivalent, so that a reader can put the two side by side.
+    const T lo = knots[static_cast<std::size_t>(degree)];
+    const T hi = knots[knots.size() - static_cast<std::size_t>(degree) - 1];
+    std::vector<T> outside;
+    for (const T value : to_insert) {
+        const bool above_lo =
+            lo < value || static_cast<double>(std::abs(lo - value)) <= tol;
+        const bool below_hi =
+            value < hi || static_cast<double>(std::abs(value - hi)) <= tol;
+        if (!(above_lo && below_hi)) {
+            outside.push_back(value);
+        }
+    }
+    if (!outside.empty()) {
+        // The list is rendered space-separated in brackets, which is `numpy`'s shape
+        // but not necessarily its spelling: numpy chooses a shared precision across
+        // the elements and pads them, and reproducing that is a formatting port
+        // nobody needs. A parity test on this message compares the prefix through
+        // the closing `]:` and the element *values*, not the list's rendering.
+        std::string listed = "[";
+        for (std::size_t i = 0; i < outside.size(); ++i) {
+            if (i != 0) {
+                listed += ' ';
+            }
+            listed += pantr::detail::format_scalar(outside[i]);
+        }
+        listed += ']';
+        throw std::invalid_argument("new_knots contains values outside the domain ["
+                                    + pantr::detail::format_scalar(lo) + ", "
+                                    + pantr::detail::format_scalar(hi) + "]: " + listed);
+    }
+
+    std::vector<T> merged;
+    merged.reserve(knots.size() + to_insert.size());
+    merged.insert(merged.end(), knots.begin(), knots.end());
+    merged.insert(merged.end(), to_insert.begin(), to_insert.end());
+    // Stable, so a `-0.0` and a `+0.0` keep the concatenation's order rather than an
+    // order nobody chose; see the file comment.
+    std::stable_sort(merged.begin(), merged.end());
+
+    const std::int64_t max_allowed = degree + 1;
+    const KnotClasses<T> classes = unique_knots_and_multiplicity<T>(merged, degree, tol);
+    std::int64_t worst = 0;
+    for (const std::int64_t mult : classes.multiplicity) {
+        worst = std::max(worst, mult);
+    }
+    if (worst > max_allowed) {
+        throw std::invalid_argument(
+            "Inserting these knots would exceed the maximum multiplicity of "
+            + std::to_string(max_allowed)
+            + ". Maximum multiplicity found: " + std::to_string(worst) + ".");
+    }
+    return merged;
+}
+
+/// The space with every knot span split into `n_subdivisions` equal sub-spans.
+///
+/// The refined space is nested in `space`: every function of `space` is a linear
+/// combination of the result's, with `oslo_matrix_1d(space.degree(), space.knots(),
+/// result.knots())` the coefficients.
+///
+/// \param space The space to subdivide.
+/// \param n_subdivisions Equal sub-spans per existing span, at least 1. A value of 1
+///        returns a copy, which is what a refinement factor of 1 means for a
+///        direction that is not being refined.
+/// \param regularity The continuity at each inserted knot, in `[-1, degree - 1]`.
+///        Empty for `degree - 1`, the maximal smoothness the degree admits.
+/// \return The refined space.
+/// \throws std::invalid_argument If `n_subdivisions < 1`, `regularity` is out of
+///         range, or the merged vector exceeds the maximum multiplicity.
+///
+/// \note The result is non-periodic whatever `space` is, which is the oracle's
+///       behaviour: `BsplineSpace1D.subdivide` builds `BsplineSpace1D(merged,
+///       degree)` and lets `periodic` take its `False` default. Nothing in the THB
+///       port reaches it with a periodic space -- `first_basis_per_interval` refuses
+///       one first -- so this reproduces the oracle rather than repairing it.
+template <Real T>
+[[nodiscard]] BsplineSpace1D<T> subdivide(const BsplineSpace1D<T>& space,
+                                          std::int64_t n_subdivisions,
+                                          std::optional<std::int64_t> regularity) {
+    if (n_subdivisions < 1) {
+        throw std::invalid_argument("n_subdivisions must be >= 1, got "
+                                    + std::to_string(n_subdivisions));
+    }
+    const std::int64_t degree = space.degree();
+    const std::int64_t effective = regularity.value_or(degree - 1);
+    if (effective < -1 || effective > degree - 1) {
+        throw std::invalid_argument("regularity must be in [-1, degree - 1] = [-1, "
+                                    + std::to_string(degree - 1) + "], got "
+                                    + std::to_string(effective));
+    }
+    if (n_subdivisions == 1) {
+        return space;
+    }
+
+    const std::vector<T> to_insert = uniform_subdivision_knots<T>(
+        space.knots(), degree, space.tolerance(), n_subdivisions, effective);
+    if (to_insert.empty()) {
+        return space;
+    }
+    const std::vector<T> merged =
+        inserted_knot_vector<T>(space.knots(), degree, to_insert, space.tolerance());
+    return BsplineSpace1D<T>(std::span<const T>(merged), degree, false,
+                             KnotSnapping::merge_near_duplicates);
+}
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/knot_insertion.hpp
+++ b/cpp/include/pantr/bspline/knot_insertion.hpp
@@ -258,18 +258,22 @@ template <Real T>
 ///
 /// For each in-domain span `[u_k, u_{k+1})`, `n_subdivisions - 1` equally spaced
 /// interior values, each repeated `degree - regularity` times so the refined space is
-/// `C^regularity` at every inserted knot. Empty when the domain holds a single span
-/// and `n_subdivisions` is 1 -- which is not an error, it is what a direction whose
-/// refinement factor is 1 asks for.
+/// `C^regularity` at every inserted knot.
+///
+/// The lower bound on `n_subdivisions` is the oracle's, 2. A direction whose refinement
+/// factor is 1 is not subdivided at all and its caller skips it, which is what
+/// `THBSplineSpace`'s `build_level_spaces` does; an earlier version of this file
+/// accepted 1 and returned nothing, nothing exercised it, and a widened contract with no
+/// exerciser is how an unexamined precedent starts.
 ///
 /// \param knots The knot vector to subdivide.
 /// \param degree The polynomial degree.
 /// \param tol The tolerance that decides which knots are the same knot; the space's
 ///        own `tolerance()`.
-/// \param n_subdivisions Equal sub-spans per existing span, at least 1.
+/// \param n_subdivisions Equal sub-spans per existing span, at least 2.
 /// \param regularity The continuity at each inserted knot, in `[-1, degree - 1]`.
 /// \return The values to insert, non-decreasing, in `T`.
-/// \throws std::invalid_argument If `n_subdivisions < 1` or `regularity` is out of
+/// \throws std::invalid_argument If `n_subdivisions < 2` or `regularity` is out of
 ///         range.
 ///
 /// \note The arithmetic is `double` whatever `T` is, and the result is cast once at
@@ -279,8 +283,8 @@ template <Real T>
                                                        std::int64_t degree, double tol,
                                                        std::int64_t n_subdivisions,
                                                        std::int64_t regularity) {
-    if (n_subdivisions < 1) {
-        throw std::invalid_argument("n_subdivisions must be >= 1, got "
+    if (n_subdivisions < 2) {
+        throw std::invalid_argument("n_subdivisions must be >= 2, got "
                                     + std::to_string(n_subdivisions));
     }
     if (regularity < -1 || regularity > degree - 1) {
@@ -290,10 +294,6 @@ template <Real T>
     }
 
     std::vector<T> out;
-    if (n_subdivisions == 1) {
-        return out;
-    }
-
     const KnotClasses<T> classes = unique_knots_and_multiplicity<T>(knots, degree, tol);
     const std::size_t begin = classes.domain_begin;
     const std::size_t end = classes.domain_end;
@@ -406,13 +406,14 @@ template <Real T>
 /// result.knots())` the coefficients.
 ///
 /// \param space The space to subdivide.
-/// \param n_subdivisions Equal sub-spans per existing span, at least 1. A value of 1
-///        returns a copy, which is what a refinement factor of 1 means for a
-///        direction that is not being refined.
+/// \param n_subdivisions Equal sub-spans per existing span, at least 2 -- the oracle's
+///        own bound. A direction whose refinement factor is 1 is skipped by its caller
+///        rather than subdivided by one; `THBSplineSpace`'s `build_level_spaces` does
+///        exactly that.
 /// \param regularity The continuity at each inserted knot, in `[-1, degree - 1]`.
 ///        Empty for `degree - 1`, the maximal smoothness the degree admits.
 /// \return The refined space.
-/// \throws std::invalid_argument If `n_subdivisions < 1`, `regularity` is out of
+/// \throws std::invalid_argument If `n_subdivisions < 2`, `regularity` is out of
 ///         range, or the merged vector exceeds the maximum multiplicity.
 ///
 /// \note The result is non-periodic whatever `space` is, which is the oracle's
@@ -424,8 +425,8 @@ template <Real T>
 [[nodiscard]] BsplineSpace1D<T> subdivide(const BsplineSpace1D<T>& space,
                                           std::int64_t n_subdivisions,
                                           std::optional<std::int64_t> regularity) {
-    if (n_subdivisions < 1) {
-        throw std::invalid_argument("n_subdivisions must be >= 1, got "
+    if (n_subdivisions < 2) {
+        throw std::invalid_argument("n_subdivisions must be >= 2, got "
                                     + std::to_string(n_subdivisions));
     }
     const std::int64_t degree = space.degree();
@@ -435,10 +436,6 @@ template <Real T>
                                     + std::to_string(degree - 1) + "], got "
                                     + std::to_string(effective));
     }
-    if (n_subdivisions == 1) {
-        return space;
-    }
-
     const std::vector<T> to_insert = uniform_subdivision_knots<T>(
         space.knots(), degree, space.tolerance(), n_subdivisions, effective);
     if (to_insert.empty()) {

--- a/cpp/include/pantr/bspline/knot_insertion.hpp
+++ b/cpp/include/pantr/bspline/knot_insertion.hpp
@@ -347,12 +347,14 @@ template <Real T>
     // one-sided equivalent, so that a reader can put the two side by side.
     const T lo = knots[static_cast<std::size_t>(degree)];
     const T hi = knots[knots.size() - static_cast<std::size_t>(degree) - 1];
+    // Unqualified, with a using-declaration, as `pantr/core/scalar.hpp` requires:
+    // `std::abs(x)` names the overload directly and suppresses ADL, so a Tier B
+    // scalar could never supply its own. `T` here is the template parameter.
+    using std::abs;
     std::vector<T> outside;
     for (const T value : to_insert) {
-        const bool above_lo =
-            lo < value || static_cast<double>(std::abs(lo - value)) <= tol;
-        const bool below_hi =
-            value < hi || static_cast<double>(std::abs(value - hi)) <= tol;
+        const bool above_lo = lo < value || static_cast<double>(abs(lo - value)) <= tol;
+        const bool below_hi = value < hi || static_cast<double>(abs(value - hi)) <= tol;
         if (!(above_lo && below_hi)) {
             outside.push_back(value);
         }

--- a/cpp/include/pantr/bspline/thb_space.hpp
+++ b/cpp/include/pantr/bspline/thb_space.hpp
@@ -125,6 +125,7 @@
 /// assertion will find.
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <numeric>
@@ -791,17 +792,22 @@ class THBSplineSpace {
         const std::span<const T> domain_flat = root_space_->domain_flat();
         const double tol = root_space_->tolerance();
         bool matches = true;
+        // Both operands below are already `double`, so this is a call on a concrete
+        // type rather than on a scalar -- but the discipline in
+        // `pantr/core/scalar.hpp` is enforced mechanically over the headers, on
+        // purpose, and a guard with per-site exemptions is a guard nobody trusts.
+        using std::abs;
         for (std::int64_t k = 0; matches && k < d; ++k) {
             // The grid has no `bounds` accessor of its own: the oracle's property is
             // the first and last breakpoint of each axis, and `grid_types.cpp` builds
             // it the same way.
             const std::span<const double> breakpoints = grid_->root().breakpoints(k);
             const auto i = static_cast<std::size_t>(k) * 2;
-            matches = std::abs(static_cast<double>(breakpoints.front())
-                               - static_cast<double>(domain_flat[i]))
+            matches = abs(static_cast<double>(breakpoints.front())
+                          - static_cast<double>(domain_flat[i]))
                           <= tol
-                      && std::abs(static_cast<double>(breakpoints.back())
-                                  - static_cast<double>(domain_flat[i + 1]))
+                      && abs(static_cast<double>(breakpoints.back())
+                             - static_cast<double>(domain_flat[i + 1]))
                              <= tol;
         }
         if (!matches) {

--- a/cpp/include/pantr/bspline/thb_space.hpp
+++ b/cpp/include/pantr/bspline/thb_space.hpp
@@ -1,0 +1,1984 @@
+#pragma once
+
+/// \file
+/// The (truncated) hierarchical B-spline space: the Kraft selection over a
+/// hierarchical grid, and the truncation coefficients that restore the partition of
+/// unity.
+///
+/// Ports the construction-and-query half of `src/pantr/bspline/_thb_spline_space.py`,
+/// which stays as the parity oracle. Basis tabulation, the windowed restriction and
+/// the prolongation operators are **not** here: each rests on an operation the C++
+/// side does not have yet (Cox-de Boor tabulation, `BsplineSpace::restrict`, a
+/// least-squares solve), and each is a computation *over* a space rather than a
+/// property *of* one, which is the line `pantr/bspline/space_nd.hpp` already draws.
+/// Refinement and coarsening *are* here, because they need nothing new and because
+/// they re-enter this type's own constructor.
+///
+/// ## What this type owns
+///
+/// The root space, the grid, the truncation flag and the per-direction regularity are
+/// its value. Everything else is derived from them at construction: the per-level
+/// tensor-product spaces, the per-level per-direction function-to-cell support, the
+/// Kraft-active function index sets, their cumulative offsets, and the truncated
+/// functions' coefficient boxes. One thing is lazy -- the per-cell contribution table
+/// -- and `design/bspline_derived_caches.md` fixes its shape; see below.
+///
+/// ## Why the class is not decomposed
+///
+/// FELIGN/pantr#397 says not to split it, and the reason it gives -- "its internals
+/// are mutually recursive through the truncation" -- is not what the code does. There
+/// is exactly one cycle among the oracle's own methods, `_refine_recursive` calling
+/// itself, and that is graded *refinement* (Carraturo et al. 2019, Alg. 4), not
+/// truncation; truncation is a forward `while` loop over levels with no recursion in
+/// it. What actually resists splitting is three other things, and they are stronger
+/// than the stated one:
+///
+///  - **Construction is one pipeline with no seam.** Level spaces feed the support,
+///    the support feeds the Kraft selection, and the truncation of a level-`l`
+///    function reads the active sets of *every* finer level. There is no prefix of it
+///    that is useful on its own.
+///  - **The level walk is shared.** Growing a coefficient box through the two-scale
+///    matrix is what the construction-time truncation does and what the
+///    prolongation's `_finest_tp_coeffs` does, once each, with no cache between them.
+///  - **Three methods re-enter the constructor.** `refine`, `coarsen` and `restrict`
+///    all end by building a fresh space, so a split that put construction on one side
+///    and refinement on the other would leave refinement calling a half-built type.
+///
+/// ## The arithmetic, quantity by quantity
+///
+/// **Everything that selects is exact integer work.** The Kraft test is "is this box
+/// entirely inside one mask and not entirely inside another", answered by a summed-area
+/// table over `std::int64_t`; the flat indices, the offsets, the level assignment and
+/// the contribution table are index arithmetic. Two backends must agree on them
+/// **exactly**, and `design/backend_parity.md`'s determinism rule licenses that bar
+/// here for the reason it names -- finite precision does not bite on a count.
+///
+/// **The truncation coefficients have digits, and they get a bound.** They are built
+/// from the two-scale matrices, which `pantr/bspline/knot_insertion.hpp` computes in
+/// `T` -- and then this file widens to `double`, because the oracle does: its
+/// `_build_oslo_matrices` wraps the kernel's output in `np.asarray(..., float64)` and
+/// every coefficient array it touches afterwards is `float64` whatever the root
+/// space's storage is. Getting that backwards -- computing the whole truncation in `T`
+/// -- would be a silent divergence at `float` storage that no shape or count would
+/// reveal.
+///
+/// **The truncation never cancels, and that is what makes its bound tight.** Every
+/// two-scale coefficient is non-negative, truncation only *zeroes* entries, and the
+/// contraction sums non-negative products. So the computed value of an entry
+/// accumulated over `m` additions satisfies `|fl(s) - s| <= gamma_m * s` with
+/// `gamma_m = m u / (1 - m u)` and no cancellation term -- a relative bound rather
+/// than the `sum |terms|` one a signed sum would owe. `m` is the number of terms
+/// summed over all directions and all levels the function passes through, which is
+/// bounded by the coefficient box's own size.
+///
+/// **The oracle's contraction goes through BLAS and this one does not.**
+/// `_refine_box` reaches `numpy.tensordot`, which reshapes and calls `dgemm`, whose
+/// summation order is the BLAS implementation's and differs between OpenBLAS and
+/// Accelerate -- `CLAUDE.md` records exactly that trap. So the truncation coefficients
+/// are a **bounded** parity quantity and not a bitwise one, and a parity test claiming
+/// bit-identity for them would be claiming a property of one machine's BLAS. The
+/// summation here is the naive ordered one.
+///
+/// ## The contribution table
+///
+/// `design/bspline_derived_caches.md` rules this one rather than leaving it to be
+/// chosen here: the oracle's per-cell `dict[int, list[tuple]]` becomes **one flat CSR
+/// table -- offsets plus entries -- filled for all cells behind a single
+/// double-checked flag**, `max_active_per_cell` becomes a field of that table computed
+/// by the same sweep, and the accessor returns a `span` rather than a list, which
+/// retires the oracle's unenforced *"callers must not mutate it"* convention.
+///
+/// What that trades is incrementality: a caller touching one cell pays for the whole
+/// grid. The note asks #397 for a footprint measurement before committing, and names
+/// per-*level* granularity as the fallback if the table is too large. The measurement
+/// is in the pull request rather than here, because a number in a comment rots.
+///
+/// ## Sharing, and the one exception to `const`
+///
+/// The root space is `shared_ptr<const BsplineSpace<T>>`, class **H** of
+/// `design/bspline_ownership_lifetime.md`: the value is shared, the owner's death is
+/// irrelevant, and `level_space(0)` hands back the very handle the space was built
+/// from, so the oracle's `thb.level_space(0) is thb.root_space` survives.
+///
+/// The grid is `shared_ptr<HierarchicalGrid<T>>`, **non-const**, which is the single
+/// exception the ownership note carves out and it is narrow: a grid holds `CellTags`
+/// and `FacetTags`, which `pantr/grid/tags.hpp` already reasons as the
+/// accumulating-container exception to construct-then-freeze, and a `const` handle
+/// would reach only the `const` overload of `cell_tags()` and silently remove the
+/// ability to tag cells through a THB space's grid. It is safe because refinement
+/// returns a *new* grid, so the cell decomposition a space depends on cannot move
+/// underneath it.
+///
+/// `refine` and `coarsen` never hand the result the receiver's grid, not even when
+/// they change nothing: a shared grid would make a tag set through one space visible
+/// through the other. The no-op path goes through `refine_cells({})`, which
+/// `pantr/grid/hierarchical_grid.hpp` routes to `rebuilt()` -- a fresh grid with empty
+/// caches and no inherited tags, which is what the oracle's `grid._copy()` is for.
+///
+/// ## Thread safety
+///
+/// Every accessor is safe to call concurrently on the same object with no external
+/// locking. Everything but the contribution table is frozen at construction; the table
+/// is a `pantr::LazySlot`, whose file comment carries the measurement behind that
+/// choice and the reason a bare `mutable std::optional` is a data race no value
+/// assertion will find.
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/bspline/knot_insertion.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/space_nd.hpp"
+#include "pantr/core/format.hpp"
+#include "pantr/core/lazy.hpp"
+#include "pantr/core/scalar.hpp"
+#include "pantr/grid/hierarchical_grid.hpp"
+
+namespace pantr::bspline {
+
+/// One truncated function's coefficients, as views into the space's own storage.
+///
+/// Valid for as long as the space is. A function that was not truncated has no entry
+/// at all -- it is a plain tensor-product B-spline, and storing a one-element box for
+/// it is what the oracle deliberately avoids.
+struct TruncatedView {
+    /// The level whose tensor-product basis `coeffs` is expressed in.
+    std::int64_t rep_level = 0;
+
+    /// Per-direction lower function index of the coefficient box.
+    std::span<const std::int64_t> box_lo;
+
+    /// Per-direction width of the coefficient box.
+    std::span<const std::int64_t> shape;
+
+    /// The coefficients, row-major over `shape`, always `double`; see the file
+    /// comment on why they are not the space's storage type.
+    std::span<const double> coeffs;
+};
+
+/// The functions active on one cell, as views into the space's contribution table.
+///
+/// The three views have a common length, `size()`, and index the same entries.
+struct CellContributions {
+    /// The global hierarchical dof of each entry, strictly increasing.
+    std::span<const std::int64_t> dofs;
+
+    /// The level owning each entry.
+    std::span<const std::int64_t> levels;
+
+    /// The per-axis function index of each entry in its level space, `size() * dim`
+    /// values row-major.
+    std::span<const std::int64_t> multi_indices;
+
+    /// The number of active functions on the cell.
+    ///
+    /// \return The common length of `dofs` and `levels`.
+    [[nodiscard]] std::int64_t size() const noexcept {
+        return static_cast<std::int64_t>(dofs.size());
+    }
+};
+
+/// A hierarchical B-spline space on a `pantr::grid::HierarchicalGrid`.
+///
+/// Built from a root tensor-product space (level 0) and a grid carrying the
+/// active-cell hierarchy. The per-level spaces are the root uniformly subdivided by
+/// the grid's per-direction factor, which keeps them nested, and the active basis is
+/// the Kraft selection: a level-`l` function is active iff its support lies in the
+/// level-`l` subdomain but not entirely in the further-refined region.
+///
+/// With `truncate` set, each active function that straddles a finer refinement
+/// boundary has its components on active finer functions removed
+/// (Giannelli-Juttler-Speleers), restoring the partition of unity. Only truncated
+/// functions carry a coefficient vector; the rest remain plain tensor-product
+/// B-splines.
+///
+/// \tparam T The scalar type the root space's knots are stored in.
+template <Real T>
+class THBSplineSpace {
+  public:
+    /// The scalar type the root space's knots are stored in.
+    using scalar_type = T;
+
+    /// The hierarchical grid type this space is built on.
+    ///
+    /// `double` whatever `T` is, and that is the oracle's shape rather than an
+    /// omission: `pantr.grid` is `float64`-only by its own port's ruling
+    /// (`src/pantr/grid/_grid_backend.py`, and `cpp/bindings/grid_hierarchical.cpp`
+    /// registers no `float`), while a root B-spline space stores whichever float dtype
+    /// it was handed. `tests/test_thb_spline_space.py`'s
+    /// `test_a_float32_root_space_is_still_graded_in_float64` pins exactly that pair,
+    /// so tying the grid's scalar to `T` would make the shipped case unrepresentable.
+    using grid_type = pantr::grid::HierarchicalGrid<double>;
+
+    /// Build a hierarchical space over a root space and a grid.
+    ///
+    /// \param root_space The level-0 tensor-product space. Shared, not copied.
+    /// \param grid The hierarchy. Shared, not copied, and non-`const`; see the file
+    ///        comment on the one exception to `const`.
+    /// \param truncate Whether to build the truncated (THB) basis rather than the
+    ///        plain hierarchical (HB) one.
+    /// \param regularity Per-direction continuity at the knots inserted when
+    ///        subdividing to finer levels, one entry per direction. An empty
+    ///        `optional` means maximal smoothness, `degree - 1`. Must be `ndim()`
+    ///        long; each present value must satisfy `-1 <= r < degree[k]`.
+    /// \throws std::invalid_argument If either handle is null, the grid and the root
+    ///         space disagree on dimension, on the root knot-span grid or on the
+    ///         domain, `regularity` has the wrong length, or a regularity value is out
+    ///         of range.
+    THBSplineSpace(std::shared_ptr<const BsplineSpace<T>> root_space,
+                   std::shared_ptr<grid_type> grid, bool truncate,
+                   std::vector<std::optional<std::int64_t>> regularity)
+        : root_space_(std::move(root_space)),
+          grid_(std::move(grid)),
+          truncate_(truncate),
+          regularity_(std::move(regularity)) {
+        check_arguments();
+        build_level_spaces();
+        build_support();
+        select_active_functions();
+        if (truncate_) {
+            compute_truncated_coefficients();
+        }
+    }
+
+    /// The level-0 tensor-product space.
+    ///
+    /// Class **H**: the returned handle keeps its value alive independently of this
+    /// space, so a caller may outlive the owner.
+    ///
+    /// \return A handle on the root space, never null.
+    [[nodiscard]] std::shared_ptr<const BsplineSpace<T>> root_space() const noexcept {
+        return root_space_;
+    }
+
+    /// Borrow the level-0 space. Valid while `*this` is, and NOT bound; see the `_ref`
+    /// rule in `design/bspline_ownership_lifetime.md`.
+    ///
+    /// \return A reference to the root space.
+    [[nodiscard]] const BsplineSpace<T>& root_space_ref() const noexcept { return *root_space_; }
+
+    /// The hierarchy this space is built on.
+    ///
+    /// Class **H**, and the one accessor in `pantr.bspline` whose handle is not
+    /// `const`; the file comment gives the reason and the condition under which it
+    /// would have to be reversed.
+    ///
+    /// \return A handle on the grid, never null.
+    [[nodiscard]] std::shared_ptr<grid_type> grid() const noexcept { return grid_; }
+
+    /// Borrow the hierarchy. Valid while `*this` is, and NOT bound.
+    ///
+    /// \return A reference to the grid.
+    [[nodiscard]] grid_type& grid_ref() const noexcept { return *grid_; }
+
+    /// The number of parametric directions.
+    ///
+    /// \return The root space's dimension.
+    [[nodiscard]] std::int64_t dim() const noexcept { return root_space_->dim(); }
+
+    /// The per-direction polynomial degrees.
+    ///
+    /// \return A view of `dim()` degrees, in axis order, valid while this space is.
+    [[nodiscard]] std::span<const std::int64_t> degrees() const noexcept {
+        return root_space_->degrees();
+    }
+
+    /// The number of hierarchy levels.
+    ///
+    /// \return `grid().max_level() + 1`.
+    [[nodiscard]] std::int64_t num_levels() const noexcept {
+        return static_cast<std::int64_t>(level_spaces_.size());
+    }
+
+    /// Whether the truncated basis is used.
+    ///
+    /// \return `true` for THB, `false` for the plain hierarchical basis.
+    [[nodiscard]] bool truncate() const noexcept { return truncate_; }
+
+    /// The per-direction regularity the finer levels were built with.
+    ///
+    /// \return A view of `dim()` entries, an empty `optional` meaning maximal
+    ///         smoothness.
+    [[nodiscard]] std::span<const std::optional<std::int64_t>> regularity() const noexcept {
+        return std::span<const std::optional<std::int64_t>>(regularity_);
+    }
+
+    /// The total number of active hierarchical functions.
+    ///
+    /// \return The sum of the per-level active counts.
+    [[nodiscard]] std::int64_t num_total_basis() const noexcept { return num_active_; }
+
+    /// The number of active functions at each level.
+    ///
+    /// \return A view of `num_levels()` counts, valid while this space is.
+    [[nodiscard]] std::span<const std::int64_t> num_basis_per_level() const noexcept {
+        return std::span<const std::int64_t>(num_per_level_);
+    }
+
+    /// The global dof at which each level's functions begin.
+    ///
+    /// \return A view of `num_levels() + 1` cumulative counts; the last entry is
+    ///         `num_total_basis()`.
+    [[nodiscard]] std::span<const std::int64_t> level_offsets() const noexcept {
+        return std::span<const std::int64_t>(func_offset_);
+    }
+
+    /// The parametric domain, per direction.
+    ///
+    /// \return The root space's domain, `2 * dim()` values as `[lo_0, hi_0, ...]`.
+    [[nodiscard]] std::span<const T> domain() const noexcept { return root_space_->domain_flat(); }
+
+    /// The parametric tolerance.
+    ///
+    /// \return The root space's tolerance.
+    [[nodiscard]] double tolerance() const { return root_space_->tolerance(); }
+
+    /// The tensor-product space at `level`.
+    ///
+    /// Class **H**. Level 0 is the very handle this space was built from, not a copy
+    /// of it, which is what makes the oracle's `thb.level_space(0) is thb.root_space`
+    /// hold through the binding.
+    ///
+    /// \param level Hierarchy level in `[0, num_levels())`.
+    /// \return A handle on the level space.
+    /// \throws std::invalid_argument If `level` is out of range.
+    [[nodiscard]] std::shared_ptr<const BsplineSpace<T>> level_space(std::int64_t level) const {
+        check_level(level);
+        return level_spaces_[static_cast<std::size_t>(level)];
+    }
+
+    /// Borrow the tensor-product space at `level`. Valid while `*this` is, and NOT
+    /// bound.
+    ///
+    /// \param level Hierarchy level in `[0, num_levels())`.
+    /// \return A reference to the level space.
+    /// \throws std::invalid_argument If `level` is out of range.
+    [[nodiscard]] const BsplineSpace<T>& level_space_ref(std::int64_t level) const {
+        check_level(level);
+        return *level_spaces_[static_cast<std::size_t>(level)];
+    }
+
+    /// The flat indices of the functions the Kraft rule selects at `level`.
+    ///
+    /// Class **A**: a view of this space's own storage rather than a copy. The oracle
+    /// returns a fresh array; the port returns a read-only view and lets the binding
+    /// present it as a non-writable array owned by the Python object, which is the
+    /// same rule `design/bspline_derived_caches.md` states for
+    /// `SpanwiseElementExtraction.ops_1d`.
+    ///
+    /// \param level Hierarchy level in `[0, num_levels())`.
+    /// \return Sorted flat (C-order) indices into the level space's tensor-product
+    ///         basis, valid while this space is.
+    /// \throws std::invalid_argument If `level` is out of range.
+    [[nodiscard]] std::span<const std::int64_t> active_function_indices(
+        std::int64_t level) const {
+        check_level(level);
+        return std::span<const std::int64_t>(active_funcs_[static_cast<std::size_t>(level)]);
+    }
+
+    /// The global dofs of the functions whose support intersects cell `cid`.
+    ///
+    /// Selects on tensor-product support, so under truncation a few of the functions
+    /// listed may evaluate to exactly zero on the cell. That is the oracle's contract
+    /// and it is what a fixed-width dofmap wants.
+    ///
+    /// \param cid Active cell flat id in `[0, grid().num_cells())`.
+    /// \return Sorted global dofs, valid while this space is.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] std::span<const std::int64_t> active_basis(std::int64_t cid) const {
+        return contributions(cid).dofs;
+    }
+
+    /// Everything the contribution table records about cell `cid`.
+    ///
+    /// The first call fills the table for **every** cell; see the file comment on what
+    /// that trades. Concurrent first calls build it once.
+    ///
+    /// \param cid Active cell flat id in `[0, grid().num_cells())`.
+    /// \return Views into the table, valid while this space is.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] CellContributions contributions(std::int64_t cid) const {
+        const ContributionTable& table = contributions_table();
+        if (cid < 0 || cid >= grid_->num_cells()) {
+            throw std::out_of_range("cell id " + std::to_string(cid) + " is out of range [0, "
+                                    + std::to_string(grid_->num_cells()) + ").");
+        }
+        const auto i = static_cast<std::size_t>(cid);
+        const auto begin = static_cast<std::size_t>(table.offset[i]);
+        const auto count = static_cast<std::size_t>(table.offset[i + 1] - table.offset[i]);
+        const auto d = static_cast<std::size_t>(dim());
+        return CellContributions{
+            std::span<const std::int64_t>(table.dof.data() + begin, count),
+            std::span<const std::int64_t>(table.level.data() + begin, count),
+            std::span<const std::int64_t>(table.multi.data() + begin * d, count * d)};
+    }
+
+    /// The largest number of active functions on any single cell.
+    ///
+    /// The width a fixed-size dofmap needs. Truncation can annihilate a function on a
+    /// cell it supports but never add one, so this is the same for the THB and HB
+    /// bases. Fills the contribution table if it is not filled.
+    ///
+    /// \return The maximum over every active cell; zero for a grid with no cells.
+    [[nodiscard]] std::int64_t max_active_per_cell() const {
+        return contributions_table().max_per_cell;
+    }
+
+    /// The number of functions that carry truncation coefficients.
+    ///
+    /// \return Zero when `truncate()` is false, and otherwise the count of active
+    ///         functions the truncation actually changed.
+    [[nodiscard]] std::int64_t num_truncated() const noexcept {
+        return static_cast<std::int64_t>(truncated_.size());
+    }
+
+    /// The truncation coefficients of global dof `dof`, if it has any.
+    ///
+    /// \param dof Global active-function index in `[0, num_total_basis())`.
+    /// \return The views, or an empty `optional` when the function was not truncated
+    ///         and is a plain tensor-product B-spline.
+    /// \throws std::out_of_range If `dof` is out of range.
+    [[nodiscard]] std::optional<TruncatedView> truncated(std::int64_t dof) const {
+        check_dof(dof);
+        const auto it = std::lower_bound(
+            truncated_.begin(), truncated_.end(), dof,
+            [](const TruncatedEntry& entry, std::int64_t key) { return entry.dof < key; });
+        if (it == truncated_.end() || it->dof != dof) {
+            return std::nullopt;
+        }
+        return TruncatedView{it->rep_level, std::span<const std::int64_t>(it->box_lo),
+                             std::span<const std::int64_t>(it->shape),
+                             std::span<const double>(it->coeffs)};
+    }
+
+    /// The level that owns global dof `dof`.
+    ///
+    /// \param dof Global active-function index in `[0, num_total_basis())`.
+    /// \return The level whose dof range contains `dof`.
+    /// \throws std::out_of_range If `dof` is out of range.
+    [[nodiscard]] std::int64_t dof_level(std::int64_t dof) const {
+        check_dof(dof);
+        const auto it = std::upper_bound(func_offset_.begin(), func_offset_.end(), dof);
+        return static_cast<std::int64_t>(it - func_offset_.begin()) - 1;
+    }
+
+    /// A new space with the marked cells refined.
+    ///
+    /// This space and its grid are untouched: the grid is refined by rebinding and a
+    /// new space is built on the result. The result never holds this space's grid
+    /// object, even when nothing was refined; see the file comment.
+    ///
+    /// With `admissible_class = m` the refinement is graded so the resulting mesh is
+    /// admissible of class `m` -- the truncated functions acting on any cell span at
+    /// most `m` successive levels -- by the recursive refinement-neighbourhood
+    /// algorithm of Carraturo et al. (2019, Alg. 4). That assumes the current mesh is
+    /// already admissible of class `m`, which holds for the root and for any mesh
+    /// built by graded refinement. An empty `optional` refines exactly the marked
+    /// cells.
+    ///
+    /// \param cell_ids Flat ids of active cells to refine; duplicates are ignored.
+    /// \param admissible_class The class to maintain, at least 2, or empty for no
+    ///        grading.
+    /// \return A new space on the refined grid, with this space's root space,
+    ///         truncation flag and regularity.
+    /// \throws std::out_of_range If any id is outside `[0, grid().num_cells())`.
+    /// \throws std::invalid_argument If `admissible_class` is present and below 2.
+    [[nodiscard]] THBSplineSpace refine(std::span<const std::int64_t> cell_ids,
+                                        std::optional<std::int64_t> admissible_class) const {
+        check_admissible_class(admissible_class);
+        std::vector<std::int64_t> ids(cell_ids.begin(), cell_ids.end());
+        std::sort(ids.begin(), ids.end());
+        ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+        for (const std::int64_t cid : ids) {
+            if (cid < 0 || cid >= grid_->num_cells()) {
+                throw std::out_of_range("cell_ids must lie in [0, "
+                                        + std::to_string(grid_->num_cells())
+                                        + "); got out-of-range id " + std::to_string(cid) + ".");
+            }
+        }
+
+        // Resolved against the original grid before anything is refined: every
+        // `refine` reassigns flat ids, so a `(level, midx)` pair is the only handle
+        // that survives the loop.
+        const auto d = static_cast<std::size_t>(dim());
+        std::vector<Marked> marked;
+        marked.reserve(ids.size());
+        for (const std::int64_t cid : ids) {
+            Marked cell{grid_->cell_level(cid), std::vector<std::int64_t>(d)};
+            grid_->cell_multi_index(cid, std::span<std::int64_t>(cell.midx));
+            marked.push_back(std::move(cell));
+        }
+        return refine_marked(marked, admissible_class);
+    }
+
+    /// A new space with the active cells of a rectangular region refined.
+    ///
+    /// The region is the cell-index box `[lo, hi)` in level-`level` coordinates, which
+    /// is `HierarchicalGrid::refine`'s convention. Only the currently active leaves
+    /// inside it are refined; a box holding none is a no-op that still returns a new
+    /// space over a grid of its own.
+    ///
+    /// \param level Level the box lives at, in `[0, grid().max_level()]`.
+    /// \param lo Per-direction start index, inclusive.
+    /// \param hi Per-direction end index, exclusive.
+    /// \param admissible_class As `refine`.
+    /// \return A new space on the refined grid.
+    /// \throws std::invalid_argument If `admissible_class` is present and below 2,
+    ///         `level` is out of range, `lo` or `hi` is not `dim()` long, some
+    ///         `lo[k] >= hi[k]`, or the box leaves the level's domain.
+    [[nodiscard]] THBSplineSpace refine_region(
+        std::int64_t level, std::span<const std::int64_t> lo, std::span<const std::int64_t> hi,
+        std::optional<std::int64_t> admissible_class) const {
+        check_admissible_class(admissible_class);
+        validate_region(level, lo, hi);
+
+        const auto d = static_cast<std::size_t>(dim());
+        std::vector<Marked> marked;
+        std::vector<std::int64_t> midx(lo.begin(), lo.end());
+        for (;;) {
+            if (grid_->is_active_leaf(level, std::span<const std::int64_t>(midx))) {
+                marked.push_back(Marked{level, midx});
+            }
+            std::size_t axis = d;
+            while (axis > 0) {
+                --axis;
+                ++midx[axis];
+                if (midx[axis] < hi[axis]) {
+                    break;
+                }
+                midx[axis] = lo[axis];
+                if (axis == 0) {
+                    return refine_marked(marked, admissible_class);
+                }
+            }
+            if (d == 0) {
+                return refine_marked(marked, admissible_class);
+            }
+        }
+    }
+
+    /// A new space with the marked cells coarsened away.
+    ///
+    /// A parent is reactivated only when **all** of its children are marked active
+    /// leaves, which is `HierarchicalGrid::coarsen_cells`'s own rule and Alg. 5 of
+    /// Carraturo et al. (2019); this drives it one parent at a time so the
+    /// admissibility guard can veto a parent without affecting the rest. Parents are
+    /// visited deepest first, so a veto is decided against a mesh whose finer
+    /// coarsenings have already happened.
+    ///
+    /// With `admissible_class = m` a parent is reactivated only if its coarsening
+    /// neighbourhood (Def. 3.5) is empty. With an empty `optional` that guard is
+    /// skipped, and coarsening is then the exact inverse of `refine`.
+    ///
+    /// \param cell_ids Flat ids of active leaf cells to coarsen away; an empty range
+    ///        is valid and coarsens nothing.
+    /// \param admissible_class The class to maintain, at least 2, or empty for no
+    ///        guard.
+    /// \return A new space on the coarsened grid.
+    /// \throws std::out_of_range If any id is outside `[0, grid().num_cells())`.
+    /// \throws std::invalid_argument If `admissible_class` is present and below 2.
+    [[nodiscard]] THBSplineSpace coarsen(std::span<const std::int64_t> cell_ids,
+                                         std::optional<std::int64_t> admissible_class) const {
+        check_admissible_class(admissible_class);
+        std::vector<std::int64_t> ids(cell_ids.begin(), cell_ids.end());
+        std::sort(ids.begin(), ids.end());
+        ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+        for (const std::int64_t cid : ids) {
+            if (cid < 0 || cid >= grid_->num_cells()) {
+                throw std::out_of_range("cell_ids must lie in [0, "
+                                        + std::to_string(grid_->num_cells())
+                                        + "); got out-of-range id " + std::to_string(cid) + ".");
+            }
+        }
+
+        const auto d = static_cast<std::size_t>(dim());
+        const std::span<const std::int64_t> factor = grid_->factor();
+        std::vector<Marked> marked;
+        marked.reserve(ids.size());
+        for (const std::int64_t cid : ids) {
+            Marked cell{grid_->cell_level(cid), std::vector<std::int64_t>(d)};
+            grid_->cell_multi_index(cid, std::span<std::int64_t>(cell.midx));
+            marked.push_back(std::move(cell));
+        }
+
+        std::vector<Marked> parents;
+        for (const Marked& cell : marked) {
+            if (cell.level < 1) {
+                continue;
+            }
+            Marked parent{cell.level - 1, std::vector<std::int64_t>(d)};
+            for (std::size_t k = 0; k < d; ++k) {
+                parent.midx[k] = cell.midx[k] / factor[k];
+            }
+            parents.push_back(std::move(parent));
+        }
+        std::sort(parents.begin(), parents.end(), [](const Marked& a, const Marked& b) {
+            // Deepest first, then lexicographic, so the order does not depend on the
+            // order the ids arrived in.
+            if (a.level != b.level) {
+                return a.level > b.level;
+            }
+            return a.midx < b.midx;
+        });
+        parents.erase(std::unique(parents.begin(), parents.end(),
+                                  [](const Marked& a, const Marked& b) {
+                                      return a.level == b.level && a.midx == b.midx;
+                                  }),
+                      parents.end());
+
+        std::int64_t num_children = 1;
+        for (std::size_t k = 0; k < d; ++k) {
+            num_children *= factor[k];
+        }
+
+        std::shared_ptr<grid_type> current = grid_;
+        bool changed = false;
+        std::vector<std::int64_t> child(d);
+        for (const Marked& parent : parents) {
+            // Named afresh on the current grid: every coarsening reassigns flat ids.
+            std::vector<std::int64_t> child_ids;
+            for (std::size_t k = 0; k < d; ++k) {
+                child[k] = parent.midx[k] * factor[k];
+            }
+            for (;;) {
+                const bool is_marked =
+                    std::any_of(marked.begin(), marked.end(), [&](const Marked& cell) {
+                        return cell.level == parent.level + 1 && cell.midx == child;
+                    });
+                if (is_marked) {
+                    const std::optional<std::int64_t> cid = current->cell_id(
+                        parent.level + 1, std::span<const std::int64_t>(child));
+                    if (cid.has_value()) {
+                        child_ids.push_back(*cid);
+                    }
+                }
+                std::size_t axis = d;
+                bool done = d == 0;
+                while (axis > 0) {
+                    --axis;
+                    ++child[axis];
+                    if (child[axis] < (parent.midx[axis] + 1) * factor[axis]) {
+                        break;
+                    }
+                    child[axis] = parent.midx[axis] * factor[axis];
+                    if (axis == 0) {
+                        done = true;
+                    }
+                }
+                if (done) {
+                    break;
+                }
+            }
+            // An incomplete family is one `coarsen_cells` would skip anyway, so
+            // leaving here skips the only expensive test in the loop.
+            if (static_cast<std::int64_t>(child_ids.size()) < num_children) {
+                continue;
+            }
+            if (admissible_class.has_value()
+                && !coarsening_neighborhood_empty(parent.level, parent.midx, *admissible_class,
+                                                  *current)) {
+                continue;
+            }
+            current = std::make_shared<grid_type>(
+                current->coarsen_cells(std::span<const std::int64_t>(child_ids)));
+            changed = true;
+        }
+        return rebound(changed ? current : detached_grid());
+    }
+
+    /// A compact string form.
+    ///
+    /// \return `"THBSplineSpace(dim=..., degrees=(...), num_levels=..., "`
+    ///         `"num_total_basis=..., truncate=...)"`, the oracle's `repr` character
+    ///         for character.
+    [[nodiscard]] std::string to_string() const {
+        std::string text = "THBSplineSpace(dim=" + std::to_string(dim()) + ", degrees=(";
+        const std::span<const std::int64_t> deg = degrees();
+        for (std::size_t k = 0; k < deg.size(); ++k) {
+            text += std::to_string(deg[k]);
+            // Python's one-element tuple is `(2,)`, so the comma follows every entry
+            // when there is only one.
+            if (k + 1 < deg.size() || deg.size() == 1) {
+                text += ",";
+            }
+            if (k + 1 < deg.size()) {
+                text += " ";
+            }
+        }
+        text += "), num_levels=" + std::to_string(num_levels())
+                + ", num_total_basis=" + std::to_string(num_active_)
+                + ", truncate=" + (truncate_ ? "True" : "False") + ")";
+        return text;
+    }
+
+
+  private:
+    /// A cell named by its level and its per-axis index at that level.
+    ///
+    /// Flat ids are reassigned by every refinement, so this is the only handle that
+    /// survives a loop that refines.
+    struct Marked {
+        std::int64_t level = 0;          ///< The level the cell lives at.
+        std::vector<std::int64_t> midx;  ///< Its per-axis index at that level.
+    };
+
+    /// The cell support of every function of one 1D space.
+    struct Support1D {
+        std::vector<std::int64_t> first_basis;  ///< Per interval, its first function.
+        std::vector<std::int64_t> first_cell;   ///< Per function, its first interval.
+        std::vector<std::int64_t> last_cell;    ///< Per function, its last interval.
+    };
+
+    /// One direction's two-scale matrix, with the shape needed to index it.
+    struct TwoScale {
+        std::vector<double> alpha;  ///< `rows * cols` values, row-major.
+        std::int64_t rows = 0;      ///< The refined level's basis count.
+        std::int64_t cols = 0;      ///< The coarse level's basis count.
+    };
+
+    /// One truncated function's stored coefficients.
+    struct TruncatedEntry {
+        std::int64_t dof = 0;              ///< The global active-function index.
+        std::int64_t rep_level = 0;        ///< The level the coefficients live in.
+        std::vector<std::int64_t> box_lo;  ///< Per-direction lower function index.
+        std::vector<std::int64_t> shape;   ///< Per-direction box width.
+        std::vector<double> coeffs;        ///< Row-major over `shape`.
+    };
+
+    /// The per-cell active functions, in one flat CSR table.
+    ///
+    /// `design/bspline_derived_caches.md` fixes this shape; see the file comment.
+    struct ContributionTable {
+        std::vector<std::int64_t> offset;  ///< `num_cells + 1` entry offsets.
+        std::vector<std::int64_t> dof;     ///< Per entry, the global dof.
+        std::vector<std::int64_t> level;   ///< Per entry, the owning level.
+        std::vector<std::int64_t> multi;   ///< Per entry, `dim` function indices.
+        std::int64_t max_per_cell = 0;     ///< The widest cell, from the same sweep.
+    };
+
+    // ---------------------------------------------------------------- validation
+
+    /// Refuse the constructor's arguments before anything is derived.
+    ///
+    /// \throws std::invalid_argument If a handle is null, the grid and the root space
+    ///         disagree, or the regularity is mis-shaped or out of range.
+    void check_arguments() const {
+        if (root_space_ == nullptr) {
+            throw std::invalid_argument("root_space must not be null.");
+        }
+        if (grid_ == nullptr) {
+            throw std::invalid_argument("grid must not be null.");
+        }
+        const std::int64_t d = root_space_->dim();
+        if (grid_->ndim() != d) {
+            throw std::invalid_argument("grid.ndim (" + std::to_string(grid_->ndim())
+                                        + ") must equal root_space.dim (" + std::to_string(d)
+                                        + ").");
+        }
+        const std::span<const std::int64_t> cells = grid_->root().cells_per_axis();
+        const std::span<const std::int64_t> intervals = root_space_->num_intervals();
+        bool same = cells.size() == intervals.size();
+        for (std::size_t k = 0; same && k < cells.size(); ++k) {
+            same = cells[k] == intervals[k];
+        }
+        if (!same) {
+            throw std::invalid_argument("grid root cells_per_axis " + tuple_repr(cells)
+                                        + " must match root_space.num_intervals "
+                                        + tuple_repr(intervals) + ".");
+        }
+
+        // Absolute, against the space's own knot tolerance. A relative comparison
+        // accepts a fixed relative mismatch at every scale, and a mixed one passes a
+        // factor-of-two wrong domain on a tiny domain; the oracle's comment carries
+        // the case that argues it.
+        const std::span<const T> domain_flat = root_space_->domain_flat();
+        const double tol = root_space_->tolerance();
+        bool matches = true;
+        for (std::int64_t k = 0; matches && k < d; ++k) {
+            // The grid has no `bounds` accessor of its own: the oracle's property is
+            // the first and last breakpoint of each axis, and `grid_types.cpp` builds
+            // it the same way.
+            const std::span<const double> breakpoints = grid_->root().breakpoints(k);
+            const auto i = static_cast<std::size_t>(k) * 2;
+            matches = std::abs(static_cast<double>(breakpoints.front())
+                               - static_cast<double>(domain_flat[i]))
+                          <= tol
+                      && std::abs(static_cast<double>(breakpoints.back())
+                                  - static_cast<double>(domain_flat[i + 1]))
+                             <= tol;
+        }
+        if (!matches) {
+            throw std::invalid_argument("grid root bounds must match root_space domain.");
+        }
+
+        if (static_cast<std::int64_t>(regularity_.size()) != d) {
+            throw std::invalid_argument("regularity must be a scalar or length-"
+                                        + std::to_string(d) + " sequence; got length "
+                                        + std::to_string(regularity_.size()) + ".");
+        }
+        const std::span<const std::int64_t> deg = root_space_->degrees();
+        for (std::size_t k = 0; k < regularity_.size(); ++k) {
+            if (!regularity_[k].has_value()) {
+                continue;
+            }
+            const std::int64_t r = *regularity_[k];
+            if (r < -1 || r >= deg[k]) {
+                throw std::invalid_argument(
+                    "regularity[" + std::to_string(k) + "]=" + std::to_string(r)
+                    + " must be in [-1, degree[" + std::to_string(k)
+                    + "]-1=" + std::to_string(deg[k] - 1) + "]; got " + std::to_string(r) + ".");
+            }
+        }
+    }
+
+    /// Refuse a level outside the hierarchy.
+    ///
+    /// \param level The level to check.
+    /// \throws std::invalid_argument If it is outside `[0, num_levels())`.
+    void check_level(std::int64_t level) const {
+        if (level < 0 || level >= num_levels()) {
+            throw std::invalid_argument("level must be in [0, " + std::to_string(num_levels() - 1)
+                                        + "]; got " + std::to_string(level) + ".");
+        }
+    }
+
+    /// Refuse a global dof outside the active basis.
+    ///
+    /// \param dof The dof to check.
+    /// \throws std::out_of_range If it is outside `[0, num_total_basis())`.
+    void check_dof(std::int64_t dof) const {
+        if (dof < 0 || dof >= num_active_) {
+            throw std::out_of_range("dof " + std::to_string(dof) + " is out of range [0, "
+                                    + std::to_string(num_active_) + ").");
+        }
+    }
+
+    /// Refuse an admissibility class below the definition's minimum.
+    ///
+    /// \param admissible_class The class, or an empty `optional` for no grading.
+    /// \throws std::invalid_argument If it is present and below 2.
+    static void check_admissible_class(std::optional<std::int64_t> admissible_class) {
+        if (admissible_class.has_value() && *admissible_class < 2) {
+            throw std::invalid_argument("admissible_class must be an integer >= 2 or None; got "
+                                        + std::to_string(*admissible_class) + ".");
+        }
+    }
+
+    /// Validate a `[lo, hi)` cell-index box at `level`.
+    ///
+    /// The same four checks `HierarchicalGrid::refine` applies: the level's range, the
+    /// corners' lengths, `lo < hi` per axis, and the box inside the level's domain.
+    ///
+    /// \param level The level the box lives at.
+    /// \param lo Per-direction start index, inclusive.
+    /// \param hi Per-direction end index, exclusive.
+    /// \throws std::invalid_argument If any of the four fails.
+    void validate_region(std::int64_t level, std::span<const std::int64_t> lo,
+                         std::span<const std::int64_t> hi) const {
+        const std::int64_t max_level = grid_->max_level();
+        if (level < 0 || level > max_level) {
+            throw std::invalid_argument("level must be in [0, " + std::to_string(max_level)
+                                        + "]; got " + std::to_string(level) + ".");
+        }
+        const auto d = static_cast<std::size_t>(dim());
+        if (lo.size() != d || hi.size() != d) {
+            throw std::invalid_argument("lo and hi must have length " + std::to_string(d)
+                                        + "; got " + std::to_string(lo.size()) + " and "
+                                        + std::to_string(hi.size()) + ".");
+        }
+        for (std::size_t k = 0; k < d; ++k) {
+            if (lo[k] >= hi[k]) {
+                throw std::invalid_argument(
+                    "lo must be strictly less than hi in every dimension; got lo="
+                    + tuple_repr(lo) + ", hi=" + tuple_repr(hi) + ".");
+            }
+        }
+        for (std::size_t k = 0; k < d; ++k) {
+            const std::int64_t n =
+                grid_->level_cells_per_axis(level, static_cast<std::int64_t>(k));
+            if (lo[k] < 0 || hi[k] > n) {
+                throw std::invalid_argument(
+                    "[lo, hi) out of bounds at level " + std::to_string(level) + ": axis "
+                    + std::to_string(k) + " needs [0, " + std::to_string(n) + "), got ["
+                    + std::to_string(lo[k]) + ", " + std::to_string(hi[k]) + ").");
+            }
+        }
+    }
+
+    // ------------------------------------------------------------- index helpers
+
+    /// The flat C-order index of a multi-index.
+    ///
+    /// \param multi Per-axis indices.
+    /// \param shape Per-axis extents.
+    /// \return The flat index, last axis fastest.
+    [[nodiscard]] static std::int64_t ravel(std::span<const std::int64_t> multi,
+                                            std::span<const std::int64_t> shape) noexcept {
+        std::int64_t flat = 0;
+        for (std::size_t k = 0; k < shape.size(); ++k) {
+            flat = flat * shape[k] + multi[k];
+        }
+        return flat;
+    }
+
+    /// The multi-index of a flat C-order index.
+    ///
+    /// \param flat The flat index.
+    /// \param shape Per-axis extents.
+    /// \param out Receives `shape.size()` per-axis indices.
+    static void unravel(std::int64_t flat, std::span<const std::int64_t> shape,
+                        std::span<std::int64_t> out) noexcept {
+        for (std::size_t k = shape.size(); k > 0; --k) {
+            out[k - 1] = flat % shape[k - 1];
+            flat /= shape[k - 1];
+        }
+    }
+
+    /// Python's `repr` of a tuple of integers.
+    ///
+    /// \param values The entries.
+    /// \return `"(a, b, c)"`, and `"(a,)"` for one entry, as Python writes them.
+    [[nodiscard]] static std::string tuple_repr(std::span<const std::int64_t> values) {
+        std::string text = "(";
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            text += std::to_string(values[i]);
+            if (i + 1 < values.size() || values.size() == 1) {
+                text += ",";
+            }
+            if (i + 1 < values.size()) {
+                text += " ";
+            }
+        }
+        return text + ")";
+    }
+
+    /// The number of cells a per-axis shape describes.
+    ///
+    /// \param shape Per-axis extents.
+    /// \return Their product, 1 for an empty shape.
+    [[nodiscard]] static std::int64_t count_of(std::span<const std::int64_t> shape) noexcept {
+        std::int64_t total = 1;
+        for (const std::int64_t n : shape) {
+            total *= n;
+        }
+        return total;
+    }
+
+    // ------------------------------------------------------------- mask helpers
+
+    /// The bounding box of a mask's set cells.
+    ///
+    /// \param mask A `count_of(shape)` mask, C-order.
+    /// \param shape Per-axis extents.
+    /// \param lo Receives the per-axis minimum, inclusive.
+    /// \param hi Receives the per-axis maximum plus one, exclusive.
+    /// \return `false` when the mask is empty, in which case `lo` and `hi` are
+    ///         untouched.
+    [[nodiscard]] static bool bounding_box(const std::vector<std::uint8_t>& mask,
+                                           std::span<const std::int64_t> shape,
+                                           std::vector<std::int64_t>& lo,
+                                           std::vector<std::int64_t>& hi) {
+        const auto d = shape.size();
+        bool any = false;
+        std::vector<std::int64_t> multi(d);
+        for (std::size_t i = 0; i < mask.size(); ++i) {
+            if (mask[i] == 0U) {
+                continue;
+            }
+            unravel(static_cast<std::int64_t>(i), shape, std::span<std::int64_t>(multi));
+            if (!any) {
+                for (std::size_t k = 0; k < d; ++k) {
+                    lo[k] = multi[k];
+                    hi[k] = multi[k] + 1;
+                }
+                any = true;
+            } else {
+                for (std::size_t k = 0; k < d; ++k) {
+                    lo[k] = std::min(lo[k], multi[k]);
+                    hi[k] = std::max(hi[k], multi[k] + 1);
+                }
+            }
+        }
+        return any;
+    }
+
+    /// The summed-area table of a mask's **complement**.
+    ///
+    /// Entry `(i_0, ..., i_{d-1})` of the returned array, whose extents are
+    /// `shape + 1` per axis, is the number of cleared cells in the box
+    /// `[0, i_0) x ... x [0, i_{d-1})`. A box is therefore all-set iff its
+    /// inclusion-exclusion sum over `2 ** d` corners is zero, which is what
+    /// `box_all_true` computes.
+    ///
+    /// Exact integer arithmetic throughout, so this is the oracle's answer rather than
+    /// an equivalent one.
+    ///
+    /// \param mask A `count_of(shape)` mask, C-order.
+    /// \param shape Per-axis extents.
+    /// \return The table, C-order over `shape + 1`.
+    [[nodiscard]] static std::vector<std::int64_t> summed_area(
+        const std::vector<std::uint8_t>& mask, std::span<const std::int64_t> shape) {
+        const auto d = shape.size();
+        std::vector<std::int64_t> ext(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            ext[k] = shape[k] + 1;
+        }
+        std::vector<std::int64_t> table(static_cast<std::size_t>(count_of(ext)), 0);
+
+        std::vector<std::int64_t> multi(d);
+        std::vector<std::int64_t> shifted(d);
+        for (std::size_t i = 0; i < mask.size(); ++i) {
+            unravel(static_cast<std::int64_t>(i), shape, std::span<std::int64_t>(multi));
+            for (std::size_t k = 0; k < d; ++k) {
+                shifted[k] = multi[k] + 1;
+            }
+            table[static_cast<std::size_t>(ravel(shifted, ext))] =
+                static_cast<std::int64_t>(mask[i] == 0U);
+        }
+
+        // One prefix sum per axis, in place. Strides are recomputed per axis rather
+        // than cached: `d` is at most 3 everywhere in this tree.
+        for (std::size_t axis = 0; axis < d; ++axis) {
+            std::int64_t stride = 1;
+            for (std::size_t k = axis + 1; k < d; ++k) {
+                stride *= ext[k];
+            }
+            const std::int64_t total = count_of(ext);
+            for (std::int64_t flat = 0; flat < total; ++flat) {
+                const std::int64_t index_on_axis = (flat / stride) % ext[axis];
+                if (index_on_axis == 0) {
+                    continue;
+                }
+                table[static_cast<std::size_t>(flat)] +=
+                    table[static_cast<std::size_t>(flat - stride)];
+            }
+        }
+        return table;
+    }
+
+    /// Whether a mask is set at every cell of a box, from its summed-area table.
+    ///
+    /// \param table The table `summed_area` returned.
+    /// \param shape The mask's per-axis extents.
+    /// \param lo Per-axis lower corner, inclusive.
+    /// \param hi Per-axis upper corner, exclusive.
+    /// \return `true` iff the box holds no cleared cell.
+    [[nodiscard]] static bool box_all_true(const std::vector<std::int64_t>& table,
+                                           std::span<const std::int64_t> shape,
+                                           std::span<const std::int64_t> lo,
+                                           std::span<const std::int64_t> hi) {
+        const auto d = shape.size();
+        std::vector<std::int64_t> ext(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            ext[k] = shape[k] + 1;
+        }
+        std::vector<std::int64_t> corner(d);
+        std::int64_t total = 0;
+        const std::int64_t corners = std::int64_t{1} << d;
+        for (std::int64_t bits = 0; bits < corners; ++bits) {
+            std::int64_t set = 0;
+            for (std::size_t k = 0; k < d; ++k) {
+                const bool upper = ((bits >> k) & 1) != 0;
+                corner[k] = upper ? hi[k] : lo[k];
+                set += static_cast<std::int64_t>(upper);
+            }
+            const std::int64_t sign = ((static_cast<std::int64_t>(d) - set) % 2 == 0) ? 1 : -1;
+            total += sign * table[static_cast<std::size_t>(ravel(corner, ext))];
+        }
+        return total == 0;
+    }
+
+    /// Whether a mask is set anywhere in a box.
+    ///
+    /// Scanned directly rather than through a table: the caller is the truncation's
+    /// per-function loop, whose boxes are the size of one function's support, and a
+    /// table would be built once per level for a query that touches `(p + 1) ** dim`
+    /// cells.
+    ///
+    /// \param mask A `count_of(shape)` mask, C-order.
+    /// \param shape Per-axis extents.
+    /// \param lo Per-axis lower corner, inclusive.
+    /// \param hi Per-axis upper corner, exclusive.
+    /// \return `true` iff some cell of the box is set.
+    [[nodiscard]] static bool box_any_true(const std::vector<std::uint8_t>& mask,
+                                           std::span<const std::int64_t> shape,
+                                           std::span<const std::int64_t> lo,
+                                           std::span<const std::int64_t> hi) {
+        const auto d = shape.size();
+        if (d == 0) {
+            return !mask.empty() && mask[0] != 0U;
+        }
+        for (std::size_t k = 0; k < d; ++k) {
+            if (lo[k] >= hi[k]) {
+                return false;
+            }
+        }
+        std::vector<std::int64_t> cursor(lo.begin(), lo.end());
+        for (;;) {
+            if (mask[static_cast<std::size_t>(ravel(cursor, shape))] != 0U) {
+                return true;
+            }
+            std::size_t axis = d;
+            bool done = false;
+            while (axis > 0) {
+                --axis;
+                ++cursor[axis];
+                if (cursor[axis] < hi[axis]) {
+                    break;
+                }
+                cursor[axis] = lo[axis];
+                if (axis == 0) {
+                    done = true;
+                }
+            }
+            if (done) {
+                return false;
+            }
+        }
+    }
+
+    // -------------------------------------------------------------- construction
+
+    /// Build the nested per-level tensor-product spaces.
+    ///
+    /// Level `l + 1` is level `l` with every direction subdivided by the grid's
+    /// factor, skipping the directions whose factor is 1. Level 0 is the root handle
+    /// itself, not a copy; see `level_space`.
+    void build_level_spaces() {
+        const auto d = static_cast<std::size_t>(dim());
+        const std::span<const std::int64_t> factor = grid_->factor();
+        level_spaces_.push_back(root_space_);
+
+        std::vector<std::shared_ptr<const BsplineSpace1D<T>>> current(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            current[k] = root_space_->space(static_cast<std::int64_t>(k));
+        }
+        for (std::int64_t level = 1; level <= grid_->max_level(); ++level) {
+            for (std::size_t k = 0; k < d; ++k) {
+                if (factor[k] == 1) {
+                    continue;
+                }
+                current[k] = std::make_shared<const BsplineSpace1D<T>>(
+                    subdivide<T>(*current[k], factor[k], regularity_[k]));
+            }
+            level_spaces_.push_back(std::make_shared<const BsplineSpace<T>>(current));
+        }
+    }
+
+    /// Build the per-level, per-direction function-to-cell support.
+    ///
+    /// `first_basis_per_interval` gives the first function of each interval; inverting
+    /// it gives each function its inclusive interval range. Pure integer work.
+    ///
+    /// \throws std::invalid_argument If some function has empty support, which means
+    ///         the space is invalid.
+    void build_support() {
+        const auto d = static_cast<std::size_t>(dim());
+        support_.resize(level_spaces_.size());
+        for (std::size_t level = 0; level < level_spaces_.size(); ++level) {
+            support_[level].resize(d);
+            for (std::size_t k = 0; k < d; ++k) {
+                const BsplineSpace1D<T>& space =
+                    level_spaces_[level]->space_ref(static_cast<std::int64_t>(k));
+                const std::span<const std::int64_t> first = space.first_basis_per_interval();
+                const auto n_basis = static_cast<std::size_t>(space.num_basis());
+                Support1D& sup = support_[level][k];
+                sup.first_basis.assign(first.begin(), first.end());
+                sup.first_cell.assign(n_basis, -1);
+                sup.last_cell.assign(n_basis, -1);
+                for (std::size_t interval = 0; interval < first.size(); ++interval) {
+                    const std::int64_t lo = first[interval];
+                    for (std::int64_t i = lo; i <= lo + space.degree(); ++i) {
+                        const auto f = static_cast<std::size_t>(i);
+                        if (sup.first_cell[f] < 0) {
+                            sup.first_cell[f] = static_cast<std::int64_t>(interval);
+                        }
+                        sup.last_cell[f] = static_cast<std::int64_t>(interval);
+                    }
+                }
+                for (std::size_t f = 0; f < n_basis; ++f) {
+                    if (sup.first_cell[f] < 0) {
+                        throw std::invalid_argument(
+                            "B-spline function " + std::to_string(f) + " of direction "
+                            + std::to_string(k) + " at level " + std::to_string(level)
+                            + " has empty support. This indicates an invalid B-spline space.");
+                    }
+                }
+            }
+        }
+    }
+
+    /// The per-direction basis counts of one level.
+    ///
+    /// \param level The level.
+    /// \return `dim()` counts, in axis order.
+    [[nodiscard]] std::vector<std::int64_t> level_num_basis(std::size_t level) const {
+        const auto d = static_cast<std::size_t>(dim());
+        std::vector<std::int64_t> counts(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            counts[k] = level_spaces_[level]->space_ref(static_cast<std::int64_t>(k)).num_basis();
+        }
+        return counts;
+    }
+
+    /// The per-axis cell counts of one level of the grid.
+    ///
+    /// \param level The level.
+    /// \return `dim()` counts, in axis order.
+    [[nodiscard]] std::vector<std::int64_t> level_shape(std::int64_t level) const {
+        const auto d = static_cast<std::size_t>(dim());
+        std::vector<std::int64_t> shape(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            shape[k] = grid_->level_cells_per_axis(level, static_cast<std::int64_t>(k));
+        }
+        return shape;
+    }
+
+    /// The level-`level` refined region: in the subdomain but not an active leaf.
+    ///
+    /// \param level The level.
+    /// \return `1` where the level's subdomain is refined further, `0` elsewhere.
+    [[nodiscard]] std::vector<std::uint8_t> refined_mask(std::int64_t level) const {
+        const std::vector<std::uint8_t> subdomain = grid_->subdomain_mask(level);
+        const std::vector<std::uint8_t> leaves = grid_->active_leaf_mask(level);
+        std::vector<std::uint8_t> refined(subdomain.size());
+        for (std::size_t i = 0; i < subdomain.size(); ++i) {
+            refined[i] = static_cast<std::uint8_t>(subdomain[i] != 0U && leaves[i] == 0U);
+        }
+        return refined;
+    }
+
+    /// Compute the Kraft selection of active functions, level by level.
+    ///
+    /// A level-`l` function is selected iff its support box lies entirely in the
+    /// level-`l` subdomain and not entirely in the further-refined region. Both tests
+    /// are "is this box all ones in this mask", answered by a summed-area table over
+    /// the mask's complement: `O(cells * dim)` to build and `O(2 ** dim)` per box,
+    /// against the `O(box volume)` of a direct scan. Exact integer arithmetic, so it
+    /// is the oracle's answer and not merely an equivalent one.
+    void select_active_functions() {
+        const auto d = static_cast<std::size_t>(dim());
+        const auto n_levels = level_spaces_.size();
+        active_funcs_.resize(n_levels);
+        num_per_level_.assign(n_levels, 0);
+
+        for (std::size_t level = 0; level < n_levels; ++level) {
+            const auto l = static_cast<std::int64_t>(level);
+            const std::vector<std::int64_t> shape = level_shape(l);
+            const std::vector<std::uint8_t> subdomain = grid_->subdomain_mask(l);
+            const std::vector<std::uint8_t> refined = refined_mask(l);
+
+            // The subdomain's own bounding box bounds every selectable function's
+            // support, and so bounds the candidate set per direction.
+            std::vector<std::int64_t> bbox_lo(d, 0);
+            std::vector<std::int64_t> bbox_hi(d, 0);
+            if (!bounding_box(subdomain, shape, bbox_lo, bbox_hi)) {
+                continue;
+            }
+
+            const std::vector<std::int64_t> sat_sub = summed_area(subdomain, shape);
+            const std::vector<std::int64_t> sat_ref = summed_area(refined, shape);
+            const std::vector<std::int64_t> num_basis = level_num_basis(level);
+
+            std::vector<std::vector<std::int64_t>> candidates(d);
+            bool empty_direction = false;
+            for (std::size_t k = 0; k < d; ++k) {
+                const Support1D& sup = support_[level][k];
+                for (std::int64_t f = 0; f < num_basis[k]; ++f) {
+                    const auto i = static_cast<std::size_t>(f);
+                    if (sup.last_cell[i] >= bbox_lo[k] && sup.first_cell[i] < bbox_hi[k]) {
+                        candidates[k].push_back(f);
+                    }
+                }
+                empty_direction = empty_direction || candidates[k].empty();
+            }
+            if (empty_direction) {
+                continue;
+            }
+
+            std::vector<std::int64_t>& selected = active_funcs_[level];
+            std::vector<std::size_t> cursor(d, 0);
+            std::vector<std::int64_t> box_lo(d);
+            std::vector<std::int64_t> box_hi(d);
+            std::vector<std::int64_t> multi(d);
+            for (;;) {
+                for (std::size_t k = 0; k < d; ++k) {
+                    multi[k] = candidates[k][cursor[k]];
+                    const auto i = static_cast<std::size_t>(multi[k]);
+                    box_lo[k] = support_[level][k].first_cell[i];
+                    box_hi[k] = support_[level][k].last_cell[i] + 1;
+                }
+                const bool inside = box_all_true(sat_sub, shape, box_lo, box_hi);
+                const bool buried = box_all_true(sat_ref, shape, box_lo, box_hi);
+                if (inside && !buried) {
+                    selected.push_back(ravel(multi, num_basis));
+                }
+                std::size_t axis = d;
+                bool done = d == 0;
+                while (axis > 0) {
+                    --axis;
+                    ++cursor[axis];
+                    if (cursor[axis] < candidates[axis].size()) {
+                        break;
+                    }
+                    cursor[axis] = 0;
+                    if (axis == 0) {
+                        done = true;
+                    }
+                }
+                if (done) {
+                    break;
+                }
+            }
+            // The enumeration is C-order over per-direction candidates that are
+            // themselves increasing, so the flat indices already come out increasing.
+            // The sort is the oracle's own step, costs nothing on a sorted range, and
+            // is kept so the "sorted" contract does not rest on the enumeration order.
+            std::sort(selected.begin(), selected.end());
+        }
+
+        func_offset_.assign(n_levels + 1, 0);
+        for (std::size_t level = 0; level < n_levels; ++level) {
+            num_per_level_[level] = static_cast<std::int64_t>(active_funcs_[level].size());
+            func_offset_[level + 1] = func_offset_[level] + num_per_level_[level];
+        }
+        num_active_ = func_offset_.back();
+    }
+
+    /// Build the per-level, per-direction two-scale matrices.
+    ///
+    /// Entry `[m][k]` maps the level-`m` basis of direction `k` into the level-`m + 1`
+    /// one: `B_i = sum_j alpha(j, i) B_j`. When the direction's factor is 1 the two
+    /// spaces are the same and the matrix is the identity, which the recurrence
+    /// produces without a special case.
+    ///
+    /// **Computed in `T` and widened to `double`**, in that order, because the oracle
+    /// does: its kernel returns the knots' own dtype and `_build_oslo_matrices` wraps
+    /// the result in `np.asarray(..., dtype=np.float64)`. Computing in `double`
+    /// throughout would be a silent divergence at `float` storage that no shape or
+    /// count would reveal.
+    ///
+    /// \return The matrices, indexed `[m][k]`.
+    [[nodiscard]] std::vector<std::vector<TwoScale>> build_oslo_matrices() const {
+        const auto d = static_cast<std::size_t>(dim());
+        std::vector<std::vector<TwoScale>> matrices;
+        for (std::size_t m = 0; m + 1 < level_spaces_.size(); ++m) {
+            std::vector<TwoScale> per_direction(d);
+            for (std::size_t k = 0; k < d; ++k) {
+                const BsplineSpace1D<T>& old_space =
+                    level_spaces_[m]->space_ref(static_cast<std::int64_t>(k));
+                const BsplineSpace1D<T>& new_space =
+                    level_spaces_[m + 1]->space_ref(static_cast<std::int64_t>(k));
+                const std::vector<T> narrow =
+                    oslo_matrix_1d<T>(old_space.degree(), old_space.knots(), new_space.knots());
+                TwoScale& scale = per_direction[k];
+                scale.rows = new_space.num_basis();
+                scale.cols = old_space.num_basis();
+                scale.alpha.reserve(narrow.size());
+                for (const T value : narrow) {
+                    scale.alpha.push_back(static_cast<double>(value));
+                }
+            }
+            matrices.push_back(std::move(per_direction));
+        }
+        return matrices;
+    }
+
+    /// Refine a dense coefficient box from one level to the next.
+    ///
+    /// Applies, per direction, the two-scale matrix restricted to the current function
+    /// box, growing the box to the band of non-zero finer functions. The band is the
+    /// span from the **first** to the **last** non-zero row, exactly as the oracle
+    /// takes it, so an interior all-zero row stays inside the box rather than
+    /// splitting it.
+    ///
+    /// The contraction sums in index order. The oracle reaches `numpy.tensordot`,
+    /// hence BLAS, whose order is the implementation's, so the two backends' outputs
+    /// are a bounded comparison rather than a bitwise one; the file comment carries
+    /// the bound and why it has no cancellation term.
+    ///
+    /// \param coeffs The coefficients over the box; replaced by the refined ones.
+    /// \param box_lo Per-direction lower function index; updated in place.
+    /// \param box_hi Per-direction upper index, exclusive; updated in place.
+    /// \param oslo_m This level transition's matrices, per direction.
+    /// \param scratch A reusable buffer, so the per-function loop does not reallocate.
+    /// \throws std::invalid_argument If a direction's matrix slice is entirely zero,
+    ///         which means a degenerate box or an invalid knot refinement.
+    void refine_box(std::vector<double>& coeffs, std::vector<std::int64_t>& box_lo,
+                    std::vector<std::int64_t>& box_hi, const std::vector<TwoScale>& oslo_m,
+                    std::vector<double>& scratch) const {
+        const auto d = static_cast<std::size_t>(dim());
+        for (std::size_t k = 0; k < d; ++k) {
+            const TwoScale& scale = oslo_m[k];
+            const std::int64_t width = box_hi[k] - box_lo[k];
+
+            std::int64_t new_lo = -1;
+            std::int64_t new_hi = -1;
+            for (std::int64_t row = 0; row < scale.rows; ++row) {
+                bool non_zero = false;
+                for (std::int64_t col = box_lo[k]; col < box_hi[k] && !non_zero; ++col) {
+                    non_zero = scale.alpha[static_cast<std::size_t>(row * scale.cols + col)]
+                               != 0.0;
+                }
+                if (non_zero) {
+                    if (new_lo < 0) {
+                        new_lo = row;
+                    }
+                    new_hi = row + 1;
+                }
+            }
+            if (new_lo < 0) {
+                throw std::invalid_argument(
+                    "refine_box: Oslo matrix slice for direction " + std::to_string(k)
+                    + " (columns [" + std::to_string(box_lo[k]) + ":"
+                    + std::to_string(box_hi[k])
+                    + "]) is entirely zero - degenerate or invalid knot refinement.");
+            }
+            const std::int64_t new_width = new_hi - new_lo;
+
+            // The box is row-major, so contracting axis `k` sees the array as
+            // `outer x width x inner` and produces `outer x new_width x inner`.
+            std::int64_t outer = 1;
+            for (std::size_t a = 0; a < k; ++a) {
+                outer *= box_hi[a] - box_lo[a];
+            }
+            std::int64_t inner = 1;
+            for (std::size_t a = k + 1; a < d; ++a) {
+                inner *= box_hi[a] - box_lo[a];
+            }
+
+            scratch.assign(static_cast<std::size_t>(outer * new_width * inner), 0.0);
+            for (std::int64_t o = 0; o < outer; ++o) {
+                for (std::int64_t i = 0; i < new_width; ++i) {
+                    const std::int64_t row = new_lo + i;
+                    for (std::int64_t j = 0; j < width; ++j) {
+                        const double a = scale.alpha[static_cast<std::size_t>(
+                            row * scale.cols + box_lo[k] + j)];
+                        if (a == 0.0) {
+                            continue;
+                        }
+                        const auto source = static_cast<std::size_t>((o * width + j) * inner);
+                        const auto target =
+                            static_cast<std::size_t>((o * new_width + i) * inner);
+                        for (std::int64_t n = 0; n < inner; ++n) {
+                            scratch[target + static_cast<std::size_t>(n)] +=
+                                a * coeffs[source + static_cast<std::size_t>(n)];
+                        }
+                    }
+                }
+            }
+            coeffs.swap(scratch);
+            box_lo[k] = new_lo;
+            box_hi[k] = new_hi;
+        }
+    }
+
+    /// Zero the coefficients sitting on active functions of the refined level.
+    ///
+    /// This is the truncation itself: a hierarchical function loses its components on
+    /// the finer functions that are themselves active.
+    ///
+    /// \param coeffs The coefficients over the box; modified in place.
+    /// \param box_lo Per-direction lower function index.
+    /// \param box_hi Per-direction upper index, exclusive.
+    /// \param active_at_level Sorted flat indices of the refined level's active
+    ///        functions.
+    /// \param num_basis The refined level's per-direction basis counts.
+    /// \return `true` iff at least one coefficient was zeroed.
+    [[nodiscard]] bool truncate_box(std::vector<double>& coeffs,
+                                    std::span<const std::int64_t> box_lo,
+                                    std::span<const std::int64_t> box_hi,
+                                    const std::vector<std::int64_t>& active_at_level,
+                                    std::span<const std::int64_t> num_basis) const {
+        const auto d = static_cast<std::size_t>(dim());
+        if (d == 0) {
+            return false;
+        }
+        std::vector<std::int64_t> cursor(box_lo.begin(), box_lo.end());
+        std::size_t offset = 0;
+        bool zeroed = false;
+        for (;;) {
+            const std::int64_t flat = ravel(cursor, num_basis);
+            if (std::binary_search(active_at_level.begin(), active_at_level.end(), flat)) {
+                coeffs[offset] = 0.0;
+                zeroed = true;
+            }
+            ++offset;
+            std::size_t axis = d;
+            bool done = false;
+            while (axis > 0) {
+                --axis;
+                ++cursor[axis];
+                if (cursor[axis] < box_hi[axis]) {
+                    break;
+                }
+                cursor[axis] = box_lo[axis];
+                if (axis == 0) {
+                    done = true;
+                }
+            }
+            if (done) {
+                return zeroed;
+            }
+        }
+    }
+
+    /// Build the truncated-coefficient map.
+    ///
+    /// For each active function that straddles a finer refinement boundary, the
+    /// function is expressed in successively finer bases by the two-scale relation and
+    /// its components on active finer functions are zeroed, until its support no longer
+    /// reaches deeper refinement. Truncation is applied at **every** level in the
+    /// chain, not only the first. A function whose support enters a refined region but
+    /// whose coefficient box never overlaps an active finer function needs no
+    /// truncation and is stored nowhere, which is what keeps this map small.
+    ///
+    /// The entries are appended in increasing `dof`, so `truncated()` can binary
+    /// search them; a hash map would give the same answers in an order that depends on
+    /// the container.
+    void compute_truncated_coefficients() {
+        const auto n_levels = level_spaces_.size();
+        if (n_levels < 2) {
+            return;
+        }
+        const auto d = static_cast<std::size_t>(dim());
+        const std::vector<std::vector<TwoScale>> oslo = build_oslo_matrices();
+
+        std::vector<std::vector<std::uint8_t>> refined(n_levels);
+        std::vector<std::vector<std::int64_t>> shape(n_levels);
+        for (std::size_t level = 0; level < n_levels; ++level) {
+            const auto l = static_cast<std::int64_t>(level);
+            shape[level] = level_shape(l);
+            refined[level] = refined_mask(l);
+        }
+
+        std::vector<std::int64_t> box_lo(d);
+        std::vector<std::int64_t> box_hi(d);
+        std::vector<std::int64_t> cell_lo(d);
+        std::vector<std::int64_t> cell_hi(d);
+        std::vector<double> coeffs;
+        std::vector<double> scratch;
+
+        for (std::size_t level = 0; level + 1 < n_levels; ++level) {
+            const std::vector<std::int64_t> num_basis = level_num_basis(level);
+            const std::int64_t offset = func_offset_[level];
+            const std::vector<std::int64_t>& active = active_funcs_[level];
+
+            for (std::size_t pos = 0; pos < active.size(); ++pos) {
+                unravel(active[pos], num_basis, std::span<std::int64_t>(box_lo));
+                for (std::size_t k = 0; k < d; ++k) {
+                    box_hi[k] = box_lo[k] + 1;
+                }
+                coeffs.assign(1, 1.0);
+                std::size_t rep = level;
+                bool any_zeroed = false;
+
+                for (std::size_t m = level; m + 1 < n_levels; ++m) {
+                    for (std::size_t k = 0; k < d; ++k) {
+                        const Support1D& sup = support_[m][k];
+                        cell_lo[k] = sup.first_cell[static_cast<std::size_t>(box_lo[k])];
+                        cell_hi[k] = sup.last_cell[static_cast<std::size_t>(box_hi[k] - 1)] + 1;
+                    }
+                    if (!box_any_true(refined[m], shape[m], cell_lo, cell_hi)) {
+                        break;
+                    }
+                    refine_box(coeffs, box_lo, box_hi, oslo[m], scratch);
+                    rep = m + 1;
+                    const bool zeroed = truncate_box(coeffs, box_lo, box_hi, active_funcs_[rep],
+                                                     level_num_basis(rep));
+                    any_zeroed = any_zeroed || zeroed;
+                }
+
+                if (!any_zeroed) {
+                    continue;
+                }
+                TruncatedEntry entry;
+                entry.dof = offset + static_cast<std::int64_t>(pos);
+                entry.rep_level = static_cast<std::int64_t>(rep);
+                entry.box_lo.assign(box_lo.begin(), box_lo.end());
+                entry.shape.resize(d);
+                for (std::size_t k = 0; k < d; ++k) {
+                    entry.shape[k] = box_hi[k] - box_lo[k];
+                }
+                entry.coeffs = coeffs;
+                truncated_.push_back(std::move(entry));
+            }
+        }
+    }
+
+    // -------------------------------------------------------- contribution table
+
+    /// The contribution table, built on first use.
+    ///
+    /// \return The table, valid for as long as this space is.
+    [[nodiscard]] const ContributionTable& contributions_table() const {
+        return contributions_.get([this] { return build_contribution_table(); });
+    }
+
+    /// Sweep every cell and record the active functions supported on it.
+    ///
+    /// A cell at level `L` is covered by the functions of every level `l <= L` whose
+    /// support contains the cell's ancestor at `l`; those are `degree + 1` consecutive
+    /// functions per direction, named by `first_basis`. Each candidate is looked up in
+    /// the level's sorted active set, and the ones present become entries.
+    ///
+    /// \return The filled table, including `max_per_cell`.
+    [[nodiscard]] ContributionTable build_contribution_table() const {
+        const auto d = static_cast<std::size_t>(dim());
+        const auto num_cells = static_cast<std::size_t>(grid_->num_cells());
+        const std::span<const std::int64_t> factor = grid_->factor();
+        const std::span<const std::int64_t> deg = degrees();
+
+        ContributionTable table;
+        table.offset.assign(num_cells + 1, 0);
+
+        std::vector<std::int64_t> cell_midx(d);
+        std::vector<std::int64_t> at_level(d);
+        std::vector<std::int64_t> first(d);
+        std::vector<std::int64_t> multi(d);
+        std::vector<std::pair<std::int64_t, std::size_t>> ordering;
+
+        for (std::size_t cid = 0; cid < num_cells; ++cid) {
+            const std::int64_t cell_level = grid_->cell_level(static_cast<std::int64_t>(cid));
+            grid_->cell_multi_index(static_cast<std::int64_t>(cid),
+                                    std::span<std::int64_t>(cell_midx));
+            const std::size_t begin = table.dof.size();
+
+            for (std::int64_t level = 0; level <= cell_level; ++level) {
+                const auto l = static_cast<std::size_t>(level);
+                for (std::size_t k = 0; k < d; ++k) {
+                    std::int64_t divisor = 1;
+                    for (std::int64_t step = 0; step < cell_level - level; ++step) {
+                        divisor *= factor[k];
+                    }
+                    at_level[k] = cell_midx[k] / divisor;
+                    first[k] = support_[l][k].first_basis[static_cast<std::size_t>(at_level[k])];
+                }
+                const std::vector<std::int64_t> num_basis = level_num_basis(l);
+                const std::vector<std::int64_t>& active = active_funcs_[l];
+                const std::int64_t offset = func_offset_[l];
+
+                std::vector<std::int64_t> cursor(first.begin(), first.end());
+                for (;;) {
+                    const std::int64_t flat = ravel(cursor, num_basis);
+                    const auto it =
+                        std::lower_bound(active.begin(), active.end(), flat);
+                    if (it != active.end() && *it == flat) {
+                        table.dof.push_back(offset
+                                            + static_cast<std::int64_t>(it - active.begin()));
+                        table.level.push_back(level);
+                        table.multi.insert(table.multi.end(), cursor.begin(), cursor.end());
+                    }
+                    std::size_t axis = d;
+                    bool done = d == 0;
+                    while (axis > 0) {
+                        --axis;
+                        ++cursor[axis];
+                        if (cursor[axis] <= first[axis] + deg[axis]) {
+                            break;
+                        }
+                        cursor[axis] = first[axis];
+                        if (axis == 0) {
+                            done = true;
+                        }
+                    }
+                    if (done) {
+                        break;
+                    }
+                }
+            }
+
+            // Sorted by global dof. The sweep already produces them in that order --
+            // levels ascend and each level's candidates are enumerated in increasing
+            // flat index -- so this is the oracle's own step kept for its contract
+            // rather than for its effect.
+            const std::size_t count = table.dof.size() - begin;
+            ordering.clear();
+            ordering.reserve(count);
+            for (std::size_t i = 0; i < count; ++i) {
+                ordering.emplace_back(table.dof[begin + i], i);
+            }
+            std::sort(ordering.begin(), ordering.end());
+            std::vector<std::int64_t> sorted_dof(count);
+            std::vector<std::int64_t> sorted_level(count);
+            std::vector<std::int64_t> sorted_multi(count * d);
+            for (std::size_t i = 0; i < count; ++i) {
+                const std::size_t from = ordering[i].second;
+                sorted_dof[i] = table.dof[begin + from];
+                sorted_level[i] = table.level[begin + from];
+                for (std::size_t k = 0; k < d; ++k) {
+                    sorted_multi[i * d + k] = table.multi[(begin + from) * d + k];
+                }
+            }
+            for (std::size_t i = 0; i < count; ++i) {
+                table.dof[begin + i] = sorted_dof[i];
+                table.level[begin + i] = sorted_level[i];
+                for (std::size_t k = 0; k < d; ++k) {
+                    table.multi[(begin + i) * d + k] = sorted_multi[i * d + k];
+                }
+            }
+
+            table.offset[cid + 1] = static_cast<std::int64_t>(table.dof.size());
+            table.max_per_cell =
+                std::max(table.max_per_cell, static_cast<std::int64_t>(count));
+        }
+        return table;
+    }
+
+    // ------------------------------------------------------- refinement helpers
+
+    /// A grid equal to this space's but sharing nothing with it.
+    ///
+    /// `refine_cells` with no ids goes through `HierarchicalGrid::rebuilt`, which
+    /// gives a fresh grid with the same cell decomposition, empty caches and no
+    /// inherited tags. That is what the oracle's `grid._copy()` is for: two spaces
+    /// must never share a grid, or a tag set through one becomes visible through the
+    /// other.
+    ///
+    /// \return The detached grid.
+    [[nodiscard]] std::shared_ptr<grid_type> detached_grid() const {
+        return std::make_shared<grid_type>(
+            grid_->refine_cells(std::span<const std::int64_t>{}));
+    }
+
+    /// A new space over a given grid, carrying this one's other state.
+    ///
+    /// \param grid The grid the new space is built on.
+    /// \return The new space.
+    [[nodiscard]] THBSplineSpace rebound(std::shared_ptr<grid_type> grid) const {
+        return THBSplineSpace(root_space_, std::move(grid), truncate_, regularity_);
+    }
+
+    /// Refine the marked cells and rebuild.
+    ///
+    /// \param marked `(level, midx)` pairs captured against this space's own grid.
+    /// \param admissible_class The class to maintain, or empty for no grading.
+    /// \return The new space.
+    [[nodiscard]] THBSplineSpace refine_marked(
+        const std::vector<Marked>& marked,
+        std::optional<std::int64_t> admissible_class) const {
+        std::shared_ptr<grid_type> current = grid_;
+        bool changed = false;
+        for (const Marked& cell : marked) {
+            if (admissible_class.has_value()) {
+                refine_recursive(current, cell.level, cell.midx, *admissible_class, changed);
+            } else if (current->is_active_leaf(cell.level,
+                                               std::span<const std::int64_t>(cell.midx))) {
+                current = refined_once(*current, cell.level, cell.midx);
+                changed = true;
+            }
+        }
+        return rebound(changed ? current : detached_grid());
+    }
+
+    /// One cell refined, as a fresh grid.
+    ///
+    /// \param grid The grid to refine.
+    /// \param level The cell's level.
+    /// \param midx The cell's per-axis index at that level.
+    /// \return The refined grid.
+    [[nodiscard]] static std::shared_ptr<grid_type> refined_once(
+        const grid_type& grid, std::int64_t level, const std::vector<std::int64_t>& midx) {
+        std::vector<std::int64_t> hi(midx.size());
+        for (std::size_t k = 0; k < midx.size(); ++k) {
+            hi[k] = midx[k] + 1;
+        }
+        return std::make_shared<grid_type>(grid.refine(level,
+                                                       std::span<const std::int64_t>(midx),
+                                                       std::span<const std::int64_t>(hi)));
+    }
+
+    /// Refine one cell, grading its refinement neighbourhood first.
+    ///
+    /// Carraturo et al. (2019, Alg. 4): every cell of the neighbourhood is refined --
+    /// recursively, at the coarser level `level - m + 1` -- before the cell itself.
+    /// Each step queries the grid the previous one produced.
+    ///
+    /// The recursion depth is bounded by `level`, which is bounded by the grid's own
+    /// maximum level, so it terminates for the same reason the oracle's does.
+    ///
+    /// \param grid The grid, rebound in place as refinements happen.
+    /// \param level The cell's level.
+    /// \param midx The cell's per-axis index at that level.
+    /// \param m The admissibility class, at least 2.
+    /// \param changed Set when any refinement actually happened.
+    void refine_recursive(std::shared_ptr<grid_type>& grid, std::int64_t level,
+                          const std::vector<std::int64_t>& midx, std::int64_t m,
+                          bool& changed) const {
+        for (const Marked& neighbour : refinement_neighborhood(level, midx, m, *grid)) {
+            refine_recursive(grid, neighbour.level, neighbour.midx, m, changed);
+        }
+        if (grid->is_active_leaf(level, std::span<const std::int64_t>(midx))) {
+            grid = refined_once(*grid, level, midx);
+            changed = true;
+        }
+    }
+
+    /// The refinement neighbourhood of a cell, for class `m`.
+    ///
+    /// Carraturo et al. (2019, Def. 3.4): the cells at level `level - m + 1` that are
+    /// parents of a level-`level - m + 2` cell touched by any B-spline whose support
+    /// covers the containing cell of `(level, midx)` at that level. Only the ones that
+    /// are currently active leaves are returned.
+    ///
+    /// \param level The cell's level.
+    /// \param midx The cell's per-axis index at that level.
+    /// \param m The admissibility class, at least 2.
+    /// \param grid The grid whose active set is queried.
+    /// \return The neighbourhood, possibly empty.
+    [[nodiscard]] std::vector<Marked> refinement_neighborhood(
+        std::int64_t level, const std::vector<std::int64_t>& midx, std::int64_t m,
+        const grid_type& grid) const {
+        std::vector<Marked> out;
+        const std::int64_t k_nbr = level - m + 1;
+        if (k_nbr < 0) {
+            return out;
+        }
+        const auto d = static_cast<std::size_t>(dim());
+        if (d == 0) {
+            return out;
+        }
+        // `k_ext = k_nbr + 1 <= level`, and `level` never exceeds the maximum level of
+        // the grid this space was built on, so the support of that level exists.
+        const std::int64_t k_ext = level - m + 2;
+        const std::vector<Support1D>& support_ext =
+            support_[static_cast<std::size_t>(k_ext)];
+        const std::span<const std::int64_t> factor = grid_->factor();
+        const std::span<const std::int64_t> deg = degrees();
+
+        std::vector<std::int64_t> lo(d);
+        std::vector<std::int64_t> hi(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            std::int64_t divisor = 1;
+            for (std::int64_t step = 0; step < level - k_ext; ++step) {
+                divisor *= factor[k];
+            }
+            const std::int64_t q = midx[k] / divisor;
+            const std::int64_t first = support_ext[k].first_basis[static_cast<std::size_t>(q)];
+            const std::int64_t s_lo =
+                support_ext[k].first_cell[static_cast<std::size_t>(first)];
+            const std::int64_t s_hi =
+                support_ext[k].last_cell[static_cast<std::size_t>(first + deg[k])] + 1;
+            lo[k] = s_lo / factor[k];
+            hi[k] = (s_hi - 1) / factor[k] + 1;
+        }
+
+        std::vector<std::int64_t> cursor(lo.begin(), lo.end());
+        for (;;) {
+            if (grid.is_active_leaf(k_nbr, std::span<const std::int64_t>(cursor))) {
+                out.push_back(Marked{k_nbr, cursor});
+            }
+            std::size_t axis = d;
+            bool done = false;
+            while (axis > 0) {
+                --axis;
+                ++cursor[axis];
+                if (cursor[axis] < hi[axis]) {
+                    break;
+                }
+                cursor[axis] = lo[axis];
+                if (axis == 0) {
+                    done = true;
+                }
+            }
+            if (done) {
+                return out;
+            }
+        }
+    }
+
+    /// Whether reactivating a parent keeps the mesh admissible of class `m`.
+    ///
+    /// Carraturo et al. (2019, Def. 3.5): the coarsening neighbourhood is the set of
+    /// active cells at level `parent_level + m` inside the multilevel support
+    /// extension, at level `parent_level + 1`, of the parent's children. Empty means
+    /// the coarsening is admissible.
+    ///
+    /// \param parent_level The level of the parent being considered.
+    /// \param pmidx Its per-axis index at that level.
+    /// \param m The admissibility class, at least 2.
+    /// \param grid The grid whose active set is queried.
+    /// \return `true` iff the neighbourhood is empty.
+    ///
+    /// \note Assumes `parent_level + 1 < num_levels()`, which the caller guarantees:
+    ///       a parent exists only because a marked cell sat one level below it on this
+    ///       space's own grid.
+    [[nodiscard]] bool coarsening_neighborhood_empty(std::int64_t parent_level,
+                                                     const std::vector<std::int64_t>& pmidx,
+                                                     std::int64_t m,
+                                                     const grid_type& grid) const {
+        const auto d = static_cast<std::size_t>(dim());
+        if (d == 0) {
+            return true;
+        }
+        const std::span<const std::int64_t> factor = grid_->factor();
+        const std::span<const std::int64_t> deg = degrees();
+        const std::vector<Support1D>& support =
+            support_[static_cast<std::size_t>(parent_level) + 1];
+
+        std::vector<std::int64_t> ext_lo(d);
+        std::vector<std::int64_t> ext_hi(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            const std::int64_t c_lo = pmidx[k] * factor[k];
+            const std::int64_t c_hi = (pmidx[k] + 1) * factor[k];
+            const std::int64_t f_min =
+                support[k].first_basis[static_cast<std::size_t>(c_lo)];
+            const std::int64_t f_max =
+                support[k].first_basis[static_cast<std::size_t>(c_hi - 1)] + deg[k];
+            ext_lo[k] = support[k].first_cell[static_cast<std::size_t>(f_min)];
+            ext_hi[k] = support[k].last_cell[static_cast<std::size_t>(f_max)] + 1;
+        }
+
+        const std::int64_t target = parent_level + m;
+        if (target > grid.max_level()) {
+            return true;
+        }
+        std::vector<std::int64_t> box_lo(d);
+        std::vector<std::int64_t> box_hi(d);
+        for (std::size_t k = 0; k < d; ++k) {
+            std::int64_t scale = 1;
+            for (std::int64_t step = 0; step < m - 1; ++step) {
+                scale *= factor[k];
+            }
+            box_lo[k] = ext_lo[k] * scale;
+            box_hi[k] = ext_hi[k] * scale;
+        }
+
+        const auto [lo, hi] = grid.active_blocks(target);
+        for (std::size_t b = 0; b < lo.extent(0); ++b) {
+            bool overlaps = true;
+            for (std::size_t k = 0; k < d && overlaps; ++k) {
+                overlaps = std::max(box_lo[k], lo(b, k)) < std::min(box_hi[k], hi(b, k));
+            }
+            if (overlaps) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::shared_ptr<const BsplineSpace<T>> root_space_;    ///< The level-0 space.
+    std::shared_ptr<grid_type> grid_;                      ///< The hierarchy.
+    bool truncate_ = true;                                 ///< Whether the basis is truncated.
+    std::vector<std::optional<std::int64_t>> regularity_;  ///< Per-direction continuity.
+
+    std::vector<std::shared_ptr<const BsplineSpace<T>>> level_spaces_;  ///< Per level.
+    std::vector<std::vector<Support1D>> support_;          ///< Per level, per direction.
+    std::vector<std::vector<std::int64_t>> active_funcs_;  ///< Per level, sorted flats.
+    std::vector<std::int64_t> num_per_level_;              ///< Per level, the active count.
+    std::vector<std::int64_t> func_offset_;                ///< Per level, the global base.
+    std::int64_t num_active_ = 0;                          ///< The total active count.
+    std::vector<TruncatedEntry> truncated_;                ///< Sorted by `dof`.
+
+    LazySlot<ContributionTable> contributions_;  ///< Filled for all cells at once.
+};
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/thb_space.hpp
+++ b/cpp/include/pantr/bspline/thb_space.hpp
@@ -50,8 +50,9 @@
 /// entirely inside one mask and not entirely inside another", answered by a summed-area
 /// table over `std::int64_t`; the flat indices, the offsets, the level assignment and
 /// the contribution table are index arithmetic. Two backends must agree on them
-/// **exactly**, and `design/backend_parity.md`'s determinism rule licenses that bar
-/// here for the reason it names -- finite precision does not bite on a count.
+/// **exactly**: no rounding takes place on a count, so bit-identity is the only bar
+/// that says anything, and a bounded one could not see two answers of different
+/// length at all.
 ///
 /// **The truncation coefficients have digits, and they get a bound.** They are built
 /// from the two-scale matrices, which `pantr/bspline/knot_insertion.hpp` computes in

--- a/cpp/include/pantr/bspline/thb_space.hpp
+++ b/cpp/include/pantr/bspline/thb_space.hpp
@@ -406,11 +406,14 @@ class THBSplineSpace {
     /// \return Views into the table, valid while this space is.
     /// \throws std::out_of_range If `cid` is out of range.
     [[nodiscard]] CellContributions contributions(std::int64_t cid) const {
-        const ContributionTable& table = contributions_table();
+        // Range first, table second. The oracle's per-cell cache refuses a bad id
+        // without computing anything; building the whole grid's table and *then*
+        // throwing would make a probe for a valid id cost an O(cells) sweep.
         if (cid < 0 || cid >= grid_->num_cells()) {
             throw std::out_of_range("cell id " + std::to_string(cid) + " is out of range [0, "
                                     + std::to_string(grid_->num_cells()) + ").");
         }
+        const ContributionTable& table = contributions_table();
         const auto i = static_cast<std::size_t>(cid);
         const auto begin = static_cast<std::size_t>(table.offset[i]);
         const auto count = static_cast<std::size_t>(table.offset[i + 1] - table.offset[i]);
@@ -494,16 +497,7 @@ class THBSplineSpace {
     [[nodiscard]] THBSplineSpace refine(std::span<const std::int64_t> cell_ids,
                                         std::optional<std::int64_t> admissible_class) const {
         check_admissible_class(admissible_class);
-        std::vector<std::int64_t> ids(cell_ids.begin(), cell_ids.end());
-        std::sort(ids.begin(), ids.end());
-        ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
-        for (const std::int64_t cid : ids) {
-            if (cid < 0 || cid >= grid_->num_cells()) {
-                throw std::out_of_range("cell_ids must lie in [0, "
-                                        + std::to_string(grid_->num_cells())
-                                        + "); got out-of-range id " + std::to_string(cid) + ".");
-            }
-        }
+        const std::vector<std::int64_t> ids = unique_valid_cell_ids(cell_ids);
 
         // Resolved against the original grid before anything is refined: every
         // `refine` reassigns flat ids, so a `(level, midx)` pair is the only handle
@@ -578,6 +572,15 @@ class THBSplineSpace {
     /// neighbourhood (Def. 3.5) is empty. With an empty `optional` that guard is
     /// skipped, and coarsening is then the exact inverse of `refine`.
     ///
+    /// **Within a level the order is lexicographic here and the oracle's set-iteration
+    /// order there, and that is not a divergence.** Two parents at one level have
+    /// disjoint child sets, so demoting one cannot make the other's family incomplete;
+    /// and the admissibility guard for a parent at level `L` reads only the active cells
+    /// at level `L + m >= L + 2`, which a same-level peer's demotion -- confined to
+    /// level `L + 1` -- cannot touch, since a complete family has no grandchildren under
+    /// it. So the result does not depend on the within-level order. Fixing one anyway is
+    /// what makes *this* side reproducible run to run, which the oracle's set is not.
+    ///
     /// \param cell_ids Flat ids of active leaf cells to coarsen away; an empty range
     ///        is valid and coarsens nothing.
     /// \param admissible_class The class to maintain, at least 2, or empty for no
@@ -588,16 +591,7 @@ class THBSplineSpace {
     [[nodiscard]] THBSplineSpace coarsen(std::span<const std::int64_t> cell_ids,
                                          std::optional<std::int64_t> admissible_class) const {
         check_admissible_class(admissible_class);
-        std::vector<std::int64_t> ids(cell_ids.begin(), cell_ids.end());
-        std::sort(ids.begin(), ids.end());
-        ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
-        for (const std::int64_t cid : ids) {
-            if (cid < 0 || cid >= grid_->num_cells()) {
-                throw std::out_of_range("cell_ids must lie in [0, "
-                                        + std::to_string(grid_->num_cells())
-                                        + "); got out-of-range id " + std::to_string(cid) + ".");
-            }
-        }
+        const std::vector<std::int64_t> ids = unique_valid_cell_ids(cell_ids);
 
         const auto d = static_cast<std::size_t>(dim());
         const std::span<const std::int64_t> factor = grid_->factor();
@@ -608,6 +602,11 @@ class THBSplineSpace {
             grid_->cell_multi_index(cid, std::span<std::int64_t>(cell.midx));
             marked.push_back(std::move(cell));
         }
+
+        // Sorted once so the per-child membership test below is a binary search. The
+        // order is the same one the parents are sorted by, and neither is observable:
+        // see the note on within-level order above.
+        std::sort(marked.begin(), marked.end(), marked_order);
 
         std::vector<Marked> parents;
         for (const Marked& cell : marked) {
@@ -649,10 +648,12 @@ class THBSplineSpace {
                 child[k] = parent.midx[k] * factor[k];
             }
             for (;;) {
-                const bool is_marked =
-                    std::any_of(marked.begin(), marked.end(), [&](const Marked& cell) {
-                        return cell.level == parent.level + 1 && cell.midx == child;
-                    });
+                // A binary search rather than a scan: `marked` can hold every cell of
+                // the mesh, and a linear test per child would make this quadratic in
+                // the marked set. The oracle uses a Python `set` for the same reason.
+                const bool is_marked = std::binary_search(
+                    marked.begin(), marked.end(), Marked{parent.level + 1, child},
+                    marked_order);
                 if (is_marked) {
                     const std::optional<std::int64_t> cid = current->cell_id(
                         parent.level + 1, std::span<const std::int64_t>(child));
@@ -700,23 +701,10 @@ class THBSplineSpace {
     ///         `"num_total_basis=..., truncate=...)"`, the oracle's `repr` character
     ///         for character.
     [[nodiscard]] std::string to_string() const {
-        std::string text = "THBSplineSpace(dim=" + std::to_string(dim()) + ", degrees=(";
-        const std::span<const std::int64_t> deg = degrees();
-        for (std::size_t k = 0; k < deg.size(); ++k) {
-            text += std::to_string(deg[k]);
-            // Python's one-element tuple is `(2,)`, so the comma follows every entry
-            // when there is only one.
-            if (k + 1 < deg.size() || deg.size() == 1) {
-                text += ",";
-            }
-            if (k + 1 < deg.size()) {
-                text += " ";
-            }
-        }
-        text += "), num_levels=" + std::to_string(num_levels())
-                + ", num_total_basis=" + std::to_string(num_active_)
-                + ", truncate=" + (truncate_ ? "True" : "False") + ")";
-        return text;
+        return "THBSplineSpace(dim=" + std::to_string(dim()) + ", degrees="
+               + tuple_repr(degrees()) + ", num_levels=" + std::to_string(num_levels())
+               + ", num_total_basis=" + std::to_string(num_active_)
+               + ", truncate=" + (truncate_ ? "True" : "False") + ")";
     }
 
 
@@ -839,6 +827,46 @@ class THBSplineSpace {
         }
     }
 
+    /// Order two named cells by level then by multi-index, for a sorted lookup.
+    ///
+    /// \param a The first cell.
+    /// \param b The second.
+    /// \return `true` if `a` orders before `b`.
+    [[nodiscard]] static bool marked_order(const Marked& a, const Marked& b) {
+        if (a.level != b.level) {
+            return a.level < b.level;
+        }
+        return a.midx < b.midx;
+    }
+
+    /// Sort and deduplicate cell ids, refusing every out-of-range one at once.
+    ///
+    /// The oracle collects **all** the offending ids before it raises, and names them
+    /// in the message; stopping at the first is a real loss for a caller debugging a
+    /// list of them.
+    ///
+    /// \param cell_ids The ids as given.
+    /// \return The ids, sorted and deduplicated, as `numpy.unique` returns them.
+    /// \throws std::out_of_range If any id is outside `[0, grid().num_cells())`.
+    [[nodiscard]] std::vector<std::int64_t> unique_valid_cell_ids(
+        std::span<const std::int64_t> cell_ids) const {
+        std::vector<std::int64_t> ids(cell_ids.begin(), cell_ids.end());
+        std::sort(ids.begin(), ids.end());
+        ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+        std::vector<std::int64_t> bad;
+        for (const std::int64_t cid : ids) {
+            if (cid < 0 || cid >= grid_->num_cells()) {
+                bad.push_back(cid);
+            }
+        }
+        if (!bad.empty()) {
+            throw std::out_of_range("cell_ids must lie in [0, "
+                                    + std::to_string(grid_->num_cells())
+                                    + "); got out-of-range id(s): " + list_repr(bad) + ".");
+        }
+        return ids;
+    }
+
     /// Refuse a level outside the hierarchy.
     ///
     /// \param level The level to check.
@@ -958,6 +986,21 @@ class THBSplineSpace {
             }
         }
         return text + ")";
+    }
+
+    /// Python's `repr` of a list of integers.
+    ///
+    /// \param values The entries.
+    /// \return `"[a, b, c]"`, and `"[]"` for none, as Python writes them.
+    [[nodiscard]] static std::string list_repr(std::span<const std::int64_t> values) {
+        std::string text = "[";
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            if (i != 0) {
+                text += ", ";
+            }
+            text += std::to_string(values[i]);
+        }
+        return text + "]";
     }
 
     /// The number of cells a per-axis shape describes.
@@ -1204,13 +1247,20 @@ class THBSplineSpace {
                         sup.last_cell[f] = static_cast<std::int64_t>(interval);
                     }
                 }
+                // The oracle's type and its message: a `RuntimeError` naming EVERY
+                // index with empty support, not the first. nanobind maps
+                // `std::runtime_error` to `RuntimeError`, so the kind survives too.
+                std::vector<std::int64_t> empty_support;
                 for (std::size_t f = 0; f < n_basis; ++f) {
                     if (sup.first_cell[f] < 0) {
-                        throw std::invalid_argument(
-                            "B-spline function " + std::to_string(f) + " of direction "
-                            + std::to_string(k) + " at level " + std::to_string(level)
-                            + " has empty support. This indicates an invalid B-spline space.");
+                        empty_support.push_back(static_cast<std::int64_t>(f));
                     }
+                }
+                if (!empty_support.empty()) {
+                    throw std::runtime_error(
+                        "B-spline function(s) with empty support detected at indices "
+                        + list_repr(empty_support)
+                        + ". This indicates an invalid B-spline space.");
                 }
             }
         }
@@ -1227,6 +1277,29 @@ class THBSplineSpace {
             counts[k] = level_spaces_[level]->space_ref(static_cast<std::int64_t>(k)).num_basis();
         }
         return counts;
+    }
+
+    /// `base ** exponent` for a per-axis refinement factor, in exact integers.
+    ///
+    /// The oracle forms these with Python's `**`, which cannot overflow. This cannot
+    /// either, and the reason is the grid rather than this function: every exponent it
+    /// is called with is bounded by the grid's own `max_level()`, and
+    /// `HierarchicalGrid::level_cells_per_axis` already refused that level unless
+    /// `root_cells * factor ** level` fits in `std::int64_t`. So `factor ** level` is
+    /// at most a count the grid accepted, and a grid that would overflow here threw
+    /// before this space could be built. Written out because the three call sites read
+    /// like an unchecked power and a reader is right to ask.
+    ///
+    /// \param base The per-axis factor, at least 1.
+    /// \param exponent The level gap, non-negative.
+    /// \return `base ** exponent`.
+    [[nodiscard]] static std::int64_t level_power(std::int64_t base,
+                                                  std::int64_t exponent) noexcept {
+        std::int64_t value = 1;
+        for (std::int64_t step = 0; step < exponent; ++step) {
+            value *= base;
+        }
+        return value;
     }
 
     /// The per-axis cell counts of one level of the grid.
@@ -1436,11 +1509,13 @@ class THBSplineSpace {
                 }
             }
             if (new_lo < 0) {
+                // The oracle's text, character for character, em dash included, so a
+                // caller matching on it keeps working when the backend changes.
                 throw std::invalid_argument(
-                    "refine_box: Oslo matrix slice for direction " + std::to_string(k)
+                    "_refine_box: Oslo matrix slice for direction " + std::to_string(k)
                     + " (columns [" + std::to_string(box_lo[k]) + ":"
                     + std::to_string(box_hi[k])
-                    + "]) is entirely zero - degenerate or invalid knot refinement.");
+                    + "]) is entirely zero \u2014 degenerate or invalid knot refinement.");
             }
             const std::int64_t new_width = new_hi - new_lo;
 
@@ -1501,6 +1576,15 @@ class THBSplineSpace {
         const auto d = static_cast<std::size_t>(dim());
         if (d == 0) {
             return false;
+        }
+        // The same guard `box_any_true` carries. `refine_box` throws rather than
+        // returning a zero-width band, so an empty box does not arise from the one
+        // caller today -- but the oracle's numpy version degrades to "nothing zeroed"
+        // for one, and holding an invariant across two functions is not a contract.
+        for (std::size_t k = 0; k < d; ++k) {
+            if (box_lo[k] >= box_hi[k]) {
+                return false;
+            }
         }
         std::vector<std::int64_t> cursor(box_lo.begin(), box_lo.end());
         std::size_t offset = 0;
@@ -1655,10 +1739,7 @@ class THBSplineSpace {
             for (std::int64_t level = 0; level <= cell_level; ++level) {
                 const auto l = static_cast<std::size_t>(level);
                 for (std::size_t k = 0; k < d; ++k) {
-                    std::int64_t divisor = 1;
-                    for (std::int64_t step = 0; step < cell_level - level; ++step) {
-                        divisor *= factor[k];
-                    }
+                    const std::int64_t divisor = level_power(factor[k], cell_level - level);
                     at_level[k] = cell_midx[k] / divisor;
                     first[k] = support_[l][k].first_basis[static_cast<std::size_t>(at_level[k])];
                 }
@@ -1843,9 +1924,6 @@ class THBSplineSpace {
             return out;
         }
         const auto d = static_cast<std::size_t>(dim());
-        if (d == 0) {
-            return out;
-        }
         // `k_ext = k_nbr + 1 <= level`, and `level` never exceeds the maximum level of
         // the grid this space was built on, so the support of that level exists.
         const std::int64_t k_ext = level - m + 2;
@@ -1857,10 +1935,7 @@ class THBSplineSpace {
         std::vector<std::int64_t> lo(d);
         std::vector<std::int64_t> hi(d);
         for (std::size_t k = 0; k < d; ++k) {
-            std::int64_t divisor = 1;
-            for (std::int64_t step = 0; step < level - k_ext; ++step) {
-                divisor *= factor[k];
-            }
+            const std::int64_t divisor = level_power(factor[k], level - k_ext);
             const std::int64_t q = midx[k] / divisor;
             const std::int64_t first = support_ext[k].first_basis[static_cast<std::size_t>(q)];
             const std::int64_t s_lo =
@@ -1877,7 +1952,11 @@ class THBSplineSpace {
                 out.push_back(Marked{k_nbr, cursor});
             }
             std::size_t axis = d;
-            bool done = false;
+            // A dimensionless space has exactly one combination, the empty
+            // multi-index, which is what `itertools.product()` gives the oracle and
+            // what every other odometer in this file does. An early return for
+            // `d == 0` would make this one function disagree with all of them.
+            bool done = d == 0;
             while (axis > 0) {
                 --axis;
                 ++cursor[axis];
@@ -1944,10 +2023,9 @@ class THBSplineSpace {
         std::vector<std::int64_t> box_lo(d);
         std::vector<std::int64_t> box_hi(d);
         for (std::size_t k = 0; k < d; ++k) {
-            std::int64_t scale = 1;
-            for (std::int64_t step = 0; step < m - 1; ++step) {
-                scale *= factor[k];
-            }
+            // `target <= max_level` above bounds `m - 1`, which is what makes this
+            // power safe; `level_power` carries the argument.
+            const std::int64_t scale = level_power(factor[k], m - 1);
             box_lo[k] = ext_lo[k] * scale;
             box_hi[k] = ext_hi[k] * scale;
         }

--- a/cpp/include/pantr/bspline/thb_space.hpp
+++ b/cpp/include/pantr/bspline/thb_space.hpp
@@ -1957,6 +1957,12 @@ class THBSplineSpace {
             // multi-index, which is what `itertools.product()` gives the oracle and
             // what every other odometer in this file does. An early return for
             // `d == 0` would make this one function disagree with all of them.
+            //
+            // No `d == 0` arm in this file is reachable, and none can be covered by a
+            // test: a `THBSplineSpace` needs a `HierarchicalGrid`, which needs a
+            // `TensorProductGrid`, which refuses zero axes. They are kept because
+            // agreeing with the oracle costs one comparison, and the refusal they rest
+            // on is asserted in `cpp/tests/test_thb_space.cpp` rather than assumed.
             bool done = d == 0;
             while (axis > 0) {
                 --axis;

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -38,7 +38,8 @@ set(PANTR_TEST_SOURCES
     test_bspline_space_nd.cpp
     test_extraction_kernels.cpp
     test_bspline_extraction.cpp
-    test_bspline_knot_insertion.cpp)
+    test_bspline_knot_insertion.cpp
+    test_thb_space.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file.

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -37,7 +37,8 @@ set(PANTR_TEST_SOURCES
     test_bspline_space_1d.cpp
     test_bspline_space_nd.cpp
     test_extraction_kernels.cpp
-    test_bspline_extraction.cpp)
+    test_bspline_extraction.cpp
+    test_bspline_knot_insertion.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file.

--- a/cpp/tests/test_bspline_knot_insertion.cpp
+++ b/cpp/tests/test_bspline_knot_insertion.cpp
@@ -17,10 +17,10 @@
 /// uniform, so the columns touched by the clamped ends are excluded -- and the check
 /// counts how many columns it verified and fails if that count is zero, because a
 /// filter that silently matched nothing is the way this kind of test goes vacuous.
-/// Measured against the Python oracle at degrees 1 to 4: the agreement is **exact**,
-/// deviation `0.0`, which is why this asserts equality rather than a bound. That is
-/// not a general claim about the recurrence; it is that this stencil's values are
-/// dyadic and every operation reaching them is exact.
+/// This asserts equality rather than a bound, and the reason is not a measurement: the
+/// stencil's values are dyadic, and every operation reaching them -- a binomial
+/// coefficient in exact integers, then a division by a power of two -- is exact in
+/// binary floating point. That is a property of these values, not of the recurrence.
 ///
 /// **Partition of unity survives refinement.** `sum_i B_i^{(m)} = 1` and
 /// `sum_j B_j^{(m+1)} = 1` together force every *row* of the matrix to sum to one,

--- a/cpp/tests/test_bspline_knot_insertion.cpp
+++ b/cpp/tests/test_bspline_knot_insertion.cpp
@@ -1,0 +1,471 @@
+/// \file
+/// Knot insertion and the two-scale refinement matrix.
+///
+/// ## The two oracles, and why neither is a rerun of the code
+///
+/// A test that recomputes the Oslo recurrence and compares is a mirror, not a test.
+/// Both checks here are closed forms established outside this file.
+///
+/// **The cardinal refinement identity.** On a uniform knot vector, halving every span
+/// gives the classical two-scale relation of the cardinal B-spline,
+///
+///     B_i^{(m)} = 2^{-p} * sum_{j=0}^{p+1} C(p+1, j) B_{2i+j}^{(m+1)},
+///
+/// so an interior column of the matrix is the binomial stencil `C(p+1, j) / 2^p` and
+/// nothing else. It is a statement about binomial coefficients, and the recurrence
+/// under test knows nothing about it. It holds only where the vector really is
+/// uniform, so the columns touched by the clamped ends are excluded -- and the check
+/// counts how many columns it verified and fails if that count is zero, because a
+/// filter that silently matched nothing is the way this kind of test goes vacuous.
+/// Measured against the Python oracle at degrees 1 to 4: the agreement is **exact**,
+/// deviation `0.0`, which is why this asserts equality rather than a bound. That is
+/// not a general claim about the recurrence; it is that this stencil's values are
+/// dyadic and every operation reaching them is exact.
+///
+/// **Partition of unity survives refinement.** `sum_i B_i^{(m)} = 1` and
+/// `sum_j B_j^{(m+1)} = 1` together force every *row* of the matrix to sum to one,
+/// for any knot vector and any refinement. It is not dyadic, so it is graded against
+/// a bound rather than asserted exactly: `p + 2` roundings act on the row's `p + 1`
+/// non-zero entries, each in `[0, 1]` and summing to one, so the accumulated error is
+/// at most `gamma_{p+2} = (p+2) u / (1 - (p+2) u)` and the constant carries no
+/// problem-size growth. `2 * gamma_{p+2}` is used, the factor of two covering the
+/// entries' own formation, and it is a stated pad rather than a derivation.
+///
+/// ## What the refusals pin
+///
+/// `inserted_knot_vector`'s two refusals are the ones a THB space can actually reach:
+/// a subdivision that would push a knot past multiplicity `degree + 1` is what
+/// `regularity = -1` does at degree 1, and it must be a message rather than a
+/// silently degenerate space. The domain refusal is unreachable from `subdivide`,
+/// whose knots are interior by construction, so it is exercised directly.
+///
+/// ## `n_subdivisions == 1` is a copy, not an error
+///
+/// `HierarchicalGrid`'s per-direction factor may be 1, and `_build_level_spaces`
+/// skips those axes rather than subdividing them. The oracle's `subdivide` refuses
+/// `n_subdivisions < 2`, so the skip lives in its *caller*; here it lives in
+/// `subdivide` itself, which returns the space unchanged. That is a deliberate
+/// widening of the oracle's domain and not a divergence on any input the oracle
+/// accepts -- pinned below so a later reader does not "fix" it back.
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bspline/knot_insertion.hpp"
+
+namespace {
+
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::KnotSnapping;
+using pantr::bspline::inserted_knot_vector;
+using pantr::bspline::oslo_bands_1d;
+using pantr::bspline::oslo_matrix_1d;
+using pantr::bspline::subdivide;
+using pantr::bspline::uniform_subdivision_knots;
+
+/// A clamped uniform knot vector on `[0, 1]`.
+///
+/// \param degree The polynomial degree.
+/// \param num_elements The number of equal spans.
+/// \return `degree` copies of 0, the `num_elements + 1` breakpoints, `degree` copies
+///         of 1 -- the open vector with an extra copy at each end supplied by the
+///         breakpoints themselves.
+std::vector<double> uniform_knots(std::int64_t degree, std::int64_t num_elements) {
+    std::vector<double> knots;
+    for (std::int64_t i = 0; i < degree; ++i) {
+        knots.push_back(0.0);
+    }
+    for (std::int64_t i = 0; i <= num_elements; ++i) {
+        knots.push_back(static_cast<double>(i) / static_cast<double>(num_elements));
+    }
+    for (std::int64_t i = 0; i < degree; ++i) {
+        knots.push_back(1.0);
+    }
+    return knots;
+}
+
+/// A space over `uniform_knots`.
+///
+/// \param degree The polynomial degree.
+/// \param num_elements The number of equal spans.
+/// \return The space, snapping near-duplicates as the oracle's default does.
+BsplineSpace1D<double> uniform_space(std::int64_t degree, std::int64_t num_elements) {
+    const std::vector<double> knots = uniform_knots(degree, num_elements);
+    return BsplineSpace1D<double>(std::span<const double>(knots), degree, false,
+                                  KnotSnapping::merge_near_duplicates);
+}
+
+/// The binomial coefficient `C(n, k)`, by the multiplicative form.
+///
+/// Exact in `std::int64_t` over the degrees this file reaches, and formed here rather
+/// than tabulated so the stencil the test compares against is visibly a binomial.
+///
+/// \param n The upper index, non-negative.
+/// \param k The lower index, in `[0, n]`.
+/// \return `C(n, k)`.
+std::int64_t binomial(std::int64_t n, std::int64_t k) {
+    std::int64_t result = 1;
+    for (std::int64_t i = 0; i < k; ++i) {
+        result = result * (n - i) / (i + 1);
+    }
+    return result;
+}
+
+/// `gamma_m = m u / (1 - m u)`, the standard accumulation constant.
+///
+/// \param m The number of roundings.
+/// \return The constant, in units of the value being bounded.
+double gamma_of(std::int64_t m) {
+    const double u = 0.5 * std::numeric_limits<double>::epsilon();
+    const double mu = static_cast<double>(m) * u;
+    return mu / (1.0 - mu);
+}
+
+/// The two-scale matrix of a dyadic refinement is the binomial stencil, exactly.
+///
+/// See the file comment for the identity and for why the check counts what it
+/// verified.
+void check_the_cardinal_refinement_identity() {
+    for (std::int64_t degree = 1; degree <= 4; ++degree) {
+        const BsplineSpace1D<double> coarse = uniform_space(degree, 8);
+        const BsplineSpace1D<double> fine = subdivide<double>(coarse, 2, std::nullopt);
+
+        const std::int64_t num_cols = coarse.num_basis();
+        const std::int64_t num_rows = fine.num_basis();
+        const std::vector<double> matrix =
+            oslo_matrix_1d<double>(degree, coarse.knots(), fine.knots());
+        PANTR_CHECK(static_cast<std::int64_t>(matrix.size()) == num_rows * num_cols);
+
+        std::vector<double> stencil(static_cast<std::size_t>(degree) + 2, 0.0);
+        for (std::int64_t j = 0; j <= degree + 1; ++j) {
+            stencil[static_cast<std::size_t>(j)] =
+                static_cast<double>(binomial(degree + 1, j)) / std::exp2(degree);
+        }
+
+        std::int64_t verified = 0;
+        for (std::int64_t col = 0; col < num_cols; ++col) {
+            std::vector<std::int64_t> support;
+            for (std::int64_t row = 0; row < num_rows; ++row) {
+                if (matrix[static_cast<std::size_t>(row * num_cols + col)] != 0.0) {
+                    support.push_back(row);
+                }
+            }
+            // An interior column has exactly `degree + 2` contiguous non-zeros. The
+            // columns the clamped ends touch have fewer, or the same count over a
+            // different stencil, and the identity does not describe them.
+            if (static_cast<std::int64_t>(support.size()) != degree + 2
+                || support.back() - support.front() != degree + 1) {
+                continue;
+            }
+            bool matched = true;
+            for (std::int64_t j = 0; j <= degree + 1; ++j) {
+                const double value = matrix[static_cast<std::size_t>(
+                    (support.front() + j) * num_cols + col)];
+                matched = matched && value == stencil[static_cast<std::size_t>(j)];
+            }
+            if (matched) {
+                ++verified;
+            } else {
+                PANTR_CHECK_MSG(false, "an interior column at degree " + std::to_string(degree)
+                                           + " is not the binomial stencil");
+            }
+        }
+        PANTR_CHECK_MSG(verified > 0, "the vacuity guard: at degree " + std::to_string(degree)
+                                          + " the filter matched no interior column, so the "
+                                            "identity was never actually compared");
+    }
+}
+
+/// Every row of a two-scale matrix sums to one, on any refinement.
+///
+/// The bound is `2 * gamma_{degree + 2}`; see the file comment for the count and for
+/// what the factor of two is and is not.
+void check_refinement_preserves_the_partition_of_unity() {
+    struct Case {
+        std::int64_t degree;
+        std::vector<double> knots;
+        std::int64_t subdivisions;
+        std::int64_t regularity;
+    };
+    // Non-uniform spans, a non-dyadic factor and a reduced regularity are each
+    // present, because on a uniform dyadic refinement the entries are dyadic and the
+    // sum is exact -- which would make the bound untested.
+    const std::vector<Case> cases = {
+        {2, {0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0}, 2, 1},
+        {2, {0.0, 0.0, 0.0, 0.1, 0.37, 0.62, 1.0, 1.0, 1.0}, 3, 1},
+        {3, {0.0, 0.0, 0.0, 0.0, 0.1, 0.37, 0.62, 1.0, 1.0, 1.0, 1.0}, 2, 0},
+        {3, {1.0e6, 1.0e6, 1.0e6, 1.0e6, 1.0e6 + 0.1, 1.0e6 + 0.37, 1.0e6 + 0.62, 1.0e6 + 1.0,
+             1.0e6 + 1.0, 1.0e6 + 1.0, 1.0e6 + 1.0},
+         2,
+         2},
+    };
+
+    for (const Case& c : cases) {
+        const BsplineSpace1D<double> coarse(std::span<const double>(c.knots), c.degree, false,
+                                            KnotSnapping::merge_near_duplicates);
+        const BsplineSpace1D<double> fine = subdivide<double>(coarse, c.subdivisions, c.regularity);
+        const std::int64_t num_cols = coarse.num_basis();
+        const std::int64_t num_rows = fine.num_basis();
+        const std::vector<double> matrix =
+            oslo_matrix_1d<double>(c.degree, coarse.knots(), fine.knots());
+
+        const double bound = 2.0 * gamma_of(c.degree + 2);
+        double worst = 0.0;
+        for (std::int64_t row = 0; row < num_rows; ++row) {
+            double sum = 0.0;
+            for (std::int64_t col = 0; col < num_cols; ++col) {
+                sum += matrix[static_cast<std::size_t>(row * num_cols + col)];
+            }
+            worst = std::max(worst, std::abs(sum - 1.0));
+        }
+        PANTR_CHECK_MSG(worst <= bound, "a row of the degree-" + std::to_string(c.degree)
+                                            + " two-scale matrix does not sum to one");
+    }
+}
+
+/// The dense matrix is the bands scattered, and the bands are where the values are.
+void check_the_dense_matrix_is_the_bands_scattered() {
+    const BsplineSpace1D<double> coarse = uniform_space(3, 5);
+    const BsplineSpace1D<double> fine = subdivide<double>(coarse, 2, std::nullopt);
+    const auto bands = oslo_bands_1d<double>(3, coarse.knots(), fine.knots());
+    const std::vector<double> dense = oslo_matrix_1d<double>(3, coarse.knots(), fine.knots());
+
+    const std::int64_t num_cols = coarse.num_basis();
+    PANTR_CHECK(bands.num_rows == fine.num_basis());
+    PANTR_CHECK(bands.width == 4);
+
+    std::int64_t placed = 0;
+    for (std::int64_t row = 0; row < bands.num_rows; ++row) {
+        for (std::int64_t l = 0; l < bands.width; ++l) {
+            const std::int64_t col = bands.first_col[static_cast<std::size_t>(row)] + l;
+            if (col < 0 || col >= num_cols) {
+                continue;
+            }
+            ++placed;
+            PANTR_CHECK(dense[static_cast<std::size_t>(row * num_cols + col)]
+                        == bands.alphas[static_cast<std::size_t>(row * bands.width + l)]);
+        }
+    }
+    // Everything the dense form holds came from a band: no entry outside one is
+    // non-zero, so the two really do describe the same matrix.
+    std::int64_t non_zero = 0;
+    for (const double value : dense) {
+        non_zero += static_cast<std::int64_t>(value != 0.0);
+    }
+    PANTR_CHECK_MSG(non_zero <= placed, "the dense form holds a value no band placed");
+}
+
+/// The subdivided knot vector: the values, the multiplicities and the counts.
+void check_subdivision_knots() {
+    const std::vector<double> knots = {0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const BsplineSpace1D<double> space(std::span<const double>(knots), 2, false,
+                                       KnotSnapping::merge_near_duplicates);
+
+    // Maximal smoothness: one copy of each interior point of each span.
+    const std::vector<double> maximal =
+        uniform_subdivision_knots<double>(space.knots(), 2, space.tolerance(), 2, 1);
+    PANTR_CHECK(maximal.size() == 2);
+    PANTR_CHECK(maximal[0] == 0.25);
+    PANTR_CHECK(maximal[1] == 0.75);
+
+    // `C^0`: multiplicity `degree - 0 = 2` at each inserted point.
+    const std::vector<double> c_zero =
+        uniform_subdivision_knots<double>(space.knots(), 2, space.tolerance(), 2, 0);
+    PANTR_CHECK(c_zero.size() == 4);
+    PANTR_CHECK(c_zero[0] == 0.25 && c_zero[1] == 0.25);
+    PANTR_CHECK(c_zero[2] == 0.75 && c_zero[3] == 0.75);
+
+    // A factor of three puts two interior points in each span.
+    const std::vector<double> thirds =
+        uniform_subdivision_knots<double>(space.knots(), 2, space.tolerance(), 3, 1);
+    PANTR_CHECK(thirds.size() == 4);
+
+    // Nothing to insert when the factor is one, which is what an unrefined direction
+    // asks for. See the file comment.
+    PANTR_CHECK(
+        uniform_subdivision_knots<double>(space.knots(), 2, space.tolerance(), 1, 1).empty());
+    const BsplineSpace1D<double> same = subdivide<double>(space, 1, std::nullopt);
+    PANTR_CHECK(same.num_basis() == space.num_basis());
+    PANTR_CHECK(same.knots().size() == space.knots().size());
+}
+
+/// Subdividing multiplies the interval count and keeps the domain.
+void check_subdivide_counts_and_domain() {
+    for (std::int64_t degree = 1; degree <= 3; ++degree) {
+        const BsplineSpace1D<double> coarse = uniform_space(degree, 3);
+        for (std::int64_t factor = 2; factor <= 4; ++factor) {
+            const BsplineSpace1D<double> fine = subdivide<double>(coarse, factor, std::nullopt);
+            PANTR_CHECK(fine.num_intervals() == coarse.num_intervals() * factor);
+            PANTR_CHECK(fine.degree() == degree);
+            // Maximal smoothness inserts one knot per new interior breakpoint, so the
+            // basis grows by exactly the number of inserted knots.
+            PANTR_CHECK(fine.num_basis()
+                        == coarse.num_basis() + coarse.num_intervals() * (factor - 1));
+            PANTR_CHECK(fine.domain()[0] == coarse.domain()[0]);
+            PANTR_CHECK(fine.domain()[1] == coarse.domain()[1]);
+        }
+    }
+}
+
+/// `float` storage computes in `double` and stores in `float`.
+///
+/// The two spellings are not the same: `float(double(j) * ((double(hi) - double(lo)) /
+/// n) + double(lo))` and `float(j) * ((hi - lo) / float(n)) + lo` differ on the span
+/// `[1/3, 1]` at `n = 2`, by one `float` ulp. The check is that the stored value is
+/// the narrowing of the `double` computation, which is what the oracle does and what
+/// `design/cross_backend_types.md` requires -- and the guard below fails if the case
+/// chosen stops distinguishing them, since then this would pass over a narrowing that
+/// never happened.
+void check_float_storage_computes_in_double() {
+    const float split = 1.0F / 3.0F;
+    const std::vector<float> knots = {0.0F, 0.0F, 0.0F, split, 1.0F, 1.0F, 1.0F};
+    const BsplineSpace1D<float> space(std::span<const float>(knots), 2, false,
+                                      KnotSnapping::merge_near_duplicates);
+    const std::vector<float> inserted =
+        uniform_subdivision_knots<float>(space.knots(), 2, space.tolerance(), 2, 1);
+    PANTR_CHECK(inserted.size() == 2);
+
+    const double lo = static_cast<double>(split);
+    const double step_low = (lo - 0.0) / 2.0;
+    const double step_high = (1.0 - lo) / 2.0;
+    const float in_double_low = static_cast<float>(1.0 * step_low + 0.0);
+    const float in_double_high = static_cast<float>(1.0 * step_high + lo);
+    PANTR_CHECK(inserted[0] == in_double_low);
+    PANTR_CHECK(inserted[1] == in_double_high);
+
+    const float in_float_high = 1.0F * ((1.0F - split) / 2.0F) + split;
+    PANTR_CHECK_MSG(in_double_high != in_float_high,
+                    "the vacuity guard: this span no longer distinguishes double-then-narrow "
+                    "from float arithmetic, so the case cannot fail on the thing it names");
+}
+
+/// The merge is order-preserving on equal values, so a signed zero keeps its place.
+///
+/// The domain has `-0.0` as an interior knot and a `+0.0` is inserted onto it, so the
+/// two are one class of multiplicity two and the degree admits it. Asserting the
+/// *sign* of the tie is what `CLAUDE.md` forbids -- the two compare equal and no
+/// implementation owes an order -- so what is asserted is the ORDER the concatenation
+/// fixed, which stability is what preserves.
+void check_the_merge_is_stable() {
+    const std::vector<double> knots = {-1.0, -1.0, -1.0, -0.0, 1.0, 1.0, 1.0};
+    const std::vector<double> insert = {0.0};
+    const BsplineSpace1D<double> space(std::span<const double>(knots), 2, false,
+                                       KnotSnapping::merge_near_duplicates);
+    const std::vector<double> merged =
+        inserted_knot_vector<double>(space.knots(), 2, std::span<const double>(insert),
+                                     space.tolerance());
+    PANTR_CHECK(merged.size() == 8);
+    PANTR_CHECK(merged[2] == -1.0);
+    PANTR_CHECK_MSG(std::signbit(merged[3]),
+                    "the knot vector's own -0.0 came first in the concatenation and must stay "
+                    "first");
+    PANTR_CHECK_MSG(!std::signbit(merged[4]), "and the inserted +0.0 must follow it");
+    PANTR_CHECK(merged[5] == 1.0);
+}
+
+/// What the two entry points refuse, and with which message.
+void check_refusals() {
+    const BsplineSpace1D<double> space = uniform_space(2, 4);
+
+    bool threw = false;
+    try {
+        static_cast<void>(subdivide<double>(space, 0, std::nullopt));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()) == "n_subdivisions must be >= 1, got 0";
+    }
+    PANTR_CHECK_MSG(threw, "a zero subdivision factor must be refused by its own message");
+
+    threw = false;
+    try {
+        static_cast<void>(subdivide<double>(space, 2, 2));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()) == "regularity must be in [-1, degree - 1] = [-1, 1], got 2";
+    }
+    PANTR_CHECK_MSG(threw, "a regularity at or above the degree must be refused");
+
+    threw = false;
+    try {
+        const std::vector<double> nothing;
+        static_cast<void>(inserted_knot_vector<double>(space.knots(), 2,
+                                                       std::span<const double>(nothing),
+                                                       space.tolerance()));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()) == "new_knots_to_insert must not be empty.";
+    }
+    PANTR_CHECK_MSG(threw, "an empty insertion must be refused");
+
+    threw = false;
+    try {
+        const std::vector<double> outside = {1.5};
+        static_cast<void>(inserted_knot_vector<double>(space.knots(), 2,
+                                                       std::span<const double>(outside),
+                                                       space.tolerance()));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()).starts_with(
+            "new_knots contains values outside the domain [0.0, 1.0]:");
+    }
+    PANTR_CHECK_MSG(threw, "a knot outside the domain must be refused, naming the domain");
+
+    // Multiplicity: at degree 2 a knot may appear three times. The vector already
+    // holds 0.5 once, so inserting it three more times is one too many.
+    threw = false;
+    try {
+        const std::vector<double> too_many = {0.5, 0.5, 0.5};
+        static_cast<void>(inserted_knot_vector<double>(space.knots(), 2,
+                                                       std::span<const double>(too_many),
+                                                       space.tolerance()));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what())
+                == "Inserting these knots would exceed the maximum multiplicity of 3. "
+                   "Maximum multiplicity found: 4.";
+    }
+    PANTR_CHECK_MSG(threw, "exceeding the maximum multiplicity must be refused by its own message");
+
+    threw = false;
+    try {
+        const std::vector<double> knots = {0.0, 1.0};
+        static_cast<void>(oslo_bands_1d<double>(-1, std::span<const double>(knots),
+                                                std::span<const double>(knots)));
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a negative degree must be refused");
+}
+
+/// Reduced regularity really reduces the smoothness, and the counts say so.
+void check_regularity_changes_the_basis_count() {
+    const BsplineSpace1D<double> coarse = uniform_space(3, 2);
+    const BsplineSpace1D<double> smooth = subdivide<double>(coarse, 2, std::nullopt);
+    const BsplineSpace1D<double> c_one = subdivide<double>(coarse, 2, 1);
+    const BsplineSpace1D<double> c_minus = subdivide<double>(coarse, 2, -1);
+
+    // Two new interior breakpoints, at multiplicity `degree - regularity`.
+    PANTR_CHECK(smooth.num_basis() == coarse.num_basis() + 2 * 1);
+    PANTR_CHECK(c_one.num_basis() == coarse.num_basis() + 2 * 2);
+    PANTR_CHECK(c_minus.num_basis() == coarse.num_basis() + 2 * 4);
+    // Every one of them still has the same interval count: multiplicity does not
+    // create spans.
+    PANTR_CHECK(smooth.num_intervals() == 4 && c_one.num_intervals() == 4
+                && c_minus.num_intervals() == 4);
+}
+
+}  // namespace
+
+int main() {
+    check_the_cardinal_refinement_identity();
+    check_refinement_preserves_the_partition_of_unity();
+    check_the_dense_matrix_is_the_bands_scattered();
+    check_subdivision_knots();
+    check_subdivide_counts_and_domain();
+    check_float_storage_computes_in_double();
+    check_the_merge_is_stable();
+    check_refusals();
+    check_regularity_changes_the_basis_count();
+    return pantr::test::summary("test_bspline_knot_insertion");
+}

--- a/cpp/tests/test_bspline_knot_insertion.cpp
+++ b/cpp/tests/test_bspline_knot_insertion.cpp
@@ -39,14 +39,13 @@
 /// silently degenerate space. The domain refusal is unreachable from `subdivide`,
 /// whose knots are interior by construction, so it is exercised directly.
 ///
-/// ## `n_subdivisions == 1` is a copy, not an error
+/// ## A factor of one is refused, not silently a copy
 ///
-/// `HierarchicalGrid`'s per-direction factor may be 1, and `_build_level_spaces`
-/// skips those axes rather than subdividing them. The oracle's `subdivide` refuses
-/// `n_subdivisions < 2`, so the skip lives in its *caller*; here it lives in
-/// `subdivide` itself, which returns the space unchanged. That is a deliberate
-/// widening of the oracle's domain and not a divergence on any input the oracle
-/// accepts -- pinned below so a later reader does not "fix" it back.
+/// `HierarchicalGrid`'s per-direction factor may be 1, and the THB space skips those
+/// axes rather than asking for a subdivision by one -- so the bound here is the oracle's,
+/// `n_subdivisions >= 2`, and `check_refusals` pins both entry points' messages. An
+/// earlier version accepted 1 and returned a copy; nothing exercised it, and a widened
+/// contract with no exerciser is how an unexamined precedent starts.
 
 #include <cmath>
 #include <cstdint>
@@ -286,13 +285,8 @@ void check_subdivision_knots() {
         uniform_subdivision_knots<double>(space.knots(), 2, space.tolerance(), 3, 1);
     PANTR_CHECK(thirds.size() == 4);
 
-    // Nothing to insert when the factor is one, which is what an unrefined direction
-    // asks for. See the file comment.
-    PANTR_CHECK(
-        uniform_subdivision_knots<double>(space.knots(), 2, space.tolerance(), 1, 1).empty());
-    const BsplineSpace1D<double> same = subdivide<double>(space, 1, std::nullopt);
-    PANTR_CHECK(same.num_basis() == space.num_basis());
-    PANTR_CHECK(same.knots().size() == space.knots().size());
+    // A factor of one is refused rather than treated as a copy; `check_refusals` pins
+    // both messages. See the file comment.
 }
 
 /// Subdividing multiplies the interval count and keeps the domain.
@@ -375,11 +369,21 @@ void check_refusals() {
 
     bool threw = false;
     try {
-        static_cast<void>(subdivide<double>(space, 0, std::nullopt));
+        static_cast<void>(subdivide<double>(space, 1, std::nullopt));
     } catch (const std::invalid_argument& e) {
-        threw = std::string(e.what()) == "n_subdivisions must be >= 1, got 0";
+        threw = std::string(e.what()) == "n_subdivisions must be >= 2, got 1";
     }
-    PANTR_CHECK_MSG(threw, "a zero subdivision factor must be refused by its own message");
+    PANTR_CHECK_MSG(threw, "a subdivision factor below the oracle's bound must be refused "
+                           "with the oracle's message");
+
+    threw = false;
+    try {
+        static_cast<void>(
+            uniform_subdivision_knots<double>(space.knots(), 2, space.tolerance(), 1, 1));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()) == "n_subdivisions must be >= 2, got 1";
+    }
+    PANTR_CHECK_MSG(threw, "and the knot generator refuses it too, not only its caller");
 
     threw = false;
     try {

--- a/cpp/tests/test_thb_space.cpp
+++ b/cpp/tests/test_thb_space.cpp
@@ -401,8 +401,8 @@ void check_the_contribution_table() {
             // Every recorded function is one the level's Kraft selection admits.
             const std::span<const std::int64_t> active =
                 space.active_function_indices(c.levels[e]);
-            const std::int64_t position = c.dofs[e] - space.level_offsets()[static_cast<std::size_t>(
-                                              c.levels[e])];
+            const auto owning = static_cast<std::size_t>(c.levels[e]);
+            const std::int64_t position = c.dofs[e] - space.level_offsets()[owning];
             std::int64_t flat = 0;
             for (std::size_t k = 0; k < d; ++k) {
                 flat = flat * space.level_space_ref(c.levels[e])
@@ -723,6 +723,29 @@ void check_refusals() {
     }
     PANTR_CHECK_MSG(threw, "an admissibility class below the definition's minimum must be "
                            "refused with the oracle's message");
+
+    // Every offending id, not the first: the oracle collects them all before raising,
+    // and a caller debugging a list of them would otherwise get one per attempt.
+    const std::int64_t past_the_end = space.grid_ref().num_cells();
+    const std::vector<std::int64_t> bad = {past_the_end + 5, -1, past_the_end};
+    for (const bool coarsening : {false, true}) {
+        threw = false;
+        try {
+            if (coarsening) {
+                static_cast<void>(space.coarsen(std::span<const std::int64_t>(bad), 2));
+            } else {
+                static_cast<void>(space.refine(std::span<const std::int64_t>(bad), 2));
+            }
+        } catch (const std::out_of_range& e) {
+            threw = std::string(e.what())
+                    == "cell_ids must lie in [0, " + std::to_string(past_the_end)
+                           + "); got out-of-range id(s): [-1, " + std::to_string(past_the_end)
+                           + ", " + std::to_string(past_the_end + 5) + "].";
+        }
+        PANTR_CHECK_MSG(threw, std::string(coarsening ? "coarsen" : "refine")
+                                   + " must name every out-of-range id, sorted, as the "
+                                     "oracle does");
+    }
 }
 
 /// A factor of 1 on one axis leaves that direction alone at every level.
@@ -762,7 +785,8 @@ void check_copy_leaves_the_memo_cold() {
     const THBSplineSpace<double> space = reference_space(true);
     const std::int64_t expected = space.max_active_per_cell();
 
-    const THBSplineSpace<double> copy = space;  // NOLINT(performance-unnecessary-copy-initialization)
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)  -- copying IS the test
+    const THBSplineSpace<double> copy = space;
     PANTR_CHECK(copy.max_active_per_cell() == expected);
     PANTR_CHECK(copy.num_total_basis() == space.num_total_basis());
     // The copy shares the nested handles, which is what makes it cheap and what the

--- a/cpp/tests/test_thb_space.cpp
+++ b/cpp/tests/test_thb_space.cpp
@@ -1,0 +1,833 @@
+/// \file
+/// The hierarchical B-spline space: what it selects, what it truncates, and what it
+/// shares.
+///
+/// ## What is asserted here and not in `tests/parity/test_thb_spline_space.py`
+///
+/// The parity file compares this type against the Python oracle over a generative sweep,
+/// which is the stronger check for everything both sides can answer. Three kinds of
+/// property are not reachable from there and live here:
+///
+///  - **Lifetime.** `design/bspline_ownership_lifetime.md` F4 records that a value
+///    assertion does not detect a broken lifetime -- a scalar read after free returns the
+///    right answer often enough that the obvious test passes on a broken design. The
+///    check below is that a nested object read *after its owner is destroyed* still
+///    reports a count the owner's destructor would have overwritten, and its gate is the
+///    `gcc-debug` preset's address sanitizer rather than the assertion.
+///  - **Thread safety.** The contribution table is a `pantr::LazySlot`, and
+///    `design/bspline_derived_caches.md` F3 measured a bare `mutable std::optional`
+///    giving 60 correct answers in 60 unsanitized runs and four ThreadSanitizer reports.
+///    So the claim gets a gate rather than a reader's trust, and no assertion on a value
+///    can be that gate. From Python the GIL hides it entirely.
+///  - **`float` storage.** The binding registers both widths, but the parity file's
+///    `float32` coverage is one case; here the whole type is censused at `float` so an
+///    instantiation error cannot hide behind the `double` one.
+///
+/// ## The identity contracts, and why they are compared by address
+///
+/// `level_space(0)` must hand back the very handle the space was built from, not a copy
+/// of what it points at. Every value assertion in this file would pass either way, and
+/// the Python contract `thb.level_space(0) is thb.root_space` would then present two
+/// Python objects agreeing on identity over two different C++ objects --
+/// `design/bspline_ownership_lifetime.md` F6. Comparing addresses is what distinguishes
+/// them.
+///
+/// The same argument runs for the grid, with the opposite conclusion in one place:
+/// `refine` and `coarsen` must **never** hand their result the receiver's grid, because a
+/// grid carries mutable tag registries and two spaces sharing one would make a tag set
+/// through the first visible through the second. That is asserted on the no-op paths,
+/// which are the ones where sharing would be the natural implementation.
+///
+/// ## The truncation is checked against an identity, not against a rerun
+///
+/// `check_the_truncation_is_a_partition_of_unity` sums every active function's
+/// coefficient vector, pushed to the finest level by pure two-scale refinement, and
+/// requires the all-ones vector -- Giannelli-Juttler-Speleers (2012) Thm 6. The pushing
+/// uses `pantr/bspline/knot_insertion.hpp`, which
+/// `cpp/tests/test_bspline_knot_insertion.cpp` pins independently against the cardinal
+/// B-spline's binomial stencil, so this is a composition of two checked things rather
+/// than the truncation grading itself.
+///
+/// It carries its discriminator: the same computation on the **untruncated** basis must
+/// fail, and does, by a wide margin. Without that, an identity that the truncation is
+/// what restores would be consistent with a test that cannot fail.
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bspline/knot_insertion.hpp"
+#include "pantr/bspline/thb_space.hpp"
+#include "pantr/grid/hierarchical_grid.hpp"
+#include "pantr/grid/tensor_product_grid.hpp"
+
+namespace {
+
+using pantr::bspline::BsplineSpace;
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::KnotSnapping;
+using pantr::bspline::THBSplineSpace;
+using pantr::grid::HierarchicalGrid;
+using pantr::grid::TensorProductGrid;
+
+/// A clamped uniform knot vector on `[lo, hi]`.
+///
+/// \tparam T The scalar type.
+/// \param degree The polynomial degree.
+/// \param num_elements The number of equal spans.
+/// \param lo The domain start.
+/// \param hi The domain end.
+/// \return The knot vector.
+template <class T>
+std::vector<T> open_knots(std::int64_t degree, std::int64_t num_elements, T lo, T hi) {
+    std::vector<T> knots(static_cast<std::size_t>(degree), lo);
+    for (std::int64_t i = 0; i <= num_elements; ++i) {
+        knots.push_back(lo
+                        + static_cast<T>(static_cast<double>(i)
+                                         * (static_cast<double>(hi) - static_cast<double>(lo))
+                                         / static_cast<double>(num_elements)));
+    }
+    knots.insert(knots.end(), static_cast<std::size_t>(degree), hi);
+    return knots;
+}
+
+/// A tensor-product root space with the same direction repeated.
+///
+/// \tparam T The scalar type.
+/// \param dim The number of directions.
+/// \param degree The polynomial degree.
+/// \param num_elements The number of equal spans per direction.
+/// \return A handle on the space.
+template <class T>
+std::shared_ptr<const BsplineSpace<T>> root_space(std::int64_t dim, std::int64_t degree,
+                                                  std::int64_t num_elements) {
+    const std::vector<T> knots = open_knots<T>(degree, num_elements, T(0), T(1));
+    auto one_d = std::make_shared<const BsplineSpace1D<T>>(
+        std::span<const T>(knots), degree, false, KnotSnapping::merge_near_duplicates);
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions(
+        static_cast<std::size_t>(dim), one_d);
+    return std::make_shared<const BsplineSpace<T>>(std::move(directions));
+}
+
+/// A hierarchy over the unit cube, refined level by level from the origin corner.
+///
+/// \param dim The number of axes.
+/// \param num_elements The root cell count per axis.
+/// \param factor The refinement factor per axis.
+/// \param levels How many successive corner refinements to apply.
+/// \return A handle on the grid.
+std::shared_ptr<HierarchicalGrid<double>> corner_hierarchy(std::int64_t dim,
+                                                           std::int64_t num_elements,
+                                                           std::int64_t factor,
+                                                           std::int64_t levels) {
+    const auto d = static_cast<std::size_t>(dim);
+    std::vector<double> axis;
+    for (std::int64_t i = 0; i <= num_elements; ++i) {
+        axis.push_back(static_cast<double>(i) / static_cast<double>(num_elements));
+    }
+    const std::vector<std::vector<double>> breakpoints(d, axis);
+    const std::vector<std::int64_t> factors(d, factor);
+    auto grid = std::make_shared<HierarchicalGrid<double>>(
+        TensorProductGrid<double>(breakpoints), std::span<const std::int64_t>(factors));
+    const std::vector<std::int64_t> lo(d, 0);
+    const std::vector<std::int64_t> hi(d, 2);
+    for (std::int64_t level = 0; level < levels; ++level) {
+        grid = std::make_shared<HierarchicalGrid<double>>(
+            grid->refine(level, std::span<const std::int64_t>(lo),
+                         std::span<const std::int64_t>(hi)));
+    }
+    return grid;
+}
+
+/// A two-dimensional, three-level, degree-2 dyadic space.
+///
+/// \param truncate Whether the truncated basis is built.
+/// \return The space.
+THBSplineSpace<double> reference_space(bool truncate) {
+    return THBSplineSpace<double>(root_space<double>(2, 2, 4), corner_hierarchy(2, 4, 2, 2),
+                                  truncate, {std::nullopt, std::nullopt});
+}
+
+/// `gamma_m = m u / (1 - m u)`, the standard accumulation constant.
+///
+/// \param m The number of roundings.
+/// \return The constant, relative.
+double gamma_of(std::int64_t m) {
+    const double u = 0.5 * std::numeric_limits<double>::epsilon();
+    const double mu = static_cast<double>(m) * u;
+    return mu / (1.0 - mu);
+}
+
+/// How far the active basis is from summing to one, in the finest level's basis.
+///
+/// Pushes every active function's coefficient vector to the finest level by pure
+/// two-scale refinement -- no truncation -- and returns the largest deviation of the sum
+/// from one. See the file comment for what makes this an independent check.
+///
+/// \param space The space to grade.
+/// \return `max |sum_i c_i - 1|` over the finest tensor-product basis.
+double partition_of_unity_defect(const THBSplineSpace<double>& space) {
+    const auto d = static_cast<std::size_t>(space.dim());
+    const std::int64_t top = space.num_levels() - 1;
+
+    // The two-scale matrices, one per level transition per direction.
+    std::vector<std::vector<std::vector<double>>> oslo;
+    std::vector<std::vector<std::int64_t>> cols;
+    for (std::int64_t m = 0; m < top; ++m) {
+        std::vector<std::vector<double>> per_direction;
+        std::vector<std::int64_t> per_direction_cols;
+        for (std::size_t k = 0; k < d; ++k) {
+            const BsplineSpace1D<double>& old_space =
+                space.level_space_ref(m).space_ref(static_cast<std::int64_t>(k));
+            const BsplineSpace1D<double>& new_space =
+                space.level_space_ref(m + 1).space_ref(static_cast<std::int64_t>(k));
+            per_direction.push_back(pantr::bspline::oslo_matrix_1d<double>(
+                old_space.degree(), old_space.knots(), new_space.knots()));
+            per_direction_cols.push_back(old_space.num_basis());
+        }
+        oslo.push_back(std::move(per_direction));
+        cols.push_back(std::move(per_direction_cols));
+    }
+
+    std::vector<std::int64_t> finest(d);
+    std::int64_t finest_total = 1;
+    for (std::size_t k = 0; k < d; ++k) {
+        finest[k] = space.level_space_ref(top).space_ref(static_cast<std::int64_t>(k)).num_basis();
+        finest_total *= finest[k];
+    }
+    std::vector<double> total(static_cast<std::size_t>(finest_total), 0.0);
+
+    for (std::int64_t dof = 0; dof < space.num_total_basis(); ++dof) {
+        const std::optional<pantr::bspline::TruncatedView> view = space.truncated(dof);
+        std::int64_t start = 0;
+        std::vector<std::int64_t> box_lo(d);
+        std::vector<std::int64_t> shape(d, 1);
+        std::vector<double> coeffs;
+        if (view.has_value()) {
+            start = view->rep_level;
+            for (std::size_t k = 0; k < d; ++k) {
+                box_lo[k] = view->box_lo[k];
+                shape[k] = view->shape[k];
+            }
+            coeffs.assign(view->coeffs.begin(), view->coeffs.end());
+        } else {
+            start = space.dof_level(dof);
+            const std::span<const std::int64_t> active =
+                space.active_function_indices(start);
+            const std::int64_t position =
+                dof - space.level_offsets()[static_cast<std::size_t>(start)];
+            std::int64_t flat = active[static_cast<std::size_t>(position)];
+            for (std::size_t k = d; k > 0; --k) {
+                const std::int64_t n = space.level_space_ref(start)
+                                           .space_ref(static_cast<std::int64_t>(k - 1))
+                                           .num_basis();
+                box_lo[k - 1] = flat % n;
+                flat /= n;
+            }
+            coeffs.assign(1, 1.0);
+        }
+
+        for (std::int64_t level = start; level < top; ++level) {
+            const auto m = static_cast<std::size_t>(level);
+            for (std::size_t k = 0; k < d; ++k) {
+                const std::vector<double>& alpha = oslo[m][k];
+                const std::int64_t num_cols = cols[m][k];
+                const std::int64_t rows =
+                    static_cast<std::int64_t>(alpha.size()) / num_cols;
+                std::int64_t new_lo = -1;
+                std::int64_t new_hi = -1;
+                for (std::int64_t row = 0; row < rows; ++row) {
+                    bool non_zero = false;
+                    for (std::int64_t col = box_lo[k]; col < box_lo[k] + shape[k]; ++col) {
+                        non_zero =
+                            non_zero
+                            || alpha[static_cast<std::size_t>(row * num_cols + col)] != 0.0;
+                    }
+                    if (non_zero) {
+                        if (new_lo < 0) {
+                            new_lo = row;
+                        }
+                        new_hi = row + 1;
+                    }
+                }
+                const std::int64_t new_width = new_hi - new_lo;
+                std::int64_t outer = 1;
+                for (std::size_t a = 0; a < k; ++a) {
+                    outer *= shape[a];
+                }
+                std::int64_t inner = 1;
+                for (std::size_t a = k + 1; a < d; ++a) {
+                    inner *= shape[a];
+                }
+                std::vector<double> next(
+                    static_cast<std::size_t>(outer * new_width * inner), 0.0);
+                for (std::int64_t o = 0; o < outer; ++o) {
+                    for (std::int64_t i = 0; i < new_width; ++i) {
+                        for (std::int64_t j = 0; j < shape[k]; ++j) {
+                            const double a = alpha[static_cast<std::size_t>(
+                                (new_lo + i) * num_cols + box_lo[k] + j)];
+                            for (std::int64_t n = 0; n < inner; ++n) {
+                                next[static_cast<std::size_t>((o * new_width + i) * inner + n)] +=
+                                    a
+                                    * coeffs[static_cast<std::size_t>((o * shape[k] + j) * inner
+                                                                      + n)];
+                            }
+                        }
+                    }
+                }
+                coeffs.swap(next);
+                box_lo[k] = new_lo;
+                shape[k] = new_width;
+            }
+        }
+
+        // Scatter the box into the finest-level accumulator.
+        std::vector<std::int64_t> cursor(box_lo.begin(), box_lo.end());
+        std::size_t offset = 0;
+        for (;;) {
+            std::int64_t flat = 0;
+            for (std::size_t k = 0; k < d; ++k) {
+                flat = flat * finest[k] + cursor[k];
+            }
+            total[static_cast<std::size_t>(flat)] += coeffs[offset];
+            ++offset;
+            std::size_t axis = d;
+            bool done = false;
+            while (axis > 0) {
+                --axis;
+                ++cursor[axis];
+                if (cursor[axis] < box_lo[axis] + shape[axis]) {
+                    break;
+                }
+                cursor[axis] = box_lo[axis];
+                if (axis == 0) {
+                    done = true;
+                }
+            }
+            if (done) {
+                break;
+            }
+        }
+    }
+
+    double worst = 0.0;
+    for (const double value : total) {
+        worst = std::max(worst, std::abs(value - 1.0));
+    }
+    return worst;
+}
+
+/// The counts and the shape of a hierarchy every other case here builds on.
+void check_the_reference_space() {
+    const THBSplineSpace<double> space = reference_space(true);
+    PANTR_CHECK(space.dim() == 2);
+    PANTR_CHECK(space.num_levels() == 3);
+    PANTR_CHECK(space.truncate());
+    PANTR_CHECK(space.degrees()[0] == 2 && space.degrees()[1] == 2);
+
+    // The per-level counts sum to the total, and the offsets are their prefix sums.
+    std::int64_t sum = 0;
+    for (const std::int64_t n : space.num_basis_per_level()) {
+        sum += n;
+    }
+    PANTR_CHECK(sum == space.num_total_basis());
+    PANTR_CHECK(space.level_offsets().size() == 4);
+    PANTR_CHECK(space.level_offsets()[0] == 0);
+    PANTR_CHECK(space.level_offsets()[3] == space.num_total_basis());
+    for (std::int64_t level = 0; level < space.num_levels(); ++level) {
+        const auto l = static_cast<std::size_t>(level);
+        PANTR_CHECK(static_cast<std::int64_t>(space.active_function_indices(level).size())
+                    == space.num_basis_per_level()[l]);
+        // Sorted and distinct, which the accessor's contract promises.
+        const std::span<const std::int64_t> active = space.active_function_indices(level);
+        PANTR_CHECK(std::is_sorted(active.begin(), active.end()));
+        PANTR_CHECK(std::adjacent_find(active.begin(), active.end()) == active.end());
+    }
+    PANTR_CHECK(space.to_string()
+                == "THBSplineSpace(dim=2, degrees=(2, 2), num_levels=3, num_total_basis="
+                       + std::to_string(space.num_total_basis()) + ", truncate=True)");
+
+    // A one-direction space's `repr` uses Python's one-element tuple spelling.
+    const THBSplineSpace<double> flat(root_space<double>(1, 2, 4), corner_hierarchy(1, 4, 2, 1),
+                                      true, {std::nullopt});
+    PANTR_CHECK_MSG(flat.to_string().find("degrees=(2,)") != std::string::npos,
+                    "a one-direction repr must spell its tuple Python's way: " + flat.to_string());
+}
+
+/// Every dof is assigned to the level whose offset range contains it.
+void check_dof_levels_partition_the_basis() {
+    const THBSplineSpace<double> space = reference_space(true);
+    std::vector<std::int64_t> seen(static_cast<std::size_t>(space.num_levels()), 0);
+    for (std::int64_t dof = 0; dof < space.num_total_basis(); ++dof) {
+        const std::int64_t level = space.dof_level(dof);
+        PANTR_CHECK(level >= 0 && level < space.num_levels());
+        PANTR_CHECK(dof >= space.level_offsets()[static_cast<std::size_t>(level)]);
+        PANTR_CHECK(dof < space.level_offsets()[static_cast<std::size_t>(level) + 1]);
+        ++seen[static_cast<std::size_t>(level)];
+    }
+    for (std::int64_t level = 0; level < space.num_levels(); ++level) {
+        PANTR_CHECK(seen[static_cast<std::size_t>(level)]
+                    == space.num_basis_per_level()[static_cast<std::size_t>(level)]);
+    }
+}
+
+/// The contribution table's three views agree with each other and with `active_basis`.
+void check_the_contribution_table() {
+    const THBSplineSpace<double> space = reference_space(true);
+    const auto d = static_cast<std::size_t>(space.dim());
+    std::int64_t widest = 0;
+    for (std::int64_t cid = 0; cid < space.grid_ref().num_cells(); ++cid) {
+        const pantr::bspline::CellContributions c = space.contributions(cid);
+        PANTR_CHECK(c.dofs.size() == c.levels.size());
+        PANTR_CHECK(c.multi_indices.size() == c.dofs.size() * d);
+        PANTR_CHECK(std::is_sorted(c.dofs.begin(), c.dofs.end()));
+        // `active_basis` is the same view, so it must be the same values.
+        const std::span<const std::int64_t> basis = space.active_basis(cid);
+        PANTR_CHECK(basis.size() == c.dofs.size());
+        PANTR_CHECK(std::equal(basis.begin(), basis.end(), c.dofs.begin()));
+        for (std::int64_t i = 0; i < c.size(); ++i) {
+            const auto e = static_cast<std::size_t>(i);
+            PANTR_CHECK(c.levels[e] == space.dof_level(c.dofs[e]));
+            // Every recorded function is one the level's Kraft selection admits.
+            const std::span<const std::int64_t> active =
+                space.active_function_indices(c.levels[e]);
+            const std::int64_t position = c.dofs[e] - space.level_offsets()[static_cast<std::size_t>(
+                                              c.levels[e])];
+            std::int64_t flat = 0;
+            for (std::size_t k = 0; k < d; ++k) {
+                flat = flat * space.level_space_ref(c.levels[e])
+                                  .space_ref(static_cast<std::int64_t>(k))
+                                  .num_basis()
+                       + c.multi_indices[e * d + k];
+            }
+            PANTR_CHECK(active[static_cast<std::size_t>(position)] == flat);
+        }
+        widest = std::max(widest, c.size());
+    }
+    PANTR_CHECK_MSG(widest == space.max_active_per_cell(),
+                    "max_active_per_cell must be the same sweep's answer");
+    // The vacuity guard: a grid with no cells would satisfy every loop above.
+    PANTR_CHECK_MSG(space.grid_ref().num_cells() > 0 && widest > 0,
+                    "this hierarchy has no cell with an active function, so the table was "
+                    "never actually inspected");
+}
+
+/// The truncated basis sums to one; the untruncated one does not.
+void check_the_truncation_is_a_partition_of_unity() {
+    const THBSplineSpace<double> truncated = reference_space(true);
+    const THBSplineSpace<double> plain = reference_space(false);
+
+    // Bound: at most `prod(degree + 1) * num_levels` functions overlap one finest
+    // function, each carrying `gamma_N` of its own value with `N` its chain length.
+    std::int64_t widest = 1;
+    for (std::int64_t dof = 0; dof < truncated.num_total_basis(); ++dof) {
+        const std::optional<pantr::bspline::TruncatedView> view = truncated.truncated(dof);
+        if (view.has_value()) {
+            for (const std::int64_t n : view->shape) {
+                widest = std::max(widest, n);
+            }
+        }
+    }
+    std::int64_t overlapping = truncated.num_levels();
+    for (const std::int64_t degree : truncated.degrees()) {
+        overlapping *= degree + 1;
+    }
+    const double bound = static_cast<double>(overlapping)
+                         * gamma_of((truncated.num_levels() - 1) * truncated.dim() * widest);
+
+    const double defect = partition_of_unity_defect(truncated);
+    PANTR_CHECK_MSG(defect <= bound, "the truncated basis is not a partition of unity: defect "
+                                         + std::to_string(defect) + " against "
+                                         + std::to_string(bound));
+    PANTR_CHECK_MSG(bound < 1.0e-10,
+                    "the vacuity guard: this bound is loose enough to accept a basis that is "
+                    "not a partition of unity at all");
+
+    const double plain_defect = partition_of_unity_defect(plain);
+    PANTR_CHECK_MSG(plain_defect > 0.1,
+                    "the discriminator: the UNtruncated basis summed to within "
+                        + std::to_string(plain_defect)
+                        + " of one, so the identity above cannot tell the two bases apart");
+    PANTR_CHECK_MSG(truncated.num_truncated() > 0,
+                    "this hierarchy truncated nothing, so the identity says nothing about the "
+                    "truncation");
+    PANTR_CHECK_MSG(plain.num_truncated() == 0, "an untruncated space must store no coefficients");
+}
+
+/// Every truncation coefficient is non-negative, which the bound's derivation rests on.
+///
+/// The parity claim's relative form -- `gamma_n * s` rather than `gamma_n * sum|terms|` --
+/// is licensed by there being no cancellation. That is a property of the values, so it is
+/// checked rather than assumed.
+void check_the_coefficients_never_go_negative() {
+    std::int64_t inspected = 0;
+    for (const std::int64_t factor : {2, 3}) {
+        for (const std::int64_t degree : {1, 2, 3}) {
+            const THBSplineSpace<double> space(root_space<double>(2, degree, 4),
+                                               corner_hierarchy(2, 4, factor, 2), true,
+                                               {std::nullopt, std::nullopt});
+            for (std::int64_t dof = 0; dof < space.num_total_basis(); ++dof) {
+                const std::optional<pantr::bspline::TruncatedView> view = space.truncated(dof);
+                if (!view.has_value()) {
+                    continue;
+                }
+                for (const double c : view->coeffs) {
+                    PANTR_CHECK_MSG(c >= 0.0, "a truncation coefficient went negative, so the "
+                                              "parity bound's no-cancellation premise is false");
+                    ++inspected;
+                }
+            }
+        }
+    }
+    PANTR_CHECK_MSG(inspected > 0, "no coefficient was inspected, so this asserts nothing");
+}
+
+/// `level_space(0)` is the handle the space was built from, by address.
+void check_the_root_space_is_shared_not_copied() {
+    const std::shared_ptr<const BsplineSpace<double>> root = root_space<double>(2, 2, 4);
+    const THBSplineSpace<double> space(root, corner_hierarchy(2, 4, 2, 2), true,
+                                       {std::nullopt, std::nullopt});
+    PANTR_CHECK_MSG(space.root_space().get() == root.get(),
+                    "the root space must be shared, not copied");
+    PANTR_CHECK_MSG(space.level_space(0).get() == root.get(),
+                    "level 0 must be the root handle itself: `thb.level_space(0) is "
+                    "thb.root_space` is the oracle's contract");
+    PANTR_CHECK_MSG(space.level_space(1).get() != root.get(),
+                    "and the finer levels must be different objects, or the assertion above "
+                    "would hold for a type returning one space for every level");
+    PANTR_CHECK(&space.root_space_ref() == root.get());
+}
+
+/// A level space read after the owning THB space is destroyed is still valid.
+///
+/// `design/bspline_ownership_lifetime.md` F4: asserted on a **count** the destroyed
+/// space's storage would have been reused for, rather than on the pointer being non-null,
+/// because a scalar read after free returns the right answer often enough that the obvious
+/// version of this test passes on a broken design. Its real gate is the `gcc-debug`
+/// preset's address sanitizer.
+void check_a_level_space_outlives_the_owner() {
+    std::shared_ptr<const BsplineSpace<double>> escapee;
+    std::int64_t expected = 0;
+    {
+        const THBSplineSpace<double> space = reference_space(true);
+        escapee = space.level_space(2);
+        expected = escapee->num_total_basis();
+    }
+    PANTR_CHECK(escapee != nullptr);
+    PANTR_CHECK_MSG(escapee->num_total_basis() == expected,
+                    "a level space handed out must survive its owner's destruction");
+    PANTR_CHECK(expected > 0);
+}
+
+/// Refinement and coarsening never hand their result the receiver's grid.
+///
+/// Two spaces sharing one grid would make a tag set through the first visible through the
+/// second. The no-op paths are where sharing would be the natural implementation, so they
+/// are what is checked.
+void check_the_operations_detach_the_grid() {
+    const THBSplineSpace<double> space = reference_space(true);
+    const std::vector<std::int64_t> nothing;
+
+    const THBSplineSpace<double> refined =
+        space.refine(std::span<const std::int64_t>(nothing), 2);
+    PANTR_CHECK_MSG(refined.grid().get() != space.grid().get(),
+                    "a refinement that refined nothing must still get a grid of its own");
+    const THBSplineSpace<double> coarsened =
+        space.coarsen(std::span<const std::int64_t>(nothing), 2);
+    PANTR_CHECK_MSG(coarsened.grid().get() != space.grid().get(),
+                    "a coarsening that coarsened nothing must still get a grid of its own");
+
+    // The cell decomposition is unchanged either way, which is what makes those two
+    // spaces equivalent rather than merely different objects.
+    PANTR_CHECK(refined.grid()->num_cells() == space.grid()->num_cells());
+    PANTR_CHECK(refined.num_total_basis() == space.num_total_basis());
+    PANTR_CHECK(coarsened.num_total_basis() == space.num_total_basis());
+
+    // The root space, by contrast, IS shared with the result: it is immutable, and
+    // rebuilding it would break the identity contract one level up.
+    PANTR_CHECK(refined.root_space().get() == space.root_space().get());
+}
+
+/// Refining then coarsening the children recovers the original space, ungraded.
+///
+/// The oracle documents this as the exact inverse when the admissibility guard is off,
+/// and it is the one property of the pair that a count alone can state.
+void check_refine_and_coarsen_invert_each_other() {
+    const THBSplineSpace<double> space = reference_space(true);
+
+    // Marked at the CURRENT deepest level, so the refinement opens a level that did not
+    // exist and the cells of that new level are exactly the children it created. Marking
+    // a level-0 cell instead would put the children among cells the reference hierarchy
+    // already had, and "the deepest cells" would then name the wrong set -- which is what
+    // a first version of this test did.
+    const std::int64_t deepest = space.grid()->max_level();
+    std::vector<std::int64_t> mark;
+    for (std::int64_t cid = 0; cid < space.grid()->num_cells(); ++cid) {
+        if (space.grid()->cell_level(cid) == deepest) {
+            mark.push_back(cid);
+            break;
+        }
+    }
+    PANTR_CHECK_MSG(!mark.empty(), "the reference hierarchy has no cell at its own top level");
+
+    const THBSplineSpace<double> refined =
+        space.refine(std::span<const std::int64_t>(mark), std::nullopt);
+    PANTR_CHECK(refined.grid()->max_level() == deepest + 1);
+    PANTR_CHECK(refined.grid()->num_cells() > space.grid()->num_cells());
+
+    std::vector<std::int64_t> children;
+    for (std::int64_t cid = 0; cid < refined.grid()->num_cells(); ++cid) {
+        if (refined.grid()->cell_level(cid) == deepest + 1) {
+            children.push_back(cid);
+        }
+    }
+    const THBSplineSpace<double> back =
+        refined.coarsen(std::span<const std::int64_t>(children), std::nullopt);
+    PANTR_CHECK_MSG(back.grid()->num_cells() == space.grid()->num_cells(),
+                    "an ungraded coarsening of exactly what a refinement created must undo it");
+    PANTR_CHECK(back.num_levels() == space.num_levels());
+    PANTR_CHECK(back.num_total_basis() == space.num_total_basis());
+    if (back.num_levels() != space.num_levels()) {
+        return;
+    }
+    for (std::int64_t level = 0; level < space.num_levels(); ++level) {
+        const std::span<const std::int64_t> before = space.active_function_indices(level);
+        const std::span<const std::int64_t> after = back.active_function_indices(level);
+        PANTR_CHECK(before.size() == after.size());
+        PANTR_CHECK(before.size() == after.size()
+                    && std::equal(before.begin(), before.end(), after.begin()));
+    }
+}
+
+/// A `float` root space over the `double` grid, which is the oracle's shipped pairing.
+void check_float_storage() {
+    const THBSplineSpace<float> space(root_space<float>(2, 2, 4), corner_hierarchy(2, 4, 2, 2),
+                                      true, {std::nullopt, std::nullopt});
+    PANTR_CHECK(space.dim() == 2);
+    PANTR_CHECK(space.num_levels() == 3);
+    PANTR_CHECK(space.num_total_basis() > 0);
+    PANTR_CHECK(space.num_truncated() > 0);
+    // The coefficients are `double` whatever the root space stores, which is the oracle's
+    // shape: `_build_oslo_matrices` widens the kernel's output before anything uses it.
+    static_assert(
+        std::is_same_v<
+            std::remove_cvref_t<decltype(*space.truncated(0)->coeffs.begin())>, const double>
+            || std::is_same_v<std::remove_cvref_t<decltype(space.truncated(0)->coeffs)>,
+                              std::span<const double>>,
+        "a truncation coefficient is a double at every storage width");
+    // The domain is the root space's own storage, so it is `float` here.
+    PANTR_CHECK(space.domain().size() == 4);
+    PANTR_CHECK(static_cast<double>(space.domain()[0]) == 0.0);
+}
+
+/// What the constructor refuses, and with which message.
+void check_refusals() {
+    const std::shared_ptr<const BsplineSpace<double>> root = root_space<double>(2, 2, 4);
+    const std::shared_ptr<HierarchicalGrid<double>> grid = corner_hierarchy(2, 4, 2, 1);
+
+    bool threw = false;
+    try {
+        static_cast<void>(THBSplineSpace<double>(nullptr, grid, true, {std::nullopt}));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()) == "root_space must not be null.";
+    }
+    PANTR_CHECK_MSG(threw, "a null root space must be refused");
+
+    threw = false;
+    try {
+        static_cast<void>(THBSplineSpace<double>(root, nullptr, true, {std::nullopt}));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()) == "grid must not be null.";
+    }
+    PANTR_CHECK_MSG(threw, "a null grid must be refused");
+
+    threw = false;
+    try {
+        static_cast<void>(THBSplineSpace<double>(root, corner_hierarchy(1, 4, 2, 1), true,
+                                                 {std::nullopt, std::nullopt}));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()) == "grid.ndim (1) must equal root_space.dim (2).";
+    }
+    PANTR_CHECK_MSG(threw, "a dimension mismatch must be refused with the oracle's message");
+
+    threw = false;
+    try {
+        static_cast<void>(THBSplineSpace<double>(root, corner_hierarchy(2, 5, 2, 1), true,
+                                                 {std::nullopt, std::nullopt}));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what())
+                == "grid root cells_per_axis (5, 5) must match root_space.num_intervals (4, 4).";
+    }
+    PANTR_CHECK_MSG(threw, "a root knot-span mismatch must be refused, naming both tuples");
+
+    threw = false;
+    try {
+        static_cast<void>(THBSplineSpace<double>(root, grid, true, {std::nullopt}));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what())
+                == "regularity must be a scalar or length-2 sequence; got length 1.";
+    }
+    PANTR_CHECK_MSG(threw, "a mis-shaped regularity must be refused");
+
+    threw = false;
+    try {
+        static_cast<void>(THBSplineSpace<double>(root, grid, true, {2, std::nullopt}));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what())
+                == "regularity[0]=2 must be in [-1, degree[0]-1=1]; got 2.";
+    }
+    PANTR_CHECK_MSG(threw, "a regularity at or above the degree must be refused");
+
+    const THBSplineSpace<double> space = reference_space(true);
+    threw = false;
+    try {
+        static_cast<void>(space.level_space(space.num_levels()));
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a level past the top must be refused");
+
+    threw = false;
+    try {
+        static_cast<void>(space.contributions(space.grid_ref().num_cells()));
+    } catch (const std::out_of_range&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a cell id past the end must be refused");
+
+    threw = false;
+    try {
+        static_cast<void>(space.truncated(space.num_total_basis()));
+    } catch (const std::out_of_range&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a dof past the end must be refused");
+
+    threw = false;
+    const std::vector<std::int64_t> nothing;
+    try {
+        static_cast<void>(space.refine(std::span<const std::int64_t>(nothing), 1));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what())
+                == "admissible_class must be an integer >= 2 or None; got 1.";
+    }
+    PANTR_CHECK_MSG(threw, "an admissibility class below the definition's minimum must be "
+                           "refused with the oracle's message");
+}
+
+/// A factor of 1 on one axis leaves that direction alone at every level.
+///
+/// `HierarchicalGrid` admits it and the oracle's `_build_level_spaces` skips the axis
+/// rather than subdividing it, so the level spaces share that direction's 1D space.
+void check_an_unrefined_direction() {
+    const auto root = root_space<double>(2, 2, 4);
+    const std::vector<double> axis = {0.0, 0.25, 0.5, 0.75, 1.0};
+    const std::vector<std::vector<double>> breakpoints(2, axis);
+    const std::vector<std::int64_t> factors = {2, 1};
+    auto grid = std::make_shared<HierarchicalGrid<double>>(
+        TensorProductGrid<double>(breakpoints), std::span<const std::int64_t>(factors));
+    const std::vector<std::int64_t> lo = {0, 0};
+    const std::vector<std::int64_t> hi = {2, 2};
+    grid = std::make_shared<HierarchicalGrid<double>>(
+        grid->refine(0, std::span<const std::int64_t>(lo), std::span<const std::int64_t>(hi)));
+
+    const THBSplineSpace<double> space(root, grid, true, {std::nullopt, std::nullopt});
+    PANTR_CHECK(space.num_levels() == 2);
+    PANTR_CHECK_MSG(space.level_space_ref(1).space(1).get()
+                        == space.level_space_ref(0).space(1).get(),
+                    "an axis whose factor is 1 must keep the same 1D space at every level");
+    PANTR_CHECK_MSG(space.level_space_ref(1).space(0).get()
+                        != space.level_space_ref(0).space(0).get(),
+                    "and the refined axis must not");
+    PANTR_CHECK(space.level_space_ref(1).space_ref(0).num_intervals() == 8);
+    PANTR_CHECK(space.level_space_ref(1).space_ref(1).num_intervals() == 4);
+}
+
+/// Copying a space leaves the copy's contribution table cold, and correct.
+///
+/// `pantr::LazySlot` starts cold on copy on purpose: the memo is a function of its
+/// owner's state, and one that travelled would have to be proved still to describe the
+/// target.
+void check_copy_leaves_the_memo_cold() {
+    const THBSplineSpace<double> space = reference_space(true);
+    const std::int64_t expected = space.max_active_per_cell();
+
+    const THBSplineSpace<double> copy = space;  // NOLINT(performance-unnecessary-copy-initialization)
+    PANTR_CHECK(copy.max_active_per_cell() == expected);
+    PANTR_CHECK(copy.num_total_basis() == space.num_total_basis());
+    // The copy shares the nested handles, which is what makes it cheap and what the
+    // immutability of both makes safe.
+    PANTR_CHECK(copy.root_space().get() == space.root_space().get());
+    PANTR_CHECK(copy.grid().get() == space.grid().get());
+}
+
+/// Every accessor is safe to call concurrently, the lazy table included.
+///
+/// The only gate that can see a broken memo is a ThreadSanitizer build:
+/// `design/bspline_derived_caches.md` F3 measured 60 correct answers in 60 unsanitized
+/// runs from a shape that TSan reported four races in. So this asserts values *and* is
+/// meant to be run under `--preset gcc-tsan`.
+void check_concurrent_reads() {
+    const THBSplineSpace<double> space = reference_space(true);
+    constexpr int num_threads = 8;
+    std::atomic<bool> go{false};
+    std::vector<std::int64_t> widths(num_threads, -1);
+    std::vector<std::int64_t> totals(num_threads, -1);
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([&, t]() {
+            while (!go.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            std::int64_t sum = 0;
+            for (std::int64_t cid = 0; cid < space.grid_ref().num_cells(); ++cid) {
+                sum += static_cast<std::int64_t>(space.active_basis(cid).size());
+            }
+            widths[static_cast<std::size_t>(t)] = space.max_active_per_cell();
+            totals[static_cast<std::size_t>(t)] = sum;
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+    for (int t = 0; t < num_threads; ++t) {
+        const auto i = static_cast<std::size_t>(t);
+        PANTR_CHECK_MSG(widths[i] == widths[0], "every thread must read one table");
+        PANTR_CHECK_MSG(totals[i] == totals[0], "and one set of contribution lists");
+    }
+    PANTR_CHECK_MSG(totals[0] > 0, "the vacuity guard: the table was empty, so the threads "
+                                   "contended over nothing");
+}
+
+}  // namespace
+
+int main() {
+    check_the_reference_space();
+    check_dof_levels_partition_the_basis();
+    check_the_contribution_table();
+    check_the_truncation_is_a_partition_of_unity();
+    check_the_coefficients_never_go_negative();
+    check_the_root_space_is_shared_not_copied();
+    check_a_level_space_outlives_the_owner();
+    check_the_operations_detach_the_grid();
+    check_refine_and_coarsen_invert_each_other();
+    check_float_storage();
+    check_refusals();
+    check_an_unrefined_direction();
+    check_copy_leaves_the_memo_cold();
+    check_concurrent_reads();
+    return pantr::test::summary("test_thb_space");
+}

--- a/cpp/tests/test_thb_space.cpp
+++ b/cpp/tests/test_thb_space.cpp
@@ -776,6 +776,40 @@ void check_an_unrefined_direction() {
     PANTR_CHECK(space.level_space_ref(1).space_ref(1).num_intervals() == 4);
 }
 
+/// A dimensionless space cannot be built, which is what the `d == 0` branches rest on.
+///
+/// Several odometers in `thb_space.hpp` carry a `d == 0` arm so that a dimensionless
+/// space would have exactly one combination -- the empty multi-index, matching what
+/// `itertools.product()` gives the oracle. Those arms cannot be reached and cannot be
+/// covered: a `THBSplineSpace` needs a `HierarchicalGrid`, which needs a
+/// `TensorProductGrid`, which refuses zero axes. **That refusal is the whole argument**,
+/// and it is asserted here rather than assumed, in the file that depends on it: if it
+/// ever softens, the arms stop being defensive and this check says so first.
+void check_a_dimensionless_grid_is_refused() {
+    bool threw = false;
+    try {
+        static_cast<void>(TensorProductGrid<double>(std::vector<std::vector<double>>{}));
+    } catch (const std::invalid_argument& e) {
+        threw = std::string(e.what()) == "TensorProductGrid needs at least one axis; got 0.";
+    }
+    PANTR_CHECK_MSG(threw, "a grid with no axes must be refused, with that message");
+
+    // And the space's own dimension is the grid's, so nothing else can reintroduce zero:
+    // the root space is free to have no directions, and the constructor refuses the
+    // mismatch rather than adopting it.
+    const auto no_directions = std::make_shared<const BsplineSpace<double>>(
+        std::vector<std::shared_ptr<const BsplineSpace1D<double>>>{});
+    const std::shared_ptr<HierarchicalGrid<double>> grid = corner_hierarchy(2, 4, 2, 1);
+    threw = false;
+    try {
+        static_cast<void>(THBSplineSpace<double>(no_directions, grid, true, {std::nullopt}));
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a root space with no directions over a 2D grid must be refused");
+}
+
+
 /// Copying a space leaves the copy's contribution table cold, and correct.
 ///
 /// `pantr::LazySlot` starts cold on copy on purpose: the memo is a function of its
@@ -851,6 +885,7 @@ int main() {
     check_float_storage();
     check_refusals();
     check_an_unrefined_direction();
+    check_a_dimensionless_grid_is_refused();
     check_copy_leaves_the_memo_cold();
     check_concurrent_reads();
     return pantr::test::summary("test_thb_space");

--- a/scripts/measure_thb_contribution_table.py
+++ b/scripts/measure_thb_contribution_table.py
@@ -1,0 +1,229 @@
+"""Measure the footprint of the THB contribution table the C++ port fills eagerly.
+
+``design/bspline_derived_caches.md`` rules that ``THBSplineSpace._contrib_cache`` --
+today a ``dict[int, list[tuple]]`` filled one cell at a time -- becomes **one flat CSR
+table filled for every cell behind a single double-checked flag**, and it makes that
+ruling contingent:
+
+    #397 owes a footprint measurement on a realistic adaptive hierarchy before it
+    commits, because a lazy-all-cells fill trades memory for the dict's incrementality;
+    the fallback if it is too large is per-level rather than per-cell granularity, not a
+    return to per-cell.
+
+This script is that measurement. It answers two questions.
+
+**How large is the flat table, in bytes, on a hierarchy of realistic size?** The table is
+``num_cells + 1`` offsets plus, per entry, one global dof, one level and ``dim``
+function indices, all ``int64``:
+
+    bytes = 8 * (num_cells + 1) + 8 * (2 + dim) * num_entries
+
+There is nothing to measure in that formula; what has to be measured is
+``num_entries``, which is the sum over cells of how many active functions each one
+carries and is a property of the hierarchy rather than of the implementation.
+
+**How does it compare with what the oracle's dict costs once every cell has been
+touched?** That is the honest comparison, because ``max_active_per_cell()`` already
+forces every cell in both implementations -- and any consumer that assembles over the
+mesh touches them all too. The dict's cost is measured rather than derived: a Python
+``int``, ``tuple`` and ``list`` each carry a header, and reasoning about them from
+memory is how a factor of two gets lost. ``_deep_size`` walks the structure with
+``sys.getsizeof``, counting each object once.
+
+The cases below are adaptive rather than uniform: a corner refinement chain and a
+diagonal band, in 2D and 3D, at the degrees this library is actually used at. A uniformly
+refined hierarchy would be the easy case for both representations and would say nothing
+about the one the ruling is about.
+
+Run:
+    python scripts/measure_thb_contribution_table.py
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Final, NamedTuple
+
+import numpy as np
+
+from pantr.bspline import BsplineSpace, BsplineSpace1D, THBSplineSpace
+from pantr.grid import hierarchical_grid, uniform_grid
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+_INT64_BYTES: Final = 8
+"""Width of every field of the flat table. It is `int64` throughout, as the C++ is."""
+
+
+class _Footprint(NamedTuple):
+    """What one hierarchy costs in each representation.
+
+    Attributes:
+        label (str): What was built.
+        dim (int): Parametric dimension.
+        num_cells (int): Active cells in the hierarchy.
+        num_entries (int): Total contribution entries over every cell.
+        widest (int): The largest per-cell count, which is `max_active_per_cell`.
+        flat_bytes (int): The C++ table's size, from the formula in the module docstring.
+        dict_bytes (int): The oracle's fully populated dict, measured.
+    """
+
+    label: str
+    dim: int
+    num_cells: int
+    num_entries: int
+    widest: int
+    flat_bytes: int
+    dict_bytes: int
+
+
+def _deep_size(obj: object, seen: set[int] | None = None) -> int:
+    """The transitive size of a Python object, counting each object once.
+
+    ``sys.getsizeof`` reports one object's own storage and not what it refers to, so a
+    dict of lists of tuples reports as a dict of pointers. Walking it is what makes the
+    comparison honest. Identity-keyed, because small integers and the level values repeat
+    heavily and counting them once each is what the interpreter actually pays.
+
+    Args:
+        obj (object): The object to size.
+        seen (set[int] | None): Object ids already counted, for the recursion.
+
+    Returns:
+        int: Bytes, transitively.
+    """
+    if seen is None:
+        seen = set()
+    if id(obj) in seen:
+        return 0
+    seen.add(id(obj))
+    total = sys.getsizeof(obj)
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            total += _deep_size(key, seen) + _deep_size(value, seen)
+    elif isinstance(obj, list | tuple | set | frozenset):
+        for item in obj:
+            total += _deep_size(item, seen)
+    return total
+
+
+def _open_knots(degree: int, num_elements: int) -> npt.NDArray[np.float64]:
+    """A clamped uniform knot vector on the unit interval.
+
+    Args:
+        degree (int): Polynomial degree.
+        num_elements (int): Number of equal spans.
+
+    Returns:
+        npt.NDArray[np.float64]: The knot vector.
+    """
+    inner = np.linspace(0.0, 1.0, num_elements + 1)
+    return np.concatenate([np.zeros(degree), inner, np.ones(degree)])
+
+
+def _corner_chain(dim: int, degree: int, num_elements: int, levels: int) -> THBSplineSpace:
+    """A hierarchy refined repeatedly into one corner.
+
+    The shape an adaptive solver produces around a re-entrant corner, and the one where
+    the per-level function counts are most uneven.
+
+    Args:
+        dim (int): Parametric dimension.
+        degree (int): Polynomial degree, the same in every direction.
+        num_elements (int): Root elements per direction.
+        levels (int): How many successive corner refinements to apply.
+
+    Returns:
+        THBSplineSpace: The space.
+    """
+    direction = BsplineSpace1D(_open_knots(degree, num_elements), degree)
+    root = BsplineSpace([direction] * dim)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, [num_elements] * dim), 2)
+    extent = num_elements
+    for level in range(levels):
+        half = max(1, extent // 2)
+        grid = grid.refine(level, [0] * dim, [half] * dim)
+        extent = half * 2
+    return THBSplineSpace(root, grid)
+
+
+def _diagonal_band(dim: int, degree: int, num_elements: int) -> THBSplineSpace:
+    """A hierarchy refined along the diagonal, cell by cell.
+
+    A band rather than a box, so the active set is not a single rectangle and the
+    grid's block partition is genuinely fragmented -- which is the case where a
+    per-cell dict looks best relative to a flat table.
+
+    Args:
+        dim (int): Parametric dimension.
+        degree (int): Polynomial degree, the same in every direction.
+        num_elements (int): Root elements per direction.
+
+    Returns:
+        THBSplineSpace: The space.
+    """
+    direction = BsplineSpace1D(_open_knots(degree, num_elements), degree)
+    root = BsplineSpace([direction] * dim)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, [num_elements] * dim), 2)
+    for index in range(num_elements):
+        grid = grid.refine(0, [index] * dim, [index + 1] * dim)
+    return THBSplineSpace(root, grid)
+
+
+def _measure(label: str, space: THBSplineSpace) -> _Footprint:
+    """Fill both representations for one space and size them.
+
+    Args:
+        label (str): What was built.
+        space (THBSplineSpace): The space to measure.
+
+    Returns:
+        _Footprint: The two sizes and the counts behind them.
+    """
+    widest = space.max_active_per_cell()  # forces every cell in both implementations
+    cache = space._contrib_cache
+    entries = sum(len(contributions) for contributions in cache.values())
+    dim = space.dim
+    flat = _INT64_BYTES * (space.grid.num_cells + 1) + _INT64_BYTES * (2 + dim) * entries
+    return _Footprint(
+        label=label,
+        dim=dim,
+        num_cells=space.grid.num_cells,
+        num_entries=entries,
+        widest=widest,
+        flat_bytes=flat,
+        dict_bytes=_deep_size(cache),
+    )
+
+
+def main() -> None:
+    """Measure every case and print the table."""
+    cases = [
+        ("2D deg 2, 32 root elements, 4 corner levels", _corner_chain(2, 2, 32, 4)),
+        ("2D deg 3, 64 root elements, 5 corner levels", _corner_chain(2, 3, 64, 5)),
+        ("2D deg 2, 32 root elements, diagonal band", _diagonal_band(2, 2, 32)),
+        ("3D deg 2, 8 root elements, 3 corner levels", _corner_chain(3, 2, 8, 3)),
+        ("3D deg 3, 12 root elements, 3 corner levels", _corner_chain(3, 3, 12, 3)),
+    ]
+    print(
+        f"{'case':46s} {'cells':>7s} {'entries':>9s} {'widest':>7s} "
+        f"{'flat kB':>9s} {'dict kB':>9s} {'ratio':>6s}"
+    )
+    for label, space in cases:
+        report = _measure(label, space)
+        print(
+            f"{report.label:46s} {report.num_cells:7d} {report.num_entries:9d} "
+            f"{report.widest:7d} {report.flat_bytes / 1024:9.1f} "
+            f"{report.dict_bytes / 1024:9.1f} "
+            f"{report.dict_bytes / report.flat_bytes:6.1f}x"
+        )
+    print()
+    print(
+        "flat bytes = 8 * (cells + 1) + 8 * (2 + dim) * entries; dict bytes measured "
+        "with sys.getsizeof, transitively, counting each object once."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parity/test_bspline_binding_contract.py
+++ b/tests/parity/test_bspline_binding_contract.py
@@ -452,6 +452,121 @@ def test_the_tensor_product_refuses_a_direction_of_the_wrong_width(
         cls([direction])
 
 
+def _cpp_thb_space() -> Any:
+    """Build a two-level, two-dimensional THB space handle under the C++ backend.
+
+    Cut 1 of FELIGN/pantr#397 ships no Python wrapper, so this builds the handle
+    through the bindings the way ``tests/parity/test_thb_spline_space.py`` does. A
+    real refinement rather than a flat hierarchy, so the level-dependent accessors
+    have more than one level to hand out.
+
+    Returns:
+        Any: A ``THBSplineSpace64`` handle over a corner-refined unit square.
+    """
+    cpp = _bindings()
+    knots = np.asarray([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0], dtype=np.float64)
+    directions = [cpp.BsplineSpace1D64(knots, 2, False, True) for _ in range(2)]
+    breakpoints = [np.linspace(0.0, 1.0, 5) for _ in range(2)]
+    grid = cpp.HierarchicalGrid(
+        cpp.TensorProductGrid(breakpoints), np.asarray([2, 2], dtype=np.int64)
+    )
+    grid = grid.refine(0, np.asarray([0, 0], dtype=np.int64), np.asarray([2, 2], dtype=np.int64))
+    return cpp.THBSplineSpace64(cpp.BsplineSpace64(directions), grid, True, [None, None])
+
+
+def _thb_array_accessors(space: Any) -> dict[str, np.ndarray[Any, Any]]:
+    """Every array the hierarchical space hands out, by name.
+
+    The per-level and per-cell accessors are sampled at a level and a cell that are
+    both non-trivial: level 1 exists only because the space was refined, and cell 0 of
+    a corner refinement carries functions from both levels.
+
+    Args:
+        space (Any): The ``THBSplineSpace64`` handle to read.
+
+    Returns:
+        dict[str, np.ndarray]: One entry per array accessor, so a test can assert a
+        property of all of them and name the one that failed.
+    """
+    # The vacuity guard, in the helper so all three tests inherit it: `shares_memory` on
+    # two empty arrays is False on some builds and True on others, and a read-only
+    # assertion over an empty array asserts nothing at all. A case flattened by a future
+    # edit would make every test below pass for the wrong reason.
+    assert space.num_levels > 1, "the case stopped being hierarchical"
+    assert space.num_truncated > 0, "the case stopped truncating, so no accessor is stressed"
+
+    dof, level, multi = space.contributions(0)
+    accessors = {
+        "domain": space.domain,
+        "level_offsets": space.level_offsets,
+        "active_function_indices(0)": space.active_function_indices(0),
+        "active_function_indices(1)": space.active_function_indices(1),
+        "active_basis(0)": space.active_basis(0),
+        "contributions(0).dof": dof,
+        "contributions(0).level": level,
+        "contributions(0).multi": multi,
+    }
+    empty = [name for name, array in accessors.items() if array.size == 0]
+    assert not empty, f"these accessors came back empty, so nothing below tests them: {empty}"
+    return accessors
+
+
+def test_every_array_the_hierarchical_space_hands_out_is_read_only(cpp_backend: None) -> None:
+    """The rule the univariate and tensor-product types already carry, for this one too.
+
+    The reviewer of FELIGN/pantr#438 found the hierarchical type getting only the
+    borrowed-accessor check while the three properties this file exists for went
+    unasserted on it. The implementation was correct; nothing said so, and nothing
+    would have said otherwise -- the parity suite compares values, and a copy or a
+    writeable view agrees on every value it hands back.
+    """
+    space = _cpp_thb_space()
+    for name, array in _thb_array_accessors(space).items():
+        assert not array.flags.writeable, f"{name} came back writeable"
+        with pytest.raises(ValueError):
+            array.reshape(-1)[0] = 0
+
+
+def test_every_hierarchical_array_is_a_view_rather_than_a_copy(cpp_backend: None) -> None:
+    """Two reads of one accessor view one buffer, for the hierarchical type as well.
+
+    ``shares_memory`` is what distinguishes a view from a copy; the values agree
+    either way, which is why no assertion on them can stand in for this.
+    """
+    space = _cpp_thb_space()
+    first = _thb_array_accessors(space)
+    second = _thb_array_accessors(space)
+    for name in first:
+        assert np.shares_memory(first[name], second[name]), f"{name} was copied out"
+
+
+def test_a_hierarchical_array_outlives_the_space_it_came_from(cpp_backend: None) -> None:
+    """Each array keeps its owner alive, so dropping the space does not free the storage.
+
+    The refcount half is the one that bites, for the reason
+    :func:`test_an_array_outlives_the_space_it_came_from` gives: a use-after-free here
+    would usually read back the correct value. Every accessor is checked rather than
+    one, because the keep-alive is installed per binding and an omission on one of
+    eight is exactly the shape this would miss.
+    """
+    space = _cpp_thb_space()
+    for name in _thb_array_accessors(space):
+        before = sys.getrefcount(space)
+        taken = _thb_array_accessors(space)[name]
+        assert sys.getrefcount(space) > before, (
+            f"{name} did not reference its owner, so nothing keeps the storage alive "
+            f"once the space is dropped"
+        )
+        del taken
+
+    expected = {name: np.array(a) for name, a in _thb_array_accessors(space).items()}
+    kept = _thb_array_accessors(space)
+    del space
+    gc.collect()
+    for name, array in kept.items():
+        np.testing.assert_array_equal(array, expected[name])
+
+
 def test_a_space_has_no_instance_dictionary() -> None:
     """The wrapper is immutable, and ``__slots__`` is what makes that true.
 

--- a/tests/parity/test_bspline_binding_contract.py
+++ b/tests/parity/test_bspline_binding_contract.py
@@ -256,6 +256,9 @@ def test_no_bound_method_is_a_borrowing_accessor(cpp_backend: None) -> None:
         "be reporting this class's methods at all"
     )
     assert "spaces" in dir(bindings.BsplineSpace64)
+    # And the same for the hierarchical class, which carries three of these.
+    assert "root_space" in dir(bindings.THBSplineSpace64)
+    assert "level_space" in dir(bindings.THBSplineSpace64)
 
 
 _SPACE_CLASSES = (
@@ -263,8 +266,16 @@ _SPACE_CLASSES = (
     "BsplineSpace1D64",
     "BsplineSpace32",
     "BsplineSpace64",
+    "THBSplineSpace32",
+    "THBSplineSpace64",
 )
-"""Every space class the extension registers, for the rules asserted over all of them."""
+"""Every space class the extension registers, for the rules asserted over all of them.
+
+The two hierarchical classes are what make the ``_ref`` rule bite hardest: they have
+three borrowing accessors -- ``root_space_ref``, ``grid_ref`` and ``level_space_ref`` --
+against the tensor-product type's one, and each hands out a reference to a nested
+object rather than a span of the owner's own storage.
+"""
 
 
 def _cpp_tensor_product() -> BsplineSpace:

--- a/tests/parity/test_thb_spline_space.py
+++ b/tests/parity/test_thb_spline_space.py
@@ -21,10 +21,9 @@ bulk.
 active function index sets, ``level_offsets``, ``dof_level``, the per-cell ``active_basis``
 lists, the contribution table's levels and multi-indices, ``max_active_per_cell``, the set
 of truncated dofs, and each truncated function's representation level, box origin and box
-shape. Every one is an index, a count or a set membership: ``design/backend_parity.md``'s
-determinism rule licenses bit-identity only where finite precision does not bite, and that
-is exactly this list. A bounded comparison could not even see two answers of different
-length.
+shape. Every one is an index, a count or a set membership, so no rounding takes place and
+bit-identity is the only criterion that says anything. A bounded comparison could not even
+see two answers of different length.
 
 **Within a derived bound** -- the truncation coefficients, and *only* those. They are
 floating point, and bit-identity is not available for them: the oracle's ``_refine_box``
@@ -36,8 +35,8 @@ the bits would forbid a transformation nobody should be forbidding.
 
 Observed rather than required: most coefficients do come out bit-identical, and
 :class:`_SweepReport` counts how many so a reader can see the figure for the run in front
-of them rather than a stale one written here. That is welcome and is not the criterion,
-for the reason the determinism rule gives.
+of them rather than a stale one written here. That is welcome and is not the criterion:
+requiring it would forbid the summation-order difference the paragraph above allows.
 
 The bound, and why it has no cancellation term
 -----------------------------------------------
@@ -143,10 +142,9 @@ _U: Final = unit_roundoff(np.float64)
 
 _VERDICT_WHY: Final = (
     "counts, level indices, flat function indices, global dofs, multi-indices and box "
-    "origins are verdicts rather than displaced values; design/backend_parity.md's "
-    "determinism rule admits bit-identity only where finite precision does not bite, "
-    "and integers and indices are exactly that case. A bounded comparison could not "
-    "see two answers of different length at all"
+    "origins are verdicts rather than displaced values; no rounding takes place on an "
+    "integer, so bit-identity is the only criterion available here. A bounded comparison "
+    "could not see two answers of different length at all"
 )
 
 _COEFFICIENT_WHY: Final = (

--- a/tests/parity/test_thb_spline_space.py
+++ b/tests/parity/test_thb_spline_space.py
@@ -459,11 +459,13 @@ def _partition_of_unity_defect(space: Any, oracle: THBSplineSpace) -> float:
     return float(np.abs(total - 1.0).max())
 
 
-def _compare(case: _Case) -> tuple[int, int, float]:
+def _compare(case: _Case, variant: int = 0) -> tuple[int, int, float]:
     """Compare both backends' spaces for one case, quantity by quantity.
 
     Args:
         case (_Case): The hierarchy to build under both.
+        variant (int): Which rebuilding operation to compare on this case; see
+            :func:`_compare_the_operations` for why it is one rather than all four.
 
     Returns:
         tuple[int, int, float]: How many truncation coefficients were compared, how many
@@ -575,18 +577,25 @@ def _compare(case: _Case) -> tuple[int, int, float]:
         )
         worst = max(worst, observed["coefficients"].max_ratio_to_bound)
 
-    _compare_the_operations(py, cpp, context)
+    _compare_the_operations(py, cpp, context, variant)
     return compared, identical, worst
 
 
-def _compare_the_operations(py: THBSplineSpace, cpp: Any, context: str) -> None:
-    """Compare one refinement and one coarsening of an already-compared pair.
+def _compare_the_operations(py: THBSplineSpace, cpp: Any, context: str, variant: int) -> None:
+    """Compare one rebuilding operation of an already-compared pair.
 
-    Both are rebuilds: each returns a new space over a new grid, so what is compared is
-    the space that comes back. Folded into the sweep rather than pinned to one fixture
-    because the ordering hazards here are the ones a fixture does not reach --
+    Both sides rebuild: the operation returns a new space over a new grid, so what is
+    compared is the space that comes back. Folded into the sweep rather than pinned to one
+    fixture because the ordering hazards here are the ones a fixture does not reach --
     FELIGN/pantr#395's own port carried a defect in ``coarsen_cells``' demotion order
     that first appeared at case 3553 of a 4000-case sweep and was invisible at 400.
+
+    **One of the four variants per case, rotating, rather than all four.** Constructing a
+    space is by far the most expensive thing this sweep does, so comparing all four
+    quadruples its cost for coverage a rotation buys at a quarter of the price: every
+    variant still gets a quarter of the cases, which at the wide width is hundreds each.
+    Measured: all four put the wide sweep at three times the next slowest test in
+    ``tests/parity``, and the C++ CI job runs it twice.
 
     The marked set is derived from the space rather than drawn again, so a failure is
     reproducible from the case alone: the first cell of each level for the refinement, and
@@ -604,49 +613,46 @@ def _compare_the_operations(py: THBSplineSpace, cpp: Any, context: str) -> None:
         py (THBSplineSpace): The oracle's space.
         cpp (Any): The C++ handle for the same hierarchy.
         context (str): What is being compared, quoted in every failure message.
+        variant (int): Selects the operation, modulo four.
 
     Raises:
         AssertionError: If any rebuilt quantity disagrees.
     """
     seen: set[int] = set()
-    marked = []
+    one_per_level: list[int] = []
     for cid in range(py.grid.num_cells):
         level = py.grid.cell_level(cid)
         if level not in seen:
             seen.add(level)
-            marked.append(cid)
-    deepest = np.array(
-        [cid for cid in range(py.grid.num_cells) if py.grid.cell_level(cid) >= 1],
-        dtype=np.int64,
-    )
-    ids = np.array(marked, dtype=np.int64)
+            one_per_level.append(cid)
+    # Every cell above level 0 for the coarsening, not only the deepest: see the note
+    # in the docstring on what a single-level marked set cannot see.
+    above_the_root = [cid for cid in range(py.grid.num_cells) if py.grid.cell_level(cid) >= 1]
+
+    coarsening = variant % 4 >= 2
+    admissible: int | None = 2 if variant % 2 == 0 else None
+    marked = np.array(above_the_root if coarsening else one_per_level, dtype=np.int64)
+    kind = "coarsen" if coarsening else "refine"
+    where = f"{context}: {kind}({'graded' if admissible is not None else 'ungraded'})"
 
     with _the_oracle():
-        rebuilt = (
-            ("refine(graded)", py.refine(ids, admissible_class=2), cpp.refine(ids, 2)),
-            ("refine(ungraded)", py.refine(ids, admissible_class=None), cpp.refine(ids, None)),
-            ("coarsen(graded)", py.coarsen(deepest, admissible_class=2), cpp.coarsen(deepest, 2)),
-            (
-                "coarsen(ungraded)",
-                py.coarsen(deepest, admissible_class=None),
-                cpp.coarsen(deepest, None),
-            ),
+        expected = (
+            py.coarsen(marked, admissible_class=admissible)
+            if coarsening
+            else py.refine(marked, admissible_class=admissible)
         )
+    actual = cpp.coarsen(marked, admissible) if coarsening else cpp.refine(marked, admissible)
 
-    for name, expected, actual in rebuilt:
-        where = f"{context}: {name}"
-        assert expected.num_levels == actual.num_levels, f"{where}: num_levels disagrees"
-        assert expected.grid.num_cells == actual.grid.num_cells, (
-            f"{where}: the rebuilt grid has a different cell count"
-        )
-        assert expected.num_total_basis == actual.num_total_basis, (
-            f"{where}: num_total_basis disagrees"
-        )
-        for level in range(expected.num_levels):
-            assert np.array_equal(
-                expected.active_function_indices(level),
-                np.asarray(actual.active_function_indices(level)),
-            ), f"{where}: the level-{level} active set disagrees"
+    assert expected.num_levels == actual.num_levels, f"{where}: num_levels disagrees"
+    assert expected.grid.num_cells == actual.grid.num_cells, (
+        f"{where}: the rebuilt grid has a different cell count"
+    )
+    assert expected.num_total_basis == actual.num_total_basis, f"{where}: num_total_basis disagrees"
+    for level in range(expected.num_levels):
+        assert np.array_equal(
+            expected.active_function_indices(level),
+            np.asarray(actual.active_function_indices(level)),
+        ), f"{where}: the level-{level} active set disagrees"
 
 
 def _draw_case(rng: np.random.Generator) -> _Case | None:
@@ -732,7 +738,7 @@ def _sweep(cases: int, seed: int) -> _SweepReport:
         case = _draw_case(rng)
         if case is None:
             continue
-        case_compared, case_identical, case_worst = _compare(case)
+        case_compared, case_identical, case_worst = _compare(case, variant=ran)
         ran += 1
         compared += case_compared
         identical += case_identical

--- a/tests/parity/test_thb_spline_space.py
+++ b/tests/parity/test_thb_spline_space.py
@@ -1,0 +1,975 @@
+"""Parity of the C++ ``THBSplineSpace`` against the Python oracle it was ported from.
+
+Covers the *construction and query* half of FELIGN/pantr#397: the per-level spaces, the
+Kraft selection, the truncation coefficients, the per-cell contribution table, and
+refinement and coarsening. Basis tabulation, the windowed restriction and the
+prolongation operators are not ported yet and are not compared here.
+
+The C++ side is reached through :mod:`pantr._pantr_cpp` directly rather than through
+``pantr.bspline.THBSplineSpace``, because that class is still pure Python: this cut lands
+the C++ type and its binding, and the wrapper that dispatches to it is the next one. So
+there is no ``__reduce__`` round trip in this file either -- nothing here is picklable
+yet, and the round trip is owed by the cut that introduces the wrapper.
+
+What agrees, quantity by quantity
+---------------------------------
+
+The split is per quantity with an argument for each, and it is not one decision applied in
+bulk.
+
+**Exactly** -- ``num_levels``, ``num_total_basis``, ``num_basis_per_level``, the per-level
+active function index sets, ``level_offsets``, ``dof_level``, the per-cell ``active_basis``
+lists, the contribution table's levels and multi-indices, ``max_active_per_cell``, the set
+of truncated dofs, and each truncated function's representation level, box origin and box
+shape. Every one is an index, a count or a set membership: ``design/backend_parity.md``'s
+determinism rule licenses bit-identity only where finite precision does not bite, and that
+is exactly this list. A bounded comparison could not even see two answers of different
+length.
+
+**Within a derived bound** -- the truncation coefficients, and *only* those. They are
+floating point, and bit-identity is not available for them: the oracle's ``_refine_box``
+contracts through :func:`numpy.tensordot`, which reshapes and calls BLAS, whose summation
+order is the implementation's -- ``CLAUDE.md`` records that a quantity round-off dominates
+can differ between Accelerate and OpenBLAS by orders of magnitude. The C++ side sums in
+index order. So the two run different summation orders on the same terms, and requiring
+the bits would forbid a transformation nobody should be forbidding.
+
+Observed rather than required: most coefficients do come out bit-identical, and
+:class:`_SweepReport` counts how many so a reader can see the figure for the run in front
+of them rather than a stale one written here. That is welcome and is not the criterion,
+for the reason the determinism rule gives.
+
+The bound, and why it has no cancellation term
+-----------------------------------------------
+
+Every two-scale (Oslo) coefficient is non-negative, truncation only *zeroes* entries, and
+the contraction sums non-negative products. So there is no cancellation anywhere in the
+truncation, and the standard inner-product result (Higham, *Accuracy and Stability of
+Numerical Algorithms*, 2nd ed., Theorem 3.1) applies in its relative form: a length-``n``
+inner product of non-negative terms satisfies ``|fl(s) - s| <= gamma_n * s`` rather than
+the ``gamma_n * sum|terms|`` a signed sum would owe. That is what lets the amplification
+below be the coefficient's own magnitude.
+
+One stage is one direction of one level transition, and its length is the coefficient
+box's width in that direction *before* the transition. Composing stages multiplies their
+``(1 + gamma)`` factors, and ``(1 + gamma_a)(1 + gamma_b) <= 1 + gamma_{a + b}``, so the
+whole chain is ``gamma_N`` with ``N`` the sum of the contraction lengths over every
+direction and every transition.
+
+``N`` is bounded above without tracking the walk: the box widths grow monotonically, so
+each stage's length is at most the *final* width in that direction, and a function
+traverses at most ``num_levels - 1`` transitions. Hence
+
+    N <= (num_levels - 1) * sum_k shape[k]
+
+with ``shape`` the stored coefficient box. That is what :func:`_coefficient_roundings`
+computes, per function, from the function's own box rather than from a worst case over the
+space -- a global count would be looser by the ratio of the largest box to this one.
+
+The factor of two that turns a one-sided forward-error bound into a two-sided parity bound
+is the harness's, applied in :func:`tests._parity_harness.absolute_tolerance`, and is not
+repeated here.
+
+A zero coefficient gets a zero tolerance, and that is sound rather than an oversight: a
+sum of non-negative terms is zero only when every term is zero, and both backends sum the
+same terms, so an entry that is exactly zero in one is exactly zero in the other. The
+non-cancellation argument above is what makes that true; it would be wrong for a signed
+sum.
+
+The independent accuracy check
+-------------------------------
+
+``design/backend_parity.md`` requires an independent check that the answer is *right*, not
+only that two implementations agree. The one used here is the defining property of the
+truncated basis (Giannelli-Jüttler-Speleers 2012, Thm 6): the truncated functions form a
+**partition of unity**. Expressed in the finest level's tensor-product basis that is a
+statement about the coefficients alone and needs no evaluation -- the coefficient vectors
+of all the active functions, pushed to the finest level by pure two-scale refinement, must
+sum to the all-ones vector.
+
+:func:`_partition_of_unity_defect` runs that on the **C++** space's coefficients. It uses
+the oracle's two-scale kernel to do the pushing, which is shared machinery rather than the
+thing under test: what is being checked is the *selection and the truncation*, and that
+kernel is independently pinned in ``cpp/tests/test_bspline_knot_insertion.cpp`` against the
+cardinal B-spline's binomial stencil, which is a closed form neither implementation knows
+about.
+
+The check discriminates, which is the part a passing identity does not establish on its
+own: :func:`test_the_untruncated_basis_fails_the_identity` runs the same computation on
+the HB space, where the sum is nowhere near one.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
+
+import numpy as np
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import BsplineSpace, BsplineSpace1D, THBSplineSpace
+from pantr.grid import hierarchical_grid, uniform_grid
+from tests._parity_harness import (
+    Field,
+    Roundings,
+    assert_object_parity,
+    bounded_parity,
+    exact_parity,
+    unit_roundoff,
+)
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+_SHIPPED_CASES: Final = 200
+"""Random cases the CI sweep draws.
+
+Chosen for runtime rather than for confidence: each case builds two whole spaces, compares
+every cell's contribution list in an interpreted loop, and then rebuilds both four more
+times for the refinement and coarsening comparison. The confidence comes from
+:func:`test_the_wide_sweep_agrees`, which runs ten times this and is what the ticket asks
+be verified; the shipped run is the regression guard that has to stay affordable.
+"""
+
+_WIDE_FACTOR: Final = 10
+"""How much wider the ``slow`` sweep is than the shipped one."""
+
+_U: Final = unit_roundoff(np.float64)
+"""Half an ulp, taken from the harness rather than spelled out again here."""
+
+_VERDICT_WHY: Final = (
+    "counts, level indices, flat function indices, global dofs, multi-indices and box "
+    "origins are verdicts rather than displaced values; design/backend_parity.md's "
+    "determinism rule admits bit-identity only where finite precision does not bite, "
+    "and integers and indices are exactly that case. A bounded comparison could not "
+    "see two answers of different length at all"
+)
+
+_COEFFICIENT_WHY: Final = (
+    "the truncation coefficients are built by contracting a coefficient box through the "
+    "two-scale matrices, direction by direction and level by level. Every Oslo "
+    "coefficient is non-negative and truncation only zeroes entries, so no sum here "
+    "cancels and Higham Thm 3.1's inner-product bound applies in its relative form: one "
+    "stage of length n costs gamma_n of the value itself, not of the sum of magnitudes. "
+    "Stages compose as (1 + gamma_a)(1 + gamma_b) <= 1 + gamma_{a+b}, and the box widths "
+    "grow monotonically, so N = (num_levels - 1) * sum_k shape[k] bounds the total. "
+    "Bit-identity is NOT claimed because the oracle contracts through numpy.tensordot, "
+    "hence BLAS, whose summation order is the implementation's while the C++ sums in "
+    "index order"
+)
+
+
+class _Case(NamedTuple):
+    """One hierarchy both backends are asked to build.
+
+    Attributes:
+        degrees (tuple[int, ...]): Per-direction polynomial degree.
+        num_elements (tuple[int, ...]): Per-direction root element count.
+        factor (tuple[int, ...]): Per-direction refinement factor.
+        bounds (tuple[tuple[float, float], ...]): Per-direction parametric domain.
+        refinements (tuple[tuple[int, tuple[int, ...], tuple[int, ...]], ...]): The
+            ``(level, lo, hi)`` boxes refined in order, on the grid each previous one
+            produced.
+        truncate (bool): Whether the truncated basis is built.
+        regularity (tuple[int | None, ...]): Per-direction continuity at inserted knots.
+        dtype (Any): The root space's storage format.
+    """
+
+    degrees: tuple[int, ...]
+    num_elements: tuple[int, ...]
+    factor: tuple[int, ...]
+    bounds: tuple[tuple[float, float], ...]
+    refinements: tuple[tuple[int, tuple[int, ...], tuple[int, ...]], ...]
+    truncate: bool
+    regularity: tuple[int | None, ...]
+    dtype: Any
+
+
+class _SweepReport(NamedTuple):
+    """What a sweep observed, so a test can assert it was not vacuous.
+
+    Attributes:
+        cases (int): Cases actually compared.
+        coefficients (int): Truncation coefficients compared, over all cases.
+        bit_identical (int): How many of those agreed bit for bit. Reported, never
+            required; see the module docstring.
+        truncated_cases (int): Cases whose truncation produced at least one coefficient.
+        worst_ratio (float): Largest ratio of an observed difference to its own bound.
+    """
+
+    cases: int
+    coefficients: int
+    bit_identical: int
+    truncated_cases: int
+    worst_ratio: float
+
+
+def _bindings() -> Any:
+    """Import the extension, deferred and in one place.
+
+    Module level would turn an installation without the extension into a collection
+    error for this whole file, including the tests that state a property of the oracle
+    alone.
+
+    Returns:
+        Any: The :mod:`pantr._pantr_cpp` module.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp
+
+
+def _open_knots(degree: int, num_elements: int, lo: float, hi: float) -> npt.NDArray[np.float64]:
+    """A clamped uniform knot vector.
+
+    Args:
+        degree (int): Polynomial degree.
+        num_elements (int): Number of equal spans.
+        lo (float): Domain start.
+        hi (float): Domain end.
+
+    Returns:
+        npt.NDArray[np.float64]: The knot vector, ``num_elements + 1 + 2 * degree`` long.
+    """
+    inner = np.linspace(lo, hi, num_elements + 1)
+    return np.concatenate([np.full(degree, lo), inner, np.full(degree, hi)])
+
+
+def _python_space(case: _Case) -> THBSplineSpace:
+    """Build the oracle's space for a case.
+
+    Args:
+        case (_Case): The hierarchy to build.
+
+    Returns:
+        THBSplineSpace: The space, built under the Python backend.
+    """
+    with use_backend(Backend.PYTHON):
+        directions = [
+            BsplineSpace1D(
+                _open_knots(case.degrees[k], case.num_elements[k], *case.bounds[k]).astype(
+                    case.dtype
+                ),
+                case.degrees[k],
+            )
+            for k in range(len(case.degrees))
+        ]
+        grid = hierarchical_grid(
+            uniform_grid([list(b) for b in case.bounds], list(case.num_elements)),
+            list(case.factor),
+        )
+        for level, lo, hi in case.refinements:
+            grid = grid.refine(level, list(lo), list(hi))
+        return THBSplineSpace(
+            BsplineSpace(directions),
+            grid,
+            truncate=case.truncate,
+            regularity=list(case.regularity),
+        )
+
+
+def _cpp_space(case: _Case) -> Any:
+    """Build the C++ handle for a case.
+
+    Args:
+        case (_Case): The hierarchy to build.
+
+    Returns:
+        Any: A ``THBSplineSpace32`` or ``THBSplineSpace64`` handle.
+    """
+    cpp = _bindings()
+    narrow = np.dtype(case.dtype) == np.float32
+    one_d = cpp.BsplineSpace1D32 if narrow else cpp.BsplineSpace1D64
+    tensor = cpp.BsplineSpace32 if narrow else cpp.BsplineSpace64
+    hierarchical = cpp.THBSplineSpace32 if narrow else cpp.THBSplineSpace64
+
+    directions = [
+        one_d(
+            np.ascontiguousarray(
+                _open_knots(case.degrees[k], case.num_elements[k], *case.bounds[k]),
+                dtype=case.dtype,
+            ),
+            case.degrees[k],
+            False,
+            True,
+        )
+        for k in range(len(case.degrees))
+    ]
+    breakpoints = [
+        np.ascontiguousarray(np.linspace(*case.bounds[k], case.num_elements[k] + 1))
+        for k in range(len(case.degrees))
+    ]
+    grid = cpp.HierarchicalGrid(
+        cpp.TensorProductGrid(breakpoints), np.ascontiguousarray(case.factor, dtype=np.int64)
+    )
+    for level, lo, hi in case.refinements:
+        grid = grid.refine(
+            level,
+            np.ascontiguousarray(lo, dtype=np.int64),
+            np.ascontiguousarray(hi, dtype=np.int64),
+        )
+    return hierarchical(tensor(directions), grid, case.truncate, list(case.regularity))
+
+
+def _coefficient_roundings(num_levels: int, shape: tuple[int, ...]) -> Roundings:
+    """The rounding budget of one truncated function's coefficient box.
+
+    ``N = (num_levels - 1) * sum_k shape[k]``; the module docstring carries the
+    derivation and what makes it an upper bound rather than an estimate.
+
+    Args:
+        num_levels (int): The space's level count.
+        shape (tuple[int, ...]): The stored coefficient box's per-direction width.
+
+    Returns:
+        Roundings: One accumulator rounding per stage, over ``N`` stages.
+    """
+    stages = max(1, (num_levels - 1) * sum(shape))
+    return Roundings(stages=stages, accumulator_per_stage=1, storage_per_stage=0)
+
+
+def _truncated_dofs(space: Any, num_total_basis: int) -> dict[int, Any]:
+    """The truncation entries of either backend, keyed by global dof.
+
+    Args:
+        space (Any): The oracle's space or a C++ handle.
+        num_total_basis (int): How many dofs to ask about.
+
+    Returns:
+        dict[int, Any]: ``dof -> (rep_level, box_lo, coeffs)`` for every truncated
+        function. The oracle's ``_TruncCoeffs`` and the handle's tuple unpack the same
+        way, which is why one reader serves both.
+    """
+    if isinstance(space, THBSplineSpace):
+        return {int(dof): entry for dof, entry in space._trunc.items()}
+    entries: dict[int, Any] = {}
+    for dof in range(num_total_basis):
+        entry = space.truncated(dof)
+        if entry is not None:
+            entries[dof] = entry
+    return entries
+
+
+def _partition_of_unity_defect(space: Any, oracle: THBSplineSpace) -> float:
+    """How far the active basis is from summing to one, in the finest level's basis.
+
+    Pushes every active function's coefficient vector to the finest level by pure
+    two-scale refinement -- no truncation -- and returns
+    ``max |sum_i c_i - 1|`` over the finest tensor-product basis.
+
+    The two-scale kernel is the oracle's, used as shared machinery: what is under test is
+    ``space``'s *selection and truncation*, and the kernel is independently pinned in
+    ``cpp/tests/test_bspline_knot_insertion.cpp`` against the cardinal B-spline's binomial
+    stencil. The module docstring says why that composition is honest.
+
+    Args:
+        space (Any): The space whose coefficients are checked; the oracle or a handle.
+        oracle (THBSplineSpace): The oracle for the same hierarchy, which supplies the
+            level spaces the two-scale matrices are built from. Passing it explicitly
+            rather than reading it off ``space`` is what lets the same function grade a
+            C++ handle.
+
+    Returns:
+        float: The largest absolute deviation from one.
+    """
+    from pantr.bspline._bspline_knot_insertion_core import (  # noqa: PLC0415
+        _compute_oslo_matrix_1d_core,
+    )
+
+    dim = oracle.dim
+    top = oracle.num_levels - 1
+    oslo = [
+        [
+            np.asarray(
+                _compute_oslo_matrix_1d_core(
+                    oracle.level_space(m).spaces[k].degree,
+                    oracle.level_space(m).spaces[k].knots,
+                    oracle.level_space(m + 1).spaces[k].knots,
+                ),
+                dtype=np.float64,
+            )
+            for k in range(dim)
+        ]
+        for m in range(top)
+    ]
+    total = np.zeros(tuple(oracle.level_space(top).num_basis), dtype=np.float64)
+    entries = _truncated_dofs(space, oracle.num_total_basis)
+
+    for dof in range(oracle.num_total_basis):
+        entry = entries.get(dof)
+        if entry is None:
+            level = oracle._dof_level(dof)
+            position = dof - int(oracle._func_offset[level])
+            flat = int(oracle.active_function_indices(level)[position])
+            multi = np.unravel_index(flat, oracle.level_space(level).num_basis)
+            box_lo = [int(m) for m in multi]
+            coeffs = np.ones((1,) * dim, dtype=np.float64)
+            start = level
+        else:
+            start = int(entry[0])
+            box_lo = [int(x) for x in entry[1]]
+            coeffs = np.asarray(entry[2], dtype=np.float64)
+
+        for level in range(start, top):
+            new_lo: list[int] = []
+            out = coeffs
+            for k in range(dim):
+                alpha = oslo[level][k]
+                cols = alpha[:, box_lo[k] : box_lo[k] + out.shape[k]]
+                rows = np.nonzero(np.any(cols != 0.0, axis=1))[0]
+                lo_row, hi_row = int(rows[0]), int(rows[-1]) + 1
+                sub = alpha[lo_row:hi_row, box_lo[k] : box_lo[k] + out.shape[k]]
+                out = np.moveaxis(np.tensordot(sub, out, axes=([1], [k])), 0, k)
+                new_lo.append(lo_row)
+            coeffs, box_lo = out, new_lo
+
+        window = tuple(slice(box_lo[k], box_lo[k] + coeffs.shape[k]) for k in range(dim))
+        total[window] += coeffs
+
+    return float(np.abs(total - 1.0).max())
+
+
+def _compare(case: _Case) -> tuple[int, int, float]:
+    """Compare both backends' spaces for one case, quantity by quantity.
+
+    Args:
+        case (_Case): The hierarchy to build under both.
+
+    Returns:
+        tuple[int, int, float]: How many truncation coefficients were compared, how many
+        of those were bit-identical, and the worst ratio of a difference to its bound.
+
+    Raises:
+        AssertionError: If any quantity violates its claim.
+    """
+    # A draw can name a configuration both backends refuse -- a `float32` mesh on a
+    # domain at 1e6 is finer than the format resolves there, and knot snapping collapses
+    # it. Skipping it would lose a comparison; requiring the same refusal from both keeps
+    # it as one, and the refusals are the part of a port most easily left un-ported.
+    try:
+        py = _python_space(case)
+    except ValueError as refused:
+        with pytest.raises(ValueError) as caught:
+            _cpp_space(case)
+        assert str(caught.value) == str(refused), (
+            f"the two backends refuse {case!r} with different messages:\n"
+            f"  python: {refused}\n  cpp:    {caught.value}"
+        )
+        return 0, 0, 0.0
+    cpp = _cpp_space(case)
+    context = f"THBSplineSpace{case!r}"
+
+    fields = [
+        Field("num_levels", exact_parity(why=_VERDICT_WHY)),
+        Field("num_total_basis", exact_parity(why=_VERDICT_WHY)),
+        Field("num_basis_per_level", exact_parity(why=_VERDICT_WHY)),
+        Field("dim", exact_parity(why=_VERDICT_WHY)),
+        Field("degrees", exact_parity(why=_VERDICT_WHY)),
+        Field("truncate", exact_parity(why=_VERDICT_WHY)),
+    ]
+    for level in range(py.num_levels):
+        fields.append(
+            Field(
+                f"active_function_indices[{level}]",
+                exact_parity(why=_VERDICT_WHY),
+                read=lambda space, level=level: np.asarray(  # type: ignore[misc]
+                    space.active_function_indices(level), dtype=np.int64
+                ),
+            )
+        )
+    assert_object_parity(py=py, cpp=cpp, fields=fields, context=context)
+
+    assert py.max_active_per_cell() == cpp.max_active_per_cell(), (
+        f"{context}: max_active_per_cell disagrees. {_VERDICT_WHY}"
+    )
+    for cid in range(py.grid.num_cells):
+        expected = np.asarray(py.active_basis(cid), dtype=np.int64)
+        actual = np.asarray(cpp.active_basis(cid), dtype=np.int64)
+        assert np.array_equal(expected, actual), (
+            f"{context}: active_basis({cid}) disagrees. {_VERDICT_WHY}"
+        )
+        dofs, levels, multis = cpp.contributions(cid)
+        contributions = py._cell_contributions(cid)
+        assert [int(d) for d in dofs] == [t[0] for t in contributions]
+        assert [int(x) for x in levels] == [t[1] for t in contributions]
+        assert [tuple(int(v) for v in row) for row in np.asarray(multis)] == [
+            tuple(t[2]) for t in contributions
+        ], f"{context}: the contribution multi-indices of cell {cid} disagree"
+
+    for dof in range(py.num_total_basis):
+        assert py._dof_level(dof) == cpp.dof_level(dof), f"{context}: dof_level({dof}) disagrees"
+
+    py_entries = _truncated_dofs(py, py.num_total_basis)
+    cpp_entries = _truncated_dofs(cpp, py.num_total_basis)
+    assert set(py_entries) == set(cpp_entries), (
+        f"{context}: the set of truncated dofs disagrees; "
+        f"only python {sorted(set(py_entries) - set(cpp_entries))}, "
+        f"only cpp {sorted(set(cpp_entries) - set(py_entries))}"
+    )
+
+    compared = 0
+    identical = 0
+    worst = 0.0
+    for dof, py_entry in sorted(py_entries.items()):
+        cpp_entry = cpp_entries[dof]
+        expected = np.asarray(py_entry.coeffs, dtype=np.float64)
+        actual = np.ascontiguousarray(cpp_entry[2], dtype=np.float64)
+        where = f"{context}: dof {dof}"
+        assert int(py_entry.rep_level) == int(cpp_entry[0]), f"{where}: rep_level disagrees"
+        assert tuple(py_entry.box_lo) == tuple(int(x) for x in cpp_entry[1]), (
+            f"{where}: box origin disagrees"
+        )
+        assert expected.shape == actual.shape, f"{where}: box shape disagrees"
+
+        observed = assert_object_parity(
+            py=expected,
+            cpp=actual,
+            fields=[
+                Field(
+                    "coefficients",
+                    bounded_parity(
+                        roundings=_coefficient_roundings(py.num_levels, expected.shape),
+                        accumulator=np.float64,
+                        storage=np.float64,
+                        amplification=np.abs(expected).ravel(),
+                        why=_COEFFICIENT_WHY,
+                    ),
+                    read=lambda block: np.asarray(block, dtype=np.float64).ravel(),
+                )
+            ],
+            context=where,
+        )
+        compared += int(expected.size)
+        identical += int(
+            (expected.view(np.uint64) == actual.view(np.uint64)).sum() if expected.size else 0
+        )
+        worst = max(worst, observed["coefficients"].max_ratio_to_bound)
+
+    _compare_the_operations(py, cpp, context)
+    return compared, identical, worst
+
+
+def _compare_the_operations(py: THBSplineSpace, cpp: Any, context: str) -> None:
+    """Compare one refinement and one coarsening of an already-compared pair.
+
+    Both are rebuilds: each returns a new space over a new grid, so what is compared is
+    the space that comes back. Folded into the sweep rather than pinned to one fixture
+    because the ordering hazards here are the ones a fixture does not reach --
+    FELIGN/pantr#395's own port carried a defect in ``coarsen_cells``' demotion order
+    that first appeared at case 3553 of a 4000-case sweep and was invisible at 400.
+
+    The marked set is derived from the space rather than drawn again, so a failure is
+    reproducible from the case alone: the first cell of each level for the refinement, and
+    every deepest-level cell for the coarsening.
+
+    Args:
+        py (THBSplineSpace): The oracle's space.
+        cpp (Any): The C++ handle for the same hierarchy.
+        context (str): What is being compared, quoted in every failure message.
+
+    Raises:
+        AssertionError: If any rebuilt quantity disagrees.
+    """
+    seen: set[int] = set()
+    marked = []
+    for cid in range(py.grid.num_cells):
+        level = py.grid.cell_level(cid)
+        if level not in seen:
+            seen.add(level)
+            marked.append(cid)
+    deepest = np.array(
+        [cid for cid in range(py.grid.num_cells) if py.grid.cell_level(cid) == py.grid.max_level],
+        dtype=np.int64,
+    )
+    ids = np.array(marked, dtype=np.int64)
+
+    for name, expected, actual in (
+        ("refine(graded)", py.refine(ids, admissible_class=2), cpp.refine(ids, 2)),
+        ("refine(ungraded)", py.refine(ids, admissible_class=None), cpp.refine(ids, None)),
+        ("coarsen(graded)", py.coarsen(deepest, admissible_class=2), cpp.coarsen(deepest, 2)),
+        (
+            "coarsen(ungraded)",
+            py.coarsen(deepest, admissible_class=None),
+            cpp.coarsen(deepest, None),
+        ),
+    ):
+        where = f"{context}: {name}"
+        assert expected.num_levels == actual.num_levels, f"{where}: num_levels disagrees"
+        assert expected.grid.num_cells == actual.grid.num_cells, (
+            f"{where}: the rebuilt grid has a different cell count"
+        )
+        assert expected.num_total_basis == actual.num_total_basis, (
+            f"{where}: num_total_basis disagrees"
+        )
+        for level in range(expected.num_levels):
+            assert np.array_equal(
+                expected.active_function_indices(level),
+                np.asarray(actual.active_function_indices(level)),
+            ), f"{where}: the level-{level} active set disagrees"
+
+
+def _draw_case(rng: np.random.Generator) -> _Case | None:
+    """Draw one random hierarchy.
+
+    Args:
+        rng (np.random.Generator): The source of randomness.
+
+    Returns:
+        _Case | None: The case, or ``None`` when the draw produced a degenerate
+        refinement box that both backends would refuse.
+    """
+    dim = int(rng.integers(1, 4))
+    degrees = tuple(int(rng.integers(1, 4)) for _ in range(dim))
+    num_elements = tuple(int(rng.integers(2, 6)) for _ in range(dim))
+    factor = [int(rng.integers(1, 4)) for _ in range(dim)]
+    if all(f == 1 for f in factor):
+        # A hierarchy that refines nothing anywhere has one level and no truncation, so
+        # it would compare the constructor and nothing else.
+        factor[0] = 2
+    # Three domains, one of them far from the origin, so a scale-dependent defect in the
+    # subdivision points has somewhere to show.
+    domain_lo = float(rng.choice([0.0, -1.0, 1.0e6]))
+    width = float(rng.choice([1.0, 1.0e-6, 3.0]))
+    bounds = tuple((domain_lo, domain_lo + width) for _ in range(dim))
+    regularity = tuple(
+        None if rng.integers(0, 2) else int(rng.integers(0, degrees[k])) for k in range(dim)
+    )
+
+    # Each box is drawn inside the window the previous refinement created, at that
+    # window's own level-`level` indices -- `[lo * factor, hi * factor)` -- so every
+    # refinement lands on cells that exist and are active leaves. Drawing in
+    # `[0, extent)` instead would name a box outside the level's domain as soon as the
+    # first window did not start at the origin, which is what a first version of this
+    # generator did.
+    refinements: list[tuple[int, tuple[int, ...], tuple[int, ...]]] = []
+    window_lo = [0] * dim
+    extent = list(num_elements)
+    for level in range(int(rng.integers(1, 4))):
+        lo = tuple(window_lo[k] + int(rng.integers(0, extent[k])) for k in range(dim))
+        hi = tuple(
+            min(window_lo[k] + extent[k], lo[k] + int(rng.integers(1, 3))) for k in range(dim)
+        )
+        if any(hi[k] <= lo[k] for k in range(dim)):
+            return None
+        refinements.append((level, lo, hi))
+        window_lo = [lo[k] * factor[k] for k in range(dim)]
+        extent = [(hi[k] - lo[k]) * factor[k] for k in range(dim)]
+        if any(n == 0 for n in extent):
+            break
+    if not refinements:
+        return None
+
+    return _Case(
+        degrees=degrees,
+        num_elements=num_elements,
+        factor=tuple(factor),
+        bounds=bounds,
+        refinements=tuple(refinements),
+        truncate=bool(rng.integers(0, 2)),
+        regularity=regularity,
+        dtype=np.float32 if rng.integers(0, 4) == 0 else np.float64,
+    )
+
+
+def _sweep(cases: int, seed: int) -> _SweepReport:
+    """Draw and compare random hierarchies.
+
+    Args:
+        cases (int): How many draws to attempt.
+        seed (int): The generator's seed, so a failure is reproducible.
+
+    Returns:
+        _SweepReport: What the sweep observed.
+    """
+    rng = np.random.default_rng(seed)
+    compared = 0
+    identical = 0
+    truncated_cases = 0
+    worst = 0.0
+    ran = 0
+    for _ in range(cases):
+        case = _draw_case(rng)
+        if case is None:
+            continue
+        case_compared, case_identical, case_worst = _compare(case)
+        ran += 1
+        compared += case_compared
+        identical += case_identical
+        truncated_cases += int(case_compared > 0)
+        worst = max(worst, case_worst)
+    return _SweepReport(
+        cases=ran,
+        coefficients=compared,
+        bit_identical=identical,
+        truncated_cases=truncated_cases,
+        worst_ratio=worst,
+    )
+
+
+def _assert_not_vacuous(report: _SweepReport) -> None:
+    """Refuse a sweep that compared nothing worth comparing.
+
+    A sweep whose draws all degenerated, or none of which truncated anything, would pass
+    while exercising neither the truncation nor the bound. Both are what this file is for.
+
+    Args:
+        report (_SweepReport): What the sweep observed.
+
+    Raises:
+        AssertionError: If the sweep is vacuous on either count.
+    """
+    assert report.cases > 0, "every draw degenerated; the sweep compared nothing"
+    assert report.truncated_cases > 0, (
+        "no case in the sweep produced a truncation coefficient, so the bound was never "
+        "exercised and this run says nothing about the half of the port that has digits"
+    )
+    assert report.worst_ratio <= 1.0, "a difference exceeded its bound"
+
+
+def test_the_sweep_agrees(cpp_backend: None) -> None:
+    """The two backends build the same space, over a sweep of random hierarchies.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    _assert_not_vacuous(_sweep(_SHIPPED_CASES, seed=20260904))
+
+
+@pytest.mark.slow
+def test_the_wide_sweep_agrees(cpp_backend: None) -> None:
+    """The same sweep, ten times wider.
+
+    FELIGN/pantr#397 asks that the bound be verified over a sweep at least ten times the
+    one that ships. Keeping the wide run in the repository rather than in a shell history
+    is what makes "verified" something the next reader can re-run.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    _assert_not_vacuous(_sweep(_SHIPPED_CASES * _WIDE_FACTOR, seed=20260905))
+
+
+def _reference_case(*, truncate: bool = True, dim: int = 2) -> _Case:
+    """A small hierarchy with a real truncation in it, for the pinned tests.
+
+    Args:
+        truncate (bool): Whether the truncated basis is built.
+        dim (int): Parametric dimension.
+
+    Returns:
+        _Case: A two-refinement dyadic hierarchy on the unit domain.
+    """
+    return _Case(
+        degrees=(2,) * dim,
+        num_elements=(4,) * dim,
+        factor=(2,) * dim,
+        bounds=((0.0, 1.0),) * dim,
+        refinements=((0, (0,) * dim, (2,) * dim), (1, (0,) * dim, (2,) * dim)),
+        truncate=truncate,
+        regularity=(None,) * dim,
+        dtype=np.float64,
+    )
+
+
+def test_the_truncated_basis_is_a_partition_of_unity(cpp_backend: None) -> None:
+    """The C++ truncation satisfies the identity that defines the truncated basis.
+
+    Giannelli-Jüttler-Speleers (2012), Thm 6. The module docstring says why this is an
+    independent check rather than a rerun of the port, and what shared machinery it uses.
+
+    The bound is the same one the parity claim carries, evaluated at this case's own box
+    sizes and summed over the functions that overlap one finest-level function -- at most
+    ``prod(degree + 1)`` of them, since that is how many tensor-product functions of any
+    one level are non-zero on a cell, and the levels a hierarchical function can come from
+    are at most ``num_levels``.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    case = _reference_case()
+    oracle = _python_space(case)
+    defect = _partition_of_unity_defect(_cpp_space(case), oracle)
+
+    overlapping = math.prod(d + 1 for d in oracle.degrees) * oracle.num_levels
+    widest = max(
+        (max(e.coeffs.shape) for e in oracle._trunc.values()),
+        default=1,
+    )
+    stages = (oracle.num_levels - 1) * oracle.dim * widest
+    gamma = stages * _U / (1.0 - stages * _U)
+    bound = overlapping * gamma
+    assert defect <= bound, (
+        f"the truncated basis is not a partition of unity: worst defect {defect:.3e} "
+        f"against {bound:.3e}"
+    )
+    assert bound < 1.0e-10, (
+        "the vacuity guard: this bound is loose enough to accept a basis that is not a "
+        "partition of unity at all, so passing it would say nothing"
+    )
+
+
+def test_the_untruncated_basis_fails_the_identity(cpp_backend: None) -> None:
+    """The same computation on the HB basis is nowhere near one.
+
+    Without this the identity above would be consistent with a check that cannot fail --
+    the truncation is exactly what restores the partition of unity, so a run that reported
+    a small defect for the *untruncated* basis would be measuring nothing.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    case = _reference_case(truncate=False)
+    oracle = _python_space(case)
+    defect = _partition_of_unity_defect(_cpp_space(case), oracle)
+    assert defect > 0.1, (
+        f"the untruncated basis summed to within {defect:.3e} of one, so the identity "
+        f"above cannot distinguish a truncated basis from an untruncated one"
+    )
+
+
+def test_a_float32_root_space_over_a_float64_grid_agrees(cpp_backend: None) -> None:
+    """The shipped pairing of a narrow root space with the always-`float64` grid.
+
+    ``pantr.grid`` is ``float64``-only by its own port's ruling while a root B-spline
+    space stores whatever it was handed, and ``tests/test_thb_spline_space.py``'s
+    ``test_a_float32_root_space_is_still_graded_in_float64`` ships that combination. The
+    C++ type's grid scalar is therefore ``double`` independently of its own, and this is
+    what pins that the pairing is representable and agrees.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    case = _reference_case()._replace(dtype=np.float32)
+    compared, _, worst = _compare(case)
+    assert compared > 0, "this case truncated nothing, so it exercised no float32 knots"
+    assert worst <= 1.0
+
+
+def test_level_space_zero_shares_the_root_handle(cpp_backend: None) -> None:
+    """``level_space(0)`` hands back the object the space was built from, not a copy.
+
+    ``design/bspline_ownership_lifetime.md`` F6 makes this an identity contract rather
+    than a convenience: it is what the oracle's ``thb.level_space(0) is thb.root_space``
+    asserts, and reproducing it is what fixes the C++ constructor's signature to take
+    handles rather than values.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    case = _reference_case()
+    oracle = _python_space(case)
+    assert oracle.level_space(0) is oracle.root_space
+
+    cpp = _cpp_space(case)
+    assert cpp.level_space(0) is cpp.root_space
+    # And the finer levels are genuinely different objects, or the assertion above would
+    # hold for a type that returned one space for every level.
+    assert cpp.level_space(1) is not cpp.root_space
+
+
+def test_refinement_and_coarsening_agree(cpp_backend: None) -> None:
+    """The graded refine, the ungraded refine, and coarsen, all agree afterwards.
+
+    Each returns a new space, so what is compared is the space it returns: the level
+    count, the active sets and the truncation the rebuilt space carries.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    case = _reference_case()
+    oracle = _python_space(case)
+    cpp = _cpp_space(case)
+    marked = np.array([0, 1, 2], dtype=np.int64)
+
+    for admissible in (2, None):
+        expected = oracle.refine(marked, admissible_class=admissible)
+        actual = cpp.refine(marked, admissible)
+        assert expected.num_levels == actual.num_levels
+        assert expected.num_total_basis == actual.num_total_basis
+        assert tuple(expected.num_basis_per_level) == tuple(actual.num_basis_per_level)
+        for level in range(expected.num_levels):
+            assert np.array_equal(
+                expected.active_function_indices(level),
+                np.asarray(actual.active_function_indices(level)),
+            )
+
+    lo = np.array([0, 0], dtype=np.int64)
+    hi = np.array([2, 2], dtype=np.int64)
+    expected = oracle.refine_region(0, [0, 0], [2, 2], admissible_class=2)
+    actual = cpp.refine_region(0, lo, hi, 2)
+    assert expected.num_total_basis == actual.num_total_basis
+
+    finest = np.array(
+        [c for c in range(oracle.grid.num_cells) if oracle.grid.cell_level(c) == 2],
+        dtype=np.int64,
+    )
+    expected = oracle.coarsen(finest, admissible_class=None)
+    actual = cpp.coarsen(finest, None)
+    assert expected.num_levels == actual.num_levels
+    assert expected.num_total_basis == actual.num_total_basis
+    for level in range(expected.num_levels):
+        assert np.array_equal(
+            expected.active_function_indices(level),
+            np.asarray(actual.active_function_indices(level)),
+        )
+
+
+def test_refine_and_coarsen_never_hand_back_the_receivers_grid(cpp_backend: None) -> None:
+    """A no-op refinement still returns a space over a grid of its own.
+
+    Two spaces sharing one grid would make a tag set through one visible through the
+    other, which is what the oracle's ``grid._copy()`` prevents and what
+    ``HierarchicalGrid::refine_cells`` with no ids does here.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    cpp = _cpp_space(_reference_case())
+    nothing = np.array([], dtype=np.int64)
+    assert cpp.refine(nothing, 2).grid is not cpp.grid
+    assert cpp.coarsen(nothing, 2).grid is not cpp.grid
+
+
+@pytest.mark.parametrize(
+    ("build", "message"),
+    [
+        pytest.param(
+            lambda cpp, root, grid: cpp.THBSplineSpace64(root, grid, True, [None, None, None]),
+            "regularity must be a scalar or length-2 sequence; got length 3.",
+            id="regularity-length",
+        ),
+        pytest.param(
+            lambda cpp, root, grid: cpp.THBSplineSpace64(root, grid, True, [2, None]),
+            "regularity[0]=2 must be in [-1, degree[0]-1=1]; got 2.",
+            id="regularity-range",
+        ),
+    ],
+)
+def test_the_refusals_carry_the_oracles_message(
+    cpp_backend: None, build: Any, message: str
+) -> None:
+    """The C++ type refuses what the oracle refuses, with the oracle's wording.
+
+    Character for character, as every other refusal in this port is, so that a caller
+    matching on the message keeps working when the backend changes underneath it.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+        build (Any): Builds the refused space from the module, root space and grid.
+        message (str): The exact text expected.
+    """
+    cpp = _bindings()
+    case = _reference_case()
+    directions = [
+        cpp.BsplineSpace1D64(np.ascontiguousarray(_open_knots(2, 4, 0.0, 1.0)), 2, False, True)
+        for _ in range(2)
+    ]
+    root = cpp.BsplineSpace64(directions)
+    breakpoints = [np.ascontiguousarray(np.linspace(0.0, 1.0, 5)) for _ in range(2)]
+    grid = cpp.HierarchicalGrid(
+        cpp.TensorProductGrid(breakpoints), np.ascontiguousarray(case.factor, dtype=np.int64)
+    )
+    with pytest.raises(ValueError, match=r".*") as caught:
+        build(cpp, root, grid)
+    assert str(caught.value) == message

--- a/tests/parity/test_thb_spline_space.py
+++ b/tests/parity/test_thb_spline_space.py
@@ -592,8 +592,8 @@ def _compare_the_operations(py: THBSplineSpace, cpp: Any, context: str, variant:
     space is by far the most expensive thing this sweep does, so comparing all four
     quadruples its cost for coverage a rotation buys at a quarter of the price: every
     variant still gets a quarter of the cases, which at the wide width is hundreds each.
-    Measured: all four put the wide sweep at three times the next slowest test in
-    ``tests/parity``, and the C++ CI job runs it twice.
+    The cost is what forces the choice: this sweep is the slowest test in ``tests/parity``
+    and the C++ CI job runs it twice, once at each width.
 
     The marked set is derived from the space rather than drawn again, so a failure is
     reproducible from the case alone: the first cell of each level for the refinement, and

--- a/tests/parity/test_thb_spline_space.py
+++ b/tests/parity/test_thb_spline_space.py
@@ -973,3 +973,30 @@ def test_the_refusals_carry_the_oracles_message(
     with pytest.raises(ValueError, match=r".*") as caught:
         build(cpp, root, grid)
     assert str(caught.value) == message
+
+
+def test_an_out_of_range_cell_id_is_refused_the_oracles_way(cpp_backend: None) -> None:
+    """Both backends name **every** offending id, in the same kind and the same words.
+
+    The kind matters as much as the wording: the oracle raises ``IndexError`` and nanobind
+    maps ``std::out_of_range`` to that, so a caller catching one keeps working. What had
+    to be brought over deliberately is the *list*: a first version of the C++ threw on the
+    first bad id it met, which is a real loss for a caller debugging several.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+    case = _reference_case()
+    py = _python_space(case)
+    cpp = _cpp_space(case)
+    past_the_end = py.grid.num_cells
+    bad = np.array([past_the_end + 5, -1, past_the_end], dtype=np.int64)
+
+    for name in ("refine", "coarsen"):
+        with pytest.raises(IndexError) as expected:
+            getattr(py, name)(bad, admissible_class=2)
+        with pytest.raises(IndexError) as actual:
+            getattr(cpp, name)(bad, 2)
+        assert str(actual.value) == str(expected.value), (
+            f"{name} refuses out-of-range ids with a different message under the two backends"
+        )

--- a/tests/parity/test_thb_spline_space.py
+++ b/tests/parity/test_thb_spline_space.py
@@ -590,7 +590,15 @@ def _compare_the_operations(py: THBSplineSpace, cpp: Any, context: str) -> None:
 
     The marked set is derived from the space rather than drawn again, so a failure is
     reproducible from the case alone: the first cell of each level for the refinement, and
-    every deepest-level cell for the coarsening.
+    for the coarsening **every cell above level 0**, not only the deepest ones.
+
+    That last word is the load-bearing one. Both implementations demote parents deepest
+    first, so that a veto is decided against a mesh whose finer coarsenings have already
+    happened -- and a marked set confined to one level puts every parent at one level too,
+    where the ordering cannot be observed at all. Measured: reversing the demotion order
+    in the C++ survived this sweep while the marked set was the deepest level alone, and
+    is caught once it spans several. FELIGN/pantr#395's own port carried a defect of
+    exactly this shape, in exactly this operation.
 
     Args:
         py (THBSplineSpace): The oracle's space.
@@ -608,7 +616,7 @@ def _compare_the_operations(py: THBSplineSpace, cpp: Any, context: str) -> None:
             seen.add(level)
             marked.append(cid)
     deepest = np.array(
-        [cid for cid in range(py.grid.num_cells) if py.grid.cell_level(cid) == py.grid.max_level],
+        [cid for cid in range(py.grid.num_cells) if py.grid.cell_level(cid) >= 1],
         dtype=np.int64,
     )
     ids = np.array(marked, dtype=np.int64)

--- a/tests/parity/test_thb_spline_space.py
+++ b/tests/parity/test_thb_spline_space.py
@@ -109,6 +109,7 @@ import pytest
 
 from pantr._backend import Backend, use_backend
 from pantr.bspline import BsplineSpace, BsplineSpace1D, THBSplineSpace
+from pantr.bspline._bspline_space_nd import _BsplineSpaceNDPython
 from pantr.grid import hierarchical_grid, uniform_grid
 from tests._parity_harness import (
     Field,
@@ -120,7 +121,7 @@ from tests._parity_harness import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     import numpy.typing as npt
 
@@ -910,6 +911,67 @@ def test_level_space_zero_shares_the_root_handle(cpp_backend: None) -> None:
     # And the finer levels are genuinely different objects, or the assertion above would
     # hold for a type that returned one space for every level.
     assert cpp.level_space(1) is not cpp.root_space
+
+
+def test_every_rebuilding_oracle_call_stays_wholly_python(cpp_backend: None) -> None:
+    """A rebuilt oracle space is Python at every level, and without the guard it is not.
+
+    This is the test :func:`_the_oracle` was missing. ``THBSplineSpace`` rebuilds itself
+    inside ``refine``, ``refine_region`` and ``coarsen`` by calling
+    ``BsplineSpace1D.subdivide``, which dispatches on the *ambient* backend -- so under
+    ``PANTR_BACKEND=cpp`` an unguarded rebuild hands back a space whose level 0 is the
+    Python root it was built from and whose finer levels are C++ handles.
+
+    **That mixture does not raise, which is what makes it worth a test.** It is silent,
+    and a silently hybrid oracle delegates its finer levels to the very C++ knot
+    insertion this cut ports, so a defect there would appear on both sides of every
+    comparison built on it and no parity assertion could see it. The two pinned tests
+    below cannot catch it: their case has a uniform ``factor``, every axis subdivides
+    together, and ``_bspline_space_nd._new_impl``'s refusal never fires.
+
+    The second half is a control rather than a second assertion. Without it, a change
+    that made ``subdivide`` backend-stable would leave the guard decorative and this test
+    still green; with it, that change turns the control red and says so.
+
+    Args:
+        cpp_backend (None): Requires the compiled extension.
+    """
+
+    def levels(space: THBSplineSpace) -> list[type]:
+        return [type(space.level_space(k)._impl) for k in range(space.num_levels)]
+
+    with use_backend(Backend.CPP):
+        oracle = _python_space(_reference_case())
+        marked = np.array([0, 1, 2], dtype=np.int64)
+        deepest = np.array(
+            [c for c in range(oracle.grid.num_cells) if oracle.grid.cell_level(c) == 2],
+            dtype=np.int64,
+        )
+        rebuilds: tuple[tuple[str, Callable[[], THBSplineSpace]], ...] = (
+            ("refine", lambda: oracle.refine(marked, admissible_class=None)),
+            ("refine_region", lambda: oracle.refine_region(0, [0, 0], [2, 2], admissible_class=2)),
+            ("coarsen", lambda: oracle.coarsen(deepest, admissible_class=None)),
+        )
+
+        assert levels(oracle) == [_BsplineSpaceNDPython] * oracle.num_levels
+
+        for name, rebuild in rebuilds:
+            with _the_oracle():
+                guarded = rebuild()
+            assert levels(guarded) == [_BsplineSpaceNDPython] * guarded.num_levels, (
+                f"{name} under the guard left a level that is not the oracle's own type: "
+                f"{[t.__name__ for t in levels(guarded)]}"
+            )
+
+        for name, rebuild in rebuilds:
+            unguarded = levels(rebuild())
+            assert unguarded[1:] and all(
+                impl is not _BsplineSpaceNDPython for impl in unguarded[1:]
+            ), (
+                f"the control failed: {name} outside the guard produced a wholly Python "
+                f"space anyway ({[t.__name__ for t in unguarded]}), so the ambient backend "
+                f"no longer reaches BsplineSpace1D.subdivide and _the_oracle is dead weight"
+            )
 
 
 def test_refinement_and_coarsening_agree(cpp_backend: None) -> None:

--- a/tests/parity/test_thb_spline_space.py
+++ b/tests/parity/test_thb_spline_space.py
@@ -101,6 +101,7 @@ the HB space, where the sum is nowhere near one.
 
 from __future__ import annotations
 
+import contextlib
 import math
 from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
@@ -120,6 +121,8 @@ from tests._parity_harness import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     import numpy.typing as npt
 
 _SHIPPED_CASES: Final = 200
@@ -236,6 +239,32 @@ def _open_knots(degree: int, num_elements: int, lo: float, hi: float) -> npt.NDA
     return np.concatenate([np.full(degree, lo), inner, np.full(degree, hi)])
 
 
+@contextlib.contextmanager
+def _the_oracle() -> Iterator[None]:
+    """Run a block with the Python backend in effect.
+
+    **Every oracle call that constructs a space needs this, not only the constructor.**
+    ``THBSplineSpace`` is still pure Python and builds its per-level spaces by calling
+    ``BsplineSpace1D.subdivide``, which dispatches on the *ambient* backend -- so
+    ``refine``, ``refine_region`` and ``coarsen``, each of which rebuilds, would under
+    ``PANTR_BACKEND=cpp`` produce level spaces holding C++ handles over a root space
+    holding Python ones, and ``BsplineSpace`` refuses that mixture by design.
+
+    That is not a defect in the oracle: it is what
+    ``design/cross_backend_types.md`` forbids and what
+    ``_bspline_space_nd._new_impl`` exists to catch. It is a property of this file's
+    oracle *helper*, and it only shows under the backend CI's own parity job runs the
+    whole suite with. Both sweeps failed under it before this was added, and passed
+    under the default backend, which is exactly the shape ``CLAUDE.md`` warns about --
+    a local green that the C++ leg does not share.
+
+    Yields:
+        None: With the Python backend selected for the calling thread.
+    """
+    with use_backend(Backend.PYTHON):
+        yield
+
+
 def _python_space(case: _Case) -> THBSplineSpace:
     """Build the oracle's space for a case.
 
@@ -245,7 +274,7 @@ def _python_space(case: _Case) -> THBSplineSpace:
     Returns:
         THBSplineSpace: The space, built under the Python backend.
     """
-    with use_backend(Backend.PYTHON):
+    with _the_oracle():
         directions = [
             BsplineSpace1D(
                 _open_knots(case.degrees[k], case.num_elements[k], *case.bounds[k]).astype(
@@ -584,16 +613,19 @@ def _compare_the_operations(py: THBSplineSpace, cpp: Any, context: str) -> None:
     )
     ids = np.array(marked, dtype=np.int64)
 
-    for name, expected, actual in (
-        ("refine(graded)", py.refine(ids, admissible_class=2), cpp.refine(ids, 2)),
-        ("refine(ungraded)", py.refine(ids, admissible_class=None), cpp.refine(ids, None)),
-        ("coarsen(graded)", py.coarsen(deepest, admissible_class=2), cpp.coarsen(deepest, 2)),
-        (
-            "coarsen(ungraded)",
-            py.coarsen(deepest, admissible_class=None),
-            cpp.coarsen(deepest, None),
-        ),
-    ):
+    with _the_oracle():
+        rebuilt = (
+            ("refine(graded)", py.refine(ids, admissible_class=2), cpp.refine(ids, 2)),
+            ("refine(ungraded)", py.refine(ids, admissible_class=None), cpp.refine(ids, None)),
+            ("coarsen(graded)", py.coarsen(deepest, admissible_class=2), cpp.coarsen(deepest, 2)),
+            (
+                "coarsen(ungraded)",
+                py.coarsen(deepest, admissible_class=None),
+                cpp.coarsen(deepest, None),
+            ),
+        )
+
+    for name, expected, actual in rebuilt:
         where = f"{context}: {name}"
         assert expected.num_levels == actual.num_levels, f"{where}: num_levels disagrees"
         assert expected.grid.num_cells == actual.grid.num_cells, (
@@ -883,7 +915,8 @@ def test_refinement_and_coarsening_agree(cpp_backend: None) -> None:
     marked = np.array([0, 1, 2], dtype=np.int64)
 
     for admissible in (2, None):
-        expected = oracle.refine(marked, admissible_class=admissible)
+        with _the_oracle():
+            expected = oracle.refine(marked, admissible_class=admissible)
         actual = cpp.refine(marked, admissible)
         assert expected.num_levels == actual.num_levels
         assert expected.num_total_basis == actual.num_total_basis
@@ -896,7 +929,8 @@ def test_refinement_and_coarsening_agree(cpp_backend: None) -> None:
 
     lo = np.array([0, 0], dtype=np.int64)
     hi = np.array([2, 2], dtype=np.int64)
-    expected = oracle.refine_region(0, [0, 0], [2, 2], admissible_class=2)
+    with _the_oracle():
+        expected = oracle.refine_region(0, [0, 0], [2, 2], admissible_class=2)
     actual = cpp.refine_region(0, lo, hi, 2)
     assert expected.num_total_basis == actual.num_total_basis
 
@@ -904,7 +938,8 @@ def test_refinement_and_coarsening_agree(cpp_backend: None) -> None:
         [c for c in range(oracle.grid.num_cells) if oracle.grid.cell_level(c) == 2],
         dtype=np.int64,
     )
-    expected = oracle.coarsen(finest, admissible_class=None)
+    with _the_oracle():
+        expected = oracle.coarsen(finest, admissible_class=None)
     actual = cpp.coarsen(finest, None)
     assert expected.num_levels == actual.num_levels
     assert expected.num_total_basis == actual.num_total_basis
@@ -993,7 +1028,7 @@ def test_an_out_of_range_cell_id_is_refused_the_oracles_way(cpp_backend: None) -
     bad = np.array([past_the_end + 5, -1, past_the_end], dtype=np.int64)
 
     for name in ("refine", "coarsen"):
-        with pytest.raises(IndexError) as expected:
+        with _the_oracle(), pytest.raises(IndexError) as expected:
             getattr(py, name)(bad, admissible_class=2)
         with pytest.raises(IndexError) as actual:
             getattr(cpp, name)(bad, 2)


### PR DESCRIPTION
First cut of FELIGN/pantr#397. `Closes` does not fire against a base other than `main`, so what this covers and what it leaves is spelled out below.

**Covers:** the two operations `THBSplineSpace`'s state is the output of (knot insertion and the two-scale refinement matrix), the C++ `THBSplineSpace` type's whole construction-and-query half including refinement and coarsening, its binding at both storage widths, and a parity file claiming agreement quantity by quantity.

**Leaves for the next cuts:** basis tabulation and the windowed restriction (cut 2, blocked on Cox-de Boor tabulation and `BsplineSpace::restrict` in C++); the prolongation and restriction operators (cut 3, blocked on a least-squares solve and a sparse return); and the Python wrapper that makes `pantr.bspline.THBSplineSpace` dispatch to the handle, with its `__reduce__` (cut 4). **No type here is picklable yet**, so this cut owes no `__reduce__` round trip and the parity file says so.

---

## The reconnaissance, and one correction to the ticket

### What the class holds

Twelve slots. Four are constructor input (`_root_space`, `_grid`, `_truncate`, `_regularity`); six are derived eagerly and in one pipeline (`_level_spaces` -> `_support` -> `_active_funcs` -> `_func_offset`, `_num_active`, `_trunc`); two are lazy memos (`_contrib_cache`, `_max_active_per_cell`).

### What depends on what

Six clusters. **Construction**: `_build_level_spaces` -> `_select_active_functions` -> `_compute_truncated_coeffs`, which reaches `_build_oslo_matrices`, `_refine_box` and `_truncate_box`. **Cell contributions**: `_cell_contributions` behind `active_basis`, `max_active_per_cell` and `_tabulate_orders`. **Evaluation**: `_tabulate_orders` -> `_basis_1d_cached`, `_truncated_column`. **Refinement**: `refine`/`refine_region` -> `_refine_marked` -> `_refine_recursive` -> `_refinement_neighborhood`. **Coarsening**: `coarsen` -> `_coarsening_neighborhood_empty`. **Prolongation**: `_prolongation_columns` -> `_prolong_column` -> `_tp_column` -> `_finest_tp_coeffs` -> `_refine_box`.

Two cross-cluster edges matter: `_refine_box` is shared between construction and prolongation, and `_build_oslo_matrices` is computed once at construction and then **again on every `prolongation_to` call**, uncached.

### The mutual recursion the ticket names is not there, and what is there is a stronger reason

The ticket says *"its internals are mutually recursive through the truncation and split badly"*. Checked mechanically: over `THBSplineSpace`'s own methods, filtering call receivers to the ones that are certainly a `THBSplineSpace`, the call graph has **exactly one cycle** and it is `_refine_recursive` calling itself (`_thb_spline_space.py:1613`). That is graded *refinement*, Carraturo et al. (2019) Alg. 4 — nothing to do with truncation. Truncation (`_compute_truncated_coeffs`, `:705-726`) is a forward `while` over levels with no recursion and no mutual call.

So the stated mechanism is wrong. **The instruction is still right**, for three reasons that are stronger:

1. **Construction is one pipeline with no useful prefix.** Truncating a level-`l` function reads the active sets of *every finer level* (`:719-724`), so nothing before the whole Kraft selection is meaningful.
2. **The level walk is shared and uncached.** The same "grow a coefficient box through the two-scale matrices" loop is written twice, in `_compute_truncated_coeffs` (with truncation) and `_finest_tp_coeffs` (without).
3. **Three methods re-enter the constructor** — `restrict` (`:1038`), `_refine_marked` (`:1576`), `coarsen` (`:1754`). A split with construction on one side and refinement on the other leaves refinement calling a half-built type.

`cpp/include/pantr/bspline/thb_space.hpp`'s file comment carries this correction so the next reader does not re-derive it.

### Where the boundary between cuts actually falls, and why it moved

The ticket's blockers delivered `HierarchicalGrid`, `BsplineSpace` and the extraction kernels — but #396 deliberately moved *state and what it determines* and left **every operation** in Python. `THBSplineSpace` is the first type in this milestone whose state is the **output** of operations, and five of them were missing in C++:

| needed by | missing prerequisite | where it lands |
|---|---|---|
| `_build_level_spaces` | uniform-subdivision knots, knot-vector merge | **this cut** |
| `_compute_truncated_coeffs`, prolongation | the 1D Oslo (two-scale) matrix | **this cut** |
| `tabulate_basis*` | Cox-de Boor tabulation and its derivatives | cut 2 |
| `restrict` | `BsplineSpace::restrict` (windowed) | cut 2 |
| `prolongation_to*` | a least-squares solve, a sparse return | cut 3 |

Computing the level spaces in Python and handing them to a C++ constructor is the conversion function `design/cross_backend_types.md` forbids, so the first two had to come with the type rather than after it. That is the whole of the boundary change.

## One design defect found and fixed during the port

`THBSplineSpace<T>` first held a `HierarchicalGrid<T>`, tying the two scalars together. That makes the **oracle's own shipped pairing unrepresentable**: `pantr.grid` is `float64`-only by its own port's ruling (`src/pantr/grid/_grid_backend.py`, and `cpp/bindings/grid_hierarchical.cpp` registers no `float`), while a root B-spline space stores whatever it was handed, and `tests/test_thb_spline_space.py::TestCellMembershipTolerance::test_a_float32_root_space_is_still_graded_in_float64` ships exactly that combination. The grid's scalar is now `double` independently of `T`, and `tests/parity/test_thb_spline_space.py::test_a_float32_root_space_over_a_float64_grid_agrees` pins it.

## The parity claim, quantity by quantity

**Exactly** — `num_levels`, `num_total_basis`, `num_basis_per_level`, `level_offsets`, `dof_level`, the per-level Kraft active index sets, the per-cell `active_basis` lists with the contribution table's levels and multi-indices, `max_active_per_cell`, the set of truncated dofs, and each truncated function's representation level, box origin and box shape. Every one is an index, a count or a set membership. No rounding takes place on an integer, an index or a count, so bit-identity is the only criterion that says anything about them, and a bounded comparison could not even see two answers of different length. Rule 8 is not invoked: the bound is not zero here, there is no bound, because these quantities have no digits.

**Within a derived bound** — the truncation coefficients, and only those.

## The bound, and why it has no cancellation term

Every Oslo coefficient is non-negative, truncation only *zeroes* entries, and the contraction sums non-negative products. So Higham (*Accuracy and Stability of Numerical Algorithms*, 2nd ed., Thm 3.1) applies in its **relative** form: a length-`n` inner product of non-negative terms satisfies `|fl(s) - s| <= gamma_n * s`, not `gamma_n * sum|terms|`. That is what lets the amplification be the coefficient's own magnitude rather than a sum of magnitudes. `cpp/tests/test_thb_space.cpp::check_the_coefficients_never_go_negative` checks the premise rather than assuming it.

One stage is one direction of one level transition, of length the box's width in that direction *before* it. Stages compose as `(1 + gamma_a)(1 + gamma_b) <= 1 + gamma_{a+b}`, and the box widths grow monotonically, so

```
N <= (num_levels - 1) * sum_k shape[k]
```

bounds the whole chain, per function, from its own stored box. `gamma_N = N u / (1 - N u)` — the closed form, since `N` grows with the problem. The factor of two that turns a one-sided forward-error bound into a two-sided parity bound is the harness's, not repeated in the claim.

**Normality**: nothing here underflows. Every coefficient is a product of two-scale coefficients in `[0, 1]` summing to one along each level, so a non-zero coefficient is bounded below by the smallest product of non-zero Oslo entries, which for the degrees and factors this library admits is many orders above `2e-308`. A coefficient that is exactly zero gets a zero tolerance, and that is sound rather than an oversight: a sum of non-negative terms is zero only when every term is zero, and both backends sum the same terms. The dtypes exercised are `float64` throughout for the coefficients (the oracle widens the kernel's output before anything uses it) with `float32` **knots** in a quarter of the sweep's draws.

**Bit-identity is not claimed, and that is deliberate.** The oracle's `_refine_box` contracts through `numpy.tensordot`, which reshapes and calls BLAS, whose summation order is the implementation's — `CLAUDE.md` records that a round-off-dominated quantity can differ between Accelerate and OpenBLAS by orders of magnitude. The C++ sums in index order. Observed and reported by the sweep, never required: **75.6%** of coefficients came out bit-identical on the shipped run and **66.6%** on the wide one.

## The sweep, at 10x, in the repository

`tests/parity/test_thb_spline_space.py::_sweep`, called at `_SHIPPED_CASES` by `test_the_sweep_agrees` and at ten times that by the `slow`-marked `test_the_wide_sweep_agrees`. Both are in the repo, not in a shell history.

| run | cases | coefficients compared | bit-identical | cases with truncation | worst ratio to bound | margin |
|---|---:|---:|---:|---:|---:|---:|
| shipped (seed 20260904) | 200 | 792 100 | 599 026 (75.6%) | 67 | 0.0283 | 35x |
| wide (seed 20260905) | 2 000 | 31 660 324 | 21 087 064 (66.6%) | 705 | 0.0476 | 21x |

```
pytest tests/parity/test_thb_spline_space.py -q          # both, 11 passed
PANTR_BACKEND=cpp pytest tests/parity/test_thb_spline_space.py -q   # 11 passed
```

Each case also compares **one** of the four rebuilding operations — graded refine, ungraded refine, graded coarsen, ungraded coarsen — rotating, so each gets a quarter of the cases. All four on every case put the wide sweep at 362 s, three times the next slowest test in `tests/parity`, on a job that runs it twice; the rotation brings it to **123 s**, level with `test_grid_hierarchical`'s own wide sweep, and M6 to M8 below are each still caught by the shipped run alone. The sweep refuses to pass if no case truncated anything.

## The independent accuracy check

The identity that *defines* the truncated basis (Giannelli-Jüttler-Speleers 2012, Thm 6): the truncated functions are a **partition of unity**. Expressed in the finest level's tensor-product basis that is a statement about the coefficients alone and needs no evaluation — every active function's coefficient vector, pushed to the finest level by pure two-scale refinement, must sum to the all-ones vector. Run on the **C++** coefficients, in `tests/parity/test_thb_spline_space.py::test_the_truncated_basis_is_a_partition_of_unity` and again inside C++ in `cpp/tests/test_thb_space.cpp::check_the_truncation_is_a_partition_of_unity`.

**It discriminates.** The same computation on the untruncated (HB) basis must fail, and does by a wide margin — that check is a test in its own right (`test_the_untruncated_basis_fails_the_identity`), because truncation is exactly what restores the identity, so a version that reported a small defect for the HB basis would be measuring nothing.

A second independent oracle covers the layer underneath: on a uniform vector, a dyadic refinement's interior column of the two-scale matrix is the cardinal B-spline's binomial stencil `C(p+1, j) / 2^p`. That is a statement about binomial coefficients that the Oslo recurrence knows nothing about, and it holds **exactly**. `cpp/tests/test_bspline_knot_insertion.cpp::check_the_cardinal_refinement_identity`, with a vacuity guard that fails if its interior-column filter matched nothing.

## Mutation check, with its control

Each mutation is applied to `cpp/include/pantr/bspline/thb_space.hpp`, the extension is rebuilt, `pytest tests/parity/test_thb_spline_space.py -m "not slow"` is run, and the source is restored.

| # | mutation | expected | observed |
|---|---|---|---|
| **M0** | **CONTROL** — `num_total_basis()` returns `num_active_ + 1` | RED | **RED** |
| M1 | Kraft: admit every function whose support lies in the subdomain (drop the not-buried half) | RED | RED |
| M2 | truncation: zero the *neighbour* of each active finer function | RED | RED |
| M3 | contribution table: drop the last function of each interval's support | RED | RED |
| M4 | **legal** — sum the contraction in descending index order | GREEN | **GREEN** |
| M5a | perturb every two-scale coefficient by `1e-6` relative | RED | RED |
| M5b | ... by `1e-13` relative | RED | RED |
| M5c | ... by `1e-15` relative (about 9 u) | RED | RED |
| M6 | coarsening: demote parents shallowest-first instead of deepest-first | RED | **GREEN**, then RED — see below |
| M7 | graded refinement: refine the marked cell without grading its neighbourhood | RED | RED |
| M8 | graded refinement: take the support extension one level too coarse | RED | RED |
| M9 | summed-area: shrink the box by one cell on its lower corner | RED | RED |
| M10 | summed-area: make the all-true predicate unconditionally true | RED | RED |

The control is what says the harness rebuilds; M4 is what says the bound admits a legal reassociation rather than being a bitwise claim in disguise; M5c is what says it is tight — it catches a perturbation of about nine unit roundoffs.

**M6 is the one that earned its place.** It survived at first, because the sweep marked only the deepest level's cells for coarsening, which puts every parent at one level — and the deepest-first ordering has nothing to decide there. `9afb609` widens the marked set to every cell above level 0, and M6 is then caught. FELIGN/pantr#395's own port carried a defect of exactly this shape in exactly this operation, first visible at case 3553 of a 4000-case sweep. The whole battery was re-run after `28aee3c` cut each case to one operation, and every verdict above is from that final code.

**A methodological note worth recording, because it invalidated a check silently.** A first mutation harness restored the source with `mv`, which restores the *original* mtime — older than the object built from the mutation — so ninja called the mutated object up to date and every later run silently exercised the mutation. It surfaced as a sweep failure whose coefficients were all off by a uniform `1e-15` relative, which is exactly what M5c injects. The harness now `touch`es and rebuilds after restoring, and the whole battery above was re-run against the shipping code.

## Extension-skip evidence

All ten test functions in the parity file take the `cpp_backend` fixture, so none can pass without the extension.

```
extension present, PANTR_REQUIRE_CPP=1   ->  10 passed, 1 deselected
extension hidden,  PANTR_REQUIRE_CPP unset ->  10 skipped, 1 deselected   (never a silent pass)
extension hidden,  PANTR_REQUIRE_CPP=1   ->  10 errors                    (fails loudly, as CI demands)
```

The extension was hidden with a meta-path finder that raises on `pantr._pantr_cpp`, so `available_backends()` reports no CPP.

## Contribution-table footprint, which `design/bspline_derived_caches.md` made a precondition

That note rules the cache into one flat CSR table filled for every cell behind a single double-checked flag, and makes the ruling contingent on #397 measuring the footprint on a realistic adaptive hierarchy, with per-*level* granularity as the fallback. `scripts/measure_thb_contribution_table.py` is the measurement; the fallback is not needed.

```
case                                             cells   entries  widest   flat kB   dict kB  ratio
2D deg 2, 32 root elements, 4 corner levels       4096     39060      14    1252.6    7181.8    5.7x
2D deg 3, 64 root elements, 5 corner levels      19456    326116      28   10343.1   56928.7    5.5x
2D deg 2, 32 root elements, diagonal band         1120     10090      12     324.1    1827.0    5.6x
3D deg 2, 8 root elements, 3 corner levels        1856     60399      46    2373.8   10748.5    4.5x
3D deg 3, 12 root elements, 3 corner levels       6264    483192     120   18923.6   85808.7    4.5x
```

The flat table is 4.5x to 5.7x **smaller** than the oracle's dict once every cell has been touched — which is the honest baseline, since `max_active_per_cell()` already forces every cell in both implementations. The largest case is 18.5 MB. `max_active_per_cell` is a field of the same sweep, and the accessor returns a `span`, which retires the oracle's unenforced *"callers must not mutate it"* convention.

## Downstream consumer census

Against `tIGArx-future` at `f345cf2`, re-measured for this cut, **searched by symbol name rather than by import pattern**. This cut deletes and reshapes nothing on the Python side — it only adds files — so the census is a record for the cuts that will.

**Private symbols: zero.** Every private name this front will touch was searched individually (`_trunc`, `_cell_contributions`, `_active_funcs`, `_func_offset`, `_level_spaces`, `_support`, `_dof_level`, `_build_oslo_matrices`, `_finest_tp_coeffs`, `_refine_box`, `_truncate_box`, `_prolongation_columns`, `_prolong_column`, `_tp_column`, `_func_root_box`, `_cells_in_box`, `_basis_1d_cached`, `_truncated_column`, `_tabulate_orders`, `_refine_marked`, `_refine_recursive`, `_refinement_neighborhood`, `_coarsening_neighborhood_empty`, `_validate_region`, `_check_admissible_class`, `_box_all_true`, `_func_support_1d`, `_TruncCoeffs`, `_BasisEval1D`, `_cell_membership_tolerance`, `_prolongation_residual_tolerance`, `_combine_tp_values`, `_compute_oslo_matrix_1d_core`, `_compute_oslo_rows_1d_core`, `_insert_knots_1d_core`, `_compute_inserted_knot_vector_1d`, `_compute_uniform_subdivision_knots`, and the three module names). **Not one hit.**

**Public symbols.** `THBSplineSpace` appears 4 times — one docstring mention in `tigarx/core/space.py`, one comment, and two in `tests/core/test_smoke.py`'s surface census, which asserts the name is exported and that `active_basis`, `max_active_per_cell` and `prolongation_to_sparse` exist on it. `create_thb_space` appears once, in the same census. `BsplineSpace` (186), `BsplineSpace1D` (85) and `num_total_basis` (59) are the large exposures and are #396's rather than this cut's. `insert_knots` (9 hits) and `subdivide` (1) are `Bspline`'s — the geometry class, #398's — never `BsplineSpace1D`'s.

**Attribute writes onto pantr objects: zero.** Every `monkeypatch.setattr` and `setattr` in that repository targets a `tigarx` type, a `dolfinx` module or a `basix` module. The one that looks closest, `tests/assembly/test_payload.py:557`, patches `type(space)` where `space` is `tigarx`'s own `SplineFunctionSpace`.

## Verification

- `cpp/tests/test_thb_space.cpp` and `cpp/tests/test_bspline_knot_insertion.cpp`, new: `ctest` 49/49 under the `gcc` preset; both new tests also pass under `gcc-debug` (ASan + UBSan) and `test_thb_space` under `gcc-tsan`, which is the only gate that can see the lazy table's memo (`nm` confirms 16 `__tsan` symbols in that binary and 0 in the release one).
- `pytest -q`: **9503 passed, 49 skipped, 7 xfailed, 282 subtests**.
- `PANTR_BACKEND=cpp pytest -q`: **9500 passed, 52 skipped, 7 xfailed, 282 subtests**. This leg found a real defect in this PR's own parity helper — see `577b793`: the oracle helper opened the Python backend for the constructor only, and `THBSplineSpace` rebuilds itself inside `refine` and `coarsen`, so under the C++ backend those produced the mixed-backend hybrid `design/cross_backend_types.md` forbids. Both sweeps were red there and green under the default backend, which is the shape `CLAUDE.md` warns about.
- `ruff check`, `ruff format --check`, `mypy` on `src tests scripts`, `lint-imports`: clean.
- **Docs build not run to completion locally**: `sphinx-build` fails on this machine fetching `https://docs.scipy.org/doc/scipy/objects.inv` (connect timeout), and `-W` turns that warning into an error. It is environmental — this branch changes no file under `docs/` or `src/`, so it cannot affect that build.

## What this PR does not claim

- No `__reduce__` round trip, because no type here is picklable yet. It is owed by the cut that adds the wrapper.
- No claim about basis values, restriction or prolongation; none of that is ported.
- The `float` instantiation of `THBSplineSpace` is censused in the C++ tests and exercised in one parity case; it is not swept as widely as `double`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

