### PR TITLE
feat(bspline): own the B-spline field in C++ (cut 1 of #398)

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -124,7 +124,7 @@ if(PANTR_NANOBIND_SPLIT)
                       grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
                       bspline_extraction.cpp bspline_extraction_operators.cpp
-                      bspline_thb_space.cpp)
+                      bspline_thb_space.cpp bspline_type.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
@@ -133,7 +133,7 @@ else()
                       grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
                       bspline_extraction.cpp bspline_extraction_operators.cpp
-                      bspline_thb_space.cpp)
+                      bspline_thb_space.cpp bspline_type.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bspline_type.cpp
+++ b/cpp/bindings/bspline_type.cpp
@@ -1,0 +1,168 @@
+/// \file
+/// nanobind bindings for `pantr::bspline::Bspline`, the B-spline field.
+///
+/// ## Two registrations, because the storage format is part of the value
+///
+/// `Bspline32` and `Bspline64`, for the reason `bezier_type.cpp` and
+/// `bspline_types.cpp` register two of each: the field stores whatever float dtype
+/// it is handed, `pantr.bspline.Bspline.dtype` is public, `float32` fields are
+/// exercised across the suite, and the class of the handle is the only thing left
+/// to carry the format. `pantr.bspline._bspline._impl_class` picks between them.
+///
+/// The split is doubly forced here. `Bspline<T>` can hold only a
+/// `BsplineSpace<T>`, so the width is already a property of the C++ type and one
+/// Python name could not front both.
+///
+/// The dtype is not converted, and that *is* a check: without `.noconvert()`
+/// nanobind silently casts, so `Bspline32(space32, a_float64_net)` would narrow the
+/// caller's geometry and `Bspline64(space64, a_float32_net)` would widen it, both
+/// without a word. Refusing the cast makes `_impl_class` picking the wrong class a
+/// loud failure instead of a quiet change of precision.
+///
+/// ## What this file validates: nothing
+///
+/// `Bspline` and `ControlNet` validate their own arguments and throw
+/// `std::invalid_argument`, which nanobind maps to `ValueError` preserving
+/// `what()`. The messages are the oracle's character for character where the
+/// oracle has one, which `tests/parity/test_bspline_type.py` compares.
+///
+/// Two refusals the wrapper still owes, and both are Python's calling convention
+/// rather than validation: coercing an `ArrayLike` to a contiguous array, and the
+/// `ValueError` for control points whose dtype is not the space's -- a type-kind
+/// fact that `Bspline<T>` cannot even represent, since it holds only a
+/// `BsplineSpace<T>`. The wrapper also owes the *order* of those two against the
+/// coefficient-count check, because the oracle raises the count one first and only
+/// the order decides which message a caller reads.
+///
+/// The rank of the control-point array is deliberately unconstrained: a field is a
+/// curve, a surface or a volume, and a mis-ranked array is refused by `Bspline`
+/// against the space's basis counts rather than by a caster talking about C++
+/// types.
+///
+/// ## The space goes in as a handle and comes out as one
+///
+/// `space` is `design/bspline_ownership_lifetime.md`'s class **H**, so the C++ type
+/// stores `std::shared_ptr<const BsplineSpace<T>>` and this binding both takes and
+/// returns a copy of the handle. No `rv_policy` question arises, because ownership
+/// travels in the return value rather than in an annotation. Three consequences,
+/// each of them the failure of an alternative that note measured:
+///
+///  - The returned Python object is **identity-stable**: `nb_type_put` looks the
+///    pointer up in `inst_c2p` before creating an instance, so
+///    `field.space is the_space_handed_in` holds. That is what lets the Python
+///    wrapper's `Bspline(space, cp).space is space` contract rest on something
+///    rather than on the wrapper alone.
+///  - `sys.getrefcount` on the field handle is **unchanged** by the access, because
+///    no keep-alive is installed. A non-zero delta means somebody reverted to
+///    `reference_internal`, and the contract test asserts the zero.
+///  - The space **outlives its field**. Passing a handle in takes a reference on
+///    its Python object (`nanobind/stl/shared_ptr.h`'s `py_deleter`), and a space
+///    taken back out keeps its own value alive after the field is dropped.
+///
+/// ## `control_points` is a view, and read-only
+///
+/// A control net is the whole geometry, read on every evaluation, so copying it per
+/// property access would make the natural spelling of every operation quadratic in
+/// nothing. The array returned views the field's own storage with the field as its
+/// owner, and is read-only because the scalar type is `const T` -- nanobind passes
+/// `std::is_const_v<Scalar>` straight into the writeable flag. The owner keeps the
+/// storage alive when the array outlives the handle; the `const` stops a caller
+/// mutating a validated geometry from outside, which
+/// `design/bspline_ownership_lifetime.md` records as a live defect of the oracle
+/// rather than a hypothetical.
+///
+/// No sentinel address is needed for an empty net, unlike `bspline_types.cpp`'s
+/// dimensionless domain block: a field has at least one basis function per
+/// direction and at least rank 1, so `values()` is never empty and its `data()` is
+/// never null.
+///
+/// ## `_ref` accessors are not bound
+///
+/// `space_ref()` borrows the space rather than copying its handle, which is what
+/// saves the atomic pair inside a C++ loop, and it is deliberately absent below.
+/// `tests/parity/test_bspline_binding_contract.py` asserts over the bound surface
+/// that no method name ends in `_ref`, which is the only available check: there is
+/// no `static_assert` for absence.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/shared_ptr.h>
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "pantr/bspline/bspline.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+/// A read-only, contiguous array of any rank as nanobind sees it.
+template <class T>
+using const_nd = nb::ndarray<const T, nb::c_contig, nb::device::cpu>;
+
+/// Register one scalar type's `Bspline`.
+///
+/// \param m The extension module.
+/// \param name The Python-visible class name, `Bspline32` or `Bspline64`.
+template <class T>
+void bind_bspline(nb::module_& m, const char* name) {
+    using Field = pantr::bspline::Bspline<T>;
+    using Space = pantr::bspline::BsplineSpace<T>;
+    using Net = typename Field::net_type;
+
+    nb::class_<Field>(m, name)
+        .def(
+            "__init__",
+            [](Field* self, std::shared_ptr<const Space> space, const_nd<T> control_points,
+               bool is_rational) {
+                std::vector<std::size_t> shape(control_points.ndim());
+                for (std::size_t d = 0; d < shape.size(); ++d) {
+                    shape[d] = control_points.shape(d);
+                }
+                new (self) Field(
+                    std::move(space),
+                    Net(std::span<const T>(control_points.data(), control_points.size()),
+                        std::span<const std::size_t>(shape)),
+                    is_rational);
+            },
+            nb::arg("space"), nb::arg("control_points").noconvert(),
+            nb::arg("is_rational") = false)
+        // Class H. No policy: the value is a `shared_ptr`, so ownership travels in
+        // the return value.
+        .def_prop_ro("space", &Field::space)
+        // Class A: a read-only view of the field's own storage, with the field as
+        // the array's owner.
+        .def_prop_ro("control_points",
+                     [](nb::handle self) {
+                         const Field& b = nb::cast<const Field&>(self);
+                         const std::span<const std::size_t> shape = b.net().shape();
+                         return nb::ndarray<nb::numpy, const T>(b.net().values().data(),
+                                                                shape.size(), shape.data(), self);
+                     })
+        .def_prop_ro("is_rational", &Field::is_rational)
+        .def_prop_ro("dim", &Field::dim)
+        .def_prop_ro("rank", &Field::rank)
+        // A tuple rather than a list or an array, because the oracle's `degree` is
+        // a tuple and a caller comparing `b.degree == (2, 3)` must not start
+        // failing under the C++ backend -- on an array the comparison is
+        // elementwise and then has no truth value.
+        .def_prop_ro("degree", [](const Field& b) {
+            nb::list degrees;
+            for (const std::int64_t p : b.degree()) {
+                degrees.append(p);
+            }
+            return nb::tuple(degrees);
+        });
+}
+
+}  // namespace
+
+void register_bspline_type(nb::module_& m) {
+    bind_bspline<float>(m, "Bspline32");
+    bind_bspline<double>(m, "Bspline64");
+}

--- a/cpp/bindings/bspline_type.cpp
+++ b/cpp/bindings/bspline_type.cpp
@@ -52,9 +52,19 @@
 ///    `field.space is the_space_handed_in` holds. That is what lets the Python
 ///    wrapper's `Bspline(space, cp).space is space` contract rest on something
 ///    rather than on the wrapper alone.
-///  - `sys.getrefcount` on the field handle is **unchanged** by the access, because
-///    no keep-alive is installed. A non-zero delta means somebody reverted to
-///    `reference_internal`, and the contract test asserts the zero.
+///  - `sys.getrefcount` on the field handle is **unchanged** by the access, and it stays
+///    unchanged under a reversion to `reference_internal` as well, so the delta is
+///    **not** the detector `design/bspline_ownership_lifetime.md` M2 offers for this
+///    accessor. Measured on this binding: rebinding it to return a reference with
+///    `rv_policy::reference_internal` leaves the delta at zero, the handed-out object
+///    identical to the one passed in, and its value readable after the owner dies.
+///    The reason is specific and worth carrying: a field's space always arrives *from
+///    Python*, so it already has a live instance that `nb_type_put`'s `inst_c2p`
+///    lookup finds, and no new instance is created for a keep-alive to be installed
+///    on. M2's detector is live only where the nested object is built in C++ and has
+///    no instance of its own -- `THBSplineSpace`'s `level_space` is such an accessor;
+///    this one is not. **What decides this accessor is the C++ test**, which compares
+///    addresses and outlives the owner: `cpp/tests/test_bspline_type.cpp`.
 ///  - The space **outlives its field**. Passing a handle in takes a reference on
 ///    its Python object (`nanobind/stl/shared_ptr.h`'s `py_deleter`), and a space
 ///    taken back out keeps its own value alive after the field is dropped.
@@ -65,11 +75,20 @@
 /// property access would make the natural spelling of every operation quadratic in
 /// nothing. The array returned views the field's own storage with the field as its
 /// owner, and is read-only because the scalar type is `const T` -- nanobind passes
-/// `std::is_const_v<Scalar>` straight into the writeable flag. The owner keeps the
-/// storage alive when the array outlives the handle; the `const` stops a caller
-/// mutating a validated geometry from outside, which
+/// `std::is_const_v<Scalar>` straight into the writeable flag. The `const` is what
+/// stops a caller mutating a validated geometry from outside, which
 /// `design/bspline_ownership_lifetime.md` records as a live defect of the oracle
 /// rather than a hypothetical.
+///
+/// **The owner argument is belt-and-braces here rather than the repair**, which is F1
+/// of that note applied to an array: `def_prop_ro` passes
+/// `rv_policy::reference_internal` positionally ahead of the caller's arguments, so a
+/// property getter already ties its return to `self`. Measured on this binding --
+/// dropping the `self` argument leaves the array aliasing the same storage, still
+/// read-only, and still valid after the field is dropped, so the two spellings are
+/// indistinguishable from Python. It is written anyway, because it is the only
+/// spelling that survives someone changing `def_prop_ro` to a plain `.def`, where the
+/// default policy is `automatic` and the omission is a dangling view.
 ///
 /// No sentinel address is needed for an empty net, unlike `bspline_types.cpp`'s
 /// dimensionless domain block: a field has at least one basis function per

--- a/cpp/bindings/bspline_types.cpp
+++ b/cpp/bindings/bspline_types.cpp
@@ -91,9 +91,19 @@
 ///    `nd.spaces[0] is one_d` holds for the handle a caller passed in. That is what
 ///    makes `tests/test_bspline_space.py:89` reachable, and it is why the C++
 ///    constructor shares rather than copies.
-///  - `sys.getrefcount` on the nD handle is **unchanged** by the access, because no
-///    keep-alive is installed. A non-zero delta means somebody reverted to
-///    `reference_internal`, and the contract test asserts the zero.
+///  - `sys.getrefcount` on the nD handle is **unchanged** by the access, and it stays
+///    unchanged under a reversion to `reference_internal` as well, so the delta is
+///    **not** the detector `design/bspline_ownership_lifetime.md` M2 offers for this
+///    accessor. Measured on this binding: rebinding it to return a reference with
+///    `rv_policy::reference_internal` leaves the delta at zero, the handed-out object
+///    identical to the one passed in, and its value readable after the owner dies.
+///    The reason is specific and worth carrying: a direction always arrives *from
+///    Python*, so it already has a live instance that `nb_type_put`'s `inst_c2p`
+///    lookup finds, and no new instance is created for a keep-alive to be installed
+///    on. M2's detector is live only where the nested object is built in C++ and has
+///    no instance of its own -- `THBSplineSpace`'s `level_space` is such an accessor;
+///    this one is not. **What decides this accessor is the C++ test**, which compares
+///    addresses and outlives the owner: `cpp/tests/test_bspline_space_nd.cpp`.
 ///  - The direction **outlives its owner**. Passing a handle in takes a reference on
 ///    its Python object (`nanobind/stl/shared_ptr.h`'s `py_deleter`), so the nD space
 ///    keeps its directions alive, and a direction taken back out keeps its own value

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -87,6 +87,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_bspline_extraction(m);
     register_bspline_extraction_operators(m);
     register_bspline_thb_space(m);
+    register_bspline_type(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -119,6 +119,16 @@ void register_bspline_extraction(nanobind::module_& m);
 /// the oracle's copies -- argue from somewhere else entirely.
 void register_bspline_thb_space(nanobind::module_& m);
 
+/// Register the `pantr.bspline.Bspline` field type.
+///
+/// Its own entry point rather than a third class inside `register_bspline_types`, for
+/// the reason `register_bspline_thb_space` is separate from it: the space and the field
+/// over it are separate ports with separate parity claims, and the comments justifying
+/// this one's checks -- why the C++ field offers no `in_place=`, why its control net is
+/// a copy where the oracle's is the caller's own array -- argue from somewhere else
+/// entirely.
+void register_bspline_type(nanobind::module_& m);
+
 /// Register `pantr.bspline`'s Bézier extraction operator builder and its mask.
 ///
 /// Separate from `register_bspline_extraction` because the two are separate ports

--- a/cpp/include/pantr/bspline/bspline.hpp
+++ b/cpp/include/pantr/bspline/bspline.hpp
@@ -233,7 +233,7 @@ class Bspline {
     ///         the resulting rank is not at least 1.
     Bspline(std::shared_ptr<const BsplineSpace<T>> space, net_type net, bool is_rational)
         : space_(std::move(space)), net_(std::move(net)), is_rational_(is_rational) {
-        check_space();
+        check_space(space_);
         check_net_matches_space();
         check_rank();
     }
@@ -337,13 +337,19 @@ class Bspline {
 
     /// Refuse a space this field cannot be built over.
     ///
+    /// Static and taking its argument, so that both constructors can run it: the
+    /// flat one needs it inside its member-initializer list, before `net_` exists,
+    /// where a non-static member function cannot go. One function rather than two
+    /// copies of two message literals, which is the drift this shape removes.
+    ///
+    /// \param space The handle to check.
     /// \throws std::invalid_argument If the handle is null or the space has no
     ///         directions.
-    void check_space() const {
-        if (space_ == nullptr) {
+    static void check_space(const std::shared_ptr<const BsplineSpace<T>>& space) {
+        if (space == nullptr) {
             throw std::invalid_argument("the B-spline space is a null handle");
         }
-        if (space_->dim() == 0) {
+        if (space->dim() == 0) {
             throw std::invalid_argument(
                 "a B-spline over a space with no directions has no control net");
         }
@@ -403,13 +409,7 @@ class Bspline {
     [[nodiscard]] static net_type
     net_from_flat(const std::shared_ptr<const BsplineSpace<T>>& space,
                   std::span<const T> values) {
-        if (space == nullptr) {
-            throw std::invalid_argument("the B-spline space is a null handle");
-        }
-        if (space->dim() == 0) {
-            throw std::invalid_argument(
-                "a B-spline over a space with no directions has no control net");
-        }
+        check_space(space);
         const auto total = static_cast<std::size_t>(space->num_total_basis());
         if (values.size() % total != 0) {
             // The oracle's text, and the missing space after the full stop is the

--- a/cpp/include/pantr/bspline/bspline.hpp
+++ b/cpp/include/pantr/bspline/bspline.hpp
@@ -1,0 +1,439 @@
+#pragma once
+
+/// \file
+/// The B-spline field: a tensor-product space, a control net over it, and the
+/// quantities the pair fixes.
+///
+/// ## What this type owns, and what it does not
+///
+/// It owns the *value* -- a handle on the space, the control points, and the
+/// rationality flag -- plus the quantities they determine: `dim`, `degree` and
+/// `rank`.
+///
+/// It owns no *operations*, exactly as `pantr/bspline/space_nd.hpp` and
+/// `pantr/bspline/space_1d.hpp` own none. Evaluation, the derivative, degree
+/// elevation and reduction, knot insertion and removal, the boundary and periodic
+/// conversions, restriction, splitting, slicing, the Bézier decomposition, the
+/// product, reversal, direction permutation and the affine transform are
+/// computations *over* a field rather than properties *of* one, so they are
+/// separate ports over free functions taking a `const Bspline&`. That is what lets
+/// them proceed independently of one another once this type exists, and it is the
+/// same line those two headers draw.
+///
+/// **Two of them cannot be ported yet, and the reason is a declared boundary
+/// rather than an omission.** `pantr.bspline.Bspline.evaluate`,
+/// `.evaluate_derivatives` and `.to_beziers` reach
+/// `BsplineSpace1D.tabulate_basis` or `.tabulate_basis_derivatives`, and
+/// `space_1d.hpp` states that basis tabulation is a separate port over free
+/// functions which no ticket in this milestone covers. So those operations wait on
+/// that port, not on this one.
+///
+/// ## The space is shared, not copied, and the identity contract is why
+///
+/// `space_` is a `std::shared_ptr<const BsplineSpace<T>>`, per
+/// `design/bspline_ownership_lifetime.md`'s class **H**: an accessor that hands out
+/// a subobject the owner keeps returns a copy of the handle, so the *value* is
+/// shared and the owner's death is irrelevant. `rv_policy::reference_internal`
+/// would put that guarantee in the binding, and the binding is scheduled for
+/// deletion; a `shared_ptr<const T>` puts it in the type, where a C++ consumer with
+/// no interpreter present gets it too.
+///
+/// This is the type that note's reason 3 was measured on. Of three storage shapes
+/// it tabulates, only "store the handle, return a copy of the handle" reproduces
+/// today's Python: storing the space by value and returning a reference makes an
+/// escaped space silently start reporting the *new* space after an in-place
+/// reseat, and storing the handle while returning a reference is a use-after-free
+/// that reads back the correct value.
+///
+/// The borrowing twin, `space_ref`, is **not bound**: copying the handle costs an
+/// uncontended atomic increment/decrement pair per access, which an inner loop must
+/// not pay for a value it does not keep.
+/// `tests/parity/test_bspline_binding_contract.py` asserts that no bound method
+/// name ends in `_ref`.
+///
+/// ## No mutation, and therefore no `in_place`
+///
+/// `pantr.bspline.Bspline` is the one type in this milestone whose Python surface
+/// mutates: `reverse`, `permute_directions` and `transform` each take
+/// `in_place=True`, and the first two *reseat* the field's space.
+/// `design/bspline_derived_caches.md` calls it the type where construct-then-freeze
+/// does not hold.
+///
+/// **It holds here.** This type offers no mutator of any kind, and that is a
+/// decision with three reasons rather than an oversight:
+///
+///  - The project's rule is that a mutating sweep earns its place only when the
+///    mutation is **unobservable**. `in_place=True` is observable by construction
+///    -- it is chosen precisely so that a caller's handle sees the new value -- so
+///    it cannot be earned. The two ways the rule does admit are to take the object
+///    by value or to mutate a private duplicate, and both of those are just
+///    "return a new field".
+///  - `design/bspline_derived_caches.md` states as a **contract** that every
+///    non-mutating public accessor on a C++-owned pantr domain type is safe to call
+///    concurrently on one object with no external locking, with exactly one
+///    exception (a grid's tag registries, which are the reasoned
+///    accumulating-container case). A reseating `Bspline` would be a second
+///    exception with no such reason: a reseat of `space_` races every reader of
+///    `space()`, and no memo discipline helps, because the racing write is on the
+///    base state rather than on a memo.
+///  - The interpreter-free consumer gains nothing from it. `b = reversed(b, 0);`
+///    costs one move of a handle and a net. The Python flag exists to keep a numpy
+///    array's *identity* stable across the mutation, and this type's storage is not
+///    a numpy array a caller can hold in the first place.
+///
+/// So the Python `in_place=True` surface survives -- it is published API and
+/// removing it is not this port's to do -- and it is implemented one level up, by
+/// `pantr.bspline.Bspline` replacing its whole implementation in a single
+/// assignment. That is also the repair `design/bspline_derived_caches.md` asks
+/// this ticket for: the oracle's three separate cache-invalidation sites become one
+/// assignment that replaces the derived block wholesale, so there is no way to
+/// reseat one part of it without the other.
+///
+/// ## Where the derived caches are, and why not here
+///
+/// The oracle memoises two derived quantities on a field: the Bézier decomposition
+/// and the point-inversion context. Neither is here, and the reason is the
+/// operation boundary above rather than a disagreement with
+/// `design/bspline_derived_caches.md`: both are *produced by operations that have
+/// not been ported*, one of which cannot be until basis tabulation is. A memo can
+/// only live beside the computation that fills it. They move here with the
+/// operations that make them, and until then the wrapper holds them in one block
+/// it replaces wholesale.
+///
+/// So there is no `LazySlot` in this type and nothing `mutable`.
+///
+/// ## The control net is a copy, and that is the one deliberate divergence
+///
+/// `ControlNet<T>` stores its own buffer, so this type does not alias the array it
+/// was built from and hands out a read-only view of its own storage. The oracle
+/// does neither: `pantr.bspline.Bspline` stores the caller's array and returns that
+/// same object from `control_points`, so a caller can mutate a constructed field
+/// through either end -- and doing so desynchronises both of the memos above with
+/// nothing raising. `design/bspline_ownership_lifetime.md` records that as a defect
+/// in today's Python which the port removes, and this is the half of the removal
+/// that this ticket owns. It is the same divergence `pantr/bezier/bezier.hpp`
+/// already carries for the same reason, in the same direction.
+///
+/// ## Reusing `ControlNet`, across the package boundary
+///
+/// `net_` is a `pantr::bezier::ControlNet<T>`, which is the first include of
+/// another package's header from `pantr/bspline/`. It is deliberate:
+/// `pantr/bezier/control_net.hpp` says of itself that it is *not* a Bézier and that
+/// "for `pantr::bezier::Bezier` an extent is `degree + 1`, for a B-spline it is a
+/// basis count, and neither reading belongs to the array". This is that second
+/// reading. Writing a second owning `(shape, values)` pair here would be two
+/// implementations of one idea, which is what this port exists to remove.
+///
+/// The dependency direction matches the Python layer's, where
+/// `pantr.bspline._bspline_to_beziers` imports `pantr.bezier`. **The type's home is
+/// still wrong**: `pantr::core` is where a shape-plus-storage array belongs, and
+/// moving it is a rename across `pantr/bezier/bezier.hpp`, its binding, its tests
+/// and the *installed* header set, which `pantr/bezier/bezier.hpp` records as a
+/// promise. That is a separate change and is flagged rather than taken here.
+///
+/// ## Validating rather than asserting
+///
+/// This is the C++ counterpart of Layer 2, so it validates and throws in a release
+/// build as much as in a debug one. `pantr/core/error.hpp` sets the split: value
+/// and range checks live here, type-kind checks stay in the Python wrapper.
+///
+/// ## Parity notes for the Python oracle
+///
+/// `pantr.bspline.Bspline` is the oracle. What this type reproduces, and where it
+/// deliberately parts company:
+///
+///  - **The refusal messages are the oracle's, character for character**, as every
+///    other refusal in this port is. `tests/parity/test_bspline_type.py` compares
+///    the two texts rather than just the exception type.
+///  - **Two refusals of the oracle's are not reachable here, and stay the
+///    wrapper's.** The dtype mismatch between the control points and the space is a
+///    type-kind fact and `Bspline<T>` cannot hold a space of another width, so
+///    there is nothing to check; and the oracle raises `numpy`'s own reshape error
+///    for a control-point buffer that is empty while the space is not, whose text
+///    is numpy's rather than pantr's. The wrapper does the reshape, so that text is
+///    common mode and is not restated here.
+///  - **The order of the checks is the oracle's.** The count check comes before
+///    the rank check, so a field that is bad in both ways reports the count. Only
+///    the order decides which message a caller reads, and
+///    `cpp/tests/test_bspline_type.cpp` asserts the C++ half against a literal
+///    while the parity file asserts it against the live oracle.
+///  - **A field over a space with no directions is refused.** The oracle refuses
+///    it too, but by accident and with a different exception: it reads
+///    `space.dtype`, which raises `IndexError` on a dimensionless space. Since no
+///    control net can have zero parametric axes -- `ControlNet` reads a rank-1
+///    shape as `(n, 1)` -- there is no shape this constructor could accept, so it
+///    says so instead of reporting a shape mismatch against an empty basis count.
+///    The Python path never reaches it: the wrapper raises the oracle's
+///    `IndexError` first.
+///
+/// ## Thread safety
+///
+/// Every accessor below is safe to call concurrently on the same object with no
+/// external locking, and here that needs no mechanism at all: there is no memo and
+/// nothing `mutable`, so every accessor reads state frozen at construction. In a
+/// sweep, hoist `space_ref()` and `net()` into locals before the loop rather than
+/// calling them per element -- the references are free, but the calls are not, and
+/// `space()` costs an atomic pair.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/bezier/control_net.hpp"
+#include "pantr/bspline/space_nd.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+/// A B-spline curve, surface, volume or field over a tensor-product space.
+///
+/// Holds a handle on the space, a control net whose parametric extents are the
+/// space's basis counts, and a flag. For a rational field the last component of
+/// every coefficient is a homogeneous weight and the coordinates are stored
+/// weighted, so `rank()` is one less than the net's component count.
+///
+/// Instances are immutable: nothing here changes a field once it is built. See the
+/// file comment for why that holds even though the Python surface has three
+/// `in_place=True` methods.
+///
+/// \tparam T The scalar type the control points and the space's knots share.
+template <Real T>
+class Bspline {
+  public:
+    /// The scalar type the control points and the space's knots share.
+    using scalar_type = T;
+
+    /// The control-net type this field stores.
+    ///
+    /// Named so that a caller building one does not have to know it comes from
+    /// another package; see the file comment on why it does.
+    using net_type = pantr::bezier::ControlNet<T>;
+
+    /// Build a field from a space and a control net.
+    ///
+    /// The primary constructor, and the one the binding calls. Taking the net
+    /// rather than a flat buffer is what makes the extents checkable: a transposed
+    /// net has the same number of coefficients as a correct one, so the flat
+    /// overload below cannot tell them apart and this one can.
+    ///
+    /// \param space The space, shared. Sharing rather than copying is what
+    ///        preserves the wrapper's identity contract; see the file comment.
+    /// \param net The control points, moved in. Its parametric extents must be the
+    ///        space's basis counts, in axis order, and its last axis is the
+    ///        component axis.
+    /// \param is_rational Whether the last component of each coefficient is a
+    ///        homogeneous weight.
+    /// \throws std::invalid_argument If `space` is null, if it has no directions,
+    ///         if the net's parametric shape is not the space's basis counts, or if
+    ///         the resulting rank is not at least 1.
+    Bspline(std::shared_ptr<const BsplineSpace<T>> space, net_type net, bool is_rational)
+        : space_(std::move(space)), net_(std::move(net)), is_rational_(is_rational) {
+        check_space();
+        check_net_matches_space();
+        check_rank();
+    }
+
+    /// Build a field from a space and a flat coefficient buffer.
+    ///
+    /// The convenience the Python surface offers, for a C++ caller that has the
+    /// coefficients and not the shape: the component count is derived as
+    /// `values.size() / space->num_total_basis()`, and the parametric extents come
+    /// from the space. It carries the oracle's own message for a buffer that is not
+    /// a whole number of coefficients.
+    ///
+    /// \param space The space, shared. None may be null.
+    /// \param values The coefficients, row-major under
+    ///        `(*num_basis, num_components)`. Its size must be a multiple of
+    ///        `space->num_total_basis()`.
+    /// \param is_rational Whether the last component of each coefficient is a
+    ///        homogeneous weight.
+    /// \throws std::invalid_argument If `space` is null, if it has no directions,
+    ///         if `values` is not a whole number of coefficients, or if the
+    ///         resulting rank is not at least 1. An empty buffer is refused by the
+    ///         rank check rather than by the count check, since zero *is* a
+    ///         multiple; the message then says `rank 0`.
+    Bspline(std::shared_ptr<const BsplineSpace<T>> space, std::span<const T> values,
+            bool is_rational)
+        : space_(std::move(space)), net_(net_from_flat(space_, values)),
+          is_rational_(is_rational) {
+        // `space_` is declared before `net_`, so it is initialized first and
+        // `net_from_flat` can read it. The space's own validation happens there,
+        // because the shape cannot be derived without it; repeating it here would
+        // report one fault twice.
+        check_rank();
+    }
+
+    /// Share this field's space.
+    ///
+    /// The returned handle keeps its value alive independently of this field, so a
+    /// caller may outlive the owner.
+    ///
+    /// \return A handle on the space.
+    [[nodiscard]] std::shared_ptr<const BsplineSpace<T>> space() const noexcept { return space_; }
+
+    /// Borrow this field's space.
+    ///
+    /// Valid while `*this` is, and **not bound**: an inner loop must not pay an
+    /// atomic pair per access. See the `_ref` rule in the file comment.
+    ///
+    /// \return A reference to the space.
+    [[nodiscard]] const BsplineSpace<T>& space_ref() const noexcept { return *space_; }
+
+    /// The control points.
+    ///
+    /// \return The stored net, valid while the field lives.
+    [[nodiscard]] const net_type& net() const noexcept { return net_; }
+
+    /// Whether the last component of each coefficient is a homogeneous weight.
+    ///
+    /// \return `true` for a rational field (a NURBS).
+    [[nodiscard]] bool is_rational() const noexcept { return is_rational_; }
+
+    /// The number of parametric directions.
+    ///
+    /// Forwarded from the space rather than read off the net, because the space is
+    /// what defines it; the constructor is what makes the two agree.
+    ///
+    /// \return `space_ref().dim()`, at least 1.
+    [[nodiscard]] std::int64_t dim() const noexcept { return space_->dim(); }
+
+    /// The polynomial degree of each parametric direction.
+    ///
+    /// \return A view of `dim()` non-negative degrees, in axis order, owned by the
+    ///         space and valid while it lives -- which is at least as long as this
+    ///         field.
+    [[nodiscard]] std::span<const std::int64_t> degree() const noexcept {
+        return space_->degrees();
+    }
+
+    /// The number of value components a caller sees.
+    ///
+    /// The weight column of a rational field is not one of them: a rational surface
+    /// in space stores four components and has rank 3.
+    ///
+    /// \return `net().num_components()`, less one when rational. At least 1.
+    [[nodiscard]] std::int64_t rank() const noexcept { return signed_rank(); }
+
+  private:
+    /// The rank, before it is known to be positive.
+    ///
+    /// Split out so that the constructor's check and the public accessor cannot
+    /// drift apart, which is `pantr/bezier/bezier.hpp`'s reason for the same split.
+    /// Signed because the oracle reports a negative rank for a rational net with no
+    /// coordinates at all, and reproducing its message means reproducing its
+    /// arithmetic.
+    ///
+    /// \return The component count less the weight column, possibly zero or
+    ///         negative.
+    [[nodiscard]] std::int64_t signed_rank() const noexcept {
+        return static_cast<std::int64_t>(net_.num_components())
+               - (is_rational_ ? std::int64_t{1} : std::int64_t{0});
+    }
+
+    /// Refuse a space this field cannot be built over.
+    ///
+    /// \throws std::invalid_argument If the handle is null or the space has no
+    ///         directions.
+    void check_space() const {
+        if (space_ == nullptr) {
+            throw std::invalid_argument("the B-spline space is a null handle");
+        }
+        if (space_->dim() == 0) {
+            throw std::invalid_argument(
+                "a B-spline over a space with no directions has no control net");
+        }
+    }
+
+    /// Refuse a net whose parametric shape is not the space's basis counts.
+    ///
+    /// The check the flat overload cannot make. It is near-vacuous on the Python
+    /// path, where the wrapper derives the shape from the same `num_basis` this
+    /// compares against, and load-bearing for a C++ caller, where a transposed net
+    /// has exactly as many coefficients as a correct one.
+    ///
+    /// \throws std::invalid_argument If the net's dimension or any extent differs
+    ///         from the space's.
+    void check_net_matches_space() const {
+        const std::span<const std::int64_t> counts = space_->num_basis();
+        if (static_cast<std::int64_t>(net_.dim()) != space_->dim()) {
+            throw std::invalid_argument(
+                "the control net has " + std::to_string(net_.dim())
+                + " parametric direction(s) and the space has " + std::to_string(space_->dim()));
+        }
+        for (std::size_t d = 0; d < net_.dim(); ++d) {
+            const auto expected = static_cast<std::size_t>(counts[d]);
+            if (net_.extent(d) != expected) {
+                throw std::invalid_argument(
+                    "the control net has " + std::to_string(net_.extent(d))
+                    + " coefficient(s) along direction " + std::to_string(d)
+                    + " and the space has " + std::to_string(expected) + " basis function(s)");
+            }
+        }
+    }
+
+    /// Refuse a field with no value components left after the weight column.
+    ///
+    /// \throws std::invalid_argument If the rank is not at least 1, with the
+    ///         oracle's message.
+    void check_rank() const {
+        const std::int64_t rank = signed_rank();
+        if (rank <= 0) {
+            throw std::invalid_argument("The B-spline must have at least rank one. Got rank "
+                                        + std::to_string(rank));
+        }
+    }
+
+    /// The net a flat coefficient buffer forms over `space`.
+    ///
+    /// A static helper rather than a member, because it runs inside the member
+    /// initializer list of the flat constructor, before `net_` exists. It validates
+    /// the space itself, since the shape cannot be derived without one.
+    ///
+    /// \param space The space, already moved into `space_`.
+    /// \param values The coefficients.
+    /// \return A net of shape `(*num_basis, values.size() / num_total_basis)`.
+    /// \throws std::invalid_argument If `space` is unusable, or if `values.size()`
+    ///         is not a multiple of `space->num_total_basis()`, with the oracle's
+    ///         message for the latter.
+    [[nodiscard]] static net_type
+    net_from_flat(const std::shared_ptr<const BsplineSpace<T>>& space,
+                  std::span<const T> values) {
+        if (space == nullptr) {
+            throw std::invalid_argument("the B-spline space is a null handle");
+        }
+        if (space->dim() == 0) {
+            throw std::invalid_argument(
+                "a B-spline over a space with no directions has no control net");
+        }
+        const auto total = static_cast<std::size_t>(space->num_total_basis());
+        if (values.size() % total != 0) {
+            // The oracle's text, and the missing space after the full stop is the
+            // oracle's too: it concatenates two f-strings without a separator.
+            // Reproducing it is what makes a caller's `pytest.raises(match=...)`
+            // backend-independent, so it is not a typo to tidy here.
+            throw std::invalid_argument(
+                "The number of control points must be a multiple of the number of basis "
+                "functions.Got "
+                + std::to_string(values.size()) + " control points and " + std::to_string(total)
+                + " basis functions.");
+        }
+        std::vector<std::size_t> shape;
+        shape.reserve(static_cast<std::size_t>(space->dim()) + 1);
+        for (const std::int64_t count : space->num_basis()) {
+            shape.push_back(static_cast<std::size_t>(count));
+        }
+        shape.push_back(values.size() / total);
+        return net_type(values, std::span<const std::size_t>(shape));
+    }
+
+    std::shared_ptr<const BsplineSpace<T>> space_;  ///< The space, shared.
+    net_type net_;                                  ///< The control points, owned.
+    bool is_rational_;  ///< Whether the last component is a homogeneous weight.
+};
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/bspline.hpp
+++ b/cpp/include/pantr/bspline/bspline.hpp
@@ -83,11 +83,15 @@
 ///
 /// So the Python `in_place=True` surface survives -- it is published API and
 /// removing it is not this port's to do -- and it is implemented one level up, by
-/// `pantr.bspline.Bspline` replacing its whole implementation in a single
-/// assignment. That is also the repair `design/bspline_derived_caches.md` asks
-/// this ticket for: the oracle's three separate cache-invalidation sites become one
-/// assignment that replaces the derived block wholesale, so there is no way to
-/// reseat one part of it without the other.
+/// `pantr.bspline.Bspline` replacing its whole implementation wholesale, through
+/// the single writer that owns all of it. "Wholesale" rather than "atomically":
+/// that writer is three successive slot stores, so a *concurrent* reader could
+/// still see a torn triple -- which is not a regression (the pre-port oracle had
+/// the same shape) and not a gap in the contract, since
+/// `design/bspline_derived_caches.md` exempts a mutating accessor from it. What
+/// the single writer buys is that no *sequential* caller can reseat one part
+/// without the other, which is the repair that document asks this ticket for: the
+/// oracle's three separate cache-invalidation sites become one.
 ///
 /// ## Where the derived caches are, and why not here
 ///

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -39,7 +39,8 @@ set(PANTR_TEST_SOURCES
     test_extraction_kernels.cpp
     test_bspline_extraction.cpp
     test_bspline_knot_insertion.cpp
-    test_thb_space.cpp)
+    test_thb_space.cpp
+    test_bspline_type.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file.

--- a/cpp/tests/test_bspline_type.cpp
+++ b/cpp/tests/test_bspline_type.cpp
@@ -16,11 +16,18 @@
 /// A tensor-product type is where a symmetric case set proves nothing: if two
 /// directions agree on their basis count then a transposed net, an off-by-one in
 /// the axis index and a shape check that compares sums all pass.
-/// `check_a_surface` and `check_a_volume` therefore differ in the degree, the basis
-/// count and the domain of every direction at once, and their component counts are
-/// different again from both, so no permutation of the shape is another admissible
-/// shape. `check_the_shape_is_the_spaces_basis_counts` asserts that of the case set
-/// itself, by feeding a transposed net to the same space and requiring a refusal.
+/// `check_a_surface` and `check_a_volume` therefore have no two directions alike in
+/// the degree, the basis count or the domain, and a component count that is none of
+/// the basis counts -- so no permutation of a net's shape is another admissible
+/// shape for its space. Those two read a valid field's properties; what they buy is
+/// that a per-direction forward cannot be right by coincidence.
+///
+/// **Refusing a wrong shape is a different property and a different case.**
+/// `check_the_shape_is_the_spaces_basis_counts` is where it is tested, on a space of
+/// its own, and it needs three nets rather than one: transposed, mis-ranked, and one
+/// whose *later* direction is wrong -- the last because a transposed net has
+/// direction 0 wrong too, so a check that compares the first extent and stops
+/// refuses it anyway.
 ///
 /// ## The five cases that exist because getting them wrong is silent
 ///
@@ -199,23 +206,32 @@ void check_a_surface() {
     PANTR_CHECK(&field.space_ref() == space.get());
 }
 
-/// A three-direction field, all three directions distinct.
+/// A three-direction field, no two directions alike in anything.
 ///
-/// A two-direction case cannot distinguish a shape check that compares the first
-/// extent and stops from one that compares all of them.
+/// A third direction is what distinguishes a per-direction forward from one that
+/// happens to be right for two: `degree()` and the net's shape are both sequences,
+/// and a two-entry sequence read backwards is still a two-entry sequence.
+///
+/// Degrees 2, 1 and 3; basis counts 5, 3 and 7; domains `[0, 3]`, `[10, 12]` and
+/// `[100, 104]`, three different scales. The component axis is 2, which is none of
+/// the basis counts, so no permutation of `(5, 3, 7, 2)` is another admissible shape
+/// for this space.
 void check_a_volume() {
     const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
-    const std::vector<double> second{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
-    const std::vector<double> third{0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0};
-    const auto space = nd<double>({one_d(first, 2), one_d(second, 2), one_d(third, 1)});
-    // The basis counts are 5, 3 and 5; the component axis is 2.
-    const Bspline<double> field(space, ramp<double>({5, 3, 5, 2}), false);
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};
+    const std::vector<double> third{100.0, 100.0, 100.0, 100.0, 101.0,
+                                    102.0, 103.0, 104.0, 104.0, 104.0, 104.0};
+    const auto space = nd<double>({one_d(first, 2), one_d(second, 1), one_d(third, 3)});
+    const Bspline<double> field(space, ramp<double>({5, 3, 7, 2}), false);
 
     PANTR_CHECK(field.dim() == 3);
-    PANTR_CHECK(equals(field.degree(), std::vector<std::int64_t>{2, 2, 1}));
+    PANTR_CHECK(equals(field.degree(), std::vector<std::int64_t>{2, 1, 3}));
+    PANTR_CHECK(equals(field.space()->num_basis(), std::vector<std::int64_t>{5, 3, 7}));
     PANTR_CHECK(field.rank() == 2);
-    PANTR_CHECK(equals(field.net().shape(), std::vector<std::size_t>{5, 3, 5, 2}));
-    PANTR_CHECK(field.net().size() == 150);
+    PANTR_CHECK(equals(field.net().shape(), std::vector<std::size_t>{5, 3, 7, 2}));
+    PANTR_CHECK(field.net().size() == 210);
+    PANTR_CHECK_MSG(field.net().values()[209] == 210.0,
+                    "the last coefficient of the largest net arrived");
 }
 
 /// A rational curve: the weight column is stored and is not part of the rank.
@@ -533,6 +549,20 @@ void check_copy_and_move() {
 /// atomic control block. The threads are released together off an atomic flag so
 /// that the reads genuinely overlap; a run in which each finished before the next
 /// began would report clean for the wrong reason.
+///
+/// **Nothing here asserts that the overlap happened, and nothing can**: that is the
+/// sanitizer's to detect, and `design/bspline_derived_caches.md` F3 is the reason --
+/// the shape one level down gave 60 correct answers in 60 unsanitized runs and four
+/// ThreadSanitizer reports. What the assertions do is stop the loop becoming dead
+/// code, which would make the sanitizer's silence meaningless. So the total is
+/// compared against a hand-computed literal rather than only against the other
+/// threads' totals: eight threads agreeing on zero is agreement.
+///
+/// An earlier version ended on `field.space().use_count() >= 2` and called that the
+/// vacuity guard. It was not one. `space` is a named local held for the whole
+/// function, so the local plus the field's own member already make the count 2 the
+/// instant the field is built -- before any thread runs, and whether or not the loop
+/// body calls anything at all.
 void check_concurrent_reads() {
     const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
     const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};
@@ -568,13 +598,19 @@ void check_concurrent_reads() {
         thread.join();
     }
 
+    // Per iteration: dim + rank (2 + 4), the two degrees (2 + 1), the flag (0), the
+    // first and last coefficients (1 + 60), the component count (4), the space's
+    // total basis count (5 * 3), and the borrowed space's dim (2). That is 91, over
+    // 2000 iterations. Hand-computed from the case above, so it dies if any accessor
+    // stops being called, starts returning something else, or the loop goes dead.
+    constexpr double expected = 91.0 * 2000.0;
     for (int t = 0; t < num_threads; ++t) {
         PANTR_CHECK_MSG(sums[static_cast<std::size_t>(t)] == sums[0],
                         "every thread must read one state");
+        PANTR_CHECK_MSG(sums[static_cast<std::size_t>(t)] == expected,
+                        "a thread's total is not the hand-computed one, so the loop body "
+                        "is not reading what this test says it reads");
     }
-    PANTR_CHECK_MSG(field.space().use_count() >= 2,
-                    "the vacuity guard: the shared handle survived the contention, so the "
-                    "atomic path really was exercised");
 }
 
 }  // namespace

--- a/cpp/tests/test_bspline_type.cpp
+++ b/cpp/tests/test_bspline_type.cpp
@@ -1,0 +1,571 @@
+/// \file
+/// The B-spline field: what it holds, what it shares, and what it refuses.
+///
+/// ## What is asserted, and against what
+///
+/// Nothing here carries a numerical tolerance, and that is a property of the type
+/// rather than a choice about the test. A field stores a handle, a buffer and a
+/// flag; `dim`, `degree` and `rank` are integer reads and one subtraction. There is
+/// no arithmetic on a coefficient anywhere in this file's subject, so `==` is the
+/// only comparison that says anything -- a tolerance would be hiding a
+/// transcription error rather than allowing for rounding. The coefficients are
+/// therefore asserted against the exact values they were built from.
+///
+/// ## The case set is asymmetric where it can be
+///
+/// A tensor-product type is where a symmetric case set proves nothing: if two
+/// directions agree on their basis count then a transposed net, an off-by-one in
+/// the axis index and a shape check that compares sums all pass.
+/// `check_a_surface` and `check_a_volume` therefore differ in the degree, the basis
+/// count and the domain of every direction at once, and their component counts are
+/// different again from both, so no permutation of the shape is another admissible
+/// shape. `check_the_shape_is_the_spaces_basis_counts` asserts that of the case set
+/// itself, by feeding a transposed net to the same space and requiring a refusal.
+///
+/// ## The five cases that exist because getting them wrong is silent
+///
+/// **`check_the_space_is_shared_not_copied`.** The constructor takes a handle and
+/// must store it, not a copy of what it points at. If it copied, every value
+/// assertion here would still pass, and the Python contract
+/// `Bspline(space, cp).space is space` would present two Python objects agreeing on
+/// identity over two different C++ objects -- `design/bspline_ownership_lifetime.md`
+/// F6. Comparing addresses is what distinguishes the two.
+///
+/// **`check_the_space_outlives_the_field`.** The reason class H stores a
+/// `shared_ptr<const T>` rather than taking `reference_internal` on the binding is
+/// that the guarantee has to live in the type, where a consumer with no interpreter
+/// gets it too. So the space is taken out, the field destroyed, and the space read.
+/// F4 of that note is why the assertion is on a *count* rather than on the pointer
+/// being non-null: a scalar read after free returns the correct value often enough
+/// that the obvious version of this test passes on a broken design.
+///
+/// **`check_the_net_is_copied_not_aliased`.** This is the one place the port
+/// deliberately disagrees with its oracle, and it disagrees in the direction that
+/// looks like nothing happening: the oracle stores the caller's array, so a write
+/// through it moves an already-validated field, and this type stores a copy so it
+/// does not. Asserted by mutating the source buffer afterwards, which is the only
+/// way to tell a copy from a view when both read back the same values.
+///
+/// **`check_a_periodic_direction`.** The net's parametric extents are the space's
+/// **basis counts**, which for a periodic direction are not `len(knots) - degree - 1`.
+/// A field built with the non-periodic count has the wrong number of coefficients
+/// and must be refused; a field built with the periodic count must be accepted. The
+/// expected counts are stated as literals derived from
+/// `pantr/bspline/knots.hpp`'s own formula rather than read off the space, so this
+/// case cannot agree with the implementation by taking its answer from it.
+///
+/// **`check_concurrent_reads`.** `bspline.hpp` claims every accessor is safe to
+/// call concurrently with no external locking. Here that should hold structurally
+/// -- there is no memo and nothing `mutable` -- but "should" is what
+/// `design/bspline_derived_caches.md` F3 refutes one level down, where a bare
+/// `mutable std::optional` gave 60 correct answers in 60 unsanitized runs and four
+/// ThreadSanitizer reports. So the claim gets a gate rather than a reader's trust,
+/// and the gate is a sanitizer build rather than an assertion on a value.
+///
+/// ## The refusal messages are compared against literals
+///
+/// `check_refusals` hardcodes each message. The parity file compares the same
+/// messages against the *live* oracle; this half is what makes a reworded message a
+/// failure even when nobody runs Python. Two of the seven have no oracle
+/// counterpart and are C++-only, and the file comment of `bspline.hpp` says which
+/// and why.
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bspline/bspline.hpp"
+
+namespace {
+
+using pantr::bezier::ControlNet;
+using pantr::bspline::Bspline;
+using pantr::bspline::BsplineSpace;
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::KnotSnapping;
+
+/// Build a shared univariate space from a knot vector and a degree.
+///
+/// \tparam T The scalar type.
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param periodic Whether the space wraps.
+/// \return A handle on the space, snapping near-duplicates as the oracle's default
+///         does.
+template <class T>
+std::shared_ptr<const BsplineSpace1D<T>> one_d(const std::vector<T>& knots, std::int64_t degree,
+                                               bool periodic = false) {
+    return std::make_shared<const BsplineSpace1D<T>>(std::span<const T>(knots), degree, periodic,
+                                                     KnotSnapping::merge_near_duplicates);
+}
+
+/// Build a shared tensor-product space from univariate handles.
+///
+/// \tparam T The scalar type.
+/// \param spaces One handle per direction, in axis order.
+/// \return A handle on the tensor-product space.
+template <class T>
+std::shared_ptr<const BsplineSpace<T>>
+nd(std::vector<std::shared_ptr<const BsplineSpace1D<T>>> spaces) {
+    return std::make_shared<const BsplineSpace<T>>(std::move(spaces));
+}
+
+/// A control net over the given shape, holding `1, 2, 3, ...`.
+///
+/// Consecutive integers rather than a constant, so that a transposed or
+/// wrongly-strided copy reads back different values instead of the same ones.
+///
+/// \tparam T The scalar type.
+/// \param shape The extents, the last being the component count.
+/// \return The net.
+template <class T>
+ControlNet<T> ramp(const std::vector<std::size_t>& shape) {
+    std::size_t size = 1;
+    for (const std::size_t extent : shape) {
+        size *= extent;
+    }
+    std::vector<T> values(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        values[i] = static_cast<T>(i + 1);
+    }
+    return ControlNet<T>(std::span<const T>(values), std::span<const std::size_t>(shape));
+}
+
+/// Whether a span holds exactly the given values, in order.
+///
+/// \tparam T The element type.
+/// \param actual The span.
+/// \param expected The values.
+/// \return `true` if the two agree elementwise.
+template <class T>
+bool equals(std::span<const T> actual, const std::vector<T>& expected) {
+    if (actual.size() != expected.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        if (!(actual[i] == expected[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// The message of the `std::invalid_argument` a call raises, or a marker.
+///
+/// \tparam F The callable.
+/// \param build A no-argument call expected to throw.
+/// \return The message, or a marker saying what happened instead, so that the
+///         caller's assertion is the one that reports.
+template <class F>
+std::string refusal_of(F build) {
+    try {
+        build();
+    } catch (const std::invalid_argument& error) {
+        return error.what();
+    } catch (const std::exception& error) {
+        return std::string("<other exception: ") + error.what() + ">";
+    }
+    return "<did not throw>";
+}
+
+/// A vector-valued surface whose every direction differs from every other.
+///
+/// Direction 0 is a clamped quadratic over three intervals on `[0, 3]`, so five
+/// basis functions; direction 1 is a clamped linear over two intervals on
+/// `[10, 12]`, so three. The component count is 4, which is neither basis count, so
+/// no permutation of `(5, 3, 4)` is another admissible shape for this space.
+void check_a_surface() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};
+    const auto space = nd<double>({one_d(first, 2), one_d(second, 1)});
+    const Bspline<double> field(space, ramp<double>({5, 3, 4}), false);
+
+    PANTR_CHECK(field.dim() == 2);
+    PANTR_CHECK(equals(field.degree(), std::vector<std::int64_t>{2, 1}));
+    PANTR_CHECK_MSG(field.rank() == 4, "non-rational: the rank is the whole component axis");
+    PANTR_CHECK(!field.is_rational());
+    PANTR_CHECK(equals(field.net().shape(), std::vector<std::size_t>{5, 3, 4}));
+    PANTR_CHECK(field.net().size() == 60);
+    PANTR_CHECK_MSG(field.net().values()[0] == 1.0 && field.net().values()[59] == 60.0,
+                    "the coefficients arrived in order and none was lost at either end");
+    PANTR_CHECK_MSG(field.space().get() == space.get(), "the space is the handle it was given");
+    PANTR_CHECK(&field.space_ref() == space.get());
+}
+
+/// A three-direction field, all three directions distinct.
+///
+/// A two-direction case cannot distinguish a shape check that compares the first
+/// extent and stops from one that compares all of them.
+void check_a_volume() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::vector<double> second{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const std::vector<double> third{0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0};
+    const auto space = nd<double>({one_d(first, 2), one_d(second, 2), one_d(third, 1)});
+    // The basis counts are 5, 3 and 5; the component axis is 2.
+    const Bspline<double> field(space, ramp<double>({5, 3, 5, 2}), false);
+
+    PANTR_CHECK(field.dim() == 3);
+    PANTR_CHECK(equals(field.degree(), std::vector<std::int64_t>{2, 2, 1}));
+    PANTR_CHECK(field.rank() == 2);
+    PANTR_CHECK(equals(field.net().shape(), std::vector<std::size_t>{5, 3, 5, 2}));
+    PANTR_CHECK(field.net().size() == 150);
+}
+
+/// A rational curve: the weight column is stored and is not part of the rank.
+void check_a_rational_curve() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const auto space = nd<double>({one_d(knots, 2)});
+    const Bspline<double> field(space, ramp<double>({3, 3}), true);
+
+    PANTR_CHECK(field.dim() == 1);
+    PANTR_CHECK(field.is_rational());
+    PANTR_CHECK_MSG(field.rank() == 2, "three stored components, one of them the weight");
+    PANTR_CHECK_MSG(field.net().num_components() == 3, "and the storage still holds all three");
+
+    const Bspline<double> polynomial(space, ramp<double>({3, 3}), false);
+    PANTR_CHECK_MSG(polynomial.rank() == 3,
+                    "the same net read as non-rational has one more component of rank, "
+                    "so the flag is what the rank depends on and not the shape alone");
+}
+
+/// A scalar field, which is the shape the projection and interpolation layers build.
+void check_a_scalar_field() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0};
+    const auto space = nd<double>({one_d(knots, 2)});
+    const Bspline<double> field(space, ramp<double>({4, 1}), false);
+
+    PANTR_CHECK(field.rank() == 1);
+    PANTR_CHECK(equals(field.net().shape(), std::vector<std::size_t>{4, 1}));
+}
+
+/// The net's parametric extents are the space's basis counts, in axis order.
+///
+/// The vacuity guard for the whole case set: a transposed net has exactly as many
+/// coefficients as a correct one, so nothing about a *size* can refuse it.
+void check_the_shape_is_the_spaces_basis_counts() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};  // 5 basis
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};           // 3 basis
+    const auto space = nd<double>({one_d(first, 2), one_d(second, 1)});
+
+    const std::string transposed = refusal_of([&] {
+        return Bspline<double>(space, ramp<double>({3, 5, 4}), false);
+    });
+    PANTR_CHECK_MSG(transposed
+                        == "the control net has 3 coefficient(s) along direction 0 and the "
+                           "space has 5 basis function(s)",
+                    "message was: " + transposed);
+
+    const std::string mis_ranked = refusal_of([&] {
+        return Bspline<double>(space, ramp<double>({15, 4}), false);
+    });
+    PANTR_CHECK_MSG(mis_ranked
+                        == "the control net has 1 parametric direction(s) and the space has 2",
+                    "message was: " + mis_ranked);
+
+    // Bad in both ways at once, which is what pins the ORDER of the net
+    // constructor's two checks: transposed AND, being rational with one stored
+    // component, of rank 0. Every other case here violates one rule and has one
+    // possible message, so a reordering would be invisible.
+    const std::string both = refusal_of([&] {
+        return Bspline<double>(space, ramp<double>({3, 5, 1}), true);
+    });
+    PANTR_CHECK_MSG(both == transposed,
+                    "the shape check runs before the rank check, so a net that is both "
+                    "transposed and rank-zero reports the shape: "
+                        + both);
+}
+
+/// The space is stored as the handle it was given, not as a copy of its value.
+void check_the_space_is_shared_not_copied() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const auto one = one_d<double>(knots, 2);
+    const auto space = nd<double>({one});
+    const auto before = space.use_count();
+    const Bspline<double> field(space, ramp<double>({3, 2}), false);
+
+    PANTR_CHECK_MSG(field.space().get() == space.get(),
+                    "a copying constructor would give a different address here and pass "
+                    "every value assertion in this file");
+    PANTR_CHECK_MSG(space.use_count() > before, "and the field really took a reference");
+    PANTR_CHECK_MSG(field.space()->space(0).get() == one.get(),
+                    "sharing composes: the field's space shares its directions too");
+}
+
+/// A space taken out of a field stays valid after the field is destroyed.
+///
+/// Asserted on a count rather than on a non-null pointer, because
+/// `design/bspline_ownership_lifetime.md` F4 measured that a scalar read after free
+/// returns the correct value often enough for the obvious test to pass on a broken
+/// design. Under a `shared_ptr` this is not a read after free at all, which is the
+/// point; under a raw reference the sanitizer leg reports one.
+void check_the_space_outlives_the_field() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};
+    std::shared_ptr<const BsplineSpace<double>> escaped;
+    {
+        const Bspline<double> field(nd<double>({one_d(first, 2), one_d(second, 1)}),
+                                    ramp<double>({5, 3, 4}), false);
+        escaped = field.space();
+        PANTR_CHECK(escaped.use_count() >= 2);
+    }
+    PANTR_CHECK_MSG(escaped.use_count() == 1, "the field released its reference");
+    PANTR_CHECK_MSG(escaped->num_total_basis() == 15, "and the value survived it");
+    PANTR_CHECK(equals(escaped->degrees(), std::vector<std::int64_t>{2, 1}));
+}
+
+/// The field copies the coefficients it is built from and does not alias them.
+///
+/// The one deliberate divergence from the oracle, and the one that looks like
+/// nothing happening: the oracle stores the caller's array, so a later write moves
+/// an already-validated field. Mutating the source afterwards is the only way to
+/// tell a copy from a view when both read back the same values at first.
+void check_the_net_is_copied_not_aliased() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const auto space = nd<double>({one_d(knots, 2)});
+    std::vector<double> values{1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    const std::vector<std::size_t> shape{3, 2};
+    const Bspline<double> field(
+        space, ControlNet<double>(std::span<const double>(values),
+                                  std::span<const std::size_t>(shape)),
+        false);
+
+    PANTR_CHECK(field.net().values()[0] == 1.0);
+    values[0] = 99.0;
+    PANTR_CHECK_MSG(field.net().values()[0] == 1.0,
+                    "a write through the source buffer must not reach a built field");
+    PANTR_CHECK_MSG(field.net().values().data() != values.data(),
+                    "and the storage is genuinely the field's own");
+}
+
+/// The flat constructor derives the shape the net constructor is handed.
+///
+/// Both spellings must produce the same field, and the flat one must derive the
+/// component count from the space rather than guess it: the same 24 coefficients
+/// are rank 2 over a 12-basis space and rank 4 over a 6-basis one.
+void check_the_flat_constructor_derives_the_shape() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};  // 5 basis
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};           // 3 basis
+    const auto space = nd<double>({one_d(first, 2), one_d(second, 1)});
+    std::vector<double> values(60);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<double>(i + 1);
+    }
+
+    const Bspline<double> flat(space, std::span<const double>(values), false);
+    const Bspline<double> shaped(space, ramp<double>({5, 3, 4}), false);
+    PANTR_CHECK(equals(flat.net().shape(), std::vector<std::size_t>{5, 3, 4}));
+    PANTR_CHECK(equals(flat.net().values(), values));
+    PANTR_CHECK(equals(flat.net().values(), std::vector<double>(shaped.net().values().begin(),
+                                                               shaped.net().values().end())));
+    PANTR_CHECK(flat.rank() == shaped.rank());
+    PANTR_CHECK(flat.rank() == 4);
+
+    // The same buffer over a space with a different total is a different rank, so
+    // the derivation reads the space rather than assuming a component count.
+    const std::vector<double> narrow{0.0, 0.0, 1.0, 1.0};  // 2 basis, degree 1
+    const auto small = nd<double>({one_d(narrow, 1), one_d(narrow, 1)});  // 4 total
+    const Bspline<double> wide(small, std::span<const double>(values), false);
+    PANTR_CHECK_MSG(wide.rank() == 15, "60 coefficients over 4 basis functions is rank 15");
+}
+
+/// A periodic direction stores its own basis count, not `len(knots) - degree - 1`.
+///
+/// The expected counts are literals derived from `pantr/bspline/knots.hpp`'s
+/// formula, not read off the space: for a periodic direction the count is
+/// `len(knots) - degree - 1 - (degree - multiplicity_of_first_in_domain) - 1`.
+/// This knot vector has 9 entries at degree 2 and the first in-domain knot is
+/// simple, so the count is `9 - 2 - 1 - (2 - 1) - 1 = 4`, against `6` if the
+/// direction were read as non-periodic.
+void check_a_periodic_direction() {
+    const std::vector<double> knots{-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    const auto direction = one_d<double>(knots, 2, true);
+    PANTR_CHECK_MSG(direction->num_basis() == 4,
+                    "the case is only meaningful if the space agrees with the hand "
+                    "derivation, and it is the hand derivation that is the oracle here");
+    const auto space = nd<double>({direction});
+
+    const Bspline<double> field(space, ramp<double>({4, 3}), false);
+    PANTR_CHECK(field.rank() == 3);
+    PANTR_CHECK(equals(field.net().shape(), std::vector<std::size_t>{4, 3}));
+
+    const std::string refused = refusal_of([&] {
+        return Bspline<double>(space, ramp<double>({6, 3}), false);
+    });
+    PANTR_CHECK_MSG(refused
+                        == "the control net has 6 coefficient(s) along direction 0 and the "
+                           "space has 4 basis function(s)",
+                    "message was: " + refused);
+}
+
+/// Every construction the type must refuse, and the exact text of each.
+///
+/// The order of the two checks the flat constructor makes is pinned by the last
+/// case, which is bad in both ways at once: every other entry violates one rule and
+/// has one possible message, so a reordering would be invisible.
+void check_refusals() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};  // 3 basis, degree 2
+    const auto space = nd<double>({one_d(knots, 2)});
+    const std::vector<double> three{1.0, 2.0, 3.0};
+    const std::vector<double> four{1.0, 2.0, 3.0, 4.0};
+
+    const std::string null_space = refusal_of([&] {
+        return Bspline<double>(nullptr, ramp<double>({3, 2}), false);
+    });
+    PANTR_CHECK_MSG(null_space == "the B-spline space is a null handle",
+                    "message was: " + null_space);
+
+    const std::string null_flat = refusal_of([&] {
+        return Bspline<double>(nullptr, std::span<const double>(three), false);
+    });
+    PANTR_CHECK_MSG(null_flat == "the B-spline space is a null handle",
+                    "the flat overload validates the space too: " + null_flat);
+
+    const auto dimensionless =
+        nd<double>(std::vector<std::shared_ptr<const BsplineSpace1D<double>>>{});
+    const std::string no_directions = refusal_of([&] {
+        return Bspline<double>(dimensionless, ramp<double>({1, 1}), false);
+    });
+    PANTR_CHECK_MSG(no_directions == "a B-spline over a space with no directions has no control net",
+                    "message was: " + no_directions);
+
+    const std::string rank_zero = refusal_of([&] {
+        return Bspline<double>(space, ramp<double>({3, 1}), true);
+    });
+    PANTR_CHECK_MSG(rank_zero == "The B-spline must have at least rank one. Got rank 0",
+                    "message was: " + rank_zero);
+
+    const std::string rank_negative = refusal_of([&] {
+        return Bspline<double>(space, ramp<double>({3, 0}), true);
+    });
+    PANTR_CHECK_MSG(rank_negative == "The B-spline must have at least rank one. Got rank -1",
+                    "a rational net with no components at all is why the arithmetic is "
+                    "signed; an unsigned one would report a number near 2^64: "
+                        + rank_negative);
+
+    const std::string not_a_multiple = refusal_of([&] {
+        return Bspline<double>(space, std::span<const double>(four), false);
+    });
+    PANTR_CHECK_MSG(not_a_multiple
+                        == "The number of control points must be a multiple of the number of "
+                           "basis functions.Got 4 control points and 3 basis functions.",
+                    "the oracle's own text, missing space included: " + not_a_multiple);
+
+    // Bad in both ways: 4 is not a multiple of 3, AND a rational field of three
+    // coefficients would have rank 0. Only the order decides which is reported.
+    const std::string both = refusal_of([&] {
+        return Bspline<double>(space, std::span<const double>(four), true);
+    });
+    PANTR_CHECK_MSG(both == not_a_multiple,
+                    "the count check runs before the rank check, as the oracle's does: "
+                        + both);
+}
+
+/// The `float32` field, which is the half of the matrix nobody reads first.
+void check_float_storage() {
+    const std::vector<float> knots{0.0F, 0.0F, 0.0F, 1.0F, 2.0F, 2.0F, 2.0F};
+    const auto space = nd<float>({one_d(knots, 2)});
+    const Bspline<float> field(space, ramp<float>({4, 3}), true);
+
+    PANTR_CHECK(field.dim() == 1);
+    PANTR_CHECK(field.rank() == 2);
+    PANTR_CHECK(equals(field.net().shape(), std::vector<std::size_t>{4, 3}));
+    PANTR_CHECK(field.net().values()[11] == 12.0F);
+}
+
+/// A field is copyable and movable, and a copy shares the space rather than cloning it.
+void check_copy_and_move() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    const auto space = nd<double>({one_d(knots, 2)});
+    const Bspline<double> field(space, ramp<double>({3, 2}), false);
+
+    const Bspline<double> copied = field;
+    PANTR_CHECK_MSG(copied.space().get() == space.get(),
+                    "a copy shares the space; there is nothing to deep-copy behind an "
+                    "immutable handle");
+    PANTR_CHECK(copied.rank() == 2);
+    PANTR_CHECK_MSG(copied.net().values().data() != field.net().values().data(),
+                    "but it owns its own coefficients");
+
+    Bspline<double> source(space, ramp<double>({3, 2}), false);
+    const Bspline<double> moved = std::move(source);
+    PANTR_CHECK(moved.space().get() == space.get());
+    PANTR_CHECK(equals(moved.net().values(), std::vector<double>{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}));
+}
+
+/// Every accessor is safe to call concurrently on one field, with no locking.
+///
+/// `space()` is included deliberately and is the only accessor here with machinery
+/// behind it: it copies a `shared_ptr`, so eight threads hammering it contend on one
+/// atomic control block. The threads are released together off an atomic flag so
+/// that the reads genuinely overlap; a run in which each finished before the next
+/// began would report clean for the wrong reason.
+void check_concurrent_reads() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};
+    const auto space = nd<double>({one_d(first, 2), one_d(second, 1)});
+    const Bspline<double> field(space, ramp<double>({5, 3, 4}), false);
+
+    constexpr int num_threads = 8;
+    std::atomic<bool> go{false};
+    std::vector<double> sums(num_threads, 0.0);
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([&field, &go, &sums, t] {
+            while (!go.load(std::memory_order_acquire)) {
+                // Spin until every thread is up, so the reads overlap.
+            }
+            double sum = 0.0;
+            for (int i = 0; i < 2000; ++i) {
+                sum += static_cast<double>(field.dim() + field.rank());
+                sum += static_cast<double>(field.degree()[0] + field.degree()[1]);
+                sum += field.is_rational() ? 1.0 : 0.0;
+                sum += field.net().values()[0] + field.net().values()[59];
+                sum += static_cast<double>(field.net().num_components());
+                // The one accessor with an atomic in it.
+                sum += static_cast<double>(field.space()->num_total_basis());
+                sum += static_cast<double>(field.space_ref().dim());
+            }
+            sums[static_cast<std::size_t>(t)] = sum;
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+
+    for (int t = 0; t < num_threads; ++t) {
+        PANTR_CHECK_MSG(sums[static_cast<std::size_t>(t)] == sums[0],
+                        "every thread must read one state");
+    }
+    PANTR_CHECK_MSG(field.space().use_count() >= 2,
+                    "the vacuity guard: the shared handle survived the contention, so the "
+                    "atomic path really was exercised");
+}
+
+}  // namespace
+
+int main() {
+    check_a_surface();
+    check_a_volume();
+    check_a_rational_curve();
+    check_a_scalar_field();
+    check_the_shape_is_the_spaces_basis_counts();
+    check_the_space_is_shared_not_copied();
+    check_the_space_outlives_the_field();
+    check_the_net_is_copied_not_aliased();
+    check_the_flat_constructor_derives_the_shape();
+    check_a_periodic_direction();
+    check_refusals();
+    check_float_storage();
+    check_copy_and_move();
+    check_concurrent_reads();
+    return pantr::test::summary("test_bspline_type");
+}

--- a/cpp/tests/test_bspline_type.cpp
+++ b/cpp/tests/test_bspline_type.cpp
@@ -481,6 +481,17 @@ void check_refusals() {
     PANTR_CHECK_MSG(both == not_a_multiple,
                     "the count check runs before the rank check, as the oracle's does: "
                         + both);
+
+    // An empty buffer is the one case the count check does NOT refuse, because zero
+    // is a multiple of everything; the rank check is what catches it, and the header
+    // says so. Asserted because a documented route through a check is a claim like
+    // any other. Unreachable from Python, where numpy's reshape refuses it first.
+    const std::vector<double> none;
+    const std::string empty = refusal_of([&] {
+        return Bspline<double>(space, std::span<const double>(none), false);
+    });
+    PANTR_CHECK_MSG(empty == "The B-spline must have at least rank one. Got rank 0",
+                    "an empty flat buffer must be refused by the rank check: " + empty);
 }
 
 /// The `float32` field, which is the half of the matrix nobody reads first.

--- a/cpp/tests/test_bspline_type.cpp
+++ b/cpp/tests/test_bspline_type.cpp
@@ -249,6 +249,11 @@ void check_a_scalar_field() {
 ///
 /// The vacuity guard for the whole case set: a transposed net has exactly as many
 /// coefficients as a correct one, so nothing about a *size* can refuse it.
+///
+/// Three refusals rather than one, and the middle one is the reason: a transposed
+/// net has direction 0 wrong, so it is caught by a check that compares the first
+/// extent and stops. `later_direction` has direction 0 *right*, which is what makes
+/// the loop's bound observable.
 void check_the_shape_is_the_spaces_basis_counts() {
     const std::vector<double> first{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};  // 5 basis
     const std::vector<double> second{10.0, 10.0, 11.0, 12.0, 12.0};           // 3 basis
@@ -261,6 +266,17 @@ void check_the_shape_is_the_spaces_basis_counts() {
                         == "the control net has 3 coefficient(s) along direction 0 and the "
                            "space has 5 basis function(s)",
                     "message was: " + transposed);
+
+    // Direction 0 correct and direction 1 wrong, which is the case that distinguishes
+    // a loop over every direction from one that compares the first and stops. Measured:
+    // without it, narrowing the check to `d < 1` left this file green.
+    const std::string later_direction = refusal_of([&] {
+        return Bspline<double>(space, ramp<double>({5, 4, 2}), false);
+    });
+    PANTR_CHECK_MSG(later_direction
+                        == "the control net has 4 coefficient(s) along direction 1 and the "
+                           "space has 3 basis function(s)",
+                    "message was: " + later_direction);
 
     const std::string mis_ranked = refusal_of([&] {
         return Bspline<double>(space, ramp<double>({15, 4}), false);

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -253,6 +253,14 @@ nitpick_ignore = [
     # `pantr.bspline.BsplineSpace1D` and `pantr.bspline.BsplineSpace` -- so this is
     # one entry rather than three, and the next ported type inherits it.
     ("py:class", "_Impl"),
+    # The annotation of `pantr.bspline.Bspline`'s `_derived` slot: a private,
+    # module-local class holding the two memos an in-place mutator discards
+    # together. Same mechanism as `_Impl` one line up -- autodoc documents the slot
+    # because it carries an inline docstring, and renders the annotation as a class
+    # reference with nothing to resolve to. Unlike `_Impl` this is one type in one
+    # module today, and it stays listed here only while `Bspline` is the one ported
+    # type whose surface mutates.
+    ("py:class", "_Derived"),
     ("py:class", "CellIndex"),
     ("py:class", "CellIndicesBatch"),
     ("py:class", "Target"),

--- a/scripts/measure_bspline_type_parity.py
+++ b/scripts/measure_bspline_type_parity.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python
+"""Sweep the `Bspline` value type's parity claim far past the size that ships.
+
+``tests/parity/test_bspline_type.py`` asserts that the two backends hold the same
+state, over a hand-written table of eight shapes and a generated sweep of 24 draws.
+That is a suite, and a suite has to stay fast. This script runs the *same* generator
+over a draw large enough for the claim to mean something: a sweep checked only by its
+own shipped size has not been checked.
+
+It is **not** a test. The parity suite asserts; this reports, because what a reader
+deciding whether to believe the claim wants is the size of the sweep and the worst
+disagreement found, not a green tick.
+
+What it sweeps, and why each axis is there:
+
+- **the storage format**, because ``float32`` is the half of the matrix nobody reads
+  first and the only one where a narrowing cast is visible;
+- **the parametric dimension**, 1 to 3, because a tensor-product layout error needs
+  more than one axis to show;
+- **the degree and the interior knot multiplicities**, because a repeated interior
+  knot changes the basis count and therefore the net's shape;
+- **the periodic flag**, because a periodic direction's basis count is not
+  ``len(knots) - degree - 1`` and the net is laid out on the smaller number;
+- **the component count and the rationality flag**, because ``rank`` folds one
+  against the other;
+- **coefficients spanning the format's exponent range**, because a value that
+  survives both formats hides a cast that a wide one would expose.
+
+Run it as::
+
+    PYTHONPATH="$(pwd)/src" .venv/bin/python scripts/measure_bspline_type_parity.py [draws]
+
+``draws`` defaults to 2400, which is 100 times the shipped sweep. The exit status is
+non-zero if any draw disagrees, so it is usable as a one-off gate as well as a
+report.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from typing import Any, Final, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr._backend import Backend, available_backends, use_backend
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+
+DEFAULT_DRAWS: Final = 2400
+"""One hundred times the sweep `tests/parity/test_bspline_type.py` ships."""
+
+SEED: Final = 20260904
+"""Fixed, so the report is reproducible; the draw count is what varies."""
+
+_HALF: Final = 0.5
+"""An even split between two choices of a draw."""
+
+_PERIODIC_SHARE: Final = 0.3
+"""Share of directions drawn periodic.
+
+Below a half on purpose: a periodic direction restricts the knot vector -- strictly
+increasing, and `3 * degree + 2` knots at least -- so drawing them evenly would spend
+most of the sweep on the narrower family.
+"""
+
+_MAX_REPORTED: Final = 20
+"""How many disagreeing draws to print before summarizing the rest."""
+
+
+class Draw(NamedTuple):
+    """One randomly generated B-spline field, described independently of any backend.
+
+    Attributes:
+        knots (tuple[npt.NDArray[Any], ...]): One knot vector per direction.
+        degrees (tuple[int, ...]): One degree per direction.
+        periodic (tuple[bool, ...]): Whether each direction wraps.
+        components (int): The length of the stored component axis.
+        is_rational (bool): Whether the last stored component is a weight.
+        dtype (np.dtype[Any]): The storage format.
+    """
+
+    knots: tuple[npt.NDArray[Any], ...]
+    degrees: tuple[int, ...]
+    periodic: tuple[bool, ...]
+    components: int
+    is_rational: bool
+    dtype: np.dtype[Any]
+
+
+def _knot_vector(
+    rng: np.random.Generator, degree: int, *, periodic: bool, dtype: np.dtype[Any]
+) -> npt.NDArray[Any]:
+    """Draw one knot vector.
+
+    A periodic direction gets a strictly increasing vector, which is what the wrap
+    needs; a clamped one gets ``degree + 1`` repeats at each end and interior knots
+    of multiplicity 1 to ``degree``, so the basis count varies with the
+    multiplicities rather than only with the interval count.
+
+    Args:
+        rng (np.random.Generator): The generator.
+        degree (int): The polynomial degree.
+        periodic (bool): Whether the direction wraps.
+        dtype (np.dtype[Any]): The storage format.
+
+    Returns:
+        npt.NDArray[Any]: A non-decreasing knot vector of at least ``2 * degree + 2``
+        entries.
+    """
+    if periodic:
+        # A periodic direction needs `3 * degree + 2` knots, not `2 * degree + 2`:
+        # its basis count is `len - 2 * degree - 1` once the wrap and the regularity
+        # at the domain's start are taken off a strictly increasing vector, and
+        # `BsplineSpace1D` refuses a count below `degree + 1`. Measured, not guessed:
+        # `2 * degree + 2` gives a count of 1 at every degree and was refused.
+        length = 3 * degree + 2 + int(rng.integers(0, 6))
+        steps = rng.uniform(0.5, 2.0, size=length - 1)
+        return np.asarray(np.concatenate([[0.0], np.cumsum(steps)]), dtype=dtype)
+
+    intervals = 1 + int(rng.integers(0, 4))
+    breaks = np.cumsum(rng.uniform(0.5, 2.0, size=intervals + 1))
+    interior: list[float] = []
+    for value in breaks[1:-1]:
+        interior += [float(value)] * (1 + int(rng.integers(0, max(degree, 1))))
+    vector = np.concatenate(
+        [
+            np.full(degree + 1, breaks[0]),
+            np.asarray(interior, dtype=np.float64),
+            np.full(degree + 1, breaks[-1]),
+        ]
+    )
+    return np.asarray(vector, dtype=dtype)
+
+
+def _draw(rng: np.random.Generator) -> Draw:
+    """Draw one field description.
+
+    Args:
+        rng (np.random.Generator): The generator.
+
+    Returns:
+        Draw: The description, which :func:`_build` turns into a field under
+        whichever backend is active.
+    """
+    dtype = np.dtype(np.float32) if rng.random() < _HALF else np.dtype(np.float64)
+    dim = 1 + int(rng.integers(0, 3))
+    degrees = tuple(int(rng.integers(0, 4)) for _ in range(dim))
+    periodic = tuple(bool(rng.random() < _PERIODIC_SHARE) for _ in range(dim))
+    knots = tuple(
+        _knot_vector(rng, degree, periodic=wraps, dtype=dtype)
+        for degree, wraps in zip(degrees, periodic, strict=True)
+    )
+    components = 1 + int(rng.integers(0, 4))
+    is_rational = bool(rng.random() < _HALF) and components > 1
+    return Draw(knots, degrees, periodic, components, is_rational, dtype)
+
+
+def _coefficients(rng: np.random.Generator, total: int, dtype: np.dtype[Any]) -> npt.NDArray[Any]:
+    """Draw coefficients spanning the storage format's exponent range.
+
+    Magnitudes spread over many decades, so a narrowing cast in the port shows up as
+    a changed bit pattern rather than as a value that happens to survive both
+    formats.
+
+    Args:
+        rng (np.random.Generator): The generator.
+        total (int): How many scalars.
+        dtype (np.dtype[Any]): The storage format.
+
+    Returns:
+        npt.NDArray[Any]: The coefficients.
+    """
+    limit = 30 if dtype == np.float32 else 100
+    mantissa = rng.uniform(-1.0, 1.0, size=total)
+    exponent = rng.integers(-limit, limit, size=total)
+    return np.asarray(mantissa * np.float64(2.0) ** exponent, dtype=dtype)
+
+
+def _build(draw: Draw, coefficients: npt.NDArray[Any]) -> Bspline:
+    """Build ``draw``'s field under whichever backend is active.
+
+    Args:
+        draw (Draw): The description.
+        coefficients (npt.NDArray[Any]): The flat coefficient buffer.
+
+    Returns:
+        Bspline: The field.
+    """
+    space = BsplineSpace(
+        [
+            BsplineSpace1D(vector, degree, periodic=wraps)
+            for vector, degree, wraps in zip(draw.knots, draw.degrees, draw.periodic, strict=True)
+        ]
+    )
+    return Bspline(space, coefficients, draw.is_rational)
+
+
+def _disagreements(py: Bspline, cpp: Bspline) -> list[str]:
+    """Every field on which the two backends disagree.
+
+    The same seven quantities ``tests/parity/test_bspline_type.py``'s ``FIELDS``
+    compares, under the same claims: bitwise for the coefficients, exact for
+    everything else.
+
+    Args:
+        py (Bspline): What the Python backend built.
+        cpp (Bspline): What the C++ backend built.
+
+    Returns:
+        list[str]: One entry per disagreeing field, empty when they agree.
+    """
+    found = []
+    if py.control_points.tobytes() != cpp.control_points.tobytes():
+        found.append("control_points")
+    if py.control_points.shape != cpp.control_points.shape:
+        found.append("control_points.shape")
+    for name in ("is_rational", "dim", "degree", "rank"):
+        if getattr(py, name) != getattr(cpp, name):
+            found.append(name)
+    if np.dtype(py.dtype) != np.dtype(cpp.dtype):
+        found.append("dtype")
+    if py.space.num_basis != cpp.space.num_basis:
+        found.append("space.num_basis")
+    return found
+
+
+def _closed_form_rank(draw: Draw, num_basis: tuple[int, ...], total: int) -> int:
+    """``draw``'s rank from the buffer size and the basis counts, in exact integers.
+
+    The independent half: nothing here reads a constructed field.
+
+    Args:
+        draw (Draw): The description.
+        num_basis (tuple[int, ...]): The per-direction basis counts.
+        total (int): The number of scalars in the buffer.
+
+    Returns:
+        int: The rank a well-formed field would report.
+    """
+    return total // math.prod(num_basis) - (1 if draw.is_rational else 0)
+
+
+def main(argv: list[str]) -> int:
+    """Run the sweep and report.
+
+    Args:
+        argv (list[str]): Command-line arguments; ``argv[1]`` is the draw count.
+
+    Returns:
+        int: 0 when every draw agreed, 1 otherwise.
+    """
+    if Backend.CPP not in available_backends():
+        print("the pantr._pantr_cpp extension is not built; nothing to compare against")
+        return 1
+
+    draws = int(argv[1]) if len(argv) > 1 else DEFAULT_DRAWS
+    rng = np.random.default_rng(SEED)
+    failures: list[str] = []
+    dtype_counts: dict[str, int] = {"float32": 0, "float64": 0}
+    dim_counts: dict[int, int] = {1: 0, 2: 0, 3: 0}
+    periodic_draws = 0
+    rational_draws = 0
+    largest_net = 0
+
+    for index in range(draws):
+        draw = _draw(rng)
+        # The basis counts come from the space, but only to size the buffer; the rank
+        # is then checked against the closed form below, which does not.
+        with use_backend(Backend.PYTHON):
+            probe_space = BsplineSpace(
+                [
+                    BsplineSpace1D(vector, degree, periodic=wraps)
+                    for vector, degree, wraps in zip(
+                        draw.knots, draw.degrees, draw.periodic, strict=True
+                    )
+                ]
+            )
+            num_basis = probe_space.num_basis
+        total = probe_space.num_total_basis * draw.components
+        coefficients = _coefficients(rng, total, draw.dtype)
+
+        with use_backend(Backend.PYTHON):
+            py = _build(draw, coefficients)
+        with use_backend(Backend.CPP):
+            cpp = _build(draw, coefficients)
+
+        found = _disagreements(py, cpp)
+        expected_rank = _closed_form_rank(draw, num_basis, total)
+        if cpp.rank != expected_rank:
+            found.append(f"rank against its closed form ({cpp.rank} != {expected_rank})")
+        if tuple(cpp.control_points.shape) != (*num_basis, draw.components):
+            found.append("the stored shape against the basis counts")
+        if found:
+            failures.append(f"draw {index} ({draw.dtype.name}, dim {len(draw.degrees)}): {found}")
+
+        dtype_counts[draw.dtype.name] += 1
+        dim_counts[len(draw.degrees)] += 1
+        periodic_draws += int(any(draw.periodic))
+        rational_draws += int(draw.is_rational)
+        largest_net = max(largest_net, total)
+
+    print(f"draws                : {draws}")
+    print(f"  by dtype           : {dtype_counts}")
+    print(f"  by parametric dim  : {dim_counts}")
+    print(f"  with a periodic dir: {periodic_draws}")
+    print(f"  rational           : {rational_draws}")
+    print(f"  largest net        : {largest_net} scalars")
+    print(f"disagreements        : {len(failures)}")
+    for line in failures[:_MAX_REPORTED]:
+        print(f"  {line}")
+    if len(failures) > _MAX_REPORTED:
+        print(f"  ... and {len(failures) - _MAX_REPORTED} more")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -120,6 +120,8 @@ from ._bspline import lagrange_extraction_1d as lagrange_extraction_1d
 from ._bspline import (
     lagrange_structural_identity_mask as lagrange_structural_identity_mask,
 )
+from ._bspline_field import Bspline32 as Bspline32
+from ._bspline_field import Bspline64 as Bspline64
 from ._geometry import AABB as AABB
 from ._grid import BVH as BVH
 from ._grid import CellTags as CellTags

--- a/src/pantr/_pantr_cpp/_bspline_field.pyi
+++ b/src/pantr/_pantr_cpp/_bspline_field.pyi
@@ -1,0 +1,97 @@
+"""Type stub for `pantr.bspline.Bspline`, bound in `cpp/bindings/bspline_type.cpp`.
+
+Its own stub module rather than a third pair of classes in ``_bspline.pyi``, for the
+reason ``__init__.pyi`` gives for splitting the stub at all: a ticket that ports a
+type edits its own file plus one import line, and the space stub is already shared by
+three binding files and three tickets to come.
+
+Two registrations per type, because the storage format is part of the value and the
+class of the handle is the only thing left to carry it. ``Bspline<T>`` can hold only a
+``BsplineSpace<T>``, so the split is forced twice over.
+
+**No mutator, and that is the design rather than an omission of the stub.** The Python
+:class:`pantr.bspline.Bspline` has three ``in_place=True`` methods; the C++ value has
+none, and the wrapper implements them by replacing this handle wholesale. See
+``cpp/include/pantr/bspline/bspline.hpp`` for the argument.
+
+``space`` is ``design/bspline_ownership_lifetime.md``'s class **H**: the handle goes
+in and a copy of it comes back, so the returned object is the one that was passed in
+and it outlives its field. ``control_points`` is class **A**: a read-only view of the
+field's own storage, kept alive by the field.
+
+See ``__init__.pyi`` for what this package promises and who has to keep it.
+"""
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline import BsplineSpace32, BsplineSpace64
+
+class Bspline32:
+    """A ``float32`` B-spline field owned by the C++ core.
+
+    Attributes:
+        space (BsplineSpace32): The tensor-product space, shared rather than copied:
+            the handle the field was built from is the one that comes back, and it
+            stays valid after the field is dropped.
+        control_points (npt.NDArray[np.float32]): Control points, shape
+            ``(*space.num_basis, rank_with_weight)``, read-only and a view of the
+            field's own storage.
+        is_rational (bool): Whether the last stored component is a homogeneous
+            weight.
+        dim (int): Number of parametric directions, ``>= 1``.
+        degree (tuple[int, ...]): Polynomial degree per parametric direction.
+        rank (int): Number of value components, weight excluded, ``>= 1``.
+    """
+
+    def __init__(
+        self,
+        space: BsplineSpace32,
+        control_points: npt.NDArray[np.float32],
+        is_rational: bool = False,
+    ) -> None: ...
+    @property
+    def space(self) -> BsplineSpace32: ...
+    @property
+    def control_points(self) -> npt.NDArray[np.float32]: ...
+    @property
+    def is_rational(self) -> bool: ...
+    @property
+    def dim(self) -> int: ...
+    @property
+    def degree(self) -> tuple[int, ...]: ...
+    @property
+    def rank(self) -> int: ...
+
+class Bspline64:
+    """The ``float64`` twin of :class:`Bspline32`; see it for what the two share.
+
+    Attributes:
+        space (BsplineSpace64): The tensor-product space, shared rather than copied.
+        control_points (npt.NDArray[np.float64]): Control points, shape
+            ``(*space.num_basis, rank_with_weight)``, read-only.
+        is_rational (bool): Whether the last stored component is a homogeneous
+            weight.
+        dim (int): Number of parametric directions, ``>= 1``.
+        degree (tuple[int, ...]): Polynomial degree per parametric direction.
+        rank (int): Number of value components, weight excluded, ``>= 1``.
+    """
+
+    def __init__(
+        self,
+        space: BsplineSpace64,
+        control_points: npt.NDArray[np.float64],
+        is_rational: bool = False,
+    ) -> None: ...
+    @property
+    def space(self) -> BsplineSpace64: ...
+    @property
+    def control_points(self) -> npt.NDArray[np.float64]: ...
+    @property
+    def is_rational(self) -> bool: ...
+    @property
+    def dim(self) -> int: ...
+    @property
+    def degree(self) -> tuple[int, ...]: ...
+    @property
+    def rank(self) -> int: ...

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -1368,8 +1368,9 @@ class Bezier:
             copy (bool): If ``True`` (default), the control points are
                 deep-copied into the new B-spline. If ``False``, the
                 B-spline shares the same underlying control point array --
-                which, under the C++ backend, is the Bézier's own storage and
-                is read-only, so the B-spline is then read-only too.
+                **under the Python backend only**. The C++ value owns its
+                storage and copies at construction, so there ``copy=False``
+                saves nothing and shares nothing.
 
         Returns:
             ~pantr.bspline.Bspline: Equivalent B-spline representation.

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -4,16 +4,50 @@ This module provides :class:`Bspline`, which pairs a
 :class:`~pantr.bspline.BsplineSpace` with control points to represent a
 parametric B-spline curve, surface, or volume. Evaluation at arbitrary points
 is dispatched to the de Boor algorithm implemented in ``_bspline_eval``.
+
+Since the 2026-08-27 amendment to ``design/cross_backend_types.md`` the *value* is
+owned by C++ (``cpp/include/pantr/bspline/bspline.hpp``) and :class:`Bspline` is a
+wrapper holding one implementation of it, exactly as
+:mod:`pantr.bspline._bspline_space_nd` does for the space it is built over. There
+are two implementations and they are not two B-splines:
+:class:`_BsplinePython` is the oracle the port is checked against, and the C++
+handle is the thing being checked. :func:`_impl_class` picks between them, per
+process and per dtype.
+
+Only the *state and what it determines* moved. Every operation -- evaluation, the
+derivative, the degree and knot operations, the conversions, the product, reversal,
+permutation and the affine transform -- is a computation *over* a B-spline rather
+than a property *of* one, so all of them are unchanged, still run on numba kernels
+and numpy, and live on the wrapper. That is the same line ``space_nd.hpp`` draws,
+and the mixed dispatch it produces is the temporary seam this front introduces; a
+cleanup ticket removes it once the whole front lands.
+
+Two of those operations cannot follow in a later cut of this front, and that is a
+declared boundary rather than an omission. :meth:`Bspline.evaluate`,
+:meth:`Bspline.evaluate_derivatives` and :meth:`Bspline.to_beziers` reach
+:meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis` or
+``tabulate_basis_derivatives``, and ``cpp/include/pantr/bspline/space_1d.hpp``
+records that basis tabulation is a separate port over free functions which no
+ticket in this milestone covers.
+
+**The three ``in_place=True`` methods survive, and the C++ value has no mutator.**
+``design/bspline_derived_caches.md`` calls :class:`Bspline` the type where
+construct-then-freeze does not hold. It holds on the C++ side: the observable
+mutation lives here, in :meth:`Bspline._mutate`, which replaces the whole
+implementation together with the whole derived block in one assignment. See
+:class:`_Derived` for why that is the repair that note asks this front for, and
+``cpp/include/pantr/bspline/bspline.hpp`` for why the C++ type refuses to carry
+the flag itself.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeAlias, cast, overload
 
 import numpy as np
 from numpy import typing as npt
 
+from .._backend import Backend, active_backend, available_backends
 from .._transform_control_points import _apply_affine_to_control_points
 from ._bspline_degree import _degree_elevate_bspline, _degree_reduce_bspline
 from ._bspline_derivative import _derivative_bspline
@@ -28,15 +62,332 @@ from ._bspline_knot_removal import _remove_knots_bspline
 from ._bspline_locate import _locate_impl
 from ._bspline_restrict import _restrict_bspline_impl
 from ._bspline_slice import _slice_bspline
+from ._bspline_space_nd import _impl_class as _space_impl_class
 from ._bspline_split import _split_bspline_impl
 from ._bspline_to_beziers import _to_beziers_impl
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from .._pantr_cpp import Bspline32 as _CppBspline32
+    from .._pantr_cpp import Bspline64 as _CppBspline64
     from ..bezier import Bezier
     from ..quad import PointsLattice
     from ..transform import AffineTransform
     from ._bspline_locate import _LocateContext
     from ._bspline_space_nd import BsplineSpace
+
+    _Impl: TypeAlias = "_BsplinePython | _CppBspline32 | _CppBspline64"
+    """The implementation a :class:`Bspline` holds: the oracle, or a C++ handle.
+
+    Type-checking only, and the same alias the space modules declare for their own
+    types: the three are unrelated nominal types that happen to offer the same
+    surface, which is the port's whole claim.
+    """
+
+    _SpaceImpl: TypeAlias = "Any"
+    """The space's implementation, as either backend holds it.
+
+    Deliberately opaque. :mod:`pantr.bspline._bspline_space_nd` owns the union of
+    the three concrete types, and restating it here would be a second place to keep
+    in step; nothing in this module does anything with a space's implementation
+    except hand it to the matching B-spline implementation.
+    """
+
+_ControlPoints: TypeAlias = "npt.NDArray[np.float32 | np.float64]"
+"""A control-point array in one of the two storage formats a B-spline may use."""
+
+
+class _Derived:
+    """The block of quantities derived from a B-spline's value, filled on demand.
+
+    Two memos live here, and the block exists so that they cannot be invalidated
+    separately. ``design/bspline_derived_caches.md`` asks this front for exactly
+    that: *an in-place method replaces the whole derived block rather than
+    invalidating pieces of it*, so there is no ``_beziers_cache = None`` path and no
+    way to reseat one without the other. The oracle's three invalidation sites --
+    one each in ``reverse``, ``permute_directions`` and ``transform`` -- become one
+    assignment, in :meth:`Bspline._take`.
+
+    **Why the block is here and not in the C++ value.** Both memos are produced by
+    operations this front has not ported, and one of them -- the Bézier
+    decomposition -- cannot be ported until basis tabulation is (see the module
+    docstring). A memo can only live beside the computation that fills it, so these
+    move to C++ with the operations that make them and not before. Until then this
+    is the only cache on either side of the seam, which is what keeps the note's
+    "nothing is cached on both sides" rule true rather than merely intended.
+
+    A plain mutable object rather than a ``NamedTuple``: a memo has to be fillable,
+    and neither slot participates in an invariant with the other. What must not
+    happen is one of them being *replaced* while the other survives, and the block
+    is what makes that unspellable.
+
+    Attributes:
+        beziers (``npt.NDArray[np.object_] | None``): The cached Bézier
+            decomposition (see :meth:`Bspline.to_beziers`), or ``None`` before the
+            first call.
+        locate (``_LocateContext | None``): The cached point-inversion state (see
+            :meth:`Bspline.locate`), or ``None`` before the first call.
+    """
+
+    __slots__ = ("beziers", "locate")
+
+    def __init__(self) -> None:
+        """Start with both memos cold."""
+        self.beziers: npt.NDArray[np.object_] | None = None
+        self.locate: _LocateContext | None = None
+
+
+class _BsplinePython:
+    """The pure-Python B-spline field: the port's parity oracle.
+
+    Holds the space's *implementation*, not its wrapper, which is what makes it the
+    exact counterpart of ``pantr::bspline::Bspline<T>``: that type holds a
+    ``BsplineSpace<T>`` handle, and this one holds whatever
+    :class:`~pantr.bspline.BsplineSpace` selected for the same backend.
+
+    It reproduces today's behaviour exactly, aliasing included: the control-point
+    array it stores is the caller's own, and :attr:`control_points` hands that same
+    object back. ``design/bspline_ownership_lifetime.md`` records that as a defect
+    -- a write through either end desynchronises both of :class:`_Derived`'s memos
+    with nothing raising -- and the C++ value does not reproduce it. A port does not
+    edit its own oracle, so the two differ there deliberately and in the safe
+    direction.
+
+    Attributes:
+        _space (Any): The tensor-product space's implementation.
+        _control_points (npt.NDArray[np.float32 | np.float64]): The control points,
+            already reshaped to ``(*num_basis, num_components)`` by
+            :func:`_validated_control_points`.
+        _is_rational (bool): Whether the last stored component is a homogeneous
+            weight.
+    """
+
+    __slots__ = ("_control_points", "_is_rational", "_space")
+
+    def __init__(
+        self, space: _SpaceImpl, control_points: _ControlPoints, is_rational: bool
+    ) -> None:
+        """Hold the given space implementation and control points.
+
+        Args:
+            space (Any): The tensor-product space's implementation.
+            control_points (npt.NDArray[np.float32 | np.float64]): The control
+                points, already validated and reshaped by
+                :func:`_validated_control_points`.
+            is_rational (bool): Whether the last stored component is a weight.
+
+        Raises:
+            ValueError: If the B-spline has rank smaller than 1.
+        """
+        self._space = space
+        self._control_points = control_points
+        self._is_rational = is_rational
+        if self.rank <= 0:
+            raise ValueError(f"The B-spline must have at least rank one. Got rank {self.rank}")
+
+    def _replace(self, control_points: _ControlPoints, space: _SpaceImpl) -> None:
+        """Adopt an already-validated value, in place.
+
+        The one mutating operation on this class, and it exists only because
+        :meth:`Bspline.reverse`, :meth:`Bspline.permute_directions` and
+        :meth:`Bspline.transform` take an ``in_place`` flag that :class:`Bspline`
+        ports faithfully. It re-validates nothing: every caller derives both
+        arguments from this B-spline's own, so the rank cannot have changed.
+
+        Args:
+            control_points (npt.NDArray[np.float32 | np.float64]): The array to
+                store.
+            space (Any): The space implementation to store.
+        """
+        self._control_points = control_points
+        self._space = space
+
+    @property
+    def space(self) -> _SpaceImpl:
+        """Get the tensor-product space's implementation.
+
+        Returns:
+            Any: The implementation this field was built over.
+        """
+        return self._space
+
+    @property
+    def control_points(self) -> _ControlPoints:
+        """Get the control points.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The stored array itself, writable.
+            See the class docstring on why that is the oracle's behaviour rather
+            than a contract.
+        """
+        return self._control_points
+
+    @property
+    def is_rational(self) -> bool:
+        """Get whether the last stored component is a homogeneous weight.
+
+        Returns:
+            bool: True for a rational B-spline (a NURBS).
+        """
+        return self._is_rational
+
+    @property
+    def dim(self) -> int:
+        """Get the number of parametric directions.
+
+        Returns:
+            int: The dimension of the parametric domain.
+        """
+        return int(self._space.dim)
+
+    @property
+    def degree(self) -> tuple[int, ...]:
+        """Get the polynomial degree of each parametric direction.
+
+        Returns:
+            tuple[int, ...]: One degree per direction, in axis order.
+        """
+        return tuple(self._space.degrees)
+
+    @property
+    def rank(self) -> int:
+        """Get the number of value components a caller sees.
+
+        Returns:
+            int: The stored component count, less one when rational. May be zero or
+            negative before the constructor has refused it, which is what lets the
+            refusal report the number.
+        """
+        rk = int(self._control_points.shape[-1])
+        return rk - 1 if self._is_rational else rk
+
+
+def _validated_control_points(space: BsplineSpace, control_points: npt.ArrayLike) -> _ControlPoints:
+    """Normalize a control-point argument to the array a B-spline stores.
+
+    The oracle's own first four lines, lifted out because both implementations need
+    the result and because two of the three refusals here cannot be either
+    implementation's:
+
+    - The **coefficient count** check has to happen before the dtype check, since
+      that is the order the oracle raises them in and a caller whose argument is bad
+      in both ways must read the same message under either backend. The C++ type
+      checks the count again for the caller that has no numpy; see
+      ``cpp/include/pantr/bspline/bspline.hpp``.
+    - The **reshape** is numpy's, and so is the error it raises for a buffer that is
+      empty while the space is not. Doing it here makes that text common mode
+      instead of something the C++ side would have to reproduce.
+    - The **dtype** check is a type-kind fact and ``Bspline<T>`` cannot hold a space
+      of another width, so there is nothing there to check.
+
+    Args:
+        space (~pantr.bspline.BsplineSpace): The space the field is built over.
+        control_points (npt.ArrayLike): The caller's argument.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The array reshaped to
+        ``(*space.num_basis, -1)``.
+
+    Raises:
+        ValueError: If the number of control points is not a multiple of the number
+            of basis functions, or if their dtype is not the space's.
+        IndexError: If the space has no directions. Reading
+            :attr:`~pantr.bspline.BsplineSpace.dtype` is what raises it, which is
+            where the oracle raises it too.
+    """
+    cp = np.asarray(control_points)
+    num_basis = space.num_total_basis
+    if cp.size % num_basis != 0:
+        raise ValueError(
+            f"The number of control points must be a multiple of the number of basis functions."
+            f"Got {cp.size} control points and {num_basis} basis functions."
+        )
+
+    cp = cp.reshape([*space.num_basis, -1])
+
+    if cp.dtype != space.dtype:
+        raise ValueError(
+            f"The control points must have the same dtype as the B-spline space."
+            f"Got {cp.dtype} control points and {space.dtype} B-spline space."
+        )
+    return cast("_ControlPoints", cp)
+
+
+def _impl_class(dtype: np.dtype[Any]) -> type[_BsplinePython] | type[Any]:
+    """The implementation class the active backend and the dtype select.
+
+    The backend is per process rather than per instance, for the reason
+    :func:`pantr.bspline._bspline_space_nd._impl_class` gives: two fields built
+    under different backends meeting in one operation -- :meth:`Bspline.multiply`
+    takes a second B-spline -- would have to be reconciled by converting one
+    implementation into the other, which is the shape
+    ``design/cross_backend_types.md`` forbids.
+
+    Args:
+        dtype (np.dtype[Any]): The storage format of the control points.
+
+    Returns:
+        type: The oracle under the Python backend, and the C++ class for that
+        storage format otherwise.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if active_backend() is Backend.PYTHON:
+        return _BsplinePython
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    if dtype == np.float32:
+        return _pantr_cpp.Bspline32
+    return _pantr_cpp.Bspline64
+
+
+def _new_impl(space: BsplineSpace, control_points: _ControlPoints, is_rational: bool) -> _Impl:
+    """Build a B-spline value in whichever implementation the active backend selects.
+
+    Args:
+        space (~pantr.bspline.BsplineSpace): The space, whose own implementation is
+            what gets held.
+        control_points (npt.NDArray[np.float32 | np.float64]): The control points,
+            already validated and reshaped by :func:`_validated_control_points`.
+        is_rational (bool): Whether the last stored component is a weight.
+
+    Returns:
+        _Impl: The implementation object; an oracle instance or a C++ handle.
+
+    Raises:
+        ValueError: If the B-spline has rank smaller than 1, or if the space was
+            built under a different backend.
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    dtype = np.dtype(control_points.dtype)
+    cls = _impl_class(dtype)
+    # Both implementations hold the space's *implementation*, so a space built under
+    # the other backend cannot be held -- and the two ways that fails are both bad.
+    # Handing a Python oracle to a C++ class raises a nanobind `TypeError` naming
+    # C++ types, which is loud but unreadable; handing a C++ handle to the oracle
+    # SUCCEEDS and yields a hybrid whose reductions run in Python over C++ values,
+    # which no parity claim covers and nothing announces.
+    # `design/cross_backend_types.md` forbids exactly that second shape.
+    space_impl = space._impl
+    if not isinstance(space_impl, _space_impl_class(dtype)):
+        raise ValueError(
+            "The B-spline space must come from the active backend; it was built under a "
+            "different one."
+        )
+    if cls is _BsplinePython:
+        return _BsplinePython(space_impl, control_points, bool(is_rational))
+    # Each C++ class accepts only its own storage format and refuses rather than
+    # casts, so the array's dtype and the class have to agree. They do: the class
+    # was chosen from that dtype above. That is a correlation between a value and a
+    # type, which the checker cannot state, and the cast is what stands in for it.
+    cpp_cls: Any = cls
+    return cast(
+        "_Impl", cpp_cls(space_impl, np.ascontiguousarray(control_points), bool(is_rational))
+    )
 
 
 class Bspline:
@@ -45,20 +396,47 @@ class Bspline:
     Combines a :class:`~pantr.bspline.BsplineSpace` (knot vectors, degrees)
     with a set of control points to represent a B-spline mapping.
 
+    **This class is a wrapper.** The value -- the space, the control points and the
+    rationality flag -- is owned by an implementation chosen by ``_impl_class``,
+    which is the C++ type (``cpp/include/pantr/bspline/bspline.hpp``) or the oracle
+    ``_BsplinePython``. Every operation below is still Python over numba
+    kernels and numpy, and is unchanged; only the state moved.
+
+    Instances are immutable *as attribute holders*, and that is enforced rather than
+    documented: ``__slots__`` means there is no ``__dict__`` to attach anything to,
+    and ``__setattr__`` refuses even a rebinding of the three slots. The three
+    ``in_place=True`` methods go through ``_mutate``, which is the one place
+    the value is replaced and the only place ``object.__setattr__`` is called.
+
+    One behaviour depends on which implementation is in hand, and it is the point of
+    the port rather than an oversight: the C++ value **copies** the control points
+    at construction and hands out a read-only view, so neither end aliases the
+    caller's array. The oracle aliases at both ends, which is the defect
+    ``design/bspline_ownership_lifetime.md`` records, and it is not fixed here
+    because a port does not edit its own oracle.
+
     Attributes:
-        _space (pantr.bspline.BsplineSpace): The multi-dimensional
-            B-spline space.
-        _control_points (npt.NDArray[np.float32 | np.float64]): Control point
-            array reshaped to ``(*num_basis, rank)``.
-        _is_rational (bool): Whether the B-spline is rational (NURBS).
-        _beziers_cache (``npt.NDArray[np.object_] | None``): Cached Bézier
-            decomposition, or ``None`` if not yet computed.
-        _locate_cache (``_LocateContext | None``): Cached point-inversion state
-            (see :meth:`locate`), or ``None`` if not yet computed. Invalidated
-            alongside ``_beziers_cache`` by the in-place mutators.
+        _impl: The implementation this wrapper holds; see ``_impl_class``. Its
+            type is the private ``_Impl`` alias, which is a union of three unrelated
+            nominal types and has no documented form to name here.
+        _space (~pantr.bspline.BsplineSpace): The space wrapper this field was built
+            over, so that ``bspline.space is space`` holds under both backends. It
+            is a *presentation* memo, never a second truth about a value: the
+            degrees, the counts and the domain all come from the space's own
+            implementation on every access.
+        _derived (_Derived): The derived block; see ``_Derived``.
     """
 
-    _control_points: npt.NDArray[np.float32 | np.float64]
+    __slots__ = ("_derived", "_impl", "_space")
+
+    _impl: _Impl
+    """The implementation this wrapper holds; see ``_impl_class``."""
+
+    _space: BsplineSpace
+    """The space wrapper this field was built over; see the class docstring."""
+
+    _derived: _Derived
+    """The block of quantities derived from this field's value; see ``_Derived``."""
 
     def __init__(
         self, space: BsplineSpace, control_points: npt.ArrayLike, is_rational: bool = False
@@ -76,32 +454,143 @@ class Bspline:
             ValueError: If the control points dtype does not match the
                 B-spline space dtype.
             ValueError: If the B-spline has rank smaller than 1.
+            ValueError: If the space was built under a different backend.
+            RuntimeError: If the C++ backend is requested and is not available.
         """
-        self._space = space
+        validated = _validated_control_points(space, control_points)
+        self._take(_new_impl(space, validated, is_rational), space)
 
-        control_points = np.asarray(control_points)
-        num_basis = space.num_total_basis
-        if control_points.size % num_basis != 0:
-            raise ValueError(
-                f"The number of control points must be a multiple of the number of basis functions."
-                f"Got {control_points.size} control points and {num_basis} basis functions."
+    def _take(self, impl: _Impl, space: BsplineSpace) -> None:
+        """Adopt an implementation and the space wrapper in front of it.
+
+        The single place this wrapper's slots are written, and the assignment
+        ``design/bspline_derived_caches.md`` asks this front for: the derived block
+        is replaced wholesale rather than invalidated piece by piece, so there is no
+        way to reseat the implementation without discarding both memos.
+
+        Args:
+            impl (_Impl): The implementation to hold.
+            space (~pantr.bspline.BsplineSpace): The space wrapper in front of
+                ``impl``'s space, which is what carries the identity contract.
+        """
+        object.__setattr__(self, "_impl", impl)
+        object.__setattr__(self, "_space", space)
+        object.__setattr__(self, "_derived", _Derived())
+
+    def _mutate(
+        self, rebuild: Callable[[_ControlPoints], tuple[_ControlPoints, BsplineSpace]]
+    ) -> None:
+        """Replace this B-spline's value in place, discarding every derived quantity.
+
+        The single place the two implementations differ in *kind* rather than in
+        provenance, so the branch lives here once instead of in each of the three
+        ``in_place=True`` methods.
+
+        Under the Python backend ``rebuild`` is handed the stored array itself, so a
+        helper writing into it mutates the B-spline exactly as it always has --
+        ``id(bspline.control_points)`` included, which ``tests/test_transform.py``
+        pins. Under the C++ backend the storage belongs to the C++ object and is
+        read-only, so ``rebuild`` gets a writable copy and the *implementation* is
+        replaced. Both leave this wrapper carrying the new value; only the array's
+        identity differs, and only where the oracle's aliasing is what defined it.
+
+        Rebuilding reads the *active* backend, so mutating a B-spline inside a
+        :func:`~pantr._backend.use_backend` block that selects a different one would
+        silently hand the caller back an object of the other implementation -- and,
+        going from C++ to Python, silently drop the read-only guarantee on an array
+        they still hold. Reconciling two implementations of one type by converting
+        between them is the shape ``design/cross_backend_types.md`` forbids, so this
+        refuses rather than converts, exactly as :meth:`pantr.bezier.Bezier` does
+        for the same three methods.
+
+        Checked *before* ``rebuild`` runs, and that ordering is load-bearing:
+        :meth:`reverse` and :meth:`permute_directions` build a new
+        :class:`~pantr.bspline.BsplineSpace` on the way, which under a switched
+        backend would raise its own ``ValueError`` first and only for a field of
+        more than one direction -- so the exception a caller sees would depend on
+        ``dim``.
+
+        Args:
+            rebuild (Callable): Given a writable control-point array, returns the
+                new control points and the new space. It may write into the array it
+                is given and return it, and it must return a space of the same
+                basis counts.
+
+        Raises:
+            TypeError: If the active backend no longer selects this B-spline's own
+                implementation.
+        """
+        impl = self._impl
+        mine = type(impl)
+        theirs = _impl_class(np.dtype(impl.control_points.dtype))
+        if mine is not theirs:
+            raise TypeError(
+                f"Bspline: cannot mutate a Bspline built under a different backend "
+                f"({mine.__name__} against the active {theirs.__name__}); the backend is "
+                f"chosen per process, so this means the active one changed after this "
+                f"Bspline was built."
             )
+        if isinstance(impl, _BsplinePython):
+            control_points, space = rebuild(impl.control_points)
+            impl._replace(control_points, space._impl)
+            self._take(impl, space)
+        else:
+            control_points, space = rebuild(np.array(impl.control_points))
+            self._take(_new_impl(space, control_points, impl.is_rational), space)
 
-        self._control_points = control_points.reshape([*space.num_basis, -1])
+    def __setattr__(self, name: str, value: object) -> NoReturn:
+        """Refuse to set an attribute, because the wrapper's slots are not a surface.
 
-        if self._control_points.dtype != self._space.dtype:
-            raise ValueError(
-                f"The control points must have the same dtype as the B-spline space."
-                f"Got {self._control_points.dtype} control points and {self._space.dtype} "
-                "B-spline space."
-            )
+        Args:
+            name (str): The attribute a caller tried to set.
+            value (object): The value it tried to set.
 
-        self._is_rational = is_rational
-        self._beziers_cache: npt.NDArray[np.object_] | None = None
-        self._locate_cache: _LocateContext | None = None
+        Raises:
+            AttributeError: Always. The value is replaced through ``_mutate``,
+                which is what keeps the derived block in step with it.
+        """
+        raise AttributeError(f"{type(self).__name__} is immutable; cannot set {name!r}")
 
-        if self.rank <= 0:
-            raise ValueError(f"The B-spline must have at least rank one. Got rank {self.rank}")
+    def __delattr__(self, name: str) -> NoReturn:
+        """Refuse to delete an attribute.
+
+        Args:
+            name (str): The attribute a caller tried to delete.
+
+        Raises:
+            AttributeError: Always.
+        """
+        raise AttributeError(f"{type(self).__name__} is immutable; cannot delete {name!r}")
+
+    def __reduce__(
+        self,
+    ) -> tuple[type[Bspline], tuple[BsplineSpace, _ControlPoints, bool]]:
+        """Pickle by the constructor's arguments rather than by implementation.
+
+        The C++ handle is not picklable and must not become part of the wire format:
+        a pickle written under the C++ backend has to load under the Python one and
+        the other way round, or the backend switch would silently become a
+        data-format switch.
+
+        The space goes out as its **wrapper**, not as its implementation, which is
+        what carries its own ``__reduce__`` -- and with it the tolerance-drift bound
+        ``design/bspline_pickle_tolerance.md`` derives for a univariate space --
+        into this one's round trip. It is also what makes sharing survive a single
+        pickle for free: ``pickle`` memoises, so dumping ``(field, field.space)``
+        restores a pair that still satisfies ``field.space is space``.
+
+        Returns:
+            tuple: The class, and the space, control points and rationality flag to
+            rebuild it from.
+        """
+        control_points = self.control_points
+        if not control_points.flags.writeable:
+            # The C++ backend hands out a read-only view and pickle preserves that
+            # flag. Reconstructing under the Python backend would then store a
+            # read-only array, where `transform(in_place=True)` raises. The copy is
+            # what keeps one backend's storage decision out of the wire format.
+            control_points = np.array(control_points)
+        return (type(self), (self.space, control_points, self.is_rational))
 
     @property
     def dim(self) -> int:
@@ -111,7 +600,7 @@ class Bspline:
             int: Number of parametric dimensions (equals the dimension of the
             underlying B-spline space).
         """
-        return self._space.dim
+        return int(self._impl.dim)
 
     @property
     def degree(self) -> tuple[int, ...]:
@@ -120,11 +609,17 @@ class Bspline:
         Returns:
             tuple[int, ...]: Polynomial degree for each parametric dimension.
         """
-        return self._space.degrees
+        return tuple(self._impl.degree)
 
     @property
     def space(self) -> BsplineSpace:
         """Get the underlying B-spline space.
+
+        The object a caller passed to the constructor, not a copy and not a
+        re-wrapping of what the implementation holds, so ``bspline.space is space``
+        holds under both backends. ``design/bspline_ownership_lifetime.md`` F6
+        records why: no C++ object can supply the constructor argument's own Python
+        object, and only the wrapper can, by keeping what it was built from.
 
         Returns:
             ~pantr.bspline.BsplineSpace: The multi-dimensional
@@ -133,14 +628,18 @@ class Bspline:
         return self._space
 
     @property
-    def control_points(self) -> npt.NDArray[np.float32 | np.float64]:
+    def control_points(self) -> _ControlPoints:
         """Get the control points of the B-spline.
 
         Returns:
             npt.NDArray[np.float32 | np.float64]: Control point array with
-            shape ``(*num_basis, rank)``.
+            shape ``(*num_basis, rank)``. Under the C++ backend this is a
+            **read-only view** of the B-spline's own storage: writing through it
+            raises, and it stays valid after the B-spline is dropped. Under the
+            Python backend it is the stored array itself, writable, which is the
+            aliasing defect the class docstring names.
         """
-        return self._control_points
+        return self._impl.control_points
 
     @property
     def is_rational(self) -> bool:
@@ -150,7 +649,7 @@ class Bspline:
             bool: True if the B-spline is rational (i.e., the last control point
             coordinate is a homogeneous weight), False otherwise.
         """
-        return self._is_rational
+        return bool(self._impl.is_rational)
 
     @property
     def rank(self) -> int:
@@ -163,18 +662,21 @@ class Bspline:
         Returns:
             int: Output rank of the B-spline.
         """
-        rk = int(self._control_points.shape[-1])
-        return rk - 1 if self.is_rational else rk
+        return int(self._impl.rank)
 
     @property
     def dtype(self) -> npt.DTypeLike:
         """Get the floating-point dtype of the B-spline.
 
+        Read off the control points rather than delegated: the C++ handle carries
+        its storage format in its class name, not as a numpy dtype it could hand
+        back.
+
         Returns:
             npt.DTypeLike: The numpy dtype (float32 or float64) of the control
             point array.
         """
-        return self._control_points.dtype
+        return self.control_points.dtype
 
     def evaluate(
         self,
@@ -634,7 +1136,7 @@ class Bspline:
             ValueError: If any knot value is not found or is a boundary knot.
         """
         # Periodic splines are not supported.
-        for i, sp in enumerate(self._space.spaces):
+        for i, sp in enumerate(self.space.spaces):
             if sp.periodic:
                 raise ValueError(
                     f"Knot removal is not supported for periodic B-splines "
@@ -847,12 +1349,12 @@ class Bspline:
         """
         from ..bezier import Bezier as BezierCls  # noqa: PLC0415
 
-        if self._space.has_Bezier_like_knots():
-            cp = self._control_points.copy() if copy else self._control_points
-            return BezierCls(cp, is_rational=self._is_rational)
+        if self.space.has_Bezier_like_knots():
+            cp = self.control_points.copy() if copy else self.control_points
+            return BezierCls(cp, is_rational=self.is_rational)
 
         # Already open but not Bezier-like → multi-element, cannot convert.
-        spaces = self._space.spaces
+        spaces = self.space.spaces
         if all(s.has_open_knots() and not s.periodic for s in spaces):
             raise ValueError(
                 "B-spline has more than one element per direction "
@@ -867,7 +1369,7 @@ class Bspline:
                 "and cannot be represented as a single Bézier."
             )
         cp = open_bspline.control_points.copy() if copy else open_bspline.control_points
-        return BezierCls(cp, is_rational=self._is_rational)
+        return BezierCls(cp, is_rational=self.is_rational)
 
     def to_beziers(self) -> npt.NDArray[np.object_]:
         """Decompose into Bézier patches.
@@ -902,9 +1404,10 @@ class Bspline:
             Bézier extraction of NURBS :cite:p:`borden2011bezier` (and its
             T-spline generalization :cite:p:`scott2011tsplines`).
         """
-        if self._beziers_cache is None:
-            self._beziers_cache = _to_beziers_impl(self)
-        return self._beziers_cache
+        derived = self._derived
+        if derived.beziers is None:
+            derived.beziers = _to_beziers_impl(self)
+        return derived.beziers
 
     def multiply(self, other: Bspline) -> Bspline:
         """Return the exact pointwise product of this B-spline and another.
@@ -1003,22 +1506,47 @@ class Bspline:
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
 
+        if in_place:
+            self._mutate(lambda cp: self._reversed(direction, cp, write_into=True))
+            return None
+        new_cp, new_space = self._reversed(direction, self.control_points, write_into=False)
+        return Bspline(new_space, new_cp, is_rational=self.is_rational)
+
+    def _reversed(
+        self, direction: int, control_points: _ControlPoints, *, write_into: bool
+    ) -> tuple[_ControlPoints, BsplineSpace]:
+        """The value :meth:`reverse` produces, without deciding where it goes.
+
+        Split out so that the in-place and the derived paths compute one thing:
+        :meth:`_mutate` hands this the array it may write into, and the derived path
+        hands it the stored one and asks for a fresh array instead.
+
+        Args:
+            direction (int): The parametric direction to reverse, already validated.
+            control_points (npt.NDArray[np.float32 | np.float64]): The array to read.
+            write_into (bool): Whether the flip and the cyclic shift may write into
+                ``control_points`` rather than allocating.
+
+        Returns:
+            tuple[npt.NDArray[np.float32 | np.float64], ~pantr.bspline.BsplineSpace]:
+            The reversed control points and the reflected space.
+        """
         from .._control_points_utils import _reverse_control_points  # noqa: PLC0415
         from ._bspline_space_1d import BsplineSpace1D  # noqa: PLC0415
         from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
 
         # Reflect the knot vector: knots_new = a + b - knots[::-1].
-        old_space = self._space.spaces[direction]
+        old_space = self.space.spaces[direction]
         knots = old_space.knots
         a, b = old_space.domain
         new_knots = (a + b) - knots[::-1]
         new_space_1d = BsplineSpace1D(new_knots, old_space.degree, periodic=old_space.periodic)
 
-        new_spaces = list(self._space.spaces)
+        new_spaces = list(self.space.spaces)
         new_spaces[direction] = new_space_1d
         new_space = BsplineSpace(new_spaces)
 
-        new_cp = _reverse_control_points(self._control_points, direction, in_place=in_place)
+        new_cp = _reverse_control_points(control_points, direction, in_place=write_into)
         if old_space.periodic:
             # The stored periodic points expand as full[j] = stored[j % n_stored];
             # reversing the full sequence therefore needs a plain flip *plus* a
@@ -1027,17 +1555,11 @@ class Bspline:
             n_full = knots.shape[0] - old_space.degree - 1
             shift = (n_full - n_stored) % n_stored
             if shift:
-                if in_place:
+                if write_into:
                     new_cp[:] = np.roll(new_cp, shift, axis=direction)
                 else:
                     new_cp = np.roll(new_cp, shift, axis=direction)
-
-        if in_place:
-            self._space = new_space
-            self._beziers_cache = None
-            self._locate_cache = None
-            return None
-        return Bspline(new_space, new_cp, is_rational=self._is_rational)
+        return new_cp, new_space
 
     @overload
     def permute_directions(
@@ -1084,27 +1606,41 @@ class Bspline:
             >>> swapped.control_points[0, 2].tolist()  # was control_points[2, 0]
             [4.0]
         """
-        from .._control_points_utils import _permute_control_points  # noqa: PLC0415
-        from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
-
         perm = list(permutation)
         if sorted(perm) != list(range(self.dim)):
             raise ValueError(f"permutation must be a permutation of range({self.dim}), got {perm}.")
 
-        new_cp = _permute_control_points(self._control_points, perm, self.dim)
-
-        # Reorder 1D spaces.
-        old_spaces = self._space.spaces
-        new_spaces = tuple(old_spaces[i] for i in perm)
-        new_space = BsplineSpace(new_spaces)
-
         if in_place:
-            self._control_points = new_cp
-            self._space = new_space
-            self._beziers_cache = None
-            self._locate_cache = None
+            self._mutate(lambda cp: self._permuted(perm, cp))
             return None
-        return Bspline(new_space, new_cp, is_rational=self._is_rational)
+        new_cp, new_space = self._permuted(perm, self.control_points)
+        return Bspline(new_space, new_cp, is_rational=self.is_rational)
+
+    def _permuted(
+        self, permutation: list[int], control_points: _ControlPoints
+    ) -> tuple[_ControlPoints, BsplineSpace]:
+        """The value :meth:`permute_directions` produces, without deciding where it goes.
+
+        No ``write_into`` twin, unlike :meth:`_reversed`: a permutation of the
+        parametric axes cannot be done in the caller's buffer, so the oracle's
+        ``in_place=True`` path already replaced the array rather than writing into
+        it.
+
+        Args:
+            permutation (list[int]): A permutation of ``range(dim)``, already
+                validated.
+            control_points (npt.NDArray[np.float32 | np.float64]): The array to read.
+
+        Returns:
+            tuple[npt.NDArray[np.float32 | np.float64], ~pantr.bspline.BsplineSpace]:
+            The permuted control points and the reordered space.
+        """
+        from .._control_points_utils import _permute_control_points  # noqa: PLC0415
+        from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
+
+        new_cp = _permute_control_points(control_points, permutation, self.dim)
+        old_spaces = self.space.spaces
+        return new_cp, BsplineSpace(tuple(old_spaces[i] for i in permutation))
 
     # ------------------------------------------------------------------
     # Affine transformation
@@ -1154,18 +1690,46 @@ class Bspline:
             >>> np.allclose(shifted.control_points, [[1.0, 2.0], [2.0, 3.0]])
             True
         """
+        if in_place:
+            self._mutate(lambda cp: self._transformed(affine, cp, write_into=True))
+            return None
+        new_cp, new_space = self._transformed(affine, self.control_points, write_into=False)
+        return Bspline(new_space, new_cp, is_rational=self.is_rational)
+
+    def _transformed(
+        self, affine: AffineTransform, control_points: _ControlPoints, *, write_into: bool
+    ) -> tuple[_ControlPoints, BsplineSpace]:
+        """The value :meth:`transform` produces, without deciding where it goes.
+
+        The space is returned unchanged, and returning it rather than leaving it
+        implicit is what keeps :meth:`_mutate`'s signature the same for all three
+        mutators. It is also the one propagation site
+        ``design/bspline_ownership_lifetime.md`` names: an affine map moves the
+        control points and not the parametrization, so the derived field hands back
+        the *source's* space wrapper and ``s.transform(t).space is s.space`` holds.
+
+        Args:
+            affine (~pantr.transform.AffineTransform): The map to apply.
+            control_points (npt.NDArray[np.float32 | np.float64]): The array to read.
+            write_into (bool): Whether the map may write into ``control_points``
+                rather than allocating.
+
+        Returns:
+            tuple[npt.NDArray[np.float32 | np.float64], ~pantr.bspline.BsplineSpace]:
+            The mapped control points and this field's own space.
+
+        Raises:
+            ValueError: If the transform dimension does not match the geometric rank
+                of the B-spline.
+        """
         new_cp = _apply_affine_to_control_points(
-            self._control_points,
-            self._is_rational,
+            control_points,
+            self.is_rational,
             affine.matrix,
             affine.offset,
-            in_place=in_place,
+            in_place=write_into,
         )
-        if in_place:
-            self._beziers_cache = None
-            self._locate_cache = None
-            return None
-        return Bspline(self._space, new_cp, is_rational=self._is_rational)
+        return new_cp, self.space
 
     def subdivide(
         self,

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -34,7 +34,7 @@ ticket in this milestone covers.
 ``design/bspline_derived_caches.md`` calls :class:`Bspline` the type where
 construct-then-freeze does not hold. It holds on the C++ side: the observable
 mutation lives here, in :meth:`Bspline._mutate`, which replaces the whole
-implementation together with the whole derived block in one assignment. See
+implementation together with the whole derived block as one unit. See
 :class:`_Derived` for why that is the repair that note asks this front for, and
 ``cpp/include/pantr/bspline/bspline.hpp`` for why the C++ type refuses to carry
 the flag itself.
@@ -1338,7 +1338,10 @@ class Bspline:
                 deep-copied into the new Bézier.  If ``False``, the Bézier
                 shares the same underlying control point array when possible
                 (direct extraction) or owns the freshly allocated array
-                produced by the open-form conversion.
+                produced by the open-form conversion -- **under the Python
+                backend only**. A C++ ``Bezier`` copies at construction, so
+                there ``copy=False`` shares nothing; that predates this
+                type's own port and is measured, not assumed.
 
         Returns:
             ~pantr.bezier.Bezier: Equivalent Bézier representation.
@@ -1954,7 +1957,10 @@ def create_from_bezier(bezier: Bezier, *, copy: bool = True) -> Bspline:
         bezier (~pantr.bezier.Bezier): The source Bézier.
         copy (bool): If ``True`` (default), the control points are
             deep-copied into the new B-spline.  If ``False``, the
-            B-spline shares the same underlying control point array.
+            B-spline shares the same underlying control point array --
+            **under the Python backend only**. The C++ value owns its
+            storage and copies at construction, so there ``copy=False``
+            saves nothing and shares nothing.
 
     Returns:
         Bspline: Equivalent B-spline with Bézier-like knots.

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -280,7 +280,8 @@ class _LocateContext(NamedTuple):
     """Per-:class:`~pantr.bspline.Bspline` state reused across :meth:`locate` calls.
 
     Cached on the B-spline instance and invalidated by the in-place mutators, exactly
-    like the Bézier decomposition cache: none of these three depends on the query
+    like the Bézier decomposition cache -- and in one block with it, so that neither
+    can be discarded without the other: none of these three depends on the query
     points, and the BVH costs ``O(num_cells)`` to build.
 
     Attributes:
@@ -1442,12 +1443,17 @@ def _locate_context(spline: Bspline) -> _LocateContext:
 
     Returns:
         _LocateContext: The cached context. Invalidated by the in-place mutators of
-        :class:`~pantr.bspline.Bspline`, which reset the cache attribute to ``None``.
+        :class:`~pantr.bspline.Bspline`, which replace the whole derived block rather
+        than resetting this slot; see ``pantr.bspline._bspline._Derived``.
     """
-    # Layer 2 owns this cache slot; Layer 1 only declares and invalidates it.
-    if spline._locate_cache is None:
-        spline._locate_cache = _build_context(spline)
-    return spline._locate_cache
+    # Layer 2 owns this cache slot; Layer 1 only declares it and replaces the block
+    # it lives in. Filled through the block rather than through an attribute of the
+    # B-spline itself, because the wrapper refuses attribute assignment: the derived
+    # quantities are reachable only where the invalidation is, which is the point.
+    derived = spline._derived
+    if derived.locate is None:
+        derived.locate = _build_context(spline)
+    return derived.locate
 
 
 __all__ = ["_locate_impl"]

--- a/tests/parity/test_bspline_binding_contract.py
+++ b/tests/parity/test_bspline_binding_contract.py
@@ -328,16 +328,33 @@ def test_the_tensor_product_shares_its_directions_rather_than_copying(
 def test_taking_a_direction_does_not_pin_its_owner(cpp_backend: None) -> None:
     """Reading ``spaces`` installs no keep-alive on the tensor-product space.
 
-    M2, and the one detector that distinguishes class H from a reversion to
-    ``rv_policy::reference_internal``: under sharing the *value* travels in the
-    return, so the owner's reference count does not move; under a keep-alive it moves
-    by one per returned element. Both behave identically for a Python caller, and
-    only one of them protects a consumer with no interpreter.
+    M2's assertion, and **not** the detector M2 says it is. Its docstring used to
+    claim this was "the one detector that distinguishes class H from a reversion to
+    ``rv_policy::reference_internal``". Measured on this binding, it is not:
+    rebinding a direction accessor to return a reference with
+    ``rv_policy::reference_internal`` leaves this delta at zero, the handed-out
+    object identical to the one passed in, and its value readable after the owner
+    dies.
 
-    The returned tuple is dropped before the second reading, deliberately:
-    ``design/bspline_ownership_lifetime.md`` F4 records two correct measurements of
-    this delta disagreeing because one run held the whole container and the other held
-    a single element, so a test must fix that rather than let a temporary decide it.
+    The reason is specific and is what to carry forward: a direction always arrives
+    *from Python*, so it already has a live instance that ``nb_type_put``'s
+    ``inst_c2p`` lookup finds, and no new instance is created for a keep-alive to be
+    installed on. ``design/bspline_ownership_lifetime.md`` F3 and F4 measured the
+    delta on a stand-in whose nested object was constructed in C++, where it does
+    move -- so the note's measurement is right and its application to this accessor
+    was wrong. The detector stays live for an accessor whose nested object has no
+    instance of its own, which ``THBSplineSpace.level_space`` is and this is not.
+
+    **What decides class H here is the C++ test**:
+    ``cpp/tests/test_bspline_space_nd.cpp`` compares addresses and reads a direction
+    after its space is destroyed, and that is the gate a reversion fails.
+
+    Kept because a non-zero delta would still be a finding -- it would mean a
+    keep-alive appeared where the design says none should -- and read **while the
+    returned objects are alive**, since a keep-alive lives on the returned object and
+    is released with it. Both holdings are checked, because F4 records two correct
+    measurements of such a delta disagreeing over exactly that: the whole container
+    against a single element.
     """
     space = _cpp_tensor_product()
     impl = space._impl
@@ -345,14 +362,24 @@ def test_taking_a_direction_does_not_pin_its_owner(cpp_backend: None) -> None:
 
     directions = impl.spaces
     assert len(directions) == 2
+    assert sys.getrefcount(impl) == before, (
+        "holding the whole tuple of directions changed the owner's reference count, "
+        "which means a keep-alive was installed per element: the accessor is aliasing "
+        "into the owner rather than sharing the value, and it will dangle for a caller "
+        "with no interpreter"
+    )
+
+    one = directions[0]
     del directions
     gc.collect()
-
     assert sys.getrefcount(impl) == before, (
-        "reading the directions changed the owner's reference count, which means a "
-        "keep-alive was installed: the accessor is aliasing into the owner rather "
-        "than sharing the value, and it will dangle for a caller with no interpreter"
+        "holding one escaped direction changed the owner's reference count, so a "
+        "keep-alive was installed on it"
     )
+
+    del one
+    gc.collect()
+    assert sys.getrefcount(impl) == before
 
 
 def test_a_direction_outlives_the_tensor_product_space(cpp_backend: None) -> None:
@@ -363,6 +390,13 @@ def test_a_direction_outlives_the_tensor_product_space(cpp_backend: None) -> Non
     handle being non-null, because F4 measured a scalar read after free returning the
     correct value -- so several tensor-product spaces are built and dropped in between
     to churn the freed storage.
+
+    Necessary and not sufficient, and the same measurement is why: for a nested
+    object that arrived from Python the value survives the owner's death under
+    ``reference_internal`` too, because the object that comes back is the caller's
+    own instance and that instance owns the C++ value. So this fails on a design
+    that hands out nothing at all, and passes on the reversion. The C++ test is
+    the gate.
     """
     space = _cpp_tensor_product()
     direction = space._impl.spaces[0]
@@ -691,16 +725,19 @@ def test_the_field_shares_its_space_rather_than_copying(cpp_backend: None) -> No
 def test_taking_the_fields_space_does_not_pin_the_field(cpp_backend: None) -> None:
     """Reading ``space`` installs no keep-alive on the field.
 
-    M2 for the field, and the one detector that distinguishes class H from a
-    reversion to ``rv_policy::reference_internal``: under sharing the *value* travels
-    in the return, so the owner's reference count does not move; under a keep-alive
-    it moves by one. Both behave identically for a Python caller, and only one of
-    them protects a consumer with no interpreter.
+    M2 for the field, and it is worth saying plainly that this **does not** decide
+    class H, whatever M2 says: measured, binding this accessor as ``space_ref`` with
+    ``rv_policy::reference_internal`` leaves the delta at zero, the handed-out object
+    identical to the one passed in, and its value readable after the field dies. A
+    field's space always arrives from Python, so it already has an instance that
+    ``nb_type_put``'s ``inst_c2p`` lookup finds and no keep-alive is created for the
+    delta to see. See the sibling assertion on ``BsplineSpace.spaces`` above for the
+    full argument, and ``cpp/tests/test_bspline_type.cpp`` for the gate that does
+    decide it.
 
-    The returned handle is dropped before the second reading, for the reason
-    ``design/bspline_ownership_lifetime.md`` F4 records: two correct measurements of
-    such a delta disagreed because one run held the escapee and the other did not,
-    so a test must fix that rather than let a temporary decide it.
+    Kept because a non-zero delta would still be a finding -- a keep-alive where the
+    design says none should be -- and read **while the escaped space is alive**, since
+    a keep-alive lives on the returned object and is released with it.
     """
     field = _cpp_field()
     impl = field._impl
@@ -708,14 +745,15 @@ def test_taking_the_fields_space_does_not_pin_the_field(cpp_backend: None) -> No
 
     taken = impl.space
     assert taken.dim == 2
-    del taken
-    gc.collect()
-
     assert sys.getrefcount(impl) == before, (
-        "reading the space changed the field's reference count, which means a "
+        "holding the escaped space changed the field's reference count, which means a "
         "keep-alive was installed: the accessor is aliasing into the owner rather "
         "than sharing the value, and it will dangle for a caller with no interpreter"
     )
+
+    del taken
+    gc.collect()
+    assert sys.getrefcount(impl) == before
 
 
 def test_the_space_outlives_the_field(cpp_backend: None) -> None:
@@ -726,6 +764,13 @@ def test_the_space_outlives_the_field(cpp_backend: None) -> None:
     than on the handle being non-null, because F4 measured a scalar read after free
     returning the correct value -- so fields are built and dropped in between to
     churn the freed storage.
+
+    Necessary and not sufficient, and the same measurement is why: for a nested
+    object that arrived from Python the value survives the owner's death under
+    ``reference_internal`` too, because the object that comes back is the caller's
+    own instance and that instance owns the C++ value. So this fails on a design
+    that hands out nothing at all, and passes on the reversion. The C++ test is
+    the gate.
     """
     field = _cpp_field()
     space = field._impl.space
@@ -753,18 +798,47 @@ def test_the_fields_control_points_are_a_read_only_view(cpp_backend: None) -> No
     read-only view is the half of its removal this front owns.
 
     ``shares_memory`` is what tells a view from a copy; the values agree either way.
+
+    **The ``self`` owner argument is not observable from Python, and that was measured
+    rather than assumed.** Dropping it leaves the array aliasing the same storage,
+    still read-only, still valid after the field is dropped, and still taking a
+    reference on the field -- so M6's symptom (a silent copy, handed out writeable)
+    does not appear. The reason is F1 applied to an array: ``def_prop_ro`` passes
+    ``rv_policy::reference_internal`` positionally, so the property already ties its
+    return to ``self``. M6 is live for an array bound on a plain ``.def``, where the
+    default policy is ``automatic``.
+
+    The reference-count assertion below is therefore a check that *a* keep-alive
+    exists, not that the owner argument supplied it: exactly ``1`` while the array is
+    alive and ``0`` once it dies. A zero while it is alive would mean the property had
+    been turned into a method and lost its default policy, which is the one way this
+    accessor can start handing out an unowned view.
     """
     field = _cpp_field()
-    handed_out = field._impl.control_points
+    impl = field._impl
+    before = sys.getrefcount(impl)
+    handed_out = impl.control_points
 
     assert not handed_out.flags.writeable, (
         "the scalar is not `const T`, so a caller can rewrite a validated geometry"
     )
     with pytest.raises(ValueError, match="read-only"):
         handed_out[0, 0, 0] = 99.0
-    assert np.shares_memory(handed_out, field._impl.control_points), (
-        "two reads do not share memory, so the accessor copies: the owner argument is "
-        "missing and the whole net is duplicated on every access"
+    assert np.shares_memory(handed_out, impl.control_points), (
+        "two reads do not share memory, so the accessor copies and the whole net is "
+        "duplicated on every access"
+    )
+    assert sys.getrefcount(impl) == before + 1, (
+        "the array does not hold a reference to the field, so the `self` owner "
+        "argument is missing: the view aliases storage it does not keep alive, and it "
+        "reads freed memory the moment the field is dropped"
+    )
+
+    del handed_out
+    gc.collect()
+    assert sys.getrefcount(impl) == before, (
+        "the reference the array held was not released, which is a leak rather than a "
+        "dangle -- and it would make the assertion above pass for the wrong reason"
     )
 
 

--- a/tests/parity/test_bspline_binding_contract.py
+++ b/tests/parity/test_bspline_binding_contract.py
@@ -1,10 +1,14 @@
-"""What the `pantr.bspline` space bindings guarantee, as opposed to what they compute.
+"""What the `pantr.bspline` bindings guarantee, as opposed to what they compute.
 
-`tests/parity/test_bspline_space_1d.py` and `tests/parity/test_bspline_space_nd.py`
-compare the two backends' *answers*. This file is about the *bindings*: what the
-arrays they hand out alias, how long they stay valid, what a constructor refuses to
-convert, what a nested object's identity and lifetime are, and one rule that is about
-the shape of the bound surface rather than about any one call.
+`tests/parity/test_bspline_space_1d.py`, `tests/parity/test_bspline_space_nd.py` and
+`tests/parity/test_bspline_type.py` compare the two backends' *answers*. This file is
+about the *bindings*: what the arrays they hand out alias, how long they stay valid,
+what a constructor refuses to convert, what a nested object's identity and lifetime
+are, and one rule that is about the shape of the bound surface rather than about any
+one call.
+
+The spaces come first and the field -- ``pantr::bspline::Bspline``, which holds a
+space *and* an array of its own -- is the last section.
 
 Every claim here is exact -- an identity, a flag, a refusal, a name -- so nothing in
 this file carries a tolerance, and `design/backend_parity.md` Rule 8 does not bite.
@@ -231,19 +235,20 @@ def test_the_space_refuses_a_dtype_it_would_have_to_cast(
 
 
 def test_no_bound_method_is_a_borrowing_accessor(cpp_backend: None) -> None:
-    """No name on any of the four bound space classes ends in ``_ref``.
+    """No name on any bound class of this front ends in ``_ref``.
 
     The rule from `design/bspline_ownership_lifetime.md`. It was vacuous while only
     ``BsplineSpace1D`` existed, which hands out spans of its own storage rather than
     references to nested objects; ``pantr::bspline::BsplineSpace`` has a real
-    ``space_ref``, so from here on this is the assertion that keeps it unbound.
-    There is no ``static_assert`` for absence, review alone will not hold across the
-    rest of this front, and the cost of the rule being broken is a dangling
-    reference with no policy anywhere to blame.
+    ``space_ref``, the two hierarchical classes have three between them and
+    ``pantr::bspline::Bspline`` has one, so from here on this is the assertion that
+    keeps them unbound. There is no ``static_assert`` for absence, review alone will
+    not hold across the rest of this front, and the cost of the rule being broken is
+    a dangling reference with no policy anywhere to blame.
     """
     bindings = _bindings()
     offenders = []
-    for class_name in _SPACE_CLASSES:
+    for class_name in _SPACE_CLASSES + _FIELD_CLASSES:
         cls = getattr(bindings, class_name)
         offenders += [f"{class_name}.{name}" for name in dir(cls) if name.endswith("_ref")]
 
@@ -259,6 +264,11 @@ def test_no_bound_method_is_a_borrowing_accessor(cpp_backend: None) -> None:
     # And the same for the hierarchical class, which carries three of these.
     assert "root_space" in dir(bindings.THBSplineSpace64)
     assert "level_space" in dir(bindings.THBSplineSpace64)
+    # And for the field, whose one borrowing accessor is `space_ref`: the owning twin
+    # is bound under the bare name, so seeing it is what says `dir` reports this
+    # class's surface at all.
+    assert "space" in dir(bindings.Bspline64)
+    assert "control_points" in dir(bindings.Bspline64)
 
 
 _SPACE_CLASSES = (
@@ -598,3 +608,250 @@ def test_a_space_has_no_instance_dictionary() -> None:
         tensor_product._impl = None  # type: ignore[assignment]
     with pytest.raises(AttributeError):
         del tensor_product._spaces
+
+
+# ===========================================================================
+# The field: `pantr::bspline::Bspline`
+# ===========================================================================
+#
+# The field is the second type in this front that holds another domain type, and
+# the first that holds one *and* an array of its own. So both halves of
+# `design/bspline_ownership_lifetime.md` are live on one class: its `space` is
+# class H and its `control_points` is class A, and the four silent failures
+# above (M1, M2, M7, M8) plus M5 and M6 all apply to it at once.
+#
+# What it adds that no space could: the field is the only ported type whose
+# Python surface *mutates*, so `Bspline._mutate` is the one place any of these
+# invariants can be broken after construction. Its own contract -- that the
+# wrapper refuses every attribute write, so nothing but `_mutate` can reseat the
+# value or leave the derived block behind -- is asserted at the end of this file.
+
+_FIELD_CLASSES = ("Bspline32", "Bspline64")
+"""The two field classes the extension registers.
+
+Swept by the ``_ref`` rule alongside the space classes: ``pantr::bspline::Bspline``
+has a ``space_ref()`` of its own, which borrows the space rather than copying the
+handle and must not reach Python.
+"""
+
+
+def _cpp_field(dtype: Any = np.float64, *, is_rational: bool = False) -> Any:
+    """Build a two-direction field under the C++ backend.
+
+    The basis counts are 6 and 3 -- ``_KNOTS`` is a quadratic over nine knots and
+    ``_OTHER_KNOTS`` a linear over five -- so the control net is ``(6, 3, rank)`` and
+    no permutation of its shape is another admissible shape for this space.
+
+    Args:
+        dtype (Any): The storage format.
+        is_rational (bool): Whether the last stored component is a weight.
+
+    Returns:
+        Any: A :class:`~pantr.bspline.Bspline` holding a C++ handle.
+    """
+    from pantr.bspline import Bspline  # noqa: PLC0415
+
+    with use_backend(Backend.CPP):
+        space = BsplineSpace(
+            [
+                BsplineSpace1D(np.asarray(_KNOTS, dtype=dtype), 2),
+                BsplineSpace1D(np.asarray(_OTHER_KNOTS, dtype=dtype), 1),
+            ]
+        )
+        control_points = np.arange(6 * 3 * 3, dtype=dtype).reshape(6, 3, 3)
+        return Bspline(space, control_points, is_rational=is_rational)
+
+
+def test_the_field_shares_its_space_rather_than_copying(cpp_backend: None) -> None:
+    """The C++ field holds the very space handle it was built from.
+
+    M7 for the field. Compared at the *implementation* level, because the wrapper
+    level cannot see it: the wrapper keeps the space wrapper it was built from, so
+    ``field.space is space`` holds whether the C++ constructor shared or copied, and
+    a copying constructor would leave two Python objects reporting identity over two
+    different C++ objects.
+    """
+    from pantr.bspline import Bspline  # noqa: PLC0415
+
+    with use_backend(Backend.CPP):
+        space = BsplineSpace([BsplineSpace1D(_KNOTS, 2), BsplineSpace1D(_OTHER_KNOTS, 1)])
+        field = Bspline(space, np.arange(6 * 3 * 3, dtype=np.float64).reshape(6, 3, 3))
+
+    assert field._impl.space is space._impl, (
+        "the field's space is not the handle it was given, so the C++ constructor copied"
+    )
+    # And the wrapper's own contract, M1 and M8: seeded from the constructor, so the
+    # object a caller passed in comes back.
+    assert field.space is space
+    # Identity-stable across two reads, which is what `nb_type_put`'s `inst_c2p`
+    # lookup buys and what a memo on the wrapper would otherwise have to fake.
+    assert field._impl.space is field._impl.space
+
+
+def test_taking_the_fields_space_does_not_pin_the_field(cpp_backend: None) -> None:
+    """Reading ``space`` installs no keep-alive on the field.
+
+    M2 for the field, and the one detector that distinguishes class H from a
+    reversion to ``rv_policy::reference_internal``: under sharing the *value* travels
+    in the return, so the owner's reference count does not move; under a keep-alive
+    it moves by one. Both behave identically for a Python caller, and only one of
+    them protects a consumer with no interpreter.
+
+    The returned handle is dropped before the second reading, for the reason
+    ``design/bspline_ownership_lifetime.md`` F4 records: two correct measurements of
+    such a delta disagreed because one run held the escapee and the other did not,
+    so a test must fix that rather than let a temporary decide it.
+    """
+    field = _cpp_field()
+    impl = field._impl
+    before = sys.getrefcount(impl)
+
+    taken = impl.space
+    assert taken.dim == 2
+    del taken
+    gc.collect()
+
+    assert sys.getrefcount(impl) == before, (
+        "reading the space changed the field's reference count, which means a "
+        "keep-alive was installed: the accessor is aliasing into the owner rather "
+        "than sharing the value, and it will dangle for a caller with no interpreter"
+    )
+
+
+def test_the_space_outlives_the_field(cpp_backend: None) -> None:
+    """A space taken out of a field still knows its own state after the field dies.
+
+    The property that justifies storing ``shared_ptr<const BsplineSpace<T>>`` in the
+    type instead of annotating the binding. Asserted on the space's counts rather
+    than on the handle being non-null, because F4 measured a scalar read after free
+    returning the correct value -- so fields are built and dropped in between to
+    churn the freed storage.
+    """
+    field = _cpp_field()
+    space = field._impl.space
+    expected_total = space.num_total_basis
+    expected_degrees = space.degrees
+
+    del field
+    gc.collect()
+    for _ in range(64):
+        _cpp_field()
+    gc.collect()
+
+    assert space.num_total_basis == expected_total
+    assert space.degrees == expected_degrees
+
+
+def test_the_fields_control_points_are_a_read_only_view(cpp_backend: None) -> None:
+    """The C++ ``control_points`` aliases the field's own storage and cannot be written.
+
+    M5 and M6 for the field's one array accessor, and the pair matters more here than
+    for a space: a write through a writeable view would leave both of the field's
+    derived memos -- the Bézier decomposition and the point-inversion context --
+    describing a geometry it no longer holds, with nothing raising. That is the defect
+    ``design/bspline_ownership_lifetime.md`` records in today's Python, and the
+    read-only view is the half of its removal this front owns.
+
+    ``shares_memory`` is what tells a view from a copy; the values agree either way.
+    """
+    field = _cpp_field()
+    handed_out = field._impl.control_points
+
+    assert not handed_out.flags.writeable, (
+        "the scalar is not `const T`, so a caller can rewrite a validated geometry"
+    )
+    with pytest.raises(ValueError, match="read-only"):
+        handed_out[0, 0, 0] = 99.0
+    assert np.shares_memory(handed_out, field._impl.control_points), (
+        "two reads do not share memory, so the accessor copies: the owner argument is "
+        "missing and the whole net is duplicated on every access"
+    )
+
+
+def test_the_control_points_view_outlives_the_field(cpp_backend: None) -> None:
+    """The array keeps the C++ storage alive after the field handle is dropped.
+
+    The owner argument is what does that. Without it the values are read from freed
+    memory, which is a use-after-free that usually reads back correct and
+    occasionally does not -- so this asserts the values, and churns the allocator in
+    between rather than trusting one read.
+    """
+    field = _cpp_field()
+    handed_out = field._impl.control_points
+    expected = np.array(handed_out)
+
+    del field
+    gc.collect()
+    for _ in range(64):
+        _cpp_field()
+    gc.collect()
+
+    np.testing.assert_array_equal(handed_out, expected)
+
+
+@pytest.mark.parametrize(
+    ("class_name", "space_dtype", "net_dtype"),
+    [
+        ("Bspline64", np.float64, np.float32),
+        ("Bspline32", np.float32, np.float64),
+    ],
+)
+def test_the_field_refuses_a_control_net_it_would_have_to_cast(
+    class_name: str, space_dtype: Any, net_dtype: Any, cpp_backend: None
+) -> None:
+    """Handing a field class a net of the other width is a refusal, not a cast.
+
+    The ``.noconvert()`` on the binding. Without it nanobind casts silently, so
+    :func:`pantr.bspline._bspline._impl_class` picking the wrong class would narrow or
+    widen a caller's geometry with nothing to notice -- the class name is the only
+    thing carrying the storage format.
+
+    The space must be of the class's own width, so that the *net* is the only thing
+    wrong: a space of the other width is refused by its own caster and would make
+    this pass for the wrong reason.
+    """
+    bindings = _bindings()
+    with use_backend(Backend.CPP):
+        space = BsplineSpace([BsplineSpace1D(np.asarray(_KNOTS, dtype=space_dtype), 2)])
+    net = np.arange(6 * 2, dtype=net_dtype).reshape(6, 2)
+
+    cls = getattr(bindings, class_name)
+    # The control-point argument is the only ill-typed one: the space handle matches.
+    with pytest.raises(TypeError):
+        cls(space._impl, net, False)
+
+
+def test_a_field_has_no_instance_dictionary() -> None:
+    """The field wrapper refuses every attribute write, so ``_mutate`` is the only writer.
+
+    A ``__dict__`` would let a memo be attached to the wrapper -- the second truth
+    ``design/bspline_derived_caches.md`` forbids -- and, worse for this type than for
+    a space, it would let a caller reseat ``_impl`` or ``_space`` without discarding
+    the derived block, which is exactly the invalidation hole that note asks this
+    front to close.
+
+    Not parametrized over the backends and not gated on the extension: ``__slots__``
+    and ``__setattr__`` belong to the wrapper class, which is the same class whichever
+    implementation it holds, so a second run would duplicate the first. Gating it
+    would have made it skip in the configuration where it is the only thing checking
+    this.
+    """
+    from pantr.bspline import Bspline  # noqa: PLC0415
+
+    space = BsplineSpace([BsplineSpace1D(_KNOTS, 2)])
+    field = Bspline(space, np.arange(6 * 2, dtype=np.float64).reshape(6, 2))
+
+    assert not hasattr(field, "__dict__")
+    with pytest.raises(AttributeError):
+        field.some_new_attribute = 1
+    with pytest.raises(AttributeError):
+        field._impl = None  # type: ignore[assignment]
+    with pytest.raises(AttributeError):
+        field._space = None  # type: ignore[assignment]
+    with pytest.raises(AttributeError):
+        del field._derived
+    # The block itself is reachable and fillable, which is what the two memos need;
+    # what is unspellable is replacing one of them without the other, because only
+    # `_take` writes the slot the block lives in.
+    assert field._derived.beziers is None
+    assert field._derived.locate is None

--- a/tests/parity/test_bspline_binding_contract.py
+++ b/tests/parity/test_bspline_binding_contract.py
@@ -923,6 +923,17 @@ def test_a_field_has_no_instance_dictionary() -> None:
     with pytest.raises(AttributeError):
         field._space = None  # type: ignore[assignment]
     with pytest.raises(AttributeError):
+        field._derived = None  # type: ignore[assignment]
+    # And both directions for every slot, not one direction each. `__setattr__` and
+    # `__delattr__` do not discriminate by name, so the implementation cannot fail
+    # selectively on a combination left untested -- but the docstring above claims
+    # the refusal for all three slots, and a claim asserted for two of three names
+    # is the shape this milestone keeps finding.
+    with pytest.raises(AttributeError):
+        del field._impl
+    with pytest.raises(AttributeError):
+        del field._space
+    with pytest.raises(AttributeError):
         del field._derived
     # The block itself is reachable and fillable, which is what the two memos need;
     # what is unspellable is replacing one of them without the other, because only

--- a/tests/parity/test_bspline_type.py
+++ b/tests/parity/test_bspline_type.py
@@ -1,0 +1,1262 @@
+"""Parity of the `Bspline` value type: the state, the rejections, and the wire format.
+
+What this file compares is a *value*, not a computation. `pantr.bspline.Bspline`
+holds a space, a control net and a flag, and answers five questions about them;
+between the Python oracle and the C++ port there is no arithmetic on a coefficient
+at all, only a copy and one integer subtraction. So every claim here is bitwise or
+exact, and a tolerance anywhere in this file would be hiding a transcription error
+rather than allowing for rounding. The operations that *do* arithmetic --
+evaluation, the degree and knot operations, the product -- are the subject of the
+existing `tests/test_bspline_*.py` files, which build their B-splines through this
+same type and therefore run under both backends already.
+
+**Each field's claim carries its own argument**, in ``FIELDS`` below, rather than one
+decision applied in bulk: the six quantities are exact for six different reasons, and
+a shared ``why`` would be a single sentence quoted in six failure messages it does not
+fit.
+
+Five things are checked that a field-by-field state comparison does not reach:
+
+- **The rejections.** Two of the four are the wrapper's and are therefore common mode
+  by construction, which this file says out loud rather than counting them as
+  evidence; the rank refusal is the one a cross-backend comparison actually decides,
+  and it is compared at the implementation level where the C++ text is really under
+  test.
+- **The copy at construction, and the read-only view on the way out.** The C++ value
+  does not alias the caller's array at either end, which the oracle does. This is the
+  one place the two backends differ on purpose: a write through either end
+  desynchronises both of the field's derived memos with nothing raising, which
+  `design/bspline_ownership_lifetime.md` records as a defect in today's Python.
+- **The reseat contract of the two space-changing in-place methods.**
+  ``before = b.space; b.reverse(0, in_place=True)`` must leave ``before`` holding the
+  *old* space and ``b.space`` a different object. That is the contract
+  `design/bspline_ownership_lifetime.md` reason 3 was measured on, and two of the
+  three storage shapes it tabulates break it silently -- one of them by making the
+  escaped space start reporting the new value.
+- **The derived block, discarded wholesale.** ``design/bspline_derived_caches.md``
+  asks this front to turn the oracle's three separate cache-invalidation sites into
+  one assignment. The test for that is not "the caches are cold after a mutation" but
+  "*both* are, after each of the three mutators", because the defect the block
+  removes is one surviving the other.
+- **The wire format.** ``__reduce__`` pickles by the constructor's arguments, so a
+  pickle written under one backend loads under the other. Without that the backend
+  switch would silently become a data-format switch, and a C++ handle is not
+  picklable in any case.
+
+## The independent check, and why it is not a mirror
+
+`design/backend_parity.md`'s first rule is that parity says the two backends agree
+and not that either is right, so a shared error is invisible to every parity test
+here. The independent oracle for a value type is not a rational reimplementation of
+an algorithm -- there is no algorithm -- it is a **closed form for the layout**:
+
+- ``test_the_stored_layout_matches_its_closed_form`` builds the control net from an
+  explicit function of the multi-index, then reads it back *through the field* at
+  each multi-index and compares against that function evaluated again. The expected
+  value comes from a formula written in this file; nothing in the comparison consults
+  either implementation. A transposition, a wrong stride, a dropped component axis or
+  a narrowing cast all move it, and the admissible deviation is zero because the
+  formula's values are exactly representable in both storage formats -- dyadic
+  fractions times small integers -- so no rounding can enter on either side.
+- ``test_the_counts_match_their_closed_forms`` derives the per-direction basis counts
+  from the B-spline definition (``len(knots) - degree - 1``, less the periodic
+  correction) and the rank from the buffer size, in exact integer arithmetic. Those
+  are the numbers the C++ constructor checks the net's extents against, so taking
+  them from ``space.num_basis`` instead would have been a mirror. Every case in
+  ``CASES`` carries them as literals for the same reason.
+"""
+
+from __future__ import annotations
+
+import copy
+import gc
+import math
+import pickle
+from collections.abc import Callable
+from typing import Any, Final, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline._bspline import _BsplinePython
+from tests._parity_harness import (
+    Field,
+    assert_accuracy,
+    assert_object_parity,
+    bitwise_parity,
+    derived_accuracy,
+    exact_parity,
+)
+
+pytestmark = pytest.mark.usefixtures("cpp_backend")
+
+DTYPES: Final = (np.float64, np.float32)
+"""Both storage formats. A B-spline stores `float32` too, so the C++ side has two classes."""
+
+FIELDS: Final = (
+    Field(
+        "control_points",
+        bitwise_parity(
+            why=(
+                "the value type stores the coefficients it is handed and performs no "
+                "arithmetic on them, so the two backends can only differ by a transcription "
+                "error -- a wrong stride, a transposed axis, a narrowing cast, a byte lost "
+                "to the shape. Every one of those is visible bitwise and invisible under any "
+                "tolerance wide enough to be called a rounding budget. It is also the only "
+                "claim here that would notice a signed zero normalized, a NaN payload "
+                "rewritten or a float32 subnormal flushed, none of which a value comparison "
+                "can see at all."
+            )
+        ),
+    ),
+    Field(
+        "is_rational",
+        exact_parity(
+            why=(
+                "the flag is stored and returned; nothing transforms it. It is named as its "
+                "own field rather than left implicit because it is what `rank` subtracts, so "
+                "a flag lost in the round trip shows up here as well as one field away, and "
+                "reading only `rank` could not say which of the two moved."
+            )
+        ),
+    ),
+    Field(
+        "dim",
+        exact_parity(
+            why=(
+                "the number of parametric directions, forwarded from the space by both "
+                "implementations. An integer count, so exactness is the only claim available; "
+                "a difference means the field is holding a different space than the one it "
+                "was given, which no comparison of the coefficients would reveal on a net "
+                "whose flat size happens to match."
+            )
+        ),
+    ),
+    Field(
+        "degree",
+        exact_parity(
+            why=(
+                "one integer per direction, forwarded from the space in axis order. The order "
+                "is the load-bearing part rather than the values: nothing about a degree "
+                "reveals a transposition on a field whose directions happen to agree, which "
+                "is why every case in `CASES` has directions that differ in it."
+            )
+        ),
+    ),
+    Field(
+        "rank",
+        exact_parity(
+            why=(
+                "the stored component count less the weight column, one subtraction in exact "
+                "integer arithmetic on both sides. A difference is an off-by-one on the "
+                "component axis, or the weight counted out of the storage instead of out of "
+                "the rank -- and it is the one field that folds the flag against the shape, "
+                "so it catches a round trip that preserved the byte count and the "
+                "per-direction counts while moving which axis carries the components."
+            )
+        ),
+    ),
+    Field(
+        "space.num_basis",
+        exact_parity(
+            why=(
+                "the per-direction basis counts the control net is laid out on. Exact integer "
+                "counts, and the field's business rather than the space's: this is the tuple "
+                "the C++ constructor checks the net's extents against, so a disagreement here "
+                "means the two backends laid one buffer out on two different grids. The "
+                "space's own parity is asserted in tests/parity/test_bspline_space_nd.py; "
+                "what is claimed here is that the field reached the same one."
+            )
+        ),
+    ),
+    Field(
+        "dtype",
+        exact_parity(
+            why=(
+                "the storage format a caller reads through `Bspline.dtype`, and on the C++ "
+                "side it is carried by the class of the handle. A disagreement means "
+                "`_impl_class` picked the wrong class, which would silently narrow or widen "
+                "the geometry -- and for a coefficient representable in both formats, which "
+                "is most of them, the bitwise claim above would not see it."
+            )
+        ),
+    ),
+)
+"""Every piece of a B-spline's state, one field each, with its own argument.
+
+`degree` and `space.num_basis` are homogeneous tuples of ints, which are one quantity
+each and stay one field; the harness refuses a value mixing element kinds, and neither
+is one.
+"""
+
+
+class _Case(NamedTuple):
+    """One B-spline shape to build under both backends, with its hand-derived counts.
+
+    The counts are **literals**, derived from the B-spline definition rather than read
+    off a constructed space, so that the layout and rank checks cannot take their
+    expected values from the thing under test. ``test_the_counts_match_their_closed_forms``
+    is what holds them to the definition; ``test_the_case_table_earns_its_keep`` is what
+    holds them to being asymmetric.
+
+    Attributes:
+        knots (tuple[tuple[float, ...], ...]): One knot vector per direction.
+        degrees (tuple[int, ...]): One degree per direction.
+        periodic (tuple[bool, ...]): Whether each direction wraps.
+        num_basis (tuple[int, ...]): The basis count of each direction, hand-derived.
+        components (int): The length of the stored component axis, weights included.
+        label (str): A short name for the failure message.
+    """
+
+    knots: tuple[tuple[float, ...], ...]
+    degrees: tuple[int, ...]
+    periodic: tuple[bool, ...]
+    num_basis: tuple[int, ...]
+    components: int
+    label: str
+
+
+_CLAMPED_QUADRATIC: Final = (0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0)
+"""Three intervals, degree 2, five basis functions, on ``[0, 3]``."""
+
+_CLAMPED_LINEAR: Final = (10.0, 10.0, 11.0, 12.0, 12.0)
+"""Two intervals, degree 1, three basis functions, on ``[10, 12]`` -- a different scale."""
+
+_SINGLE_SPAN: Final = (0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+"""One interval, degree 2, three basis functions: the Bézier-like case."""
+
+_CLAMPED_LINEAR_4: Final = (10.0, 10.0, 11.0, 12.0, 13.0, 13.0)
+"""Three intervals, degree 1, four basis functions, on ``[10, 13]``."""
+
+_CLAMPED_CUBIC: Final = (
+    100.0,
+    100.0,
+    100.0,
+    100.0,
+    101.0,
+    102.0,
+    103.0,
+    104.0,
+    104.0,
+    104.0,
+    104.0,
+)
+"""Four intervals, degree 3, seven basis functions, on ``[100, 104]`` -- a third scale."""
+
+_UNIFORM: Final = (-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+"""A uniform vector, usable clamped or periodic.
+
+Read non-periodically it is degree 2 with ``9 - 2 - 1 = 6`` basis functions; read
+periodically the count drops by ``degree - 1 = 1`` more, to 4, because the first
+in-domain knot is simple. Both readings appear in ``CASES``, which is what makes the
+periodic correction visible rather than assumed.
+"""
+
+CASES: Final = (
+    _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 1, "a scalar Bezier-like curve"),
+    _Case((_CLAMPED_QUADRATIC,), (2,), (False,), (5,), 3, "a space curve"),
+    _Case((_CLAMPED_QUADRATIC,), (2,), (False,), (5,), 4, "a rational space curve"),
+    _Case(
+        (_CLAMPED_QUADRATIC, _CLAMPED_LINEAR),
+        (2, 1),
+        (False, False),
+        (5, 3),
+        2,
+        "an asymmetric surface",
+    ),
+    _Case(
+        (_CLAMPED_QUADRATIC, _CLAMPED_LINEAR, _CLAMPED_CUBIC),
+        (2, 1, 3),
+        (False, False, False),
+        (5, 3, 7),
+        4,
+        "an asymmetric volume",
+    ),
+    _Case((_UNIFORM,), (2,), (True,), (4,), 2, "a periodic curve"),
+    _Case(
+        (_UNIFORM, _CLAMPED_LINEAR),
+        (2, 1),
+        (True, False),
+        (4, 3),
+        2,
+        "one periodic direction and one clamped",
+    ),
+    _Case((_UNIFORM,), (2,), (False,), (6,), 1, "the same vector read non-periodically"),
+)
+"""The shapes both backends must agree on.
+
+Each multi-direction case differs between its directions in the degree, the basis
+count, the domain and the domain's width at once, and its component count is none of
+its basis counts, so no permutation of a net's shape is another admissible shape for
+its space and a transposition cannot pass. ``test_the_case_table_earns_its_keep``
+asserts every one of those rather than leaving this paragraph to be believed.
+
+The periodic pair -- the same knot vector read periodically and not -- is what makes
+the periodic basis-count correction visible instead of taken on trust.
+"""
+
+
+def _make_space(case: _Case) -> BsplineSpace:
+    """Build ``case``'s space under whichever backend is active.
+
+    Args:
+        case (_Case): The shape to build.
+
+    Returns:
+        ~pantr.bspline.BsplineSpace: The space, in the active backend's
+        implementation.
+    """
+    return BsplineSpace(
+        [
+            BsplineSpace1D(np.asarray(knots, dtype=np.float64), degree, periodic=periodic)
+            for knots, degree, periodic in zip(case.knots, case.degrees, case.periodic, strict=True)
+        ]
+    )
+
+
+def _make_space_at(case: _Case, dtype: npt.DTypeLike) -> BsplineSpace:
+    """Build ``case``'s space at a given storage format, under the active backend.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The knot storage format.
+
+    Returns:
+        ~pantr.bspline.BsplineSpace: The space.
+    """
+    return BsplineSpace(
+        [
+            BsplineSpace1D(np.asarray(knots, dtype=dtype), degree, periodic=periodic)
+            for knots, degree, periodic in zip(case.knots, case.degrees, case.periodic, strict=True)
+        ]
+    )
+
+
+def _coefficient(index: tuple[int, ...]) -> float:
+    """The coefficient a case's control net holds at one multi-index.
+
+    The closed form the independent check compares against, and the reason the check
+    is not a mirror: it is a function of the *index*, written here, and neither
+    implementation is consulted to evaluate it.
+
+    Exactly representable in both storage formats at every index a case here reaches,
+    which is what lets the accuracy bound be zero rather than a rounding budget: the
+    factors are a power of two, a dyadic fraction with denominator 8, and a sign. So
+    ``np.asarray(..., dtype=np.float32)`` rounds nothing and the same literal value is
+    stored by both backends.
+
+    The exponent moves with the *first* parametric index and the mantissa with the
+    rest, so a transposition changes the magnitude by decades rather than by a bit --
+    which is what makes a failure legible instead of a last-digit puzzle.
+
+    Args:
+        index (tuple[int, ...]): The multi-index, ``(*parametric, component)``.
+
+    Returns:
+        float: The coefficient.
+    """
+    exponent = 3 * index[0] - 12
+    mantissa = 1.0
+    for position, value in enumerate(index[1:], start=1):
+        mantissa += value / float(2**position)
+    return (-1.0 if index[-1] % 2 else 1.0) * mantissa * float(2.0**exponent)
+
+
+def _control_net(case: _Case, dtype: npt.DTypeLike) -> npt.NDArray[np.float32 | np.float64]:
+    """Build ``case``'s control net from :func:`_coefficient`, index by index.
+
+    Filled through an explicit loop over ``np.ndindex`` rather than by a vectorized
+    expression, so that the array's own layout is numpy's doing and the check reading
+    it back through the field is comparing two independent routes to one element.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The net, C-contiguous, of shape
+        ``(*case.num_basis, case.components)``.
+    """
+    shape = (*case.num_basis, case.components)
+    net = np.zeros(shape, dtype=dtype)
+    for index in np.ndindex(*shape):
+        net[index] = _coefficient(index)
+    return net
+
+
+def _both(
+    case: _Case, control_points: npt.NDArray[np.float32 | np.float64], *, is_rational: bool
+) -> tuple[Bspline, Bspline]:
+    """Build the same B-spline under each backend.
+
+    The space is rebuilt per backend rather than shared, and that is forced rather
+    than tidy: each implementation holds the space's own implementation, so a space
+    built under one backend is refused by the other.
+
+    Args:
+        case (_Case): The shape to build.
+        control_points (npt.NDArray[np.float32 | np.float64]): The control net.
+        is_rational (bool): Whether the last stored component is a weight.
+
+    Returns:
+        tuple[Bspline, Bspline]: ``(py, cpp)``, in the order
+        :func:`assert_object_parity` names its arguments.
+    """
+    dtype = control_points.dtype
+    with use_backend(Backend.PYTHON):
+        py = Bspline(_make_space_at(case, dtype), control_points, is_rational)
+    with use_backend(Backend.CPP):
+        cpp = Bspline(_make_space_at(case, dtype), control_points, is_rational)
+    return py, cpp
+
+
+def _cpp_class(dtype: npt.DTypeLike) -> Any:
+    """The bound C++ class for one storage format.
+
+    Args:
+        dtype (npt.DTypeLike): `float32` or `float64`.
+
+    Returns:
+        Any: `pantr._pantr_cpp.Bspline32` or `Bspline64`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp.Bspline32 if np.dtype(dtype) == np.float32 else _pantr_cpp.Bspline64
+
+
+def _expected_num_basis(case: _Case) -> tuple[int, ...]:
+    """``case``'s basis counts from the B-spline definition, not from a space.
+
+    For a non-periodic direction a knot vector of ``m`` entries at degree ``p``
+    carries ``m - p - 1`` basis functions. A periodic direction drops the regularity
+    at the domain's start as well, which is ``p`` less the multiplicity of the first
+    in-domain knot, plus the wrap itself -- so ``m - p - 1 - (p - s) - 1`` where ``s``
+    is that multiplicity. Every knot vector in ``CASES`` is strictly increasing where
+    it is read periodically, so ``s`` is 1 there.
+
+    Args:
+        case (_Case): The shape.
+
+    Returns:
+        tuple[int, ...]: One count per direction.
+    """
+    counts = []
+    for knots, degree, periodic in zip(case.knots, case.degrees, case.periodic, strict=True):
+        count = len(knots) - degree - 1
+        if periodic:
+            multiplicity_of_first_in_domain = sum(1 for knot in knots if knot == knots[degree])
+            count -= degree - multiplicity_of_first_in_domain + 1
+        counts.append(count)
+    return tuple(counts)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.label)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_the_two_backends_hold_the_same_value(
+    case: _Case, dtype: npt.DTypeLike, is_rational: bool
+) -> None:
+    """Every piece of state agrees, at both storage formats.
+
+    What this catches: a stride or shape mistake in the flat-buffer round trip, a
+    narrowing cast in the wrong-dtype class, an off-by-one in `rank`, the weight
+    column counted into the rank or out of the storage, and the field reaching a
+    different space than the one it was handed.
+    """
+    if is_rational and case.components < 2:
+        pytest.skip("a rational B-spline needs a weight and at least one coordinate")
+    control_points = _control_net(case, dtype)
+    py, cpp = _both(case, control_points, is_rational=is_rational)
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=FIELDS,
+        context=f"Bspline({case.label}, {np.dtype(dtype).name}, rational={is_rational})",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.label)
+def test_the_stored_layout_matches_its_closed_form(case: _Case, dtype: npt.DTypeLike) -> None:
+    """Every coefficient reads back, through the field, as the formula that placed it.
+
+    The independent check `design/backend_parity.md` requires, and the reason it is
+    not a mirror is in the module docstring: the expected value is
+    :func:`_coefficient` evaluated at the multi-index, written in this file, and
+    nothing in the comparison consults either implementation.
+
+    The bound is zero, which is a claim about *transport* rather than about rounding:
+    :func:`_coefficient` returns a dyadic value exactly representable in both formats
+    at every index reached here, so neither the construction of the input nor the
+    storage of it can round. A non-zero deviation is therefore a defect and never
+    noise, and there is no regime in which the bound would have to be loosened.
+
+    What this catches that the parity comparison cannot: a layout error made *the
+    same way* by both backends -- the shared-error case parity is blind to by
+    construction. The exponent moves with the first parametric index, so a
+    transposition shows as decades rather than as a last digit.
+    """
+    net = _control_net(case, dtype)
+    shape = (*case.num_basis, case.components)
+    with use_backend(Backend.CPP):
+        field = Bspline(_make_space_at(case, dtype), net)
+
+    stored = np.asarray(field.control_points, dtype=np.float64)
+    assert stored.shape == shape, f"{case.label}: the field reshaped the net to {stored.shape}"
+    exact = np.zeros(shape, dtype=np.float64)
+    for index in np.ndindex(*shape):
+        exact[index] = _coefficient(index)
+
+    assert_accuracy(
+        stored,
+        exact,
+        derived_accuracy(
+            bound=np.zeros((), dtype=np.float64),
+            why=(
+                "the type transports its coefficients rather than computing them, and "
+                "`_coefficient` returns a dyadic value -- a sign, a mantissa with "
+                "denominator a power of two, and a power-of-two scale -- exactly "
+                "representable in float32 and float64 alike. So no rounding occurs on "
+                "either the way in or the way out, and the admissible deviation is "
+                "exactly zero rather than a budget."
+            ),
+        ),
+        context=f"stored layout of {case.label} at {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.label)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_the_counts_match_their_closed_forms(case: _Case, is_rational: bool) -> None:
+    """The basis counts and the rank follow the B-spline definition, on both backends.
+
+    The integer half of the independent check. ``space.num_basis`` is compared against
+    ``len(knots) - degree - 1`` -- less the periodic correction -- computed in
+    :func:`_expected_num_basis` from the case's own knot vectors, and ``rank`` against
+    ``size / prod(num_basis) - is_rational`` in exact integer arithmetic. Neither
+    reads a constructed space, which is what stops this being a mirror: those counts
+    are exactly what the C++ constructor checks the net's extents against.
+
+    It is also the guard on ``CASES`` itself. Every case states its basis counts as
+    literals so that the layout check has an oracle, and a literal nobody checks is a
+    comment: if a knot vector is ever edited without its count, this fails and the
+    layout check does not.
+    """
+    if is_rational and case.components < 2:
+        pytest.skip("a rational B-spline needs a weight and at least one coordinate")
+    expected_basis = _expected_num_basis(case)
+    assert case.num_basis == expected_basis, (
+        f"{case.label}: the table says {case.num_basis} and the definition gives {expected_basis}"
+    )
+
+    net = _control_net(case, np.float64)
+    expected_rank = net.size // math.prod(expected_basis) - (1 if is_rational else 0)
+
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field = Bspline(_make_space(case), net, is_rational)
+        assert field.space.num_basis == expected_basis, backend.name
+        assert field.rank == expected_rank, backend.name
+        assert field.dim == len(expected_basis), backend.name
+
+
+def test_the_case_table_earns_its_keep() -> None:
+    """Every multi-direction case really does differ between its directions.
+
+    A test of the case set, not of the library, and the file's own vacuity guard: a
+    tensor-product type compared over a table whose directions agree cannot
+    distinguish a transposition, an off-by-one in an axis index, or a reduction that
+    returns its first argument. So the claim that the table is asymmetric is asserted
+    rather than described.
+
+    The two single-direction cases are exempt by construction and are not counted; the
+    periodic pair is what covers the axis a single case cannot.
+
+    Gated on the extension by this module's mark even though it needs none, and that
+    is consistent rather than an oversight: what it guards -- the layout and count
+    checks that take their expected values from this table -- is gated too, so the
+    table is never relied on in a configuration where this has not run.
+    """
+    multi = [case for case in CASES if len(case.degrees) > 1]
+    assert len(multi) >= 2, "no multi-direction case is left to compare"
+    for case in multi:
+        assert len(set(case.degrees)) == len(case.degrees), f"{case.label}: degrees repeat"
+        assert len(set(case.num_basis)) == len(case.num_basis), (
+            f"{case.label}: basis counts repeat, so a transposed net would pass"
+        )
+        assert case.components not in case.num_basis, (
+            f"{case.label}: the component count equals a basis count, so a permutation "
+            f"of the net's shape is another admissible shape for this space"
+        )
+        # The domains differ in location and in width, which is what makes the
+        # per-direction domain and tolerance reductions observable. Derived from the
+        # definition -- `(knots[degree], knots[-degree - 1])` -- rather than read off
+        # a space, for the reason `_expected_num_basis` is.
+        domains = {
+            (knots[degree], knots[len(knots) - degree - 1])
+            for knots, degree in zip(case.knots, case.degrees, strict=True)
+        }
+        assert len(domains) == len(case.degrees), f"{case.label}: two directions share a domain"
+        widths = {hi - lo for lo, hi in domains}
+        assert len(widths) == len(case.degrees), f"{case.label}: two directions share a width"
+    # And the periodic axis is exercised in both readings of one vector, which is what
+    # makes the basis-count correction observable rather than assumed.
+    periodic_labels = {case.label for case in CASES if any(case.periodic)}
+    assert periodic_labels, "no periodic direction is exercised"
+    same_vector = [case for case in CASES if case.knots == (_UNIFORM,)]
+    assert {case.num_basis for case in same_vector} == {(4,), (6,)}, (
+        "the periodic and non-periodic readings of one knot vector must give different "
+        "counts, or the periodic correction is untested"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_the_ieee_menagerie_transits_unchanged(dtype: npt.DTypeLike, is_rational: bool) -> None:
+    """NaN, both zeros, a subnormal and both infinities survive the copy.
+
+    What this catches: the whole premise of this file is that the two backends only
+    copy, and a copy is exactly where these values are cheap to test and expensive to
+    lose. A caster round-tripping through a wider intermediate, a narrowing cast, or a
+    memcpy replaced by element-wise assignment through a different type all show
+    first on a NaN payload, on a ``-0.0`` whose sign an addition drops, or on a
+    ``float32`` subnormal flushed to zero -- and every one of those is invisible to a
+    value comparison and visible bitwise.
+
+    The finite specials go through the same ``FIELDS``, so ``dtype``, ``degree`` and
+    ``rank`` are checked over them too: a B-spline of NaNs is not a special case in
+    the type's eyes and must not become one.
+
+    **The two infinities are asserted separately, and not by choice.**
+    ``assert_parity`` computes a diagnostic ``|actual - reference|`` before it reports
+    a bitwise result, and ``inf - inf`` raises the IEEE invalid flag, which numpy
+    reports as ``RuntimeWarning: invalid value encountered in subtract`` and this
+    suite turns into an error. So a bitwise claim cannot presently be made about an
+    array holding an infinity, and the harness is where that has to be fixed rather
+    than here. NaN is unaffected: quiet-NaN propagation raises no flag.
+    """
+    case = _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 2, "the menagerie")
+    finfo = np.finfo(np.dtype(dtype))
+    finite_specials = np.asarray(
+        [
+            [0.0, np.nan],
+            [-0.0, float(finfo.smallest_subnormal)],
+            [float(finfo.max), float(finfo.tiny)],
+        ],
+        dtype=dtype,
+    )
+    py, cpp = _both(case, finite_specials, is_rational=is_rational)
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=FIELDS,
+        context=f"IEEE menagerie ({np.dtype(dtype).name}, rational={is_rational})",
+    )
+    # Asserted on the bytes rather than through the harness, because that is the
+    # specific loss this case exists for: `assert_object_parity` would pass if BOTH
+    # backends had flushed the subnormal or normalized the signed zero the same way,
+    # and it is the transit that is under test, not the agreement.
+    assert cpp.control_points.tobytes() == finite_specials.tobytes()
+
+    with_infinities = np.asarray([[np.inf, -np.inf], [1.0, -0.0], [2.0, 3.0]], dtype=dtype)
+    _, cpp_inf = _both(case, with_infinities, is_rational=is_rational)
+    assert cpp_inf.control_points.tobytes() == with_infinities.tobytes()
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_a_non_contiguous_control_net_reaches_both_backends_alike(dtype: npt.DTypeLike) -> None:
+    """A Fortran-ordered or strided net builds the same B-spline under either backend.
+
+    What this catches: the ``np.ascontiguousarray`` step in ``_new_impl``. The C++
+    binding refuses a non-contiguous array outright rather than copying it, so
+    without that step the public constructor would raise a ``TypeError`` about C++
+    argument types under one backend and succeed under the other. Nothing else
+    exercises the branch: ``test_bspline_binding_contract.py`` tests the raw
+    binding's refusals, which is the opposite path.
+
+    A B-spline reshapes its net before storing it, so the interesting input is one
+    whose *reshaped* form is still non-contiguous. A Fortran-ordered array of exactly
+    the stored shape is that: ``reshape`` returns it unchanged.
+    """
+    case = _Case((_CLAMPED_QUADRATIC, _CLAMPED_LINEAR), (2, 1), (False, False), (5, 3), 2, "f")
+    fortran = np.asfortranarray(np.arange(30.0, dtype=dtype).reshape(5, 3, 2))
+    strided = np.arange(60.0, dtype=dtype).reshape(10, 3, 2)[::2]
+    for control_points, how in ((fortran, "Fortran-ordered"), (strided, "strided")):
+        assert not control_points.flags.c_contiguous, how
+        py, cpp = _both(case, control_points, is_rational=False)
+        assert_object_parity(
+            py=py,
+            cpp=cpp,
+            fields=FIELDS,
+            context=f"{how} control net ({np.dtype(dtype).name})",
+        )
+
+
+def _message_of(build: Any) -> str:
+    """The text and type of the exception ``build`` raises.
+
+    Args:
+        build (Any): A no-argument call expected to raise.
+
+    Returns:
+        str: ``"<ExceptionType>: <message>"``, or a marker saying what happened
+        instead, so that the caller's assertion is the one that reports.
+    """
+    try:
+        build()
+    except (ValueError, IndexError, TypeError) as error:
+        return f"{type(error).__name__}: {error}"
+    return "<did not raise>"
+
+
+_MALFORMED: Final = (
+    (
+        lambda: Bspline(_make_space(CASES[0]), np.zeros(4, dtype=np.float64)),
+        "a coefficient count that is not a multiple of the basis count",
+        "wrapper",
+    ),
+    (
+        lambda: Bspline(_make_space(CASES[0]), np.zeros((3, 1), dtype=np.float32)),
+        "control points of the wrong dtype",
+        "wrapper",
+    ),
+    (
+        lambda: Bspline(_make_space(CASES[0]), np.zeros((3, 1), dtype=np.float64), True),
+        "a rational field with a weight and nothing else",
+        "implementation",
+    ),
+    (
+        lambda: Bspline(_make_space(CASES[0]), np.zeros(0, dtype=np.float64)),
+        "an empty control net over a non-empty space",
+        "wrapper",
+    ),
+    (
+        lambda: Bspline(BsplineSpace([]), np.zeros(3, dtype=np.float64)),
+        "a space with no directions",
+        "wrapper",
+    ),
+)
+"""Every construction both backends must refuse, and which layer owns the refusal.
+
+The third column is the honest part. Only the ``implementation`` entry is decided by
+this comparison: the other four are raised by the wrapper, which is one piece of
+shared code, so the two backends agree on them by construction and their agreement is
+not evidence about the port. They are swept anyway because the *reachability* is what
+is claimed -- a C++ constructor that accepted one of them would make the wrapper's
+check the only thing standing between a caller and a malformed field, and the count
+check is duplicated in the C++ type precisely so that it is not.
+
+``cpp/tests/test_bspline_type.cpp`` is the half that pins the C++ texts against
+literals, and it covers three refusals no Python caller can reach at all: a null
+space handle, a net whose parametric extents are not the space's basis counts, and
+the coefficient-count message of the flat constructor.
+"""
+
+
+@pytest.mark.parametrize(("build", "what", "owner"), _MALFORMED)
+def test_refusals_agree_verbatim(build: Any, what: str, owner: str) -> None:
+    """Both backends refuse the same constructions with the same exception and text.
+
+    What this catches, for the one entry it can: a reworded rank message on the C++
+    side. A caller catching ``pytest.raises(ValueError, match=...)`` must not have to
+    know which backend built the object, and the exception type alone does not carry
+    that -- both sides raise ``ValueError`` here, so only the text can tell a
+    reordered or rewritten check from a faithful one.
+    """
+    with use_backend(Backend.PYTHON):
+        oracle = _message_of(build)
+    with use_backend(Backend.CPP):
+        ported = _message_of(build)
+    assert oracle == ported, f"{what} ({owner}): oracle said {oracle!r}, C++ said {ported!r}"
+    assert not oracle.startswith("<"), f"{what}: neither backend refused it"
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_implementations_agree_on_the_rank_refusal(dtype: npt.DTypeLike) -> None:
+    """The two implementation classes report a rank-zero field identically.
+
+    The one refusal both implementations own, compared where the C++ text is actually
+    under test rather than through the wrapper that would have agreed anyway. Reached
+    by handing each class the space's own implementation directly, which is what the
+    wrapper does.
+
+    Two ranks are checked and the second is the reason the C++ arithmetic is signed: a
+    rational net with no coordinate components at all is rank ``-1``, and an unsigned
+    subtraction would refuse it while reporting a number near ``2**64``. That case
+    cannot be reached through the public constructor, because numpy's reshape refuses
+    an empty buffer over a non-empty space first, so it has no entry in
+    ``_MALFORMED``.
+    """
+    case = CASES[0]
+    with use_backend(Backend.PYTHON):
+        py_space = _make_space_at(case, dtype)
+    with use_backend(Backend.CPP):
+        cpp_space = _make_space_at(case, dtype)
+    cls = _cpp_class(dtype)
+
+    for components, expected_rank in ((1, 0), (0, -1)):
+        net = np.zeros((3, components), dtype=dtype)
+        oracle = _message_of(lambda: _BsplinePython(py_space._impl, net, True))  # noqa: B023
+        ported = _message_of(lambda: cls(cpp_space._impl, net, True))  # noqa: B023
+        assert oracle == ported, f"rank {expected_rank}: {oracle!r} against {ported!r}"
+        assert oracle == (
+            f"ValueError: The B-spline must have at least rank one. Got rank {expected_rank}"
+        ), oracle
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_cpp_value_does_not_alias_the_array_it_was_built_from(dtype: npt.DTypeLike) -> None:
+    """Mutating the constructor's argument afterwards does not move the B-spline.
+
+    What this catches: the C++ constructor taking a view of the caller's buffer
+    instead of copying, which would let a validated geometry change under its owner's
+    feet -- and, worse than for a Bézier, would leave both of the field's derived
+    memos describing a geometry it no longer holds.
+    """
+    case = _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 2, "alias")
+    control_points = np.asarray([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]], dtype=dtype)
+    with use_backend(Backend.CPP):
+        field = Bspline(_make_space_at(case, dtype), control_points)
+
+    before = field.control_points.copy()
+    control_points[0, 0] = 99.0
+    assert np.array_equal(field.control_points, before)
+    assert not np.shares_memory(field.control_points, control_points)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_writing_through_control_points_is_refused(dtype: npt.DTypeLike) -> None:
+    """The array handed out is read-only, and the B-spline is unchanged either way.
+
+    What this catches: the way *out* of the same defect. A writeable view would let a
+    caller edit a constructed geometry through the property, which is the half a
+    criterion about construction alone leaves unpinned.
+    """
+    case = _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 2, "read-only")
+    with use_backend(Backend.CPP):
+        field = Bspline(
+            _make_space_at(case, dtype),
+            np.asarray([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]], dtype=dtype),
+        )
+
+    handed_out = field.control_points
+    assert not handed_out.flags.writeable
+    with pytest.raises(ValueError, match="read-only"):
+        handed_out[0, 0] = 99.0
+    assert field.control_points[0, 0] == 0.0
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_view_outlives_the_bspline_it_came_from(dtype: npt.DTypeLike) -> None:
+    """The array keeps the C++ storage alive after the handle is dropped.
+
+    What this catches: a view returned without an owner. The values would be read
+    from freed memory, which is a use-after-free that usually reads back correct and
+    occasionally does not -- so this asserts the values rather than merely that
+    nothing crashed.
+    """
+    case = _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 2, "outlive")
+    expected = np.asarray([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]], dtype=dtype)
+    with use_backend(Backend.CPP):
+        handed_out = Bspline(_make_space_at(case, dtype), expected.copy()).control_points
+    gc.collect()
+    assert np.array_equal(handed_out, expected)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_a_bspline_survives_pickling_across_every_backend_pair(
+    dtype: npt.DTypeLike, is_rational: bool
+) -> None:
+    """A pickle written under one backend loads under the other, at both dtypes.
+
+    What this catches: a ``__reduce__`` that reaches the implementation rather than
+    the constructor's arguments. The C++ handle is not picklable at all, and a
+    payload that carried one would make ``PANTR_BACKEND`` a data-format switch -- a
+    pickle written on one machine unreadable on another. ``copy.deepcopy`` goes
+    through ``__reduce_ex__`` by the same route, so it is swept over the same pairs.
+
+    The space is part of the payload and is checked as such: it goes out as its
+    *wrapper*, so its own ``__reduce__`` runs and the knot vectors survive rather
+    than the handle being smuggled through.
+    """
+    case = CASES[3]
+    net = _control_net(case, dtype)
+    for writer in (Backend.PYTHON, Backend.CPP):
+        with use_backend(writer):
+            original = Bspline(_make_space_at(case, dtype), net, is_rational)
+            payload = pickle.dumps(original)
+        for reader in (Backend.PYTHON, Backend.CPP):
+            where = f"{writer.name} -> {reader.name}"
+            with use_backend(reader):
+                loaded = pickle.loads(payload)
+                cloned = copy.deepcopy(original)
+            for rebuilt, how in ((loaded, "pickle"), (cloned, "deepcopy")):
+                assert rebuilt.control_points.tobytes() == net.tobytes(), f"{where} {how}"
+                assert rebuilt.dtype == np.dtype(dtype), f"{where} {how}"
+                assert rebuilt.is_rational is is_rational, f"{where} {how}"
+                assert rebuilt.degree == original.degree, f"{where} {how}"
+                # `rank` folds the flag against the component axis, so it is the one
+                # field that would catch a round trip which kept the byte count and
+                # the per-direction counts while moving which axis carries the
+                # components.
+                assert rebuilt.rank == original.rank, f"{where} {how}"
+                assert rebuilt.space.num_basis == case.num_basis, f"{where} {how}"
+                np.testing.assert_array_equal(
+                    np.asarray(rebuilt.space.spaces[0].knots),
+                    np.asarray(original.space.spaces[0].knots),
+                    err_msg=f"{where} {how}",
+                )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_space_survives_the_round_trip_as_one_object(dtype: npt.DTypeLike) -> None:
+    """Pickling a field and its space together restores a pair that still shares it.
+
+    ``pickle`` memoises, so the sharing the identity contract rests on survives one
+    ``dumps`` for free -- and only because ``__reduce__`` hands out the space
+    *wrapper*. A reduction that rebuilt the space from arrays would restore two
+    equal-valued spaces instead, and ``field.space is space`` would stop holding
+    across a round trip while every value assertion still passed.
+
+    Two independent ``dumps`` calls do not share, which is also true today and is not
+    claimed here.
+    """
+    case = CASES[3]
+    net = _control_net(case, dtype)
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = _make_space_at(case, dtype)
+            field = Bspline(space, net)
+            restored_field, restored_space = pickle.loads(pickle.dumps((field, space)))
+        assert restored_field.space is restored_space, backend.name
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_an_unpickled_bspline_can_still_be_mutated_in_place(dtype: npt.DTypeLike) -> None:
+    """The wire format does not carry one backend's read-only flag to the other.
+
+    What this catches: ``__reduce__`` handing out the C++ backend's read-only view.
+    numpy preserves that flag through a pickle, so a payload written under the C++
+    backend would rebuild, under the Python backend, a B-spline whose stored array
+    cannot be written -- and ``transform(in_place=True)`` would raise on an object the
+    caller built by ordinary means.
+    """
+    from pantr.transform import AffineTransform  # noqa: PLC0415
+
+    case = _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 2, "unpickled")
+    net = np.asarray([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]], dtype=dtype)
+    with use_backend(Backend.CPP):
+        payload = pickle.dumps(Bspline(_make_space_at(case, dtype), net))
+    with use_backend(Backend.PYTHON):
+        rebuilt = pickle.loads(payload)
+        rebuilt.transform(AffineTransform.translation([1.0, 2.0]), in_place=True)
+    np.testing.assert_allclose(rebuilt.control_points, net + np.asarray([1.0, 2.0]))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_the_in_place_mutators_agree_on_the_value_they_leave_behind(
+    dtype: npt.DTypeLike, is_rational: bool
+) -> None:
+    """``reverse``, ``permute_directions`` and ``transform`` agree under both backends.
+
+    What this catches: the C++ path's rebuild-the-implementation strategy losing the
+    rationality flag, the reseated space, the dtype or a permuted stride. Only the
+    array's *identity* is allowed to differ -- the C++ value owns its storage, so an
+    in-place mutation replaces it -- and ``tests/test_transform.py`` pins that
+    identity for the Python backend alone.
+
+    All three run in sequence rather than one per test, deliberately: the defect the
+    derived block removes is a mutator leaving *part* of the state behind, and a
+    single mutation cannot expose a reseat that half happened.
+    """
+    from pantr.transform import AffineTransform  # noqa: PLC0415
+
+    case = _Case((_CLAMPED_QUADRATIC, _CLAMPED_LINEAR_4), (2, 1), (False, False), (5, 4), 3, "m")
+    net = _control_net(case, dtype)
+    shift = AffineTransform.translation([1.0, 2.0] if is_rational else [1.0, 2.0, 3.0])
+
+    def mutated(backend: Backend) -> Bspline:
+        # A fresh copy per backend, and not a convenience: the Python implementation
+        # aliases what it is given, so an in-place mutation under that backend edits
+        # `net` itself and the C++ run would then start from an already-reversed net.
+        with use_backend(backend):
+            field = Bspline(_make_space_at(case, dtype), net.copy(), is_rational)
+            field.reverse(1, in_place=True)
+            field.permute_directions([1, 0], in_place=True)
+            field.transform(shift, in_place=True)
+            return field
+
+    assert_object_parity(
+        py=mutated(Backend.PYTHON),
+        cpp=mutated(Backend.CPP),
+        fields=FIELDS,
+        context=(
+            f"in-place reverse, permute and transform "
+            f"({np.dtype(dtype).name}, rational={is_rational})"
+        ),
+    )
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+def test_a_space_changing_mutator_reseats_the_space_and_leaves_the_old_one_intact(
+    backend: Backend,
+) -> None:
+    """``reverse`` and ``permute_directions`` replace the space; an escaped one keeps its value.
+
+    The contract ``design/bspline_ownership_lifetime.md`` reason 3 was measured on,
+    and the reason class H stores a ``shared_ptr<const T>`` and hands out a copy of
+    the handle rather than a reference. Two of the three storage shapes that note
+    tabulates break this, and one of them breaks it **silently**: with the space
+    stored by value and handed out as a reference, the escaped object starts
+    reporting the *new* space while ``escaped is field.space`` still reads ``True``.
+
+    So both halves are asserted. Identity alone would pass on that shape, and the
+    value alone would pass on a shape that never reseated at all.
+    """
+    case = CASES[3]
+    net = _control_net(case, np.float64)
+    with use_backend(backend):
+        field = Bspline(_make_space_at(case, np.float64), net.copy())
+        before = field.space
+        before_domain = np.array(before.domain)
+
+        field.reverse(0, in_place=True)
+        assert field.space is not before, "the space was not reseated"
+        np.testing.assert_array_equal(
+            np.array(before.domain),
+            before_domain,
+            err_msg="the escaped space started reporting the new value",
+        )
+        # The reflected direction really is different, so the reseat was not a
+        # no-op that this test would otherwise report as a pass.
+        assert not np.array_equal(np.array(field.space.spaces[0].knots), before_domain)
+
+        after_reverse = field.space
+        field.permute_directions([1, 0], in_place=True)
+        assert field.space is not after_reverse
+        assert field.space.degrees == tuple(reversed(after_reverse.degrees))
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+def test_transform_propagates_the_source_space_rather_than_rebuilding_it(
+    backend: Backend,
+) -> None:
+    """A non-in-place ``transform`` hands back the *source's* space object.
+
+    The one propagation site ``design/bspline_ownership_lifetime.md`` names, pinned by
+    ``tests/test_transform.py`` for the default backend and here for both: an affine
+    map moves the control points and not the parametrization, so re-wrapping the
+    implementation's space would give a different Python object even when the C++
+    pointer is identical, and the identity assertion would fail while every value
+    still agreed.
+    """
+    from pantr.transform import AffineTransform  # noqa: PLC0415
+
+    case = CASES[1]
+    with use_backend(backend):
+        field = Bspline(_make_space_at(case, np.float64), _control_net(case, np.float64))
+        moved = field.transform(AffineTransform.translation([1.0, 2.0, 3.0]))
+    assert moved.space is field.space
+    if backend is Backend.CPP:
+        assert moved._impl.space is field._impl.space
+
+
+def _memos_of(field: Bspline) -> tuple[Any, Any]:
+    """Return the field's two derived memos, without narrowing either.
+
+    Read through a function rather than inline, for the reason
+    ``tests/test_bspline_locate.py`` gives: an inline ``assert field._derived.locate
+    is not None`` narrows the attribute's type for the rest of the test, and mypy
+    then calls the later assertions unreachable. A call expression is not narrowed.
+
+    Args:
+        field (Bspline): The field to read.
+
+    Returns:
+        tuple[Any, Any]: ``(beziers, locate)``, either of which may be ``None``.
+    """
+    return field._derived.beziers, field._derived.locate
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+@pytest.mark.parametrize("mutator", ["reverse", "permute_directions", "transform"])
+def test_every_in_place_mutator_discards_the_whole_derived_block(
+    backend: Backend, mutator: str
+) -> None:
+    """Each of the three mutators leaves *both* memos cold, not one of them.
+
+    ``design/bspline_derived_caches.md`` asks this front to replace the derived block
+    wholesale rather than invalidate its parts, and the failure that shape removes is
+    one memo surviving the other -- a stale Bézier decomposition of a geometry that
+    has been reversed, or a point-inversion hierarchy over control-point boxes that
+    have moved. Neither raises; both return wrong answers.
+
+    So the assertion is on both slots after each mutator, and the memos are *filled*
+    first: a test that only checked they were ``None`` afterwards would pass on a
+    field that never cached anything at all.
+    """
+    from pantr.transform import AffineTransform  # noqa: PLC0415
+
+    case = _Case((_CLAMPED_QUADRATIC, _CLAMPED_LINEAR), (2, 1), (False, False), (5, 3), 2, "d")
+    net = _control_net(case, np.float64)
+    with use_backend(backend):
+        field = Bspline(_make_space_at(case, np.float64), net.copy())
+
+        field.to_beziers()
+        field.locate(np.asarray(field.evaluate(np.asarray([[1.5, 11.0]]))))
+        beziers, locate = _memos_of(field)
+        assert beziers is not None, "the Bezier memo did not fill"
+        assert locate is not None, "the locate memo did not fill"
+
+        if mutator == "reverse":
+            field.reverse(0, in_place=True)
+        elif mutator == "permute_directions":
+            field.permute_directions([1, 0], in_place=True)
+        else:
+            field.transform(AffineTransform.translation([1.0, 2.0]), in_place=True)
+
+        beziers, locate = _memos_of(field)
+        assert beziers is None, f"{mutator} left the Bezier memo behind"
+        assert locate is None, f"{mutator} left the locate memo behind"
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_wrapper_holds_the_implementation_its_backend_selects(dtype: npt.DTypeLike) -> None:
+    """The dtype picks the class, and the backend picks the family.
+
+    What this catches: ``_impl_class`` ignoring its dtype argument. Every other
+    assertion in this file would still pass if it always returned ``Bspline64``,
+    because nothing else here can see which class was chosen -- the ``.noconvert()``
+    on the binding turns the mistake into a refusal for one direction only.
+    """
+    case = _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 2, "impl")
+    net = np.zeros((3, 2), dtype=dtype)
+    with use_backend(Backend.PYTHON):
+        assert isinstance(Bspline(_make_space_at(case, dtype), net)._impl, _BsplinePython)
+    with use_backend(Backend.CPP):
+        assert isinstance(Bspline(_make_space_at(case, dtype), net)._impl, _cpp_class(dtype))
+
+
+def test_a_space_from_the_other_backend_is_refused_rather_than_mixed() -> None:
+    """Building a field over a space of the other backend refuses instead of hybridising.
+
+    The failure this prevents is asymmetric and one half of it is silent. Handing a
+    Python oracle space to a C++ field raises a nanobind ``TypeError`` naming C++
+    types, which is loud but unreadable. Handing a C++ space handle to the oracle
+    *succeeds* and yields a hybrid whose reductions run in Python over C++ values --
+    which no parity claim in this file covers and nothing announces.
+    ``design/cross_backend_types.md`` forbids exactly that second shape.
+    """
+    case = CASES[1]
+    net = _control_net(case, np.float64)
+    with use_backend(Backend.PYTHON):
+        py_space = _make_space(case)
+    with use_backend(Backend.CPP):
+        cpp_space = _make_space(case)
+
+    with use_backend(Backend.CPP), pytest.raises(ValueError, match="active backend"):
+        Bspline(py_space, net)
+    with use_backend(Backend.PYTHON), pytest.raises(ValueError, match="active backend"):
+        Bspline(cpp_space, net)
+
+
+def test_mutating_under_a_switched_backend_is_refused_rather_than_converted() -> None:
+    """An in-place mutator refuses a backend that is not the one this field was built under.
+
+    Rebuilding the implementation reads the *active* backend, so without this check a
+    field built under C++ and reversed inside a ``use_backend(Backend.PYTHON)`` block
+    would come back as ``_BsplinePython`` -- and the caller's ``control_points`` would
+    go from read-only to writeable underneath them, on an array they still held.
+
+    Pins that the refusal leaves the object untouched, and that a mutation under the
+    matching backend still works -- a check that merely raised everywhere would pass
+    the first half. Each of the three mutators is swept, because the guard lives in
+    ``Bspline._mutate`` and a method that reached the value another way would bypass
+    it.
+    """
+    from pantr.transform import AffineTransform  # noqa: PLC0415
+
+    case = _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 2, "switched")
+    net = np.asarray([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]], dtype=np.float64)
+    shift = AffineTransform.translation([1.0, 2.0])
+
+    mutators: tuple[Callable[[Bspline], None], ...] = (
+        lambda field: field.reverse(0, in_place=True),
+        lambda field: field.permute_directions([0], in_place=True),
+        lambda field: field.transform(shift, in_place=True),
+    )
+    for mutate in mutators:
+        with use_backend(Backend.CPP):
+            field = Bspline(_make_space_at(case, np.float64), net.copy())
+        assert not field.control_points.flags.writeable
+
+        with use_backend(Backend.PYTHON), pytest.raises(TypeError, match="different backend"):
+            mutate(field)
+
+        assert isinstance(field._impl, _cpp_class(np.float64))
+        assert not field.control_points.flags.writeable
+        np.testing.assert_array_equal(field.control_points, net)
+
+        with use_backend(Backend.CPP):
+            mutate(field)
+        assert not field.control_points.flags.writeable
+
+
+@pytest.mark.parametrize("seed", range(24))
+def test_a_generated_field_agrees_field_by_field(seed: int) -> None:
+    """A random space, net, dtype and rationality agree on every field.
+
+    The shipped sweep. It exists because ``CASES`` is a table someone chose, and a
+    table cannot cover the interaction of a degree, a knot multiplicity, a component
+    count and a storage format all at once. ``scripts/measure_bspline_type_parity.py``
+    runs the same generator over a far larger draw, which is what the claim actually
+    rests on: a sweep checked only by its own shipped size has not been checked.
+    """
+    rng = np.random.default_rng(20260904 + seed)
+    dim = int(rng.integers(1, 4))
+    dtype = np.float32 if rng.random() < 0.5 else np.float64
+    knots = []
+    degrees = []
+    for _ in range(dim):
+        degree = int(rng.integers(0, 4))
+        interior = int(rng.integers(0, 4))
+        breaks = np.cumsum(rng.uniform(0.5, 2.0, size=interior + 1))
+        vector = np.concatenate(
+            [np.zeros(degree + 1), np.repeat(breaks[:-1], 1), np.full(degree + 1, breaks[-1])]
+        )
+        knots.append(np.asarray(vector, dtype=dtype))
+        degrees.append(degree)
+
+    components = int(rng.integers(1, 5))
+    is_rational = bool(rng.random() < 0.5) and components > 1
+
+    def build() -> Bspline:
+        space = BsplineSpace(
+            [BsplineSpace1D(vector, degree) for vector, degree in zip(knots, degrees, strict=True)]
+        )
+        total = space.num_total_basis
+        values = rng.standard_normal(total * components) * 2.0 ** rng.integers(
+            -20, 20, size=total * components
+        )
+        return Bspline(space, np.asarray(values, dtype=dtype), is_rational)
+
+    # One draw of the coefficients, so the two backends get the same numbers: the
+    # generator is re-seeded rather than shared, because `build` advances `rng`.
+    state = rng.bit_generator.state
+    with use_backend(Backend.PYTHON):
+        py = build()
+    rng.bit_generator.state = state
+    with use_backend(Backend.CPP):
+        cpp = build()
+
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=FIELDS,
+        context=f"generated field, seed {seed}, {np.dtype(dtype).name}",
+    )

--- a/tests/parity/test_bspline_type.py
+++ b/tests/parity/test_bspline_type.py
@@ -228,6 +228,17 @@ _CLAMPED_LINEAR: Final = (10.0, 10.0, 11.0, 12.0, 12.0)
 _SINGLE_SPAN: Final = (0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
 """One interval, degree 2, three basis functions: the Bézier-like case."""
 
+_ASYMMETRIC: Final = (0.0, 0.0, 0.0, 1.0, 3.0, 3.0, 3.0)
+"""Two intervals, degree 2, four basis functions, on ``[0, 3]``.
+
+The one knot vector here whose reflection ``a + b - knots[::-1]`` is a *different*
+vector: its single interior knot sits at 1 and reflects to 2. Every other vector in
+this file is symmetric about its own domain midpoint, which makes a reversal
+unobservable in the knots -- ``_CLAMPED_QUADRATIC``'s interior pair ``{1, 2}`` on
+``[0, 3]`` reflects onto itself. ``test_a_space_changing_mutator_reseats_the_space``
+asserts that asymmetry of this constant before relying on it.
+"""
+
 _CLAMPED_LINEAR_4: Final = (10.0, 10.0, 11.0, 12.0, 13.0, 13.0)
 """Three intervals, degree 1, four basis functions, on ``[10, 13]``."""
 
@@ -1023,29 +1034,115 @@ def test_a_space_changing_mutator_reseats_the_space_and_leaves_the_old_one_intac
 
     So both halves are asserted. Identity alone would pass on that shape, and the
     value alone would pass on a shape that never reseated at all.
+
+    **Two things had to be got right for the second half to say anything**, and both
+    were wrong first time. The comparison has to be between two arrays of the same
+    shape: ``np.array_equal`` returns ``False`` whenever the shapes differ, before it
+    compares a single value, so a knot vector held up against a ``(dim, 2)`` domain
+    block reports "different" for a field that was never touched. And the knot vector
+    has to be asymmetric about its own domain midpoint, or the reflection is the
+    vector it started from -- which ``_CLAMPED_QUADRATIC`` is, so this case uses
+    ``_ASYMMETRIC`` and asserts that of it first.
+
+    The reflected vector is stated as a literal rather than recomputed, so the
+    expected value does not come from the code under test: reflecting
+    ``(0, 0, 0, 1, 3, 3, 3)`` about ``[0, 3]`` gives ``(0, 0, 0, 2, 3, 3, 3)``.
     """
-    case = CASES[3]
+    case = _Case(
+        (_ASYMMETRIC, _CLAMPED_LINEAR), (2, 1), (False, False), (4, 3), 2, "reseat"
+    )
+    reflected = (0.0, 0.0, 0.0, 2.0, 3.0, 3.0, 3.0)
+    assert reflected != _ASYMMETRIC, (
+        "the case's knot vector reflects onto itself, so a reversal is invisible in "
+        "the knots and the value half of this test would pass on a no-op"
+    )
+
     net = _control_net(case, np.float64)
     with use_backend(backend):
         field = Bspline(_make_space_at(case, np.float64), net.copy())
         before = field.space
-        before_domain = np.array(before.domain)
+        before_knots = np.array(before.spaces[0].knots)
 
         field.reverse(0, in_place=True)
         assert field.space is not before, "the space was not reseated"
         np.testing.assert_array_equal(
-            np.array(before.domain),
-            before_domain,
+            np.array(before.spaces[0].knots),
+            before_knots,
             err_msg="the escaped space started reporting the new value",
         )
-        # The reflected direction really is different, so the reseat was not a
-        # no-op that this test would otherwise report as a pass.
-        assert not np.array_equal(np.array(field.space.spaces[0].knots), before_domain)
+        # And the new space really is the reflected one, against a hand-derived
+        # literal -- so the reseat was not a no-op this test would report as a pass.
+        np.testing.assert_array_equal(
+            np.array(field.space.spaces[0].knots), np.asarray(reflected)
+        )
 
         after_reverse = field.space
         field.permute_directions([1, 0], in_place=True)
         assert field.space is not after_reverse
         assert field.space.degrees == tuple(reversed(after_reverse.degrees))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_reversing_a_periodic_direction_in_place_agrees_with_the_derived_form(
+    dtype: npt.DTypeLike,
+) -> None:
+    """The periodic branch of ``reverse`` gives the same value in place as not.
+
+    The branch this covers is ``_reversed``'s cyclic shift, and it is reached only
+    through ``_mutate``: a periodic direction stores fewer coefficients than the
+    full sequence expands to, so reversing it needs a plain flip **plus** a shift by
+    the ghost count, and the in-place path writes that shift back through
+    ``new_cp[:] = np.roll(...)`` while the derived path rebinds a fresh array. This
+    split is what the port introduced -- the two used to be one expression -- and
+    nothing else in the suite combines a periodic direction with ``in_place=True``.
+
+    Three assertions, and the third is what stops the first two being vacuous:
+
+    - both backends agree on the value the in-place mutation leaves behind;
+    - it equals what the derived form returns, whose pointwise correctness
+      ``tests/test_review_regressions.py::test_periodic_reverse_is_pointwise_mirror``
+      already establishes against an independent mirror -- so this inherits that
+      rather than resting on parity alone;
+    - it is **not** the plain flip. The shift here is
+      ``(n_full - n_stored) % n_stored = (6 - 4) % 4 = 2``, so a flip alone would
+      give ``[4, 3, 2, 1]`` and the correct answer is ``[2, 1, 4, 3]``. Without this
+      the whole test would pass on an implementation that dropped the shift, since
+      both paths would drop it together.
+
+    The expected value is stated as a literal, derived by hand from the ghost count
+    rather than taken from either path.
+    """
+    knots = np.asarray(_UNIFORM, dtype=dtype)
+    control_points = np.arange(1.0, 5.0, dtype=dtype).reshape(4, 1)
+    expected = np.asarray([[2.0], [1.0], [4.0], [3.0]], dtype=dtype)
+    plain_flip = np.asarray([[4.0], [3.0], [2.0], [1.0]], dtype=dtype)
+
+    mutated = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = BsplineSpace([BsplineSpace1D(knots, 2, periodic=True)])
+            assert space.num_basis == (4,), "the case no longer has ghost coefficients"
+            field = Bspline(space, control_points.copy())
+            derived = field.reverse(0)
+            field.reverse(0, in_place=True)
+            mutated[backend] = field
+            np.testing.assert_array_equal(
+                np.asarray(field.control_points),
+                np.asarray(derived.control_points),
+                err_msg=f"{backend.name}: in place and derived disagree",
+            )
+            np.testing.assert_array_equal(np.asarray(field.control_points), expected)
+            assert not np.array_equal(np.asarray(field.control_points), plain_flip), (
+                "the reversal is a plain flip, so the cyclic shift the ghost "
+                "coefficients need was not applied"
+            )
+
+    assert_object_parity(
+        py=mutated[Backend.PYTHON],
+        cpp=mutated[Backend.CPP],
+        fields=FIELDS,
+        context=f"periodic reverse in place ({np.dtype(dtype).name})",
+    )
 
 
 @pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])

--- a/tests/parity/test_bspline_type.py
+++ b/tests/parity/test_bspline_type.py
@@ -753,6 +753,12 @@ check is duplicated in the C++ type precisely so that it is not.
 literals, and it covers three refusals no Python caller can reach at all: a null
 space handle, a net whose parametric extents are not the space's basis counts, and
 the coefficient-count message of the flat constructor.
+
+**And the ORDER of the wrapper's two refusals is not decided here either**, for the
+same reason: every entry violates one rule and so has one possible message. Measured
+-- moving the dtype check ahead of the coefficient-count check left this whole file
+green. ``tests/test_bspline.py::TestBsplineInit::test_initialization_refusal_order``
+is what pins it, with control points that are bad in both ways at once.
 """
 
 

--- a/tests/parity/test_bspline_type.py
+++ b/tests/parity/test_bspline_type.py
@@ -45,10 +45,13 @@ Five things are checked that a field-by-field state comparison does not reach:
 
 ## The independent check, and why it is not a mirror
 
-`design/backend_parity.md`'s first rule is that parity says the two backends agree
-and not that either is right, so a shared error is invisible to every parity test
-here. The independent oracle for a value type is not a rational reimplementation of
-an algorithm -- there is no algorithm -- it is a **closed form for the layout**:
+`design/backend_parity.md` opens with the fact everything else there follows from:
+parity says the two backends agree and not that either is right, so a shared error
+is invisible to every parity test here. (That is the document's premise, stated
+before its twelve numbered rules, and not one of them.)
+
+The independent oracle for a value type is not a rational reimplementation of an
+algorithm -- there is no algorithm -- it is a **closed form for the layout**:
 
 - ``test_the_stored_layout_matches_its_closed_form`` builds the control net from an
   explicit function of the multi-index, then reads it back *through the field* at
@@ -845,6 +848,47 @@ def test_the_cpp_value_does_not_alias_the_array_it_was_built_from(dtype: npt.DTy
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
+def test_an_in_place_mutation_replaces_the_cpp_buffer(dtype: npt.DTypeLike) -> None:
+    """Under the C++ backend an ``in_place=True`` mutator leaves a *different* array.
+
+    Two files state this in prose -- ``_bspline.py``'s ``_mutate`` docstring and the
+    agreement test below -- and until now nothing asserted it. It followed
+    deductively from "construction always copies", which
+    :func:`test_the_cpp_value_does_not_alias_the_array_it_was_built_from` does pin,
+    but a deduced property is not the same evidence as a direct one: an
+    implementation that reused the buffer in the mutating path alone would satisfy
+    that test and contradict this claim.
+
+    The contrast is the point, so the Python backend is asserted too: there the
+    identity is *preserved*, and that asymmetry is exactly what the ``copy=False``
+    docstrings now warn about.
+    """
+    from pantr.transform import AffineTransform  # noqa: PLC0415
+
+    case = _Case((_SINGLE_SPAN,), (2,), (False,), (3,), 2, "reseat")
+    net = np.asarray([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]], dtype=dtype)
+    shift = AffineTransform.translation([1.0, 2.0])
+
+    with use_backend(Backend.CPP):
+        field = Bspline(_make_space_at(case, dtype), net)
+        before = field.control_points
+        field.transform(shift, in_place=True)
+        assert not np.shares_memory(before, field.control_points), (
+            "the C++ in-place mutator kept the buffer, so the prose in `_mutate` and "
+            "in the agreement test is wrong and a caller could hold a live view"
+        )
+
+    with use_backend(Backend.PYTHON):
+        oracle = Bspline(_make_space_at(case, dtype), net)
+        kept = oracle.control_points
+        oracle.transform(shift, in_place=True)
+        assert np.shares_memory(kept, oracle.control_points), (
+            "the oracle stopped preserving the array's identity, so the asymmetry "
+            "the `copy=False` docstrings document no longer exists"
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
 def test_writing_through_control_points_is_refused(dtype: npt.DTypeLike) -> None:
     """The array handed out is read-only, and the B-spline is unchanged either way.
 
@@ -1048,9 +1092,7 @@ def test_a_space_changing_mutator_reseats_the_space_and_leaves_the_old_one_intac
     expected value does not come from the code under test: reflecting
     ``(0, 0, 0, 1, 3, 3, 3)`` about ``[0, 3]`` gives ``(0, 0, 0, 2, 3, 3, 3)``.
     """
-    case = _Case(
-        (_ASYMMETRIC, _CLAMPED_LINEAR), (2, 1), (False, False), (4, 3), 2, "reseat"
-    )
+    case = _Case((_ASYMMETRIC, _CLAMPED_LINEAR), (2, 1), (False, False), (4, 3), 2, "reseat")
     reflected = (0.0, 0.0, 0.0, 2.0, 3.0, 3.0, 3.0)
     assert reflected != _ASYMMETRIC, (
         "the case's knot vector reflects onto itself, so a reversal is invisible in "
@@ -1072,9 +1114,7 @@ def test_a_space_changing_mutator_reseats_the_space_and_leaves_the_old_one_intac
         )
         # And the new space really is the reflected one, against a hand-derived
         # literal -- so the reseat was not a no-op this test would report as a pass.
-        np.testing.assert_array_equal(
-            np.array(field.space.spaces[0].knots), np.asarray(reflected)
-        )
+        np.testing.assert_array_equal(np.array(field.space.spaces[0].knots), np.asarray(reflected))
 
         after_reverse = field.space
         field.permute_directions([1, 0], in_place=True)

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -12,14 +12,18 @@ from pantr.quad import PointsLattice
 _SHARING_IS_PYTHON_ONLY = pytest.mark.skipif(
     active_backend() is not Backend.PYTHON,
     reason=(
-        "This records the Python Bezier's known aliasing defect rather than a contract: the "
-        "C++ value copies its control points at construction, so `copy=False` shares nothing "
-        "under that backend; FELIGN/pantr#375 is the ticket that fixes the Python side. The "
-        "C++ path is not left untested by the skip -- what it does instead is asserted in "
-        "tests/parity/test_bezier_type.py, which pins the copy at both ends."
+        "This records the Python implementations' known aliasing defect rather than a "
+        "contract: both C++ values -- Bezier and Bspline -- copy their control points at "
+        "construction, so `copy=False` shares nothing under that backend, whichever of the "
+        "two is on the receiving end. FELIGN/pantr#375 is the ticket that fixes the Python "
+        "Bezier; the Python Bspline half is flagged in "
+        "design/bspline_ownership_lifetime.md and has no ticket yet. The C++ path is not "
+        "left untested by the skip -- what it does instead is asserted in "
+        "tests/parity/test_bezier_type.py and tests/parity/test_bspline_type.py, each of "
+        "which pins the copy at both ends."
     ),
 )
-"""Marks an assertion that pins sharing only the Python implementation offers."""
+"""Marks an assertion that pins sharing only the Python implementations offer."""
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -170,6 +174,7 @@ class TestBezierConversion:
         bs = b.to_bspline(copy=True)
         assert not np.shares_memory(b.control_points, bs.control_points)
 
+    @_SHARING_IS_PYTHON_ONLY
     def test_to_bspline_copy_false(self) -> None:
         """Test that to_bspline with copy=False shares the control point array."""
         b = _make_bezier_1d([1.0, 2.0, 3.0])

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -144,6 +144,28 @@ class TestBsplineInit:
         with pytest.raises(ValueError, match="The control points must have the same dtype"):
             Bspline(space, control_points)
 
+    def test_initialization_refusal_order(self) -> None:
+        """Control points bad in two ways at once report the coefficient count first.
+
+        Every other refusal case here violates one rule and so has one possible
+        message, which makes the *order* of the three checks invisible: measured, moving
+        the dtype check ahead of the coefficient-count check left the whole suite --
+        including every parity test -- green, because the two live in one piece of
+        shared wrapper code and therefore agree across the backends by construction.
+        Only a case that violates both can say which one a caller reads.
+
+        The order is a published contract rather than an accident: a caller writing
+        ``pytest.raises(ValueError, match=...)`` around a constructor gets one message,
+        and which one must not depend on a refactor.
+        """
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float32)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        # Two coefficients where three are needed, AND float64 against a float32 space.
+        control_points = np.array([1.0, 2.0], dtype=np.float64)
+
+        with pytest.raises(ValueError, match="The number of control points must be a multiple"):
+            Bspline(space, control_points)
+
     def test_initialization_rank_zero_error(self) -> None:
         """Test that rank <= 0 raises ValueError for rational B-splines."""
         knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -22,14 +22,18 @@ from pantr.bspline.spanwise_element_extraction import SpanwiseElementExtraction
 _SHARING_IS_PYTHON_ONLY = pytest.mark.skipif(
     active_backend() is not Backend.PYTHON,
     reason=(
-        "This records the Python Bezier's known aliasing defect rather than a contract: the "
-        "C++ value copies its control points at construction, so `copy=False` shares nothing "
-        "under that backend; FELIGN/pantr#375 is the ticket that fixes the Python side. The "
-        "C++ path is not left untested by the skip -- what it does instead is asserted in "
-        "tests/parity/test_bezier_type.py, which pins the copy at both ends."
+        "This records the Python implementations' known aliasing defect rather than a "
+        "contract: both C++ values -- Bezier and Bspline -- copy their control points at "
+        "construction, so `copy=False` shares nothing under that backend, whichever of the "
+        "two is on the receiving end. FELIGN/pantr#375 is the ticket that fixes the Python "
+        "Bezier; the Python Bspline half is flagged in "
+        "design/bspline_ownership_lifetime.md and has no ticket yet. The C++ path is not "
+        "left untested by the skip -- what it does instead is asserted in "
+        "tests/parity/test_bezier_type.py and tests/parity/test_bspline_type.py, each of "
+        "which pins the copy at both ends."
     ),
 )
-"""Marks an assertion that pins sharing only the Python implementation offers."""
+"""Marks an assertion that pins sharing only the Python implementations offer."""
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -81,7 +85,7 @@ def _eval_periodic_correct(f: Bspline, pts: npt.NDArray[np.float64]) -> npt.NDAr
     p = space_1d.degree
     tol = float(space_1d.tolerance)
     n_stored = f.space.num_total_basis
-    ctrl = f._control_points  # shape (n_stored, rank)
+    ctrl = f.control_points  # shape (n_stored, rank)
 
     # Compute knot spans using the non-periodic (unclamped) algorithm
     basis_out = np.zeros((len(pts), p + 1), dtype=np.float64)
@@ -635,6 +639,7 @@ class TestFromBezier:
         bs = create_from_bezier(bez, copy=True)
         assert not np.shares_memory(bez.control_points, bs.control_points)
 
+    @_SHARING_IS_PYTHON_ONLY
     def test_from_bezier_copy_false(self) -> None:
         """Test that from_bezier with copy=False shares the control point array."""
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)

--- a/tests/test_bspline_evaluation.py
+++ b/tests/test_bspline_evaluation.py
@@ -277,7 +277,7 @@ def _eval_periodic_correct(f: Bspline, pts: npt.NDArray[np.float64]) -> npt.NDAr
     p = space_1d.degree
     tol = float(space_1d.tolerance)
     n_stored = f.space.num_total_basis
-    ctrl = f._control_points  # shape (n_stored, rank)
+    ctrl = f.control_points  # shape (n_stored, rank)
 
     # Compute knot spans using the non-periodic (unclamped) algorithm
     basis_out = np.zeros((len(pts), p + 1), dtype=np.float64)

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -438,13 +438,17 @@ def _scale_of(spline: Bspline) -> float:
 
 
 def _cache_of(spline: Bspline) -> _LocateContext | None:
-    """Return the point-inversion cache attribute of ``spline``.
+    """Return the point-inversion memo of ``spline``.
 
-    Read through a function rather than inline: an inline ``assert spline._locate_cache is
-    None`` narrows the attribute's type for the rest of the test, and mypy then calls the
-    later assertions unreachable. A call expression is not narrowed.
+    Read through a function rather than inline: an inline ``assert spline._derived.locate
+    is None`` narrows the attribute's type for the rest of the test, and mypy then calls
+    the later assertions unreachable. A call expression is not narrowed.
+
+    The memo lives in the derived block rather than in a slot of its own, so that an
+    in-place mutator cannot discard it without also discarding the Bézier
+    decomposition; see ``pantr.bspline._bspline._Derived``.
     """
-    return spline._locate_cache
+    return spline._derived.locate
 
 
 def _sample_parametric(

--- a/tests/test_bspline_product.py
+++ b/tests/test_bspline_product.py
@@ -386,7 +386,7 @@ def _eval_periodic_correct(f: Bspline, pts: npt.NDArray[np.float64]) -> npt.NDAr
     p = space_1d.degree
     tol = float(space_1d.tolerance)
     n_stored = f.space.num_total_basis
-    ctrl = f._control_points  # shape (n_stored, rank)
+    ctrl = f.control_points  # shape (n_stored, rank)
 
     basis_out = np.zeros((len(pts), p + 1), dtype=np.float64)
     first_basis_arr = np.zeros(len(pts), dtype=np.int64)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -18,15 +18,18 @@ if TYPE_CHECKING:
 _PYTHON_BACKEND_ONLY = pytest.mark.skipif(
     active_backend() is not Backend.PYTHON,
     reason=(
-        "This records the Python Bezier's known aliasing defect rather than a contract: the "
-        "C++ value copies its control points and hands back a read-only view, so an in-place "
-        "mutation replaces the array instead of writing into it; FELIGN/pantr#375 is the "
-        "ticket that fixes the Python side. The skip loses no coverage of the C++ path: the "
-        "value an in-place mutation leaves behind is compared across both backends in "
-        "tests/parity/test_bezier_type.py, and only the array's identity is unpinned here."
+        "This records the Python implementations' known aliasing defect rather than a "
+        "contract: both C++ values -- Bezier and Bspline -- copy their control points and "
+        "hand back a read-only view, so an in-place mutation replaces the array instead of "
+        "writing into it. FELIGN/pantr#375 is the ticket that fixes the Python Bezier; the "
+        "Python Bspline half is flagged in design/bspline_ownership_lifetime.md and has no "
+        "ticket yet. The skip loses no coverage of the C++ path: the value an in-place "
+        "mutation leaves behind is compared across both backends in "
+        "tests/parity/test_bezier_type.py and tests/parity/test_bspline_type.py, and only "
+        "the array's identity is unpinned here."
     ),
 )
-"""Marks an assertion that pins aliasing only the Python implementation has."""
+"""Marks an assertion that pins aliasing only the Python implementations have."""
 
 # ======================================================================
 # Helpers
@@ -613,6 +616,7 @@ class TestBsplineTransform:
         assert result is None
         npt.assert_allclose(s.control_points[0], [5.0, 5.0])
 
+    @_PYTHON_BACKEND_ONLY
     def test_inplace_no_extra_alloc(self) -> None:
         """in_place=True writes directly into the existing array."""
         knots = [0.0, 0.0, 1.0, 1.0]


### PR DESCRIPTION
Cut 1 of #398, part of epic #374. Moves the *value* of `pantr.bspline.Bspline` to C++ and leaves the Python class as a wrapper in front of it, as `BsplineSpace` and `Bezier` already are. Every operation stays Python.

## What cut 1 is, and where the boundary with cut 2 falls

**Cut 1 = the field's state and what it determines**: the C++ type, its unit tests, the binding, the wrapper, the stub, the parity claim and the binding contract. Concretely: construction, `dim`, `degree`, `space`, `control_points`, `is_rational`, `rank`, `dtype`, `__reduce__`, and the storage layout the whole rest of the port will index into.

**Cut 2 and beyond = the operations**, all 36 of which are unchanged here. That boundary is not a matter of taste: the state is the one thing no operation can be ported without, so it has to come first, and it is also the only piece that cannot be split further — the wrapper has to hold *something*, and half a wrapper is not a thing. The precedent from the five merged cuts is the same shape.

The operations then split naturally into four independent groups, in rough order of how much each needs from the state and nothing else: the **degree** group (`derivative`, `elevate_degree`, `reduce_degree`), the **knot** group (`insert_knots`, `remove_knots`, `subdivide`, `to_open_bspline`, `to_periodic`, `restrict`, `split`), the **shape** group (`reverse`, `permute_directions`, `transform`, `slice`, `boundary`, `to_bezier`, `create_from_bezier`) and the **product** (`multiply`).

### The `tabulate_basis` exclusion: verified, and it does bite — for four methods, none of them cut 1's

I checked rather than trusted. `_bspline.py` itself calls `tabulate_basis` **zero** times, as reported. But the operations reach it:

| method | route | status |
|---|---|---|
| `evaluate` | `_bspline_eval.py:1099,1163` → `BsplineSpace1D.tabulate_basis` | **excluded** |
| `evaluate_derivatives` | `_bspline_eval.py:610,681,747,772` → `tabulate_basis_derivatives` | **excluded** |
| `locate` | calls `spline.evaluate` | **excluded** |
| `to_beziers` | `_bspline_to_beziers.py:105` → `tabulate_basis` | **excluded, but see below** |

Every other method is clear: I traced each ops module's imports and direct calls, and the remaining nine modules reach basis tabulation neither directly nor through a sibling.

So `space_1d.hpp`'s declared boundary is inherited as a declared boundary, not forced: those four wait on the basis-tabulation port, and no cut of #398 should try to carry them.

**One of the four is excluded by a one-line detour rather than by need**, and it is worth recording because it is cheap to remove. `_first_basis_per_element` evaluates `tabulate_basis` at interval midpoints and throws the values away, keeping only the second return — which is exactly `BsplineSpace1D.first_basis_per_interval()`, already ported and already bound. Measured over 400 randomly generated non-periodic spaces with interior multiplicities up to `degree`: the two agree on every element of every space. So `to_beziers` could be unblocked without the tabulation port. I did **not** do it here — it rewrites an existing Layer 2 helper, it is outside cut 1, and the periodic case is not covered by that sweep.

## The `in_place=` question: the C++ type gets no mutator

**Decided: `pantr::bspline::Bspline<T>` is immutable and offers no `in_place=` anything.** The Python surface keeps all three flags, implemented one level up by the wrapper replacing its whole implementation in a single assignment.

Three arguments, in the order that decides it:

1. **The project's own rule forbids it.** A sweep that mutates earns its place only when the mutation is *unobservable*; `in_place=True` is observable by construction — that is what it is for. The two ways the rule does admit — take the object by value, or mutate a private duplicate — are both just "return a new field", so there is nothing to earn.
2. **It would be a second exception to a contract with only one.** `design/bspline_derived_caches.md` states as a contract that every non-mutating public accessor on a C++-owned pantr domain type is safe to call concurrently on one object with no external locking, with exactly one exception: a grid's tag registries, which are the reasoned accumulating-container case. A field that reseats `space_` races every reader of `space()`, and no memo discipline helps, because the racing write is on *base state* rather than on a memo. There is no accumulating-container reason to offer in its place.
3. **The interpreter-free consumer gains nothing.** `b = reversed(b, 0);` moves a handle and a net. The Python flag exists to keep a numpy array's *identity* stable across the mutation, and the C++ storage is not a numpy array a caller can hold.

**And the shape it forced is the repair `design/bspline_derived_caches.md` asks this ticket for.** Because the wrapper must replace the implementation anyway, `Bspline._take` writes `_impl`, `_space` and `_derived` together and is the only writer — `__setattr__` refuses everything else. The oracle's three separate `_beziers_cache = None; _locate_cache = None` sites become one assignment, and there is now no way to spell "discard the Bézier decomposition but keep the point-inversion hierarchy". The two memos live in one `_Derived` block for exactly that reason.

Two consequences worth flagging:

- `_Derived` is on the **wrapper**, not in C++, and that is not a disagreement with the caches note. Both memos are filled by operations this cut does not port, and one of them cannot be ported until basis tabulation is. A memo can only live beside the computation that fills it. They move with their operations. Until then it is the only cache on either side of the seam, which is what keeps "nothing is cached on both sides" true rather than merely intended.
- `_bspline_locate.py` fills its memo through `spline._derived.locate` rather than through an attribute of the field, because the wrapper refuses attribute assignment. That is deliberate: the derived quantities are reachable only where the invalidation is.

`_mutate` also refuses a backend switch, and the guard runs **before** the rebuild. That ordering is load-bearing rather than tidy: `reverse` and `permute_directions` build a new `BsplineSpace` on the way, which under a switched backend raises its own `ValueError` first and only for a field of more than one direction — so without the early guard the exception a caller sees would depend on `dim`.

## The parity criterion, quantity by quantity

Every claim is exact or bitwise, and each quantity carries its own written argument in `FIELDS` — seven quantities, seven reasons, no bulk decision. No tolerance appears anywhere in the file, and the reason is a property of the type rather than a choice: it transports a buffer and computes one integer subtraction, so a tolerance would be hiding a transcription error rather than allowing for rounding.

| quantity | claim | why that claim and not another |
|---|---|---|
| `control_points` | **bitwise** | The type stores what it is handed and performs no arithmetic on it, so the two backends can differ only by a transcription error — a wrong stride, a transposed axis, a narrowing cast, a byte lost to the shape. Every one of those is visible bitwise and invisible under any tolerance wide enough to be called a rounding budget. It is also the only claim here that would notice a signed zero normalized, a NaN payload rewritten or a `float32` subnormal flushed. |
| `is_rational` | **exact** | Stored and returned; nothing transforms it. Named as its own field rather than folded into `rank` because it is what `rank` subtracts, so reading only `rank` could not say which of the two moved. |
| `dim` | **exact** | The direction count, forwarded from the space by both implementations. An integer, so exactness is the only claim available; a difference means the field is holding a different space than the one it was given, which no comparison of the coefficients would reveal on a net whose flat size happens to match. |
| `degree` | **exact** | One integer per direction, in axis order. The **order** is the load-bearing part rather than the values: nothing about a degree reveals a transposition on a field whose directions happen to agree, which is why every case has directions that differ in it. |
| `rank` | **exact** | The stored component count less the weight column: one subtraction in exact integer arithmetic on both sides. It is the one field that folds the flag against the shape, so it catches a round trip that kept the byte count and the per-direction counts while moving which axis carries the components. |
| `space.num_basis` | **exact** | The per-direction counts the net is laid out on — the field's business rather than the space's, because this is the tuple the C++ constructor checks the net's extents against. A disagreement means the two backends laid one buffer out on two different grids. The space's own parity is `tests/parity/test_bspline_space_nd.py`'s; what is claimed here is that the field reached the same one. |
| `dtype` | **exact** | The storage format a caller reads, carried on the C++ side by the class of the handle. A disagreement means `_impl_class` picked the wrong class — and for a coefficient representable in both formats, which is most of them, the bitwise claim above would not see it. |

**What the parity file says it does not decide, out loud.** Four of the five refusal cases are raised by the wrapper, which is one piece of shared code, so the two backends agree on them by construction and their agreement is not evidence about the port. The file says so in the case table's own docstring, and the rank refusal — the one both implementations own — is additionally compared at the *implementation* level, where the C++ text is really under test.

## The independent accuracy check, and why it is not a mirror

Parity says the backends agree; it does not say either is right. For a value type the independent oracle is not a second implementation of an algorithm — there is no algorithm — it is a **closed form for the layout**, and it is written in the test file rather than read off either backend:

- **`test_the_stored_layout_matches_its_closed_form`** builds the control net by looping over `np.ndindex` and writing `_coefficient(index)` at each multi-index, then reads it back *through the field* and compares against `_coefficient(index)` evaluated again. The expected value never touches `_BsplinePython`, `Bspline64`, or `space.num_basis`. A transposition, a wrong stride, a dropped component axis or a narrowing cast all move it, and the exponent moves with the *first* parametric index so a transposition shows as decades rather than as a last digit.
  The bound is **exactly zero**, and that is a derivation rather than a convenient number: `_coefficient` returns a sign times a mantissa with denominator a power of two times a power-of-two scale, exactly representable in `float32` and `float64` alike at every index reached, so no rounding can occur on the way in or the way out. There is no regime in which this bound would have to be loosened, which is what makes zero honest here and would make it dishonest anywhere arithmetic happened.
- **`test_the_counts_match_their_closed_forms`** derives the basis counts from the B-spline definition — `len(knots) - degree - 1`, less `degree - s + 1` for a periodic direction, where `s` is the multiplicity of the first in-domain knot — and the rank from `size / prod(num_basis) - is_rational` in exact integer arithmetic. Taking those from `space.num_basis` instead would have been a mirror: they are *exactly* what the C++ constructor checks the net's extents against. Every case in the table carries them as literals for the same reason, and this test is what holds the literals to the definition so that they cannot become comments.
- The C++ unit test's periodic case does the same one level down: it asserts `direction->num_basis() == 4` against a hand-derivation stated in the comment before it uses that 4 anywhere.
- The **IEEE menagerie** is asserted on `tobytes()` against the input array rather than through the harness, because `assert_object_parity` would pass if *both* backends had flushed the subnormal or normalized the signed zero the same way, and it is the transit that is under test.

## The sweep, at 100x what ships

`tests/parity/test_bspline_type.py` ships a hand-written table of eight shapes (times 2 dtypes times 2 rationality = 32 parametrizations) plus a generated sweep of 24 draws. `scripts/measure_bspline_type_parity.py` runs the same generator over 2400:

```
$ PYTHONPATH="$(pwd)/src" .venv/bin/python scripts/measure_bspline_type_parity.py
draws                : 2400
  by dtype           : {'float32': 1162, 'float64': 1238}
  by parametric dim  : {1: 793, 2: 782, 3: 825}
  with a periodic dir: 1192
  rational           : 860
  largest net        : 2268 scalars
disagreements        : 0
```

Every axis the claim rests on is swept: both storage formats, one to three parametric directions, degrees 0 to 3, interior knot multiplicities up to `degree`, periodic and clamped directions, one to four components, rationality, and coefficients drawn across the format's exponent range. The script also checks the rank and the stored shape against their closed forms per draw, so it is an accuracy sweep and not only a parity sweep.

## The mutation run, with its control

Thirteen mutations, each with a named expected detector; applied, built, run, reverted by script. **`P1` and `C1` are the controls** — the same defect injected once into the oracle and once into the C++ value, which is what proves the harness is live rather than that the mutated region is untested.

| # | mutation | verdict |
|---|---|---|
| P1 | *(control)* the oracle stops taking the weight column out of `rank` | **CAUGHT** — parity `rank` |
| C1 | *(control)* the C++ value stops taking the weight column out of `rank` | **CAUGHT** — parity `rank` |
| P2 | an in-place mutator keeps the derived block instead of replacing it | **CAUGHT** |
| P3 | an in-place mutator keeps the old space wrapper | **CAUGHT** |
| P4 | mutating under a switched backend converts instead of refusing | **CAUGHT** |
| P5 | the dtype refusal moves ahead of the coefficient-count refusal | **MISSED, then CAUGHT** |
| P6 | `_impl_class` ignores its dtype and always picks `Bspline64` | **CAUGHT** |
| C4 | the net constructor reports the rank before the shape mismatch | **CAUGHT** — C++ test |
| C4b | the flat constructor stops refusing a non-multiple coefficient count | **CAUGHT** — C++ test |
| C5 | the binding drops `.noconvert()` and casts a net of the other width | **CAUGHT** |
| C6 | the net/space extent check only compares direction 0 | **MISSED, then CAUGHT** |
| C7 | the C++ constructor copies the space instead of sharing it | **CAUGHT** — 6 C++ assertions, plus 2 Python |
| C2 | `control_points` is bound with no `self` owner | **no observable difference** |
| C3 | `space` is rebound as `space_ref` with `rv_policy::reference_internal` | **no observable difference** |

Three more were run after the review round, against the checks it produced:

| # | mutation | verdict |
|---|---|---|
| R1 | `_reversed` returns the old space, so the reseat is a no-op | **CAUGHT** under both backends — and it was **not** caught before the round |
| R2 | `_reversed` drops the periodic cyclic shift | **CAUGHT** under both backends by the new test |
| R3 | the concurrency loop stops calling `field.space()` | **CAUGHT** on all eight threads — the old `use_count()` guard passed |

Plus a **ThreadSanitizer liveness check**, because a clean TSan run on a type with no mutable state is the expected result and therefore proves nothing on its own: adding one `mutable int` incremented in `dim()` produces **4 race reports**, and removing it returns to clean. So the concurrency claim's gate is genuine rather than blind.

**The two that were MISSED are the point of doing this**, and both are closed in `5d50dff`:

- **P5.** Every refusal case in the whole suite violated exactly one rule, so each had one possible message and the *order* of the three construction checks was invisible. Moving the dtype check ahead of the count check left the entire suite green, parity included — because both live in one piece of shared wrapper code and therefore agree across the backends by construction. Closed by `tests/test_bspline.py::TestBsplineInit::test_initialization_refusal_order`, whose control points are bad in both ways at once.
- **C6.** The only case exercising the C++ extent check had direction 0 wrong, which a check that compares the first extent and stops also refuses. Closed by a case with direction 0 right and direction 1 wrong.

**The two marked "no observable difference" are a finding rather than a test gap**, and they are why `566fb1a` exists — see the next section.

## The claim I had to retract: M2's refcount detector does not work for these accessors

`design/bspline_ownership_lifetime.md` M2 offers `sys.getrefcount` on the owner as *the* detector that tells class H from a reversion to `rv_policy::reference_internal`, and the merged tensor-product contract test has claimed to be that detector since it landed. **Measured on the shipped binding, it is not.** Rebinding `space` to return a reference with `rv_policy::reference_internal` leaves the delta at zero, the handed-out object identical to the one passed in, and its value readable after the field dies. Every assertion in that file stayed green.

The reason is specific and is not a flaw in the note's own measurement. F3 and F4 were measured on a stand-in whose nested object was constructed in C++; here a direction and a field's space always arrive **from Python**, so the object already has a live instance that `nb_type_put`'s `inst_c2p` lookup finds, and no new instance is created for a keep-alive to be installed on. The detector stays live for an accessor whose nested object has none of its own — `THBSplineSpace.level_space` is such an accessor; these two are not.

The same measurement retires M6's owner-argument claim for a **property**: dropping `self` from the `control_points` view leaves the array aliasing the same storage, still read-only, and still valid after the field is dropped, because `def_prop_ro` already passes `rv_policy::reference_internal` positionally. That is F1 of the same note applied to an array. The argument is kept as the only spelling that survives someone turning the property into a plain `.def`, where the default is `automatic` and the omission is a dangling view.

So `566fb1a` retracts the claim where it was made — two binding file comments and three test docstrings, one of them in already-merged code — keeps the assertions, because a non-zero delta would still mean a keep-alive appeared where the design says none should, and moves them to read the delta **while the returned object is alive**, which is the only place a keep-alive is visible at all. **What decides class H for these accessors is the C++ test**: injecting a copying constructor turns six of its assertions red.

**This is a correction to a merged design note that I did not edit.** `design/bspline_ownership_lifetime.md`'s M2 and M6 rows want the accessor-specific caveat written into them, and that is the user's call rather than mine.

## Verification

| gate | result |
|---|---|
| `ruff check .` / `ruff format --check .` | clean, 342 files |
| `mypy --config-file mypy.ini src tests scripts` | clean, 317 files |
| import-linter (through the worktree's own venv) | 2 contracts kept, 144 files |
| doctests, `NUMBA_DISABLE_JIT=1`, both backends | 82 passed, 7 skipped |
| `ctest --preset gcc` | 100% of 50 |
| `test_bspline_type` under `gcc-debug` (ASan + UBSan) | clean |
| `test_bspline_type` under `gcc-tsan` | clean, and shown live |
| full suite, `PANTR_BACKEND=python` | **9680 passed**, 52 skipped, 7 xfailed |
| full suite, `PANTR_BACKEND=cpp PANTR_REQUIRE_CPP=1` | **9674 passed**, 58 skipped, 7 xfailed |
| **the extension moved aside** | the two parity files **skip** — 160 skipped, 2 passed, and those 2 are the backend-independent ones by design — while under `PANTR_REQUIRE_CPP=1` the same run gives **136 errors** rather than skipping |

Baseline at `07e7ba3` was 9541 passed / 46 skipped, so this adds 139 passing tests. The six-test gap between the backends is exactly the six assertions that pin the oracle's aliasing and are now marked Python-only.

The last row is the mandatory check, and it passes in both directions.

**Docs.** My files contribute **zero** Sphinx warnings, verified by building with `-W --keep-going` and grepping for them. The local build is nonetheless red at 37 warnings in modules this PR does not touch — 21 `duplicate object description ... other instance in api/reference` and 14 unresolvable private-class references in `geometry`, `transform`, `grid`, `quad`, `bezier` and `_bspline_space_1d`. I could not establish whether that is a local-environment difference (my sphinx cannot reach the intersphinx inventories CI caches) or the docs gate being red at base, because the worktree venv's editable finder beats `PYTHONPATH` and my first attempt at a clean baseline silently measured this branch's source instead. **`scripts/ci_local.sh` at the gate will say which.** Flagged rather than guessed at.

## The downstream-consumer census, by symbol name

Censused `/home/antolin/Dev/tIGArx-future` at `f345cf2` by **name**, not by `pantr.` prefix, over every symbol on `Bspline`'s surface plus `create_from_bezier` and the five private attributes this cut reshapes. Excluded that repo's own `.claude/worktrees/` copy, which doubles every count.

- **No private pantr import anywhere**: `grep -rE "(from|import)\s+pantr[a-z_.]*\._"` returns nothing.
- **`_control_points`, `_beziers_cache`, `_locate_cache`: zero hits.** `_is_rational` has 3 and `_space` has 2, all of them the consumer's own attributes on its own classes (`tigarx/core/geometry.py:570,678,951`, `tests/core/test_partitioner.py:1083,1148` — the latter two are lambda parameter names).
- It reads pantr `Bspline` state at exactly two sites, both read-only: `tigarx/core/geometry.py:245` and `tigarx/projection.py:273`, each `np.ascontiguousarray(x.control_points, dtype=np.float64)`.
- **It never selects a backend**: no `use_backend`, no `PANTR_BACKEND`, no `Backend.` anywhere. So it always runs the oracle, and the two behaviour changes below cannot reach it until it opts in.
- No attribute is ever assigned onto a pantr geometry object, so losing `__dict__` cannot reach it either — and `Bezier`, `BsplineSpace1D` and `BsplineSpace` already lost theirs in earlier cuts.

**Two behaviour changes it would see if it opted in**, both inherited from the `Bezier` port rather than chosen here: the field copies its control points at construction so `copy=False` shares nothing, and `control_points` is a read-only view. The second is worth one line for whoever reads that repo next: `homogeneous_control_points` returns `rows` unmodified for a **rational** patch, which under the C++ backend would be a read-only view of pantr's own storage — where today it is a *writable* one, i.e. a latent aliasing bug in that function that the port removes. Nothing there writes through it today.

Three existing pantr assertions that pinned the oracle's aliasing are now marked Python-only, each with the reason on the marker: `test_bezier.py::test_to_bspline_copy_false`, `test_bspline_conversion.py::test_from_bezier_copy_false`, `test_transform.py::TestBsplineTransform::test_inplace_no_extra_alloc`.

## Reuse

`pantr::bezier::ControlNet<T>` is reused for the control net rather than reimplemented — the first cross-package include in `pantr/bspline/`, and deliberate: that header states of itself that it is *not* a Bézier and that "for `pantr::bezier::Bezier` an extent is `degree + 1`, for a B-spline it is a basis count, and neither reading belongs to the array". This is the second reading. The dependency direction matches the Python layer's, where `_bspline_to_beziers` imports `pantr.bezier`.

**Its home is still wrong** and I did not move it: `pantr::core` is where a shape-plus-storage array belongs, but moving it renames a type across `pantr/bezier/bezier.hpp`, its binding, its tests and the *installed* header set, which `bezier.hpp` records as a promise. Flagged in the new header rather than taken here.

Everything else is the established pattern: `BsplineSpace`'s two-constructor share/copy split, `Bezier`'s `_impl_class` / `_new_impl` / `_mutate_control_points` shape, `bezier_type.cpp`'s array-view idiom, `bspline_types.cpp`'s `.noconvert()` and per-dtype registration, the wrapper's `__slots__` + raising `__setattr__` + `object.__setattr__` fills, and `_parity_harness`'s `Field` / `assert_object_parity` / `derived_accuracy` vocabulary — which needed no new claim kind.

## The review round on this branch

Two reviewers over the two slices, and the findings are folded in as their own
commits rather than squashed into the work:

- **`7c3ee3c`** — the reseat test's "the reflected direction really is different"
  assertion **could not fail**, in two ways at once: it compared arrays of different
  shapes, where `np.array_equal` short-circuits to `False`; and the case's knot vector
  was symmetric about its own domain midpoint, so a shape-correct comparison would
  have compared a vector with itself. Also: nothing anywhere combined a periodic
  direction with `in_place=True`, which is a branch this front created; and the flat
  constructor documented a route through the rank check that nothing asserted.
- **`c08bf59`** — the concurrency test ended on a "vacuity guard" that guarded
  nothing, because the space was a named local and the count it asserted was already
  satisfied before any thread started. Also `check_a_volume` claimed an asymmetry it
  did not have, and the two space refusals were spelled out twice.
- **`566fb1a`** is the round's largest finding and is described in its own section
  above: a detector the design note offers, and a merged test claims to be, does not
  work for these accessors.

Closes #398 is deliberately **not** written here: this is one cut of several.
