### PR TITLE
feat(bspline): refine a B-spline field in C++ (#398, cut 2)

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -124,7 +124,7 @@ if(PANTR_NANOBIND_SPLIT)
                       grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
                       bspline_extraction.cpp bspline_extraction_operators.cpp
-                      bspline_thb_space.cpp bspline_type.cpp)
+                      bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
@@ -133,7 +133,7 @@ else()
                       grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
                       bspline_extraction.cpp bspline_extraction_operators.cpp
-                      bspline_thb_space.cpp bspline_type.cpp)
+                      bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bspline_refinement.cpp
+++ b/cpp/bindings/bspline_refinement.cpp
@@ -1,0 +1,148 @@
+/// \file
+/// nanobind bindings for refining a `pantr::bspline::Bspline`.
+///
+/// Two entry points, `insert_bspline_knots` and `subdivide_bspline`, each registered
+/// twice -- once per storage format -- exactly as `bezier.cpp` registers its
+/// n-dimensional degree and shape operations. Overload resolution separates the two
+/// instantiations on the field handle's own class, so neither needs a dtype argument
+/// and neither can be reached with a mismatched one.
+///
+/// ## What crosses, and what does not
+///
+/// **The field itself crosses, not its arrays.** These are operations on a domain type
+/// that C++ owns since the 2026-08-27 amendment to `design/cross_backend_types.md`, so
+/// the binding is handed the `Bspline32`/`Bspline64` handle the Python wrapper already
+/// holds and hands back a new one. Unpacking a field into a knot vector and a control
+/// net on one side and reassembling it on the other is the shape that amendment
+/// forbids, and the rationality flag is exactly the invariant a reassembly drops.
+/// `pantr.bezier._bezier_backend` says the same of its own n-dimensional entry points.
+///
+/// What does cross as arrays is the *arguments*: one 1-D knot array per direction, and
+/// the per-direction subdivision counts. Those are plain data with no invariant to
+/// lose.
+///
+/// The dtype is not converted, and that *is* a check: without `.noconvert()` nanobind
+/// silently casts, so `insert_bspline_knots(a_float32_field, a_float64_list)` would
+/// narrow the caller's knots without a word and the refined vector would not be the
+/// one the caller asked for. Refusing the cast makes a wrapper that forgot to cast a
+/// loud failure instead of a quiet change of precision.
+///
+/// An **empty array skips its direction**, which is how the oracle reads `None` or an
+/// empty array in the same position. `pantr.bspline.Bspline.insert_knots` normalises
+/// `None` to an empty array before it gets here, so there is no `std::optional` in
+/// these signatures and no second spelling of "skip". `subdivide_bspline` reads a count
+/// of 1 the same way, which is again the oracle's reading of `None` there: every branch
+/// in `Bspline.subdivide` treats `None` and `1` identically.
+///
+/// ## What this file validates: nothing
+///
+/// `pantr/bspline/refinement.hpp` validates its own arguments and throws
+/// `std::invalid_argument`, which nanobind maps to `ValueError` preserving `what()`.
+/// The messages are the oracle's character for character;
+/// `tests/parity/test_bspline_refinement.py` compares the two texts rather than just
+/// the exception type.
+///
+/// One refusal of the oracle's cannot be made on either side of this seam and stays the
+/// Python wrapper's: `f"new_knots must be a 1D array-like, got shape ..."` quotes a
+/// numpy shape, and `nb::ndim<1>` would refuse a rank-2 array with nanobind's own
+/// message about C++ types instead. `pantr.bspline._knot_insertion_backend` raises it,
+/// which also keeps its text common mode between the backends.
+///
+/// ## The GIL is held through the computation, unlike the kernels
+///
+/// `pantr_cpp.cpp` records that the GIL is released around a kernel, because a kernel
+/// touches no Python object. These two are not kernels and the reason is specific
+/// rather than stylistic: the space handles reachable from the field were created by
+/// `nanobind/stl/shared_ptr.h`, so their deleter is `py_deleter`, which touches a
+/// Python refcount. Dropping the last reference to one with the GIL released would be
+/// a crash rather than a slowdown, and while no path here *can* drop a last reference
+/// -- the caller's field keeps every handle alive for the whole call -- that is an
+/// argument about the current body rather than a property of the signature.
+///
+/// `bezier.cpp`'s returning entry points (`elevate_bezier_degree`, `restrict_bezier`,
+/// `split_bezier`) hold the GIL for the same shape of reason. If refinement ever shows
+/// up in a profile as a serialisation point, the fix is to release it around
+/// `refine_along_axis` alone, which touches nothing but `T`.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/vector.h>
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/refinement.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+/// A read-only, contiguous 1-D array as nanobind sees it.
+template <class T>
+using const_vec = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// Reinterpret a bound list of 1-D arrays as the spans the header takes.
+///
+/// \tparam T The scalar type the arrays hold.
+/// \param arrays The arrays, borrowed for the duration of the call.
+/// \return One span per entry, in the same order. An empty array yields an empty span,
+///         which is how the header spells "skip this direction".
+template <class T>
+std::vector<std::span<const T>> as_spans(const std::vector<const_vec<T>>& arrays) {
+    std::vector<std::span<const T>> spans;
+    spans.reserve(arrays.size());
+    for (const const_vec<T>& array : arrays) {
+        spans.emplace_back(array.data(), array.shape(0));
+    }
+    return spans;
+}
+
+/// Insert knots into a field, returning a new one.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field The field to refine.
+/// \param new_knots One array of knot values per direction, in axis order.
+/// \return The refined field.
+template <class T>
+pantr::bspline::Bspline<T> bind_insert_knots(const pantr::bspline::Bspline<T>& field,
+                                             const std::vector<const_vec<T>>& new_knots) {
+    const std::vector<std::span<const T>> lists = as_spans<T>(new_knots);
+    return pantr::bspline::insert_knots<T>(field,
+                                           std::span<const std::span<const T>>(lists));
+}
+
+/// Subdivide a field's knot spans uniformly, returning a new one.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field The field to refine.
+/// \param n_subdivisions Equal sub-spans per existing span, one per direction; 1 skips.
+/// \param regularity The continuity at each inserted knot, or `None` for
+///        `degree - 1` per direction.
+/// \return The refined field.
+template <class T>
+pantr::bspline::Bspline<T> bind_subdivide(const pantr::bspline::Bspline<T>& field,
+                                          const std::vector<std::int64_t>& n_subdivisions,
+                                          std::optional<std::int64_t> regularity) {
+    return pantr::bspline::subdivide<T>(
+        field, std::span<const std::int64_t>(n_subdivisions), regularity);
+}
+
+}  // namespace
+
+void register_bspline_refinement(nb::module_& m) {
+    m.def("insert_bspline_knots", &bind_insert_knots<double>, nb::arg("bspline"),
+          nb::arg("new_knots").noconvert());
+    m.def("insert_bspline_knots", &bind_insert_knots<float>, nb::arg("bspline"),
+          nb::arg("new_knots").noconvert());
+
+    m.def("subdivide_bspline", &bind_subdivide<double>, nb::arg("bspline"),
+          nb::arg("n_subdivisions"), nb::arg("regularity"));
+    m.def("subdivide_bspline", &bind_subdivide<float>, nb::arg("bspline"),
+          nb::arg("n_subdivisions"), nb::arg("regularity"));
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -88,6 +88,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_bspline_extraction_operators(m);
     register_bspline_thb_space(m);
     register_bspline_type(m);
+    register_bspline_refinement(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -129,6 +129,16 @@ void register_bspline_thb_space(nanobind::module_& m);
 /// entirely.
 void register_bspline_type(nanobind::module_& m);
 
+/// Register the operations that refine a `pantr.bspline.Bspline`.
+///
+/// Its own entry point rather than two more functions inside `register_bspline_type`,
+/// for the reason that one is separate from `register_bspline_types`: the field's
+/// *state* and the operations *over* it are separate ports with separate parity
+/// claims, and the comments justifying this one's decisions -- why the field crosses
+/// rather than its arrays, why the GIL is held where a kernel would release it, why a
+/// periodic direction is refused -- argue from somewhere else entirely.
+void register_bspline_refinement(nanobind::module_& m);
+
 /// Register `pantr.bspline`'s Bézier extraction operator builder and its mask.
 ///
 /// Separate from `register_bspline_extraction` because the two are separate ports

--- a/cpp/include/pantr/bspline/bspline.hpp
+++ b/cpp/include/pantr/bspline/bspline.hpp
@@ -18,7 +18,8 @@
 /// computations *over* a field rather than properties *of* one, so they are
 /// separate ports over free functions taking a `const Bspline&`. That is what lets
 /// them proceed independently of one another once this type exists, and it is the
-/// same line those two headers draw.
+/// same line those two headers draw. Knot insertion and uniform subdivision have
+/// landed that way, in `pantr/bspline/refinement.hpp`.
 ///
 /// **Two of them cannot be ported yet, and the reason is a declared boundary
 /// rather than an omission.** `pantr.bspline.Bspline.evaluate`,

--- a/cpp/include/pantr/bspline/knot_insertion.hpp
+++ b/cpp/include/pantr/bspline/knot_insertion.hpp
@@ -5,8 +5,9 @@
 ///
 /// Ports `src/pantr/bspline/_bspline_knot_insertion_core.py` and the two Layer 2
 /// helpers a *space* needs from `_bspline_knot_insertion.py`, which stay as the
-/// parity oracle. The control-point half of knot insertion is not here: a space
-/// carries no control points, and `Bspline` is FELIGN/pantr#398.
+/// parity oracle. The control-point half of knot insertion is not here, because a
+/// space carries no control points: it is in `pantr/bspline/refinement.hpp`, which
+/// applies the bands this file computes to a `Bspline`'s net.
 ///
 /// ## Why this file exists ahead of its own ticket
 ///

--- a/cpp/include/pantr/bspline/refinement.hpp
+++ b/cpp/include/pantr/bspline/refinement.hpp
@@ -1,0 +1,448 @@
+#pragma once
+
+/// \file
+/// Refining a B-spline field: knot insertion and uniform subdivision.
+///
+/// Ports `pantr.bspline.Bspline.insert_knots` and `.subdivide`, whose substance is
+/// `_bspline_knot_insertion.py`'s `_insert_knots_bspline`. The Python side stays as
+/// the parity oracle.
+///
+/// ## What this file adds, and what it only calls
+///
+/// `pantr/bspline/knot_insertion.hpp` already carries the whole *space* half --
+/// `oslo_bands_1d`, `oslo_matrix_1d`, `inserted_knot_vector` and
+/// `uniform_subdivision_knots` -- and says of itself that "the control-point half of
+/// knot insertion is not here: a space carries no control points". This is that half,
+/// and it is deliberately thin: **the only new numerics below is
+/// `refine_along_axis`**, which applies bands that file computes. There is no second
+/// Oslo recurrence here, no second merge and no second subdivision-point formula. A
+/// reader looking for the recurrence should read that file; a reader looking for what
+/// a *field* does with it should read this one.
+///
+/// ## Free functions, not methods
+///
+/// `pantr/bspline/bspline.hpp` lists knot insertion among the computations *over* a
+/// field rather than properties *of* one, and states that each is "a separate port
+/// over free functions taking a `const Bspline&`". `pantr/bspline/space_1d.hpp` and
+/// `pantr/bspline/space_nd.hpp` draw the same line for a space. So `insert_knots`
+/// and `subdivide` take a `const Bspline<T>&` and return a new field; the type has
+/// no mutator and this file adds none, which is the `in_place=` decision
+/// `bspline.hpp` records in full.
+///
+/// `subdivide` overloads the one in `knot_insertion.hpp`, which takes a
+/// `const BsplineSpace1D<T>&`. The two are unambiguous on their first argument and
+/// they *are* the same operation at two levels, so one name is right: a caller
+/// refining a space and a caller refining a field over it should not have to
+/// remember two spellings.
+///
+/// ## The floating-point discipline, quantity by quantity
+///
+/// **The refined knot vectors are `inserted_knot_vector`'s and
+/// `uniform_subdivision_knots`', unchanged.** Their own file comment derives why they
+/// are bit-identical to the oracle's -- numpy's `linspace` expression reproduced
+/// rather than simplified, the arithmetic in `double` whatever `T` is, a stable
+/// merge -- and nothing here re-derives or re-rounds them.
+///
+/// **The control-point sweep accumulates in `T`, not in `double`.** That is
+/// `design/backend_parity.md` Rule 9 applied to this kernel rather than inferred from
+/// its neighbours: `_insert_knots_1d_core` allocates `result` in `ctrl.dtype`, and its
+/// `result[i, r] += weight * ctrl[col, r]` reads three array elements and writes one,
+/// so no assignment ever unifies a variable to `float64` and the whole accumulation is
+/// `float32` on a `float32` net. Accumulating in `double` here would be exact at
+/// `float64` and quietly wrong at `float32`, which is the half of the matrix Rule 9
+/// says nobody reads first.
+///
+/// The band recurrence *does* widen one variable, and it does not matter. Numba
+/// unifies `saved`, `to_left` and `to_right` to `float64` because each is seeded with
+/// the literal `0.0`; but each then holds the value of a `float32` expression, and the
+/// exact sum of two `float32` numbers is representable in `float64`, so
+/// `fl32(saved + to_left)` and `fl64(saved + to_left)` narrowed on the store are the
+/// same number. There is no double-rounding hazard to inherit, which is why
+/// `oslo_bands_1d` computing entirely in `T` matches.
+///
+/// **The summation order per output coefficient is the oracle's**: ascending `l` over
+/// the band, terms whose column falls outside `[0, num_cols)` skipped rather than
+/// added as zero, starting from an exact `T(0)`. Nothing else about the loop nest is
+/// load-bearing, and that is a statement worth making precisely: output coefficient
+/// `(i, r)` accumulates over `l` *alone*, so every other loop -- over the outer block,
+/// over the component, over the direction's own index -- is a loop over independent
+/// destinations. Permuting them, or vectorising the innermost one, changes no
+/// operation and no operand.
+///
+/// That is also why this file sweeps the net **strided in place of the oracle's
+/// transpose**. `_insert_knots_bspline` calls `_flatten_along_axis`, which is
+/// `np.moveaxis` plus `np.ascontiguousarray`: a permutation of values, not an
+/// arithmetic step. Reproducing it would cost two full copies of the geometry per
+/// direction and could not change a bit, so `refine_along_axis` takes the axis's
+/// `outer` and `inner` extents instead.
+///
+/// Under this build -- `-ffp-contract=on`, no `-march`, so baseline x86-64 with no FMA
+/// to fuse into, `cpp/README.md` -- the two backends therefore execute the same
+/// IEEE-754 operations in the same order and every coefficient is bit-identical. That
+/// is a property of the *host* rather than of the code, which is
+/// `design/backend_parity.md` Rule 7: a target with an FMA fuses
+/// `row[k] + weight * source[k]` and the claim becomes Rule 10's budget.
+/// `pantr._pantr_cpp.__fp_contract__` is the gate that tells them apart.
+///
+/// ## The one operation of the oracle's this file does not reproduce
+///
+/// **A periodic direction is refused, and that is a declared boundary rather than a
+/// defect.** `_insert_knots_bspline` refines a periodic direction by a round trip
+/// through the open representation: `_to_open_bspline_1d_impl`, insert, then
+/// `_to_periodic_bspline_1d_impl`. Those two are the *boundary and periodic
+/// conversions*, which `pantr/bspline/bspline.hpp` lists as their own port and which
+/// no ticket in this milestone covers -- exactly as `space_1d.hpp` treats
+/// `get_cardinal_intervals`. Porting them here would be porting two more operations
+/// under cover of this one.
+///
+/// So `refine_along_axis` is dimension-agnostic and periodicity-agnostic, and the two
+/// entry points refuse a periodic direction that would receive knots. A periodic
+/// direction that receives *none* is untouched: its space handle is carried over, the
+/// same way the oracle carries over its wrapper.
+/// `pantr.bspline._knot_insertion_backend` routes such a field to the oracle rather
+/// than meeting this refusal.
+///
+/// ## Validating rather than asserting
+///
+/// This is the C++ counterpart of Layer 2, so it validates and throws in a release
+/// build as much as in a debug one, with the oracle's messages character for
+/// character. `pantr/core/error.hpp` sets the split: value and range checks here,
+/// type-kind checks in the Python wrapper.
+///
+/// Three of the refusals below are the oracle's **Layer 1** checks -- the
+/// per-direction argument count, "at least one direction", and the per-direction
+/// regularity range. They are near-vacuous on the Python path, where
+/// `pantr.bspline.Bspline` has already made them, and load-bearing for a C++ caller
+/// with no wrapper in front of it. That is the same reason `bspline.hpp` re-checks the
+/// coefficient count its own wrapper checked.
+///
+/// One refusal of the oracle's cannot live here and stays the wrapper's: the rank of
+/// the insertion array. `f"new_knots must be a 1D array-like, got shape ..."` quotes a
+/// numpy shape, and a `std::span` has no rank to check.
+///
+/// ## Thread safety
+///
+/// Both entry points read their argument and allocate their result, and every type
+/// they touch is immutable. They are safe to call concurrently on the same field with
+/// no external locking, which is the contract `design/bspline_derived_caches.md`
+/// states for this package.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "pantr/bezier/control_net.hpp"
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/knot_insertion.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/space_nd.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+/// Apply a two-scale refinement to one axis of a row-major array.
+///
+/// The array is read as `(outer, num_cols, inner)` and written as
+/// `(outer, bands.num_rows, inner)`: for a control net of shape
+/// `(e_0, ..., e_{d-1}, num_components)` refined along direction `d`, `outer` is the
+/// product of the extents before `d` and `inner` the product of those after it, the
+/// component axis included.
+///
+/// Output coefficient `(o, i, k)` is `sum_l alphas(i, l) * values(o, first_col(i) + l,
+/// k)` over the columns of the band that fall inside `[0, num_cols)`, accumulated in
+/// `T` in ascending `l` from an exact zero. Off-band columns are skipped rather than
+/// added as zeros; a dense sweep computes exact zeros there, so the two agree entry
+/// for entry, and skipping is what makes one output coefficient cost
+/// `O(bands.width)` instead of `O(num_cols)`.
+///
+/// A row whose `first_col` is negative -- which happens on a non-clamped vector -- has
+/// leading band entries that address no column, and they are the ones skipped.
+///
+/// \param bands The refinement matrix in banded form, from `oslo_bands_1d`.
+/// \param num_cols The refined direction's extent in `values`, which is the coarse
+///        space's basis count.
+/// \param values The coefficients, row-major under `(outer, num_cols, inner)`.
+/// \param outer The product of the extents ahead of the refined axis; 1 when it is
+///        the first.
+/// \param inner The product of the extents behind it, component axis included.
+/// \return `outer * bands.num_rows * inner` coefficients, row-major.
+/// \throws std::invalid_argument If any extent is negative, or if `values.size()` is
+///         not `outer * num_cols * inner`.
+///
+/// \note The accumulation is in `T` and in the oracle's order; see the file comment
+///       for why that is a per-kernel fact rather than a module convention.
+template <Real T>
+[[nodiscard]] std::vector<T> refine_along_axis(const OsloBands<T>& bands, std::int64_t num_cols,
+                                               std::span<const T> values, std::int64_t outer,
+                                               std::int64_t inner) {
+    if (num_cols < 0 || outer < 0 || inner < 0) {
+        throw std::invalid_argument("refine_along_axis: the extents are counts, so none of "
+                                    "them can be negative.");
+    }
+    const std::int64_t expected = outer * num_cols * inner;
+    if (static_cast<std::int64_t>(values.size()) != expected) {
+        throw std::invalid_argument(
+            "refine_along_axis: the buffer holds " + std::to_string(values.size())
+            + " coefficients and the shape (" + std::to_string(outer) + ", "
+            + std::to_string(num_cols) + ", " + std::to_string(inner) + ") needs "
+            + std::to_string(expected) + ".");
+    }
+
+    const std::int64_t num_rows = bands.num_rows;
+    std::vector<T> out(static_cast<std::size_t>(outer * num_rows * inner), T(0));
+
+    for (std::int64_t o = 0; o < outer; ++o) {
+        const T* const in_block = values.data() + o * num_cols * inner;
+        T* const out_block = out.data() + o * num_rows * inner;
+        for (std::int64_t i = 0; i < num_rows; ++i) {
+            T* const row = out_block + i * inner;
+            const std::int64_t base = bands.first_col[static_cast<std::size_t>(i)];
+            for (std::int64_t l = 0; l < bands.width; ++l) {
+                const std::int64_t col = base + l;
+                if (col < 0 || col >= num_cols) {
+                    continue;
+                }
+                const T weight = bands.alphas[static_cast<std::size_t>(i * bands.width + l)];
+                const T* const source = in_block + col * inner;
+                for (std::int64_t k = 0; k < inner; ++k) {
+                    // The oracle's `result[i, r] += weight * ctrl[col, r]`, operand for
+                    // operand. `row[k]` starts at an exact zero, so the first term is
+                    // added to zero exactly as it is there.
+                    row[k] = row[k] + weight * source[k];
+                }
+            }
+        }
+    }
+    return out;
+}
+
+namespace detail {
+
+/// Refine every direction that was given knots, one after another.
+///
+/// The shared body of `insert_knots` and `subdivide`: each of those validates its own
+/// arguments and reduces them to a per-direction list of values to insert, and this
+/// walks the directions in axis order, refining the space and the net together.
+///
+/// A direction whose list is empty is skipped, and its space handle is carried into
+/// the result rather than rebuilt -- which is what the oracle does with its wrapper,
+/// and what lets the Python side keep `refined.space.spaces[d] is field.space.spaces[d]`
+/// for an untouched direction. When every list is empty the field itself is returned.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field The field to refine.
+/// \param per_direction One list of values to insert per direction, in axis order.
+///        Repeats raise a knot's multiplicity by that many.
+/// \return The refined field.
+/// \throws std::invalid_argument If `per_direction` does not have one entry per
+///         direction, if a direction with a non-empty list is periodic, or if
+///         `inserted_knot_vector` refuses a list.
+template <Real T>
+[[nodiscard]] Bspline<T> refine_field(const Bspline<T>& field,
+                                      std::span<const std::span<const T>> per_direction) {
+    const BsplineSpace<T>& space = field.space_ref();
+    const std::int64_t dim = space.dim();
+    if (static_cast<std::int64_t>(per_direction.size()) != dim) {
+        throw std::invalid_argument("one list of knots per direction is needed; got "
+                                    + std::to_string(per_direction.size()) + " for a field of "
+                                    + std::to_string(dim) + " direction(s).");
+    }
+
+    bool refined_anything = false;
+    for (const std::span<const T> to_insert : per_direction) {
+        refined_anything = refined_anything || !to_insert.empty();
+    }
+    if (!refined_anything) {
+        return field;
+    }
+
+    // The handles start as the field's own and are replaced only where knots go in,
+    // so an untouched direction is shared rather than copied.
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions(space.spaces().begin(),
+                                                                     space.spaces().end());
+    std::vector<std::size_t> shape(field.net().shape().begin(), field.net().shape().end());
+    std::vector<T> values(field.net().values().begin(), field.net().values().end());
+
+    for (std::int64_t d = 0; d < dim; ++d) {
+        const std::span<const T> to_insert = per_direction[static_cast<std::size_t>(d)];
+        if (to_insert.empty()) {
+            continue;
+        }
+        const BsplineSpace1D<T>& coarse = *directions[static_cast<std::size_t>(d)];
+        if (coarse.periodic()) {
+            throw std::invalid_argument(
+                "refining a periodic direction needs the open-to-periodic conversion, which "
+                "is not part of pantr's C++ core; direction "
+                + std::to_string(d) + " is periodic.");
+        }
+        const std::int64_t degree = coarse.degree();
+
+        // The merged vector, not the refined space's stored knots. Snapping may move a
+        // knot on the way into `BsplineSpace1D`, and the oracle applies the recurrence
+        // to the merged vector and *then* builds the space from it; applying it to the
+        // snapped vector instead would be a different matrix.
+        const std::vector<T> merged =
+            inserted_knot_vector<T>(coarse.knots(), degree, to_insert, coarse.tolerance());
+
+        const std::int64_t num_cols = static_cast<std::int64_t>(coarse.num_basis());
+        const OsloBands<T> bands =
+            oslo_bands_1d<T>(degree, coarse.knots(), std::span<const T>(merged));
+
+        std::int64_t outer = 1;
+        for (std::int64_t before = 0; before < d; ++before) {
+            outer *= static_cast<std::int64_t>(shape[static_cast<std::size_t>(before)]);
+        }
+        std::int64_t inner = 1;
+        for (std::size_t after = static_cast<std::size_t>(d) + 1; after < shape.size(); ++after) {
+            inner *= static_cast<std::int64_t>(shape[after]);
+        }
+
+        values = refine_along_axis<T>(bands, num_cols, std::span<const T>(values), outer, inner);
+        shape[static_cast<std::size_t>(d)] = static_cast<std::size_t>(bands.num_rows);
+        directions[static_cast<std::size_t>(d)] = std::make_shared<const BsplineSpace1D<T>>(
+            std::span<const T>(merged), degree, false, KnotSnapping::merge_near_duplicates);
+    }
+
+    return Bspline<T>(std::make_shared<const BsplineSpace<T>>(std::move(directions)),
+                      typename Bspline<T>::net_type(std::span<const T>(values),
+                                                    std::span<const std::size_t>(shape)),
+                      field.is_rational());
+}
+
+}  // namespace detail
+
+/// The field with knots inserted, over the same geometry.
+///
+/// Each direction's knots are merged into its knot vector and the control net is
+/// pushed through the two-scale matrix, so the result is the same map over a refined
+/// space: exactly, up to the rounding the file comment bounds. A direction given no
+/// knots is left alone.
+///
+/// \param field The field to refine.
+/// \param new_knots_per_direction One list of knot values per direction, in axis
+///        order. Repeats raise that knot's multiplicity by as many. An empty list
+///        skips its direction; at least one must be non-empty.
+/// \return The refined field.
+/// \throws std::invalid_argument If `new_knots_per_direction` does not have one entry
+///         per direction, if every entry is empty, if a direction receiving knots is
+///         periodic, if a value lies outside its direction's domain by more than the
+///         space's tolerance, or if a merge would push a knot's multiplicity above
+///         `degree + 1`.
+///
+/// \note The domain and multiplicity refusals are `inserted_knot_vector`'s, so their
+///       messages are the oracle's; see that function.
+template <Real T>
+[[nodiscard]] Bspline<T> insert_knots(const Bspline<T>& field,
+                                      std::span<const std::span<const T>> new_knots_per_direction) {
+    const std::int64_t dim = field.dim();
+    if (static_cast<std::int64_t>(new_knots_per_direction.size()) != dim) {
+        // The oracle's Layer 1 message, which the wrapper has already raised on the
+        // Python path; see the file comment on why it is restated.
+        throw std::invalid_argument("new_knots sequence length ("
+                                    + std::to_string(new_knots_per_direction.size())
+                                    + ") must match dim (" + std::to_string(dim) + ").");
+    }
+    bool any = false;
+    for (const std::span<const T> to_insert : new_knots_per_direction) {
+        any = any || !to_insert.empty();
+    }
+    if (!any) {
+        throw std::invalid_argument(
+            "At least one direction must have a non-empty array of knots to insert.");
+    }
+    return detail::refine_field<T>(field, new_knots_per_direction);
+}
+
+/// The field with every knot span of the named directions split into equal sub-spans.
+///
+/// For each in-domain span of direction `d`, `n_subdivisions[d] - 1` equally spaced
+/// interior values, each repeated `degree - regularity` times so that the refined
+/// field is `C^regularity` at every inserted knot. The geometry does not move: the
+/// control net is pushed through the two-scale matrix exactly as `insert_knots` does.
+///
+/// \param field The field to refine.
+/// \param n_subdivisions Equal sub-spans per existing span, one per direction. A
+///        direction whose count is 1 is skipped rather than subdivided by one, which
+///        is the oracle's reading of `None`; at least one count must be at least 2.
+/// \param regularity The continuity at each inserted knot, applied to every
+///        subdivided direction. Empty for `degree - 1` per direction, the maximal
+///        smoothness each degree admits.
+/// \return The refined field.
+/// \throws std::invalid_argument If `n_subdivisions` does not have one entry per
+///         direction, if any count is below 1, if no count reaches 2, if `regularity`
+///         is outside `[-1, degree - 1]` for a subdivided direction, if such a
+///         direction is periodic, or if the merge would exceed the maximum
+///         multiplicity.
+///
+/// \note **The multiplicity refusal is all but unreachable from here**, which is worth
+///       saying because a comment in `cpp/tests/test_bspline_knot_insertion.cpp` says
+///       the opposite. `regularity = -1` asks for multiplicity `degree + 1` at each
+///       inserted knot, which is exactly the ceiling and not above it, and the points
+///       `uniform_subdivision_knots` produces are strictly interior to their own span,
+///       so they collide with no existing knot and with no other span's. The one way
+///       left is a span so narrow that an interior point lands within the space's
+///       tolerance of an endpoint. `cpp/tests/test_bspline_refinement.cpp` pins the
+///       positive half of that: `regularity = -1` succeeds and lands on `degree + 1`
+///       exactly.
+template <Real T>
+[[nodiscard]] Bspline<T> subdivide(const Bspline<T>& field,
+                                   std::span<const std::int64_t> n_subdivisions,
+                                   std::optional<std::int64_t> regularity) {
+    const BsplineSpace<T>& space = field.space_ref();
+    const std::int64_t dim = space.dim();
+    if (static_cast<std::int64_t>(n_subdivisions.size()) != dim) {
+        throw std::invalid_argument("n_subdivisions sequence length ("
+                                    + std::to_string(n_subdivisions.size())
+                                    + ") must match dim (" + std::to_string(dim) + ").");
+    }
+    // The oracle checks every count before looking at any regularity, so a field that
+    // is bad in both ways reports the count. Only the order decides which message a
+    // caller reads.
+    for (const std::int64_t count : n_subdivisions) {
+        if (count < 1) {
+            throw std::invalid_argument("n_subdivisions must be >= 1, got "
+                                        + std::to_string(count));
+        }
+    }
+    bool any = false;
+    for (const std::int64_t count : n_subdivisions) {
+        any = any || count >= 2;
+    }
+    if (!any) {
+        throw std::invalid_argument("At least one direction must have n_subdivisions >= 2.");
+    }
+
+    std::vector<std::vector<T>> owned(static_cast<std::size_t>(dim));
+    std::vector<std::span<const T>> per_direction(static_cast<std::size_t>(dim));
+    for (std::int64_t d = 0; d < dim; ++d) {
+        const std::int64_t count = n_subdivisions[static_cast<std::size_t>(d)];
+        if (count == 1) {
+            continue;
+        }
+        const BsplineSpace1D<T>& direction = space.space_ref(d);
+        const std::int64_t degree = direction.degree();
+        const std::int64_t effective = regularity.value_or(degree - 1);
+        if (effective < -1 || effective > degree - 1) {
+            // The oracle's message names the direction, which the space-level
+            // `subdivide` in knot_insertion.hpp does not: there is only one direction
+            // there to blame.
+            throw std::invalid_argument("regularity must be in [-1, degree - 1] = [-1, "
+                                        + std::to_string(degree - 1) + "] for direction "
+                                        + std::to_string(d) + ", got "
+                                        + std::to_string(effective));
+        }
+        owned[static_cast<std::size_t>(d)] = uniform_subdivision_knots<T>(
+            direction.knots(), degree, direction.tolerance(), count, effective);
+        per_direction[static_cast<std::size_t>(d)] =
+            std::span<const T>(owned[static_cast<std::size_t>(d)]);
+    }
+
+    return detail::refine_field<T>(field, std::span<const std::span<const T>>(per_direction));
+}
+
+}  // namespace pantr::bspline

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(PANTR_TEST_SOURCES
     test_extraction_kernels.cpp
     test_bspline_extraction.cpp
     test_bspline_knot_insertion.cpp
+    test_bspline_refinement.cpp
     test_thb_space.cpp
     test_bspline_type.cpp)
 

--- a/cpp/tests/test_bspline_knot_insertion.cpp
+++ b/cpp/tests/test_bspline_knot_insertion.cpp
@@ -33,11 +33,16 @@
 ///
 /// ## What the refusals pin
 ///
-/// `inserted_knot_vector`'s two refusals are the ones a THB space can actually reach:
-/// a subdivision that would push a knot past multiplicity `degree + 1` is what
-/// `regularity = -1` does at degree 1, and it must be a message rather than a
-/// silently degenerate space. The domain refusal is unreachable from `subdivide`,
-/// whose knots are interior by construction, so it is exercised directly.
+/// **Neither of `inserted_knot_vector`'s two refusals is reachable from `subdivide`**,
+/// so both are exercised directly. The domain refusal is not, because a subdivision's
+/// knots are interior by construction. Nor is the multiplicity one: `regularity = -1`
+/// asks for multiplicity `degree - regularity = degree + 1` at each inserted knot,
+/// which is exactly the ceiling and not above it, and the points
+/// `uniform_subdivision_knots` produces are strictly interior to their own span, so
+/// they collide with no existing knot and with no other span's. The only way left is a
+/// span so narrow that an interior point lands within the space's tolerance of an
+/// endpoint. `cpp/tests/test_bspline_refinement.cpp` pins the positive half of that:
+/// `regularity = -1` at degree 1 *succeeds* and lands on multiplicity 2.
 ///
 /// ## A factor of one is refused, not silently a copy
 ///

--- a/cpp/tests/test_bspline_refinement.cpp
+++ b/cpp/tests/test_bspline_refinement.cpp
@@ -33,6 +33,15 @@
 /// system `sum_l alpha_l * g_l^{(r)} = ghat^{(r)}`, `r = 0..p`, has the monomial
 /// moments of `p + 1` distinct knot windows as its matrix.
 ///
+/// **That the system is nonsingular is not proved here, and the qualifier matters.**
+/// It is *false* in general: a window over a collapsed (zero-width) span makes the
+/// matrix singular. It holds for every window a refinement can actually produce, which
+/// is Curry-Schoenberg local polynomial reproduction (Schoenberg's B-spline basis
+/// reproduces polynomials of degree <= p exactly on each nonempty span). Checked in
+/// exact rational arithmetic over the reachable bands rather than assumed, and the
+/// unreachable singular windows were found and confirmed unreachable -- **observed
+/// with an argument, not proved in this file.**
+///
 /// Nothing in it consults the Oslo recurrence: elementary symmetric polynomials of
 /// knots and a binomial coefficient, formed in this file.
 ///
@@ -79,7 +88,13 @@
 ///  - Relative errors compose sub-additively and `gamma_a + gamma_b <= gamma_{a+b}`,
 ///    so `D` refined directions cost `D (7p + 2)`.
 ///
-/// `K = 2p + 3 + D (7p + 2)`, the last `1` being the store into the result. The
+///  - **The store into the result**: the sweep accumulates in `double` and writes the
+///    coefficient back into `T`, which at `float32` is a real rounding on the *output*,
+///    symmetric to the input cast above and derived the same way. `1`.
+///
+/// `K = 2p + 3 + D (7p + 2)`, so the `2p + 3` is the oracle's `e_r` recurrence plus one
+/// rounding on each end -- the cast in and the store out. Every term above names the
+/// operations it charges; none is a pad. The
 /// magnitude it multiplies is `prod_d max_i A^d_{i, r_d}`, per component: the discrete
 /// B-splines of a refinement are non-negative, so each output coefficient is a convex
 /// combination of coarse ones and no partial sum exceeds the largest of them. That
@@ -416,6 +431,15 @@ void check_marsden_survives(const Bspline<T>& refined, const std::string& label,
 /// The premise the accuracy bound rests on, asserted rather than assumed; see the file
 /// comment. The row sum is graded against `2 * gamma_{p+2}`, the same constant
 /// `test_bspline_knot_insertion.cpp` derives for it.
+///
+/// **The non-negativity half is an exact comparison on purpose, and a review asked
+/// why.** `most_negative` starts at `0.0` and only ever passes through `std::min`,
+/// which returns one of its arguments unaltered -- no arithmetic is performed on it, so
+/// `== 0.0` is a sign test over the weights and not an equality on a computed
+/// magnitude. A tolerance here would be the wrong bar in the strict sense: it would
+/// accept a slightly negative weight, which is exactly the defect this forbids, and
+/// negativity is a discrete property that finite precision does not blur. A `-0.0`
+/// weight compares equal and so passes, which is correct -- it is not negative.
 void check_the_bands_are_a_convex_combination() {
     struct Case {
         std::int64_t degree;

--- a/cpp/tests/test_bspline_refinement.cpp
+++ b/cpp/tests/test_bspline_refinement.cpp
@@ -1,0 +1,902 @@
+/// \file
+/// Refining a B-spline field: `insert_knots`, `subdivide`, and the axis sweep.
+///
+/// ## The independent oracle, and why it is not a rerun of the code
+///
+/// The obvious invariant -- *inserting knots does not move the curve* -- is checked by
+/// evaluating before and after, and evaluation needs basis tabulation, which
+/// `pantr/bspline/space_1d.hpp` keeps off this milestone. So the oracle here is the
+/// same statement written in **coefficients** instead of in values, which needs no
+/// basis at all.
+///
+/// **Marsden's identity.** For a knot vector `t` and degree `p`,
+///
+///     (u - y)^p = sum_i prod_{k=1}^{p} (t_{i+k} - y) * N_{i,p}(u),
+///
+/// and expanding both sides in `y` and matching the coefficient of `(-y)^{p-r}` gives,
+/// for every `r` in `[0, p]`,
+///
+///     u^r = sum_i [ e_r(t_{i+1}, ..., t_{i+p}) / C(p, r) ] * N_{i,p}(u),
+///
+/// with `e_r` the elementary symmetric polynomial. So the B-spline coefficients of the
+/// monomial `u^r` are a closed form in the knots. A field whose control points are
+/// those numbers *is* the map `u -> u^r`; refinement must not move it; therefore the
+/// refined coefficients must be the same closed form evaluated on the **refined** knot
+/// vector.
+///
+/// That is a complete oracle rather than a partial one, and the difference matters.
+/// `r = 1` alone is the Greville abscissa and says the refinement is affine-invariant;
+/// `r = 0` alone is the partition of unity. Either on its own leaves a row of `p + 1`
+/// entries pinned by one linear functional, so a wrong matrix that happens to preserve
+/// affine maps would pass. Taking **all** `r` in `[0, p]` gives `p + 1` independent
+/// functionals per row, which determines the row completely: the Vandermonde-like
+/// system `sum_l alpha_l * g_l^{(r)} = ghat^{(r)}`, `r = 0..p`, has the monomial
+/// moments of `p + 1` distinct knot windows as its matrix.
+///
+/// Nothing in it consults the Oslo recurrence: elementary symmetric polynomials of
+/// knots and a binomial coefficient, formed in this file.
+///
+/// **In several directions at once it stays a closed form.** The refinement is a
+/// tensor product of the per-direction matrices, so the field
+/// `prod_d u_d^{r_d}` has control points `prod_d A^d_{i_d, r_d}`, and each component
+/// of the net below carries one power multi-index. Refining direction `d` must move
+/// that direction's factor to its refined value and leave every other factor alone --
+/// which is the check that catches an axis sweep applied to the wrong axis, a
+/// transposed stride, or a component axis mistaken for a parametric one.
+///
+/// ## Where the oracle does not hold, and the vacuity guard that says so
+///
+/// On a **clamped** vector every row's band lies inside `[0, num_cols)`: the leading
+/// knots are the left endpoint repeated `p + 1` times, so `mu >= p` for every refined
+/// knot and `first_col >= 0`. On an **unclamped** one the leading rows address columns
+/// that do not exist, their bands are truncated, and their coefficients are not the
+/// closed form. Such a vector is legal -- `BsplineSpace1D` accepts it with
+/// `periodic = false` -- so it is exercised, with the identity asserted only on the
+/// rows whose band is whole and a **count of what was verified** that fails if the
+/// filter matched nothing. That is the same discipline
+/// `test_bspline_knot_insertion.cpp` applies to its binomial-stencil columns, and for
+/// the same reason: a filter that silently matched nothing is how this kind of test
+/// goes vacuous.
+///
+/// ## The bound, and why it is not `1e-12`
+///
+/// Every quantity compared is a relative one on non-negative data, so the bound is
+/// `gamma_K = K u / (1 - K u)` times the magnitude the value is built from, with `K`
+/// counted rather than fitted:
+///
+///  - **The oracle's own formation**: `e_r` by the recurrence `E_j <- E_j + x E_{j-1}`
+///    commits two roundings per knot along the dominant chain, then one division by
+///    `C(p, r)`. `2p + 1`.
+///  - **One direction's band recurrence**: `p` levels, and each level's dominant path
+///    is two subtractions (`t[j+k] - x` and the denominator), a division, a
+///    multiplication and an addition. `5p`.
+///  - **One direction's control-point sweep**: `p + 1` terms, each a multiplication
+///    and an addition. `2p + 2`.
+///  - Relative errors compose sub-additively and `gamma_a + gamma_b <= gamma_{a+b}`,
+///    so `D` refined directions cost `D (7p + 2)`.
+///
+/// `K = 2p + 2 + D (7p + 2)`, the extra `1` being the store into the result. The
+/// magnitude it multiplies is `prod_d max_i A^d_{i, r_d}`, per component: the discrete
+/// B-splines of a refinement are non-negative, so each output coefficient is a convex
+/// combination of coarse ones and no partial sum exceeds the largest of them. That
+/// non-negativity is a classical property (Cohen, Lyche & Riesenfeld 1980) and it is
+/// **asserted here rather than assumed**, because it is the premise the whole bound
+/// rests on and an assumed premise is exactly the kind of claim nothing else in the
+/// suite would notice.
+///
+/// The counts are charged at `u(T)` throughout, including the oracle's, which is
+/// formed in `double` whatever `T` is. That over-states the `float` case, where
+/// `double` roundings are 2^29 times smaller, and it keeps one derivation for both.
+///
+/// A dyadic refinement of a dyadic vector rounds nothing, so the bound would go
+/// untested on halvings alone. Every group below carries a non-dyadic case -- a factor
+/// of three, and knot vectors with thirds and sevenths in them.
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bezier/control_net.hpp"
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/knot_insertion.hpp"
+#include "pantr/bspline/refinement.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/space_nd.hpp"
+
+namespace {
+
+using pantr::bspline::Bspline;
+using pantr::bspline::BsplineSpace;
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::KnotSnapping;
+using pantr::bspline::insert_knots;
+using pantr::bspline::oslo_bands_1d;
+using pantr::bspline::oslo_matrix_1d;
+using pantr::bspline::refine_along_axis;
+using pantr::bspline::subdivide;
+
+/// `gamma_m = m u / (1 - m u)`, the standard accumulation constant.
+///
+/// \tparam T The format the roundings are charged in.
+/// \param m The number of roundings.
+/// \return The constant, in units of the value being bounded.
+template <class T>
+double gamma_of(std::int64_t m) {
+    const double u = 0.5 * static_cast<double>(std::numeric_limits<T>::epsilon());
+    const double mu = static_cast<double>(m) * u;
+    return mu / (1.0 - mu);
+}
+
+/// The binomial coefficient `C(n, k)`, by the multiplicative form.
+///
+/// \param n The upper index, non-negative.
+/// \param k The lower index, in `[0, n]`.
+/// \return `C(n, k)`, exact in `std::int64_t` over the degrees this file reaches.
+std::int64_t binomial(std::int64_t n, std::int64_t k) {
+    std::int64_t result = 1;
+    for (std::int64_t i = 0; i < k; ++i) {
+        result = result * (n - i) / (i + 1);
+    }
+    return result;
+}
+
+/// The Marsden coefficients of `u^r` in one direction's B-spline basis.
+///
+/// `A_i = e_r(t_{i+1}, ..., t_{i+degree}) / C(degree, r)`; see the file comment for the
+/// identity. Formed in `double` whatever the knots are stored in, by the elementary
+/// symmetric recurrence, so nothing here re-runs the code under test.
+///
+/// \tparam T The scalar type the knots are stored in.
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param r The monomial power, in `[0, degree]`.
+/// \return One coefficient per basis function, `knots.size() - degree - 1` of them.
+template <class T>
+std::vector<double> marsden_coefficients(std::span<const T> knots, std::int64_t degree,
+                                         std::int64_t r) {
+    const std::int64_t count = static_cast<std::int64_t>(knots.size()) - degree - 1;
+    std::vector<double> out(static_cast<std::size_t>(count), 0.0);
+    for (std::int64_t i = 0; i < count; ++i) {
+        // e[j] over the window `knots[i+1 .. i+degree]`, built one knot at a time.
+        std::vector<double> e(static_cast<std::size_t>(degree) + 1, 0.0);
+        e[0] = 1.0;
+        for (std::int64_t k = 1; k <= degree; ++k) {
+            const double x = static_cast<double>(knots[static_cast<std::size_t>(i + k)]);
+            for (std::int64_t j = k; j >= 1; --j) {
+                e[static_cast<std::size_t>(j)] += x * e[static_cast<std::size_t>(j - 1)];
+            }
+        }
+        out[static_cast<std::size_t>(i)] =
+            e[static_cast<std::size_t>(r)] / static_cast<double>(binomial(degree, r));
+    }
+    return out;
+}
+
+/// One field to refine, its expected refinement, and the bound between them.
+///
+/// The net's component axis enumerates power multi-indices row-major: component `c`
+/// decodes to `(r_0, ..., r_{dim-1})` with `r_d` in `[0, degree_d]`, and holds
+/// `prod_d A^d_{i_d, r_d}`. So one net carries every monomial the degrees admit, and
+/// one refinement checks all of them at once.
+///
+/// \tparam T The scalar type the field stores.
+struct Expectation {
+    /// The net values, row-major under `(*num_basis, num_components)`.
+    std::vector<double> values;
+    /// The elementwise magnitude the bound is proportional to.
+    std::vector<double> magnitude;
+    /// The shape, `(*num_basis, num_components)`.
+    std::vector<std::size_t> shape;
+};
+
+/// The Marsden net over a set of directions, with its per-element magnitude.
+///
+/// \tparam T The scalar type the knots are stored in.
+/// \param directions One knot vector and degree per parametric direction.
+/// \return The net, its shape and the magnitude each entry is a convex combination of.
+template <class T>
+Expectation marsden_net(const std::vector<const BsplineSpace1D<T>*>& directions) {
+    const std::size_t dim = directions.size();
+    std::vector<std::size_t> counts(dim);
+    std::vector<std::size_t> powers(dim);
+    // Per direction and per power, the coefficients and their largest magnitude.
+    std::vector<std::vector<std::vector<double>>> tables(dim);
+    std::vector<std::vector<double>> largest(dim);
+    for (std::size_t d = 0; d < dim; ++d) {
+        const BsplineSpace1D<T>& space = *directions[d];
+        counts[d] = static_cast<std::size_t>(space.num_basis());
+        powers[d] = static_cast<std::size_t>(space.degree()) + 1;
+        for (std::int64_t r = 0; r <= space.degree(); ++r) {
+            std::vector<double> column = marsden_coefficients<T>(space.knots(), space.degree(), r);
+            double biggest = 0.0;
+            for (const double value : column) {
+                biggest = std::max(biggest, std::abs(value));
+            }
+            tables[d].push_back(std::move(column));
+            largest[d].push_back(biggest);
+        }
+    }
+
+    std::size_t num_components = 1;
+    for (const std::size_t p : powers) {
+        num_components *= p;
+    }
+
+    Expectation out;
+    out.shape.assign(counts.begin(), counts.end());
+    out.shape.push_back(num_components);
+    std::size_t total = num_components;
+    for (const std::size_t count : counts) {
+        total *= count;
+    }
+    out.values.assign(total, 0.0);
+    out.magnitude.assign(total, 0.0);
+
+    std::vector<std::size_t> index(dim, 0);
+    std::size_t flat = 0;
+    while (true) {
+        for (std::size_t c = 0; c < num_components; ++c) {
+            std::size_t rest = c;
+            double value = 1.0;
+            double bound = 1.0;
+            for (std::size_t d = dim; d-- > 0;) {
+                const std::size_t r = rest % powers[d];
+                rest /= powers[d];
+                value *= tables[d][r][index[d]];
+                bound *= largest[d][r];
+            }
+            out.values[flat * num_components + c] = value;
+            out.magnitude[flat * num_components + c] = bound;
+        }
+        ++flat;
+        // Odometer over the parametric multi-index, last axis fastest, which is the
+        // net's own row-major order.
+        std::size_t axis = dim;
+        while (axis-- > 0) {
+            if (++index[axis] < counts[axis]) {
+                break;
+            }
+            index[axis] = 0;
+            if (axis == 0) {
+                return out;
+            }
+        }
+    }
+}
+
+/// A space over the given knot vectors and degrees, snapping as the oracle's default.
+///
+/// \tparam T The scalar type the knots are stored in.
+/// \param knots One knot vector per direction.
+/// \param degrees One degree per direction.
+/// \return The handles, in axis order.
+template <class T>
+std::vector<std::shared_ptr<const BsplineSpace1D<T>>>
+make_directions(const std::vector<std::vector<T>>& knots,
+                const std::vector<std::int64_t>& degrees) {
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> out;
+    for (std::size_t d = 0; d < knots.size(); ++d) {
+        out.push_back(std::make_shared<const BsplineSpace1D<T>>(
+            std::span<const T>(knots[d]), degrees[d], false, KnotSnapping::merge_near_duplicates));
+    }
+    return out;
+}
+
+/// Borrow the directions of a space, for `marsden_net`.
+///
+/// \tparam T The scalar type.
+/// \param space The space.
+/// \return One pointer per direction, in axis order.
+template <class T>
+std::vector<const BsplineSpace1D<T>*> borrow(const BsplineSpace<T>& space) {
+    std::vector<const BsplineSpace1D<T>*> out;
+    for (std::int64_t d = 0; d < space.dim(); ++d) {
+        out.push_back(&space.space_ref(d));
+    }
+    return out;
+}
+
+/// The Marsden field over a space, at storage format `T`.
+///
+/// \tparam T The scalar type the field stores.
+/// \param space The space, shared into the field.
+/// \param is_rational Whether the last component is declared a homogeneous weight.
+/// \return The field.
+template <class T>
+Bspline<T> marsden_field(const std::shared_ptr<const BsplineSpace<T>>& space, bool is_rational) {
+    const Expectation expected = marsden_net<T>(borrow(*space));
+    std::vector<T> stored(expected.values.size());
+    for (std::size_t i = 0; i < stored.size(); ++i) {
+        stored[i] = static_cast<T>(expected.values[i]);
+    }
+    return Bspline<T>(space,
+                      typename Bspline<T>::net_type(std::span<const T>(stored),
+                                                    std::span<const std::size_t>(expected.shape)),
+                      is_rational);
+}
+
+/// Assert that a refined field's coefficients are Marsden's closed form again.
+///
+/// \tparam T The scalar type the field stores.
+/// \param refined The refined field.
+/// \param label What is being checked, for the failure message.
+/// \param num_refined How many directions received knots, the `D` of the bound.
+/// \param clamped Whether every direction is clamped; when false, only the rows whose
+///        band is whole are compared and the count of them is asserted non-zero.
+template <class T>
+void check_marsden_survives(const Bspline<T>& refined, const std::string& label,
+                            std::int64_t num_refined, bool clamped) {
+    const BsplineSpace<T>& space = refined.space_ref();
+    const Expectation expected = marsden_net<T>(borrow(space));
+    const std::span<const T> got = refined.net().values();
+
+    PANTR_CHECK_MSG(got.size() == expected.values.size(),
+                    label + ": the refined net has " + std::to_string(got.size())
+                        + " coefficients and the closed form has "
+                        + std::to_string(expected.values.size()));
+    if (got.size() != expected.values.size()) {
+        return;
+    }
+
+    std::int64_t worst_degree = 0;
+    for (const std::int64_t degree : space.degrees()) {
+        worst_degree = std::max(worst_degree, degree);
+    }
+    const std::int64_t roundings = 2 * worst_degree + 2 + num_refined * (7 * worst_degree + 2);
+    const double relative = gamma_of<T>(roundings);
+
+    double worst_ratio = 0.0;
+    for (std::size_t i = 0; i < got.size(); ++i) {
+        const double bound = relative * expected.magnitude[i];
+        const double difference = std::abs(static_cast<double>(got[i]) - expected.values[i]);
+        if (bound > 0.0) {
+            worst_ratio = std::max(worst_ratio, difference / bound);
+        } else {
+            worst_ratio = std::max(worst_ratio, difference == 0.0 ? 0.0 : 1.0e300);
+        }
+    }
+    if (clamped) {
+        PANTR_CHECK_MSG(worst_ratio <= 1.0,
+                        label + ": Marsden's identity does not survive the refinement; worst "
+                                "difference is "
+                            + std::to_string(worst_ratio) + " times its derived bound");
+    }
+}
+
+/// The discrete B-splines of a refinement are non-negative and their rows sum to one.
+///
+/// The premise the accuracy bound rests on, asserted rather than assumed; see the file
+/// comment. The row sum is graded against `2 * gamma_{p+2}`, the same constant
+/// `test_bspline_knot_insertion.cpp` derives for it.
+void check_the_bands_are_a_convex_combination() {
+    struct Case {
+        std::int64_t degree;
+        std::vector<double> knots;
+        std::int64_t subdivisions;
+    };
+    const std::vector<Case> cases = {
+        {1, {0.0, 0.0, 0.5, 1.0, 1.0}, 3},
+        {2, {0.0, 0.0, 0.0, 1.0 / 3.0, 1.0, 1.0, 1.0}, 3},
+        {3, {0.0, 0.0, 0.0, 0.0, 0.25, 3.0 / 7.0, 1.0, 1.0, 1.0, 1.0}, 2},
+    };
+    for (const Case& c : cases) {
+        const BsplineSpace1D<double> coarse(std::span<const double>(c.knots), c.degree, false,
+                                            KnotSnapping::merge_near_duplicates);
+        const BsplineSpace1D<double> fine =
+            subdivide<double>(coarse, c.subdivisions, std::nullopt);
+        const auto bands = oslo_bands_1d<double>(c.degree, coarse.knots(), fine.knots());
+        const std::int64_t num_cols = coarse.num_basis();
+
+        double most_negative = 0.0;
+        double worst_row = 0.0;
+        for (std::int64_t row = 0; row < bands.num_rows; ++row) {
+            double sum = 0.0;
+            for (std::int64_t l = 0; l < bands.width; ++l) {
+                const std::int64_t col = bands.first_col[static_cast<std::size_t>(row)] + l;
+                if (col < 0 || col >= num_cols) {
+                    continue;
+                }
+                const double value =
+                    bands.alphas[static_cast<std::size_t>(row * bands.width + l)];
+                most_negative = std::min(most_negative, value);
+                sum += value;
+            }
+            worst_row = std::max(worst_row, std::abs(sum - 1.0));
+        }
+        PANTR_CHECK_MSG(most_negative == 0.0,
+                        "a discrete B-spline of a degree-" + std::to_string(c.degree)
+                            + " refinement is negative, which is the premise the accuracy "
+                              "bound in this file rests on");
+        PANTR_CHECK_MSG(worst_row <= 2.0 * gamma_of<double>(c.degree + 2),
+                        "a row of the degree-" + std::to_string(c.degree)
+                            + " two-scale matrix does not sum to one");
+    }
+}
+
+/// Marsden's identity survives `subdivide` in one direction, over degrees and factors.
+template <class T>
+void check_subdivide_1d(const std::string& format) {
+    // Non-dyadic knots and a factor of three appear so the bound is exercised rather
+    // than trivially satisfied; see the file comment.
+    const std::vector<std::vector<T>> vectors = {
+        {T(0), T(0), T(0.5), T(1), T(1)},
+        {T(0), T(0), T(0), T(0.25), T(0.75), T(1), T(1), T(1)},
+        {T(0), T(0), T(0), T(1.0 / 3.0), T(1), T(1), T(1)},
+        {T(0), T(0), T(0), T(0), T(0.25), T(3.0 / 7.0), T(1), T(1), T(1), T(1)},
+    };
+    const std::vector<std::int64_t> degrees = {1, 2, 2, 3};
+
+    for (std::size_t k = 0; k < vectors.size(); ++k) {
+        for (const std::int64_t factor : {2, 3, 4}) {
+            const auto directions = make_directions<T>({vectors[k]}, {degrees[k]});
+            const auto space = std::make_shared<const BsplineSpace<T>>(directions);
+            const Bspline<T> field = marsden_field<T>(space, false);
+            const std::vector<std::int64_t> counts = {factor};
+            const Bspline<T> refined =
+                subdivide<T>(field, std::span<const std::int64_t>(counts), std::nullopt);
+
+            const std::string label = format + " subdivide degree "
+                                      + std::to_string(degrees[k]) + " by "
+                                      + std::to_string(factor);
+            PANTR_CHECK_MSG(refined.space_ref().space_ref(0).num_intervals()
+                                == space->space_ref(0).num_intervals() * factor,
+                            label + ": the interval count did not multiply");
+            PANTR_CHECK_MSG(refined.rank() == field.rank(), label + ": the rank moved");
+            PANTR_CHECK_MSG(refined.is_rational() == field.is_rational(),
+                            label + ": the rationality flag moved");
+            check_marsden_survives<T>(refined, label, 1, true);
+        }
+    }
+}
+
+/// Marsden's identity survives an explicit `insert_knots`, repeats included.
+template <class T>
+void check_insert_knots_1d(const std::string& format) {
+    const std::vector<T> knots = {T(0), T(0), T(0), T(0.25), T(0.75), T(1), T(1), T(1)};
+    const auto directions = make_directions<T>({knots}, {2});
+    const auto space = std::make_shared<const BsplineSpace<T>>(directions);
+    const Bspline<T> field = marsden_field<T>(space, false);
+
+    // A repeat raises the multiplicity to two, which is legal at degree 2 and drops the
+    // continuity to C^0 there; an existing knot gets a second copy; and 1/3 is not
+    // representable, so the bound is what decides the comparison.
+    const std::vector<T> to_insert = {T(1.0 / 3.0), T(1.0 / 3.0), T(0.25), T(0.9)};
+    const std::vector<std::span<const T>> per_direction = {std::span<const T>(to_insert)};
+    const Bspline<T> refined =
+        insert_knots<T>(field, std::span<const std::span<const T>>(per_direction));
+
+    const std::string label = format + " insert_knots with a repeat";
+    PANTR_CHECK_MSG(refined.space_ref().space_ref(0).knots().size() == knots.size() + 4,
+                    label + ": the refined knot vector is the wrong length");
+    check_marsden_survives<T>(refined, label, 1, true);
+}
+
+/// Marsden's identity survives refinement of a surface and of a volume.
+///
+/// The multi-direction cases are asymmetric in the degree, the basis count and the
+/// domain at once, so no permutation of the net's shape is another admissible shape and
+/// a transposed sweep cannot pass.
+template <class T>
+void check_multidimensional(const std::string& format) {
+    const std::vector<std::vector<T>> surface = {
+        {T(0), T(0), T(0), T(1.0 / 3.0), T(1), T(1), T(1)},
+        {T(10), T(10), T(11), T(12), T(12)},
+    };
+    const std::vector<std::int64_t> surface_degrees = {2, 1};
+
+    {
+        const auto space =
+            std::make_shared<const BsplineSpace<T>>(make_directions<T>(surface, surface_degrees));
+        const Bspline<T> field = marsden_field<T>(space, false);
+        // Only the second direction is refined: the first has to come back untouched,
+        // handle and all.
+        const std::vector<std::int64_t> counts = {1, 3};
+        const Bspline<T> refined =
+            subdivide<T>(field, std::span<const std::int64_t>(counts), std::nullopt);
+        PANTR_CHECK_MSG(refined.space_ref().space(0) == space->space(0),
+                        format + " surface: an unrefined direction did not keep its space");
+        PANTR_CHECK_MSG(refined.space_ref().space(1) != space->space(1),
+                        format + " surface: the refined direction kept its space");
+        check_marsden_survives<T>(refined, format + " surface, one direction", 1, true);
+    }
+    {
+        const auto space =
+            std::make_shared<const BsplineSpace<T>>(make_directions<T>(surface, surface_degrees));
+        const Bspline<T> field = marsden_field<T>(space, false);
+        const std::vector<std::int64_t> counts = {2, 3};
+        const Bspline<T> refined =
+            subdivide<T>(field, std::span<const std::int64_t>(counts), std::nullopt);
+        check_marsden_survives<T>(refined, format + " surface, both directions", 2, true);
+    }
+    {
+        const std::vector<std::vector<T>> volume = {
+            {T(0), T(0), T(0), T(1.0 / 3.0), T(1), T(1), T(1)},
+            {T(10), T(10), T(11), T(12), T(12)},
+            {T(0), T(0), T(0), T(0), T(0.25), T(3.0 / 7.0), T(1), T(1), T(1), T(1)},
+        };
+        const auto space =
+            std::make_shared<const BsplineSpace<T>>(make_directions<T>(volume, {2, 1, 3}));
+        // Declared rational, so the last component is a homogeneous weight. Refinement
+        // is component-blind and linear, so the closed form describes the weight column
+        // exactly as it describes the coordinates -- which is the whole reason a
+        // weighted net can be refined at all.
+        const Bspline<T> field = marsden_field<T>(space, true);
+        const std::vector<std::int64_t> counts = {2, 1, 3};
+        const Bspline<T> refined =
+            subdivide<T>(field, std::span<const std::int64_t>(counts), std::nullopt);
+        PANTR_CHECK_MSG(refined.is_rational(), format + " volume: the weight flag was dropped");
+        PANTR_CHECK_MSG(refined.rank() == field.rank(), format + " volume: the rank moved");
+        check_marsden_survives<T>(refined, format + " rational volume", 2, true);
+    }
+}
+
+/// `regularity` drives the multiplicity, and the identity survives every legal value.
+void check_regularity() {
+    const std::vector<double> knots = {0.0, 0.0, 0.0, 0.0, 0.25, 3.0 / 7.0, 1.0, 1.0, 1.0, 1.0};
+    const auto space =
+        std::make_shared<const BsplineSpace<double>>(make_directions<double>({knots}, {3}));
+    const Bspline<double> field = marsden_field<double>(space, false);
+    const std::vector<std::int64_t> counts = {2};
+
+    for (const std::int64_t regularity : {-1, 0, 1, 2}) {
+        const Bspline<double> refined =
+            subdivide<double>(field, std::span<const std::int64_t>(counts), regularity);
+        const std::int64_t multiplicity = 3 - regularity;
+        // Three in-domain spans, so three new interior breakpoints, each at
+        // multiplicity `degree - regularity`.
+        PANTR_CHECK_MSG(refined.space_ref().space_ref(0).knots().size()
+                            == knots.size() + static_cast<std::size_t>(3 * multiplicity),
+                        "regularity " + std::to_string(regularity)
+                            + ": the wrong number of knots was inserted");
+        check_marsden_survives<double>(
+            refined, "regularity " + std::to_string(regularity), 1, true);
+    }
+}
+
+/// An unclamped, non-periodic direction: legal, refined, and only partly a closed form.
+///
+/// See the file comment for why the leading rows are not Marsden's numbers and why the
+/// count of verified rows is asserted.
+void check_unclamped() {
+    // Strictly increasing and unclamped at both ends, so the leading and trailing bands
+    // address columns outside the coarse space.
+    const std::vector<double> knots = {-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    const auto space =
+        std::make_shared<const BsplineSpace<double>>(make_directions<double>({knots}, {2}));
+    const Bspline<double> field = marsden_field<double>(space, false);
+    const std::vector<std::int64_t> counts = {3};
+    const Bspline<double> refined =
+        subdivide<double>(field, std::span<const std::int64_t>(counts), std::nullopt);
+
+    const BsplineSpace1D<double>& coarse = space->space_ref(0);
+    const BsplineSpace1D<double>& fine = refined.space_ref().space_ref(0);
+    const auto bands = oslo_bands_1d<double>(2, coarse.knots(), fine.knots());
+    const Expectation expected = marsden_net<double>(borrow(refined.space_ref()));
+    const std::span<const double> got = refined.net().values();
+    const std::size_t num_components = expected.shape.back();
+
+    const double relative = gamma_of<double>(2 * 2 + 2 + 1 * (7 * 2 + 2));
+    std::int64_t verified = 0;
+    std::int64_t truncated = 0;
+    for (std::int64_t row = 0; row < bands.num_rows; ++row) {
+        const std::int64_t base = bands.first_col[static_cast<std::size_t>(row)];
+        if (base < 0 || base + bands.width > coarse.num_basis()) {
+            ++truncated;
+            continue;
+        }
+        ++verified;
+        for (std::size_t c = 0; c < num_components; ++c) {
+            const std::size_t flat = static_cast<std::size_t>(row) * num_components + c;
+            const double bound = relative * expected.magnitude[flat];
+            PANTR_CHECK_MSG(std::abs(got[flat] - expected.values[flat]) <= bound,
+                            "unclamped: an interior row does not reproduce Marsden's "
+                            "coefficient at row "
+                                + std::to_string(row));
+        }
+    }
+    PANTR_CHECK_MSG(verified > 0, "the vacuity guard: no whole band was found on the unclamped "
+                                  "vector, so the identity was never compared");
+    PANTR_CHECK_MSG(truncated > 0, "the unclamped case has no truncated band, so it is not "
+                                   "exercising what it was written for");
+}
+
+/// The strided sweep addresses the axis it was asked for.
+///
+/// The refinement matrix is `oslo_matrix_1d`'s, so what is under test here is the index
+/// arithmetic and nothing else: the reference is written as an explicit gather of each
+/// fibre of a three-dimensional array, one dense matrix-vector product per fibre. A
+/// transposed stride, an outer and inner swapped, or a component axis counted as
+/// parametric all move it.
+void check_the_axis_sweep_addresses_the_right_fibres() {
+    const std::vector<double> knots = {0.0, 0.0, 0.0, 1.0 / 3.0, 1.0, 1.0, 1.0};
+    const BsplineSpace1D<double> coarse(std::span<const double>(knots), 2, false,
+                                        KnotSnapping::merge_near_duplicates);
+    const BsplineSpace1D<double> fine = subdivide<double>(coarse, 3, std::nullopt);
+    const auto bands = oslo_bands_1d<double>(2, coarse.knots(), fine.knots());
+    const std::vector<double> dense = oslo_matrix_1d<double>(2, coarse.knots(), fine.knots());
+    const std::int64_t num_cols = coarse.num_basis();
+    const std::int64_t num_rows = fine.num_basis();
+
+    for (const std::int64_t outer : {1, 2, 5}) {
+        for (const std::int64_t inner : {1, 3, 4}) {
+            std::vector<double> values(
+                static_cast<std::size_t>(outer * num_cols * inner));
+            for (std::size_t i = 0; i < values.size(); ++i) {
+                // Distinct per position and spread over decades, so a swapped stride
+                // cannot coincide with the right answer.
+                values[i] = 1.0 + static_cast<double>(i) * 0.125;
+            }
+            const std::vector<double> got = refine_along_axis<double>(
+                bands, num_cols, std::span<const double>(values), outer, inner);
+            PANTR_CHECK(static_cast<std::int64_t>(got.size()) == outer * num_rows * inner);
+
+            for (std::int64_t o = 0; o < outer; ++o) {
+                for (std::int64_t k = 0; k < inner; ++k) {
+                    for (std::int64_t row = 0; row < num_rows; ++row) {
+                        double reference = 0.0;
+                        for (std::int64_t col = 0; col < num_cols; ++col) {
+                            reference +=
+                                dense[static_cast<std::size_t>(row * num_cols + col)]
+                                * values[static_cast<std::size_t>((o * num_cols + col) * inner
+                                                                  + k)];
+                        }
+                        const double mine =
+                            got[static_cast<std::size_t>((o * num_rows + row) * inner + k)];
+                        // Same terms, and the reference adds the off-band exact zeros
+                        // the sweep skips, so the two differ by nothing at all.
+                        PANTR_CHECK_MSG(std::abs(mine - reference)
+                                            <= 4.0 * gamma_of<double>(num_cols + 1)
+                                                   * std::abs(reference),
+                                        "the axis sweep and the dense product disagree at "
+                                        "outer "
+                                            + std::to_string(outer) + ", inner "
+                                            + std::to_string(inner));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Subdividing is inserting the knots `uniform_subdivision_knots` names.
+///
+/// Not a mirror of the recurrence: it pins that the two entry points agree on *which*
+/// knots go in and on nothing else, which is the one thing a reader would otherwise
+/// have to take on trust when reading `subdivide` beside `insert_knots`.
+void check_subdivide_is_insert_knots_of_the_subdivision_knots() {
+    const std::vector<double> knots = {0.0, 0.0, 0.0, 1.0 / 3.0, 1.0, 1.0, 1.0};
+    const auto space =
+        std::make_shared<const BsplineSpace<double>>(make_directions<double>({knots}, {2}));
+    const Bspline<double> field = marsden_field<double>(space, false);
+
+    const std::vector<std::int64_t> counts = {3};
+    const Bspline<double> by_subdivide =
+        subdivide<double>(field, std::span<const std::int64_t>(counts), 0);
+    const std::vector<double> to_insert = pantr::bspline::uniform_subdivision_knots<double>(
+        space->space_ref(0).knots(), 2, space->space_ref(0).tolerance(), 3, 0);
+    const std::vector<std::span<const double>> per_direction = {
+        std::span<const double>(to_insert)};
+    const Bspline<double> by_insert = insert_knots<double>(
+        field, std::span<const std::span<const double>>(per_direction));
+
+    PANTR_CHECK(by_subdivide.net().values().size() == by_insert.net().values().size());
+    bool identical = by_subdivide.space_ref().space_ref(0).knots().size()
+                     == by_insert.space_ref().space_ref(0).knots().size();
+    for (std::size_t i = 0; identical && i < by_insert.net().values().size(); ++i) {
+        identical = by_subdivide.net().values()[i] == by_insert.net().values()[i];
+    }
+    PANTR_CHECK_MSG(identical, "subdivide and insert_knots disagree on the same knots");
+}
+
+/// Every refusal, by its message.
+void check_refusals() {
+    const std::vector<double> knots = {0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const auto space =
+        std::make_shared<const BsplineSpace<double>>(make_directions<double>({knots}, {2}));
+    const Bspline<double> field = marsden_field<double>(space, false);
+
+    const auto refused = [](const std::string& expected, const auto& call) {
+        try {
+            call();
+        } catch (const std::invalid_argument& error) {
+            const std::string text = error.what();
+            PANTR_CHECK_MSG(text == expected,
+                            "expected \"" + expected + "\" and got \"" + text + "\"");
+            return;
+        }
+        PANTR_CHECK_MSG(false, "no refusal where \"" + expected + "\" was expected");
+    };
+
+    const std::vector<double> one = {0.25};
+    const std::vector<std::span<const double>> two_lists = {std::span<const double>(one),
+                                                            std::span<const double>(one)};
+    refused("new_knots sequence length (2) must match dim (1).", [&] {
+        static_cast<void>(
+            insert_knots<double>(field, std::span<const std::span<const double>>(two_lists)));
+    });
+
+    const std::vector<std::span<const double>> empty_list = {std::span<const double>()};
+    refused("At least one direction must have a non-empty array of knots to insert.", [&] {
+        static_cast<void>(
+            insert_knots<double>(field, std::span<const std::span<const double>>(empty_list)));
+    });
+
+    const std::vector<double> outside = {1.5};
+    const std::vector<std::span<const double>> outside_list = {std::span<const double>(outside)};
+    refused("new_knots contains values outside the domain [0.0, 1.0]: [1.5]", [&] {
+        static_cast<void>(
+            insert_knots<double>(field, std::span<const std::span<const double>>(outside_list)));
+    });
+
+    // Degree 2, so a knot may reach multiplicity 3; a fourth copy is refused.
+    const std::vector<double> crowded = {0.5, 0.5, 0.5};
+    const std::vector<std::span<const double>> crowded_list = {std::span<const double>(crowded)};
+    refused("Inserting these knots would exceed the maximum multiplicity of 3. Maximum "
+            "multiplicity found: 4.",
+            [&] {
+                static_cast<void>(insert_knots<double>(
+                    field, std::span<const std::span<const double>>(crowded_list)));
+            });
+
+    const std::vector<std::int64_t> two_counts = {2, 2};
+    refused("n_subdivisions sequence length (2) must match dim (1).", [&] {
+        static_cast<void>(
+            subdivide<double>(field, std::span<const std::int64_t>(two_counts), std::nullopt));
+    });
+
+    const std::vector<std::int64_t> zero = {0};
+    refused("n_subdivisions must be >= 1, got 0", [&] {
+        static_cast<void>(
+            subdivide<double>(field, std::span<const std::int64_t>(zero), std::nullopt));
+    });
+
+    const std::vector<std::int64_t> ones = {1};
+    refused("At least one direction must have n_subdivisions >= 2.", [&] {
+        static_cast<void>(
+            subdivide<double>(field, std::span<const std::int64_t>(ones), std::nullopt));
+    });
+
+    const std::vector<std::int64_t> twos = {2};
+    refused("regularity must be in [-1, degree - 1] = [-1, 1] for direction 0, got 2", [&] {
+        static_cast<void>(subdivide<double>(field, std::span<const std::int64_t>(twos), 2));
+    });
+    refused("regularity must be in [-1, degree - 1] = [-1, 1] for direction 0, got -2", [&] {
+        static_cast<void>(subdivide<double>(field, std::span<const std::int64_t>(twos), -2));
+    });
+
+    // The count check runs over every direction before any regularity is looked at, so a
+    // field bad in both ways reports the count. Only the order decides which message a
+    // caller reads, which is why it is pinned rather than left to the implementation.
+    const std::vector<std::vector<double>> pair = {knots, knots};
+    const auto surface =
+        std::make_shared<const BsplineSpace<double>>(make_directions<double>(pair, {2, 2}));
+    const Bspline<double> field_2d = marsden_field<double>(surface, false);
+    const std::vector<std::int64_t> bad_both = {2, 0};
+    refused("n_subdivisions must be >= 1, got 0", [&] {
+        static_cast<void>(
+            subdivide<double>(field_2d, std::span<const std::int64_t>(bad_both), 5));
+    });
+
+    // `regularity = -1` lands ON the ceiling rather than above it, so it succeeds. This
+    // is the positive half of the reachability argument in `subdivide`'s own note, and
+    // it is asserted because a comment in `cpp/tests/test_bspline_knot_insertion.cpp`
+    // states the opposite -- that this very call is what makes the multiplicity refusal
+    // reachable from a subdivision. It is not: the interior points of a span collide
+    // with nothing, so `degree - regularity <= degree + 1` is never exceeded.
+    const std::vector<double> linear = {0.0, 0.0, 0.5, 1.0, 1.0};
+    const auto linear_space =
+        std::make_shared<const BsplineSpace<double>>(make_directions<double>({linear}, {1}));
+    const Bspline<double> linear_field = marsden_field<double>(linear_space, false);
+    const Bspline<double> discontinuous =
+        subdivide<double>(linear_field, std::span<const std::int64_t>(twos), -1);
+    const BsplineSpace1D<double>& refined = discontinuous.space_ref().space_ref(0);
+    // Two spans, one interior point each, each at multiplicity `degree + 1 = 2`.
+    PANTR_CHECK_MSG(refined.knots().size() == linear.size() + 4,
+                    "regularity -1 at degree 1 did not insert two double knots");
+    std::int64_t worst = 0;
+    for (const std::int64_t mult : refined.multiplicity()) {
+        worst = std::max(worst, mult);
+    }
+    PANTR_CHECK_MSG(worst == 2, "regularity -1 at degree 1 should reach multiplicity "
+                                "degree + 1 exactly, and reached "
+                                    + std::to_string(worst));
+    check_marsden_survives<double>(discontinuous, "regularity -1 at degree 1", 1, true);
+}
+
+/// A periodic direction is refused, and the message says it is a boundary.
+void check_periodic_is_refused() {
+    const std::vector<double> uniform = {-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    const std::vector<double> clamped = {0.0, 0.0, 0.5, 1.0, 1.0};
+    std::vector<std::shared_ptr<const BsplineSpace1D<double>>> directions;
+    directions.push_back(std::make_shared<const BsplineSpace1D<double>>(
+        std::span<const double>(uniform), 2, true, KnotSnapping::merge_near_duplicates));
+    directions.push_back(std::make_shared<const BsplineSpace1D<double>>(
+        std::span<const double>(clamped), 1, false, KnotSnapping::merge_near_duplicates));
+    const auto space = std::make_shared<const BsplineSpace<double>>(directions);
+    const Bspline<double> field = marsden_field<double>(space, false);
+
+    const std::vector<double> one = {0.25};
+    const std::vector<std::span<const double>> refine_periodic = {
+        std::span<const double>(one), std::span<const double>()};
+    bool refused = false;
+    try {
+        static_cast<void>(insert_knots<double>(
+            field, std::span<const std::span<const double>>(refine_periodic)));
+    } catch (const std::invalid_argument& error) {
+        refused = true;
+        PANTR_CHECK_MSG(std::string(error.what())
+                            == "refining a periodic direction needs the open-to-periodic "
+                               "conversion, which is not part of pantr's C++ core; direction "
+                               "0 is periodic.",
+                        std::string("the periodic refusal reads \"") + error.what() + "\"");
+    }
+    PANTR_CHECK_MSG(refused, "a periodic direction was refined rather than refused");
+
+    // The other direction still refines, and the periodic one is carried over whole:
+    // untouched means untouched, not converted.
+    const std::vector<std::span<const double>> refine_clamped = {std::span<const double>(),
+                                                                 std::span<const double>(one)};
+    const Bspline<double> refined =
+        insert_knots<double>(field, std::span<const std::span<const double>>(refine_clamped));
+    PANTR_CHECK_MSG(refined.space_ref().space(0) == space->space(0),
+                    "the periodic direction did not keep its space");
+    PANTR_CHECK_MSG(refined.space_ref().space_ref(0).periodic(),
+                    "the periodic direction stopped being periodic");
+}
+
+/// `refine_along_axis` refuses a shape it cannot address.
+void check_the_sweep_refuses_a_bad_shape() {
+    const std::vector<double> knots = {0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const BsplineSpace1D<double> coarse(std::span<const double>(knots), 2, false,
+                                        KnotSnapping::merge_near_duplicates);
+    const BsplineSpace1D<double> fine = subdivide<double>(coarse, 2, std::nullopt);
+    const auto bands = oslo_bands_1d<double>(2, coarse.knots(), fine.knots());
+    const std::vector<double> values(7, 1.0);
+
+    bool refused = false;
+    try {
+        static_cast<void>(refine_along_axis<double>(
+            bands, coarse.num_basis(), std::span<const double>(values), 1, 1));
+    } catch (const std::invalid_argument&) {
+        refused = true;
+    }
+    PANTR_CHECK_MSG(refused, "a buffer that is not outer * num_cols * inner was accepted");
+
+    refused = false;
+    try {
+        static_cast<void>(refine_along_axis<double>(
+            bands, coarse.num_basis(), std::span<const double>(values), -1, 1));
+    } catch (const std::invalid_argument&) {
+        refused = true;
+    }
+    PANTR_CHECK_MSG(refused, "a negative extent was accepted");
+}
+
+}  // namespace
+
+int main() {
+    check_the_bands_are_a_convex_combination();
+    check_subdivide_1d<double>("float64");
+    check_subdivide_1d<float>("float32");
+    check_insert_knots_1d<double>("float64");
+    check_insert_knots_1d<float>("float32");
+    check_multidimensional<double>("float64");
+    check_multidimensional<float>("float32");
+    check_regularity();
+    check_unclamped();
+    check_the_axis_sweep_addresses_the_right_fibres();
+    check_subdivide_is_insert_knots_of_the_subdivision_knots();
+    check_refusals();
+    check_periodic_is_refused();
+    check_the_sweep_refuses_a_bad_shape();
+    return pantr::test::summary("test_bspline_refinement");
+}

--- a/cpp/tests/test_bspline_refinement.cpp
+++ b/cpp/tests/test_bspline_refinement.cpp
@@ -67,6 +67,10 @@
 ///  - **The oracle's own formation**: `e_r` by the recurrence `E_j <- E_j + x E_{j-1}`
 ///    commits two roundings per knot along the dominant chain, then one division by
 ///    `C(p, r)`. `2p + 1`.
+///  - **The cast into the field's storage.** `marsden_field` forms the closed form in
+///    `double` and stores it in `T`, which at `float32` is a real rounding on the
+///    *input* the sweep then propagates. It costs one, because the sweep's convex
+///    combination does not amplify a relative perturbation. `1`.
 ///  - **One direction's band recurrence**: `p` levels, and each level's dominant path
 ///    is two subtractions (`t[j+k] - x` and the denominator), a division, a
 ///    multiplication and an addition. `5p`.
@@ -75,7 +79,7 @@
 ///  - Relative errors compose sub-additively and `gamma_a + gamma_b <= gamma_{a+b}`,
 ///    so `D` refined directions cost `D (7p + 2)`.
 ///
-/// `K = 2p + 2 + D (7p + 2)`, the extra `1` being the store into the result. The
+/// `K = 2p + 3 + D (7p + 2)`, the last `1` being the store into the result. The
 /// magnitude it multiplies is `prod_d max_i A^d_{i, r_d}`, per component: the discrete
 /// B-splines of a refinement are non-negative, so each output coefficient is a convex
 /// combination of coarse ones and no partial sum exceeds the largest of them. That
@@ -83,6 +87,12 @@
 /// **asserted here rather than assumed**, because it is the premise the whole bound
 /// rests on and an assumed premise is exactly the kind of claim nothing else in the
 /// suite would notice.
+///
+/// A magnitude can be an exact zero -- `e_p` of a window containing the knot 0 -- and a
+/// relative bound of zero asserts bit-identity nothing here has grounds for, so `K`
+/// underflow floors are added. That is the absolute half of Higham's model, and it is
+/// what lets `accuracy_bound` return a strictly positive number for every entry
+/// instead of the comparison carrying a special case for zero.
 ///
 /// The counts are charged at `u(T)` throughout, including the oracle's, which is
 /// formed in `double` whatever `T` is. That over-states the `float` case, where
@@ -324,17 +334,53 @@ Bspline<T> marsden_field(const std::shared_ptr<const BsplineSpace<T>>& space, bo
                       is_rational);
 }
 
+/// The number of roundings the accuracy bound charges; see the file comment.
+///
+/// \param degree The largest degree among the field's directions.
+/// \param num_refined How many directions received knots, the `D` of the derivation.
+/// \return `K`.
+std::int64_t bound_roundings(std::int64_t degree, std::int64_t num_refined) {
+    return 2 * degree + 3 + num_refined * (7 * degree + 2);
+}
+
+/// The elementwise accuracy bound between a net and Marsden's closed form.
+///
+/// `gamma_K` times the magnitude, plus `K` underflow floors. The floor is the absolute
+/// half of Higham's model and it is not decoration here: a component whose closed form
+/// is an exact zero has a relative bound of zero, and a bound of zero asserts
+/// bit-identity that nothing in this file has grounds for.
+///
+/// \tparam T The scalar type the field stores.
+/// \param magnitude The per-entry magnitude from `marsden_net`.
+/// \param roundings `K`, from `bound_roundings`.
+/// \return One bound per entry, all strictly positive.
+template <class T>
+std::vector<double> accuracy_bound(const std::vector<double>& magnitude,
+                                   std::int64_t roundings) {
+    const double relative = gamma_of<T>(roundings);
+    const double floor = static_cast<double>(std::numeric_limits<T>::denorm_min());
+    std::vector<double> bound(magnitude.size());
+    for (std::size_t i = 0; i < magnitude.size(); ++i) {
+        bound[i] = relative * magnitude[i] + static_cast<double>(roundings) * floor;
+    }
+    return bound;
+}
+
 /// Assert that a refined field's coefficients are Marsden's closed form again.
+///
+/// Every direction must be clamped, which is what makes the identity describe the whole
+/// net; `check_unclamped` is where a truncated band is handled, row by row and with its
+/// own vacuity guard. This took a `clamped` flag until a review found that every call
+/// site passed `true` and the `false` branch asserted nothing at all, which is the
+/// shape of dead test code that reads as coverage.
 ///
 /// \tparam T The scalar type the field stores.
 /// \param refined The refined field.
 /// \param label What is being checked, for the failure message.
 /// \param num_refined How many directions received knots, the `D` of the bound.
-/// \param clamped Whether every direction is clamped; when false, only the rows whose
-///        band is whole are compared and the count of them is asserted non-zero.
 template <class T>
 void check_marsden_survives(const Bspline<T>& refined, const std::string& label,
-                            std::int64_t num_refined, bool clamped) {
+                            std::int64_t num_refined) {
     const BsplineSpace<T>& space = refined.space_ref();
     const Expectation expected = marsden_net<T>(borrow(space));
     const std::span<const T> got = refined.net().values();
@@ -351,25 +397,18 @@ void check_marsden_survives(const Bspline<T>& refined, const std::string& label,
     for (const std::int64_t degree : space.degrees()) {
         worst_degree = std::max(worst_degree, degree);
     }
-    const std::int64_t roundings = 2 * worst_degree + 2 + num_refined * (7 * worst_degree + 2);
-    const double relative = gamma_of<T>(roundings);
+    const std::vector<double> bound = accuracy_bound<T>(
+        expected.magnitude, bound_roundings(worst_degree, num_refined));
 
     double worst_ratio = 0.0;
     for (std::size_t i = 0; i < got.size(); ++i) {
-        const double bound = relative * expected.magnitude[i];
         const double difference = std::abs(static_cast<double>(got[i]) - expected.values[i]);
-        if (bound > 0.0) {
-            worst_ratio = std::max(worst_ratio, difference / bound);
-        } else {
-            worst_ratio = std::max(worst_ratio, difference == 0.0 ? 0.0 : 1.0e300);
-        }
+        worst_ratio = std::max(worst_ratio, difference / bound[i]);
     }
-    if (clamped) {
-        PANTR_CHECK_MSG(worst_ratio <= 1.0,
-                        label + ": Marsden's identity does not survive the refinement; worst "
-                                "difference is "
-                            + std::to_string(worst_ratio) + " times its derived bound");
-    }
+    PANTR_CHECK_MSG(worst_ratio <= 1.0,
+                    label + ": Marsden's identity does not survive the refinement; worst "
+                            "difference is "
+                        + std::to_string(worst_ratio) + " times its derived bound");
 }
 
 /// The discrete B-splines of a refinement are non-negative and their rows sum to one.
@@ -453,7 +492,7 @@ void check_subdivide_1d(const std::string& format) {
             PANTR_CHECK_MSG(refined.rank() == field.rank(), label + ": the rank moved");
             PANTR_CHECK_MSG(refined.is_rational() == field.is_rational(),
                             label + ": the rationality flag moved");
-            check_marsden_survives<T>(refined, label, 1, true);
+            check_marsden_survives<T>(refined, label, 1);
         }
     }
 }
@@ -477,7 +516,7 @@ void check_insert_knots_1d(const std::string& format) {
     const std::string label = format + " insert_knots with a repeat";
     PANTR_CHECK_MSG(refined.space_ref().space_ref(0).knots().size() == knots.size() + 4,
                     label + ": the refined knot vector is the wrong length");
-    check_marsden_survives<T>(refined, label, 1, true);
+    check_marsden_survives<T>(refined, label, 1);
 }
 
 /// Marsden's identity survives refinement of a surface and of a volume.
@@ -506,7 +545,7 @@ void check_multidimensional(const std::string& format) {
                         format + " surface: an unrefined direction did not keep its space");
         PANTR_CHECK_MSG(refined.space_ref().space(1) != space->space(1),
                         format + " surface: the refined direction kept its space");
-        check_marsden_survives<T>(refined, format + " surface, one direction", 1, true);
+        check_marsden_survives<T>(refined, format + " surface, one direction", 1);
     }
     {
         const auto space =
@@ -515,7 +554,7 @@ void check_multidimensional(const std::string& format) {
         const std::vector<std::int64_t> counts = {2, 3};
         const Bspline<T> refined =
             subdivide<T>(field, std::span<const std::int64_t>(counts), std::nullopt);
-        check_marsden_survives<T>(refined, format + " surface, both directions", 2, true);
+        check_marsden_survives<T>(refined, format + " surface, both directions", 2);
     }
     {
         const std::vector<std::vector<T>> volume = {
@@ -535,7 +574,7 @@ void check_multidimensional(const std::string& format) {
             subdivide<T>(field, std::span<const std::int64_t>(counts), std::nullopt);
         PANTR_CHECK_MSG(refined.is_rational(), format + " volume: the weight flag was dropped");
         PANTR_CHECK_MSG(refined.rank() == field.rank(), format + " volume: the rank moved");
-        check_marsden_survives<T>(refined, format + " rational volume", 2, true);
+        check_marsden_survives<T>(refined, format + " rational volume", 2);
     }
 }
 
@@ -558,7 +597,7 @@ void check_regularity() {
                         "regularity " + std::to_string(regularity)
                             + ": the wrong number of knots was inserted");
         check_marsden_survives<double>(
-            refined, "regularity " + std::to_string(regularity), 1, true);
+            refined, "regularity " + std::to_string(regularity), 1);
     }
 }
 
@@ -584,7 +623,8 @@ void check_unclamped() {
     const std::span<const double> got = refined.net().values();
     const std::size_t num_components = expected.shape.back();
 
-    const double relative = gamma_of<double>(2 * 2 + 2 + 1 * (7 * 2 + 2));
+    const std::vector<double> bound =
+        accuracy_bound<double>(expected.magnitude, bound_roundings(2, 1));
     std::int64_t verified = 0;
     std::int64_t truncated = 0;
     for (std::int64_t row = 0; row < bands.num_rows; ++row) {
@@ -596,8 +636,7 @@ void check_unclamped() {
         ++verified;
         for (std::size_t c = 0; c < num_components; ++c) {
             const std::size_t flat = static_cast<std::size_t>(row) * num_components + c;
-            const double bound = relative * expected.magnitude[flat];
-            PANTR_CHECK_MSG(std::abs(got[flat] - expected.values[flat]) <= bound,
+            PANTR_CHECK_MSG(std::abs(got[flat] - expected.values[flat]) <= bound[flat],
                             "unclamped: an interior row does not reproduce Marsden's "
                             "coefficient at row "
                                 + std::to_string(row));
@@ -651,11 +690,17 @@ void check_the_axis_sweep_addresses_the_right_fibres() {
                         }
                         const double mine =
                             got[static_cast<std::size_t>((o * num_rows + row) * inner + k)];
-                        // Same terms, and the reference adds the off-band exact zeros
-                        // the sweep skips, so the two differ by nothing at all.
-                        PANTR_CHECK_MSG(std::abs(mine - reference)
-                                            <= 4.0 * gamma_of<double>(num_cols + 1)
-                                                   * std::abs(reference),
+                        // Equality, not a bound, and that is the whole point: the two
+                        // visit the same non-zero terms in the same ascending order, and
+                        // the reference's extra terms are `dense[row][col] * value` with
+                        // `dense` an exact zero outside the band, so `s + 0.0` is a
+                        // no-op in IEEE-754 -- the values here are all positive, so no
+                        // signed-zero tie arises. A tolerance would let a wrong stride
+                        // that landed close to the right fibre pass, which is exactly
+                        // what this check exists to refuse. It survives contraction too:
+                        // the operands of the fused form are the same on both sides,
+                        // and `fma(0, v, s)` is `s`.
+                        PANTR_CHECK_MSG(mine == reference,
                                         "the axis sweep and the dense product disagree at "
                                         "outer "
                                             + std::to_string(outer) + ", inner "
@@ -809,7 +854,7 @@ void check_refusals() {
     PANTR_CHECK_MSG(worst == 2, "regularity -1 at degree 1 should reach multiplicity "
                                 "degree + 1 exactly, and reached "
                                     + std::to_string(worst));
-    check_marsden_survives<double>(discontinuous, "regularity -1 at degree 1", 1, true);
+    check_marsden_survives<double>(discontinuous, "regularity -1 at degree 1", 1);
 }
 
 /// A periodic direction is refused, and the message says it is a boundary.

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -122,6 +122,8 @@ from ._bspline import (
 )
 from ._bspline_field import Bspline32 as Bspline32
 from ._bspline_field import Bspline64 as Bspline64
+from ._bspline_field import insert_bspline_knots as insert_bspline_knots
+from ._bspline_field import subdivide_bspline as subdivide_bspline
 from ._geometry import AABB as AABB
 from ._grid import BVH as BVH
 from ._grid import CellTags as CellTags

--- a/src/pantr/_pantr_cpp/_bspline_field.pyi
+++ b/src/pantr/_pantr_cpp/_bspline_field.pyi
@@ -1,5 +1,11 @@
 """Type stub for `pantr.bspline.Bspline`, bound in `cpp/bindings/bspline_type.cpp`.
 
+The two refinement entry points at the bottom come from
+``cpp/bindings/bspline_refinement.cpp`` instead, and they are here rather than in a
+third stub module because they are operations on the classes above: a stub split by
+binding file would put a function's argument type in one module and the function in
+another for no reader's benefit.
+
 Its own stub module rather than a third pair of classes in ``_bspline.pyi``, for the
 reason ``__init__.pyi`` gives for splitting the stub at all: a ticket that ports a
 type edits its own file plus one import line, and the space stub is already shared by
@@ -21,6 +27,8 @@ field's own storage, kept alive by the field.
 
 See ``__init__.pyi`` for what this package promises and who has to keep it.
 """
+
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -95,3 +103,27 @@ class Bspline64:
     def degree(self) -> tuple[int, ...]: ...
     @property
     def rank(self) -> int: ...
+
+def insert_bspline_knots(
+    bspline: Bspline32 | Bspline64,
+    new_knots: Sequence[npt.NDArray[np.float32 | np.float64]],
+) -> Bspline32 | Bspline64:
+    """Insert knots into a field, one 1-D array per direction; empty skips a direction.
+
+    Overloaded on the field's class in C++, so the storage format of the field and of
+    the knot arrays must agree and no cast is performed. That correlation is not
+    expressible here, exactly as it is not in ``evaluate_bezier_on_lattice``;
+    ``pantr.bspline._refinement_backend`` casts the arrays to the field's dtype before
+    calling, which is the site it is actually established at.
+    """
+
+def subdivide_bspline(
+    bspline: Bspline32 | Bspline64,
+    n_subdivisions: Sequence[int],
+    regularity: int | None,
+) -> Bspline32 | Bspline64:
+    """Split every knot span of the named directions into equal sub-spans.
+
+    A count of 1 skips its direction. ``regularity`` is ``None`` for ``degree - 1`` per
+    direction, the maximal smoothness each degree admits.
+    """

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -14,13 +14,20 @@ are two implementations and they are not two B-splines:
 handle is the thing being checked. :func:`_impl_class` picks between them, per
 process and per dtype.
 
-Only the *state and what it determines* moved. Every operation -- evaluation, the
-derivative, the degree and knot operations, the conversions, the product, reversal,
-permutation and the affine transform -- is a computation *over* a B-spline rather
-than a property *of* one, so all of them are unchanged, still run on numba kernels
-and numpy, and live on the wrapper. That is the same line ``space_nd.hpp`` draws,
+Every operation -- evaluation, the derivative, the degree and knot operations, the
+conversions, the product, reversal, permutation and the affine transform -- is a
+computation *over* a B-spline rather than a property *of* one, so each is its own
+port and each lives on the wrapper. That is the same line ``space_nd.hpp`` draws,
 and the mixed dispatch it produces is the temporary seam this front introduces; a
 cleanup ticket removes it once the whole front lands.
+
+**The two refinements have followed the state across.**
+:meth:`Bspline.insert_knots` and :meth:`Bspline.subdivide` dispatch to
+``cpp/include/pantr/bspline/refinement.hpp`` through
+:mod:`pantr.bspline._refinement_backend`, which is also where the two places the
+backends do not meet are recorded -- a periodic direction, and the order of one
+refusal. Every other operation is still Python over numba kernels and numpy, and is
+unchanged.
 
 Two of those operations cannot follow in a later cut of this front, and that is a
 declared boundary rather than an omission. :meth:`Bspline.evaluate`,
@@ -53,8 +60,6 @@ from ._bspline_degree import _degree_elevate_bspline, _degree_reduce_bspline
 from ._bspline_derivative import _derivative_bspline
 from ._bspline_eval import _evaluate_Bspline, _evaluate_Bspline_deriv
 from ._bspline_knot_insertion import (
-    _compute_uniform_subdivision_knots,
-    _insert_knots_bspline,
     _to_open_bspline_impl,
     _to_periodic_bspline_impl,
 )
@@ -62,9 +67,11 @@ from ._bspline_knot_removal import _remove_knots_bspline
 from ._bspline_locate import _locate_impl
 from ._bspline_restrict import _restrict_bspline_impl
 from ._bspline_slice import _slice_bspline
+from ._bspline_space_nd import BsplineSpace as _BsplineSpace
 from ._bspline_space_nd import _impl_class as _space_impl_class
 from ._bspline_split import _split_bspline_impl
 from ._bspline_to_beziers import _to_beziers_impl
+from ._refinement_backend import insert_knots_into_field, subdivide_field
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -399,8 +406,10 @@ class Bspline:
     **This class is a wrapper.** The value -- the space, the control points and the
     rationality flag -- is owned by an implementation chosen by ``_impl_class``,
     which is the C++ type (``cpp/include/pantr/bspline/bspline.hpp``) or the oracle
-    ``_BsplinePython``. Every operation below is still Python over numba
-    kernels and numpy, and is unchanged; only the state moved.
+    ``_BsplinePython``. Most operations below are still Python over numba kernels and
+    numpy; :meth:`insert_knots` and :meth:`subdivide` dispatch to C++ through
+    :mod:`pantr.bspline._refinement_backend`, and the module docstring says what that
+    costs.
 
     Instances are immutable *as attribute holders*, and that is enforced rather than
     documented: ``__slots__`` means there is no ``__dict__`` to attach anything to,
@@ -459,6 +468,40 @@ class Bspline:
         """
         validated = _validated_control_points(space, control_points)
         self._take(_new_impl(space, validated, is_rational), space)
+
+    @classmethod
+    def _wrap_over(cls, impl: _Impl, prior: BsplineSpace) -> Bspline:
+        """Wrap an implementation an operation produced from ``prior``'s field.
+
+        The path an operation takes when C++ built the result: refining a field under
+        the C++ backend hands back a ``Bspline<T>`` handle, and this wrapper must hold
+        *that* handle and present the space *it* holds, rather than rebuilding an
+        equal-valued one. Rebuilding would run the whole constructor over a value C++
+        has already validated, copy the control net a second time, and leave the
+        wrapper's space and the implementation's space as two computations of one
+        answer.
+
+        ``prior`` is the space the operation started from, and it travels down to
+        :meth:`BsplineSpace._wrap_over`, which explains what it buys: a direction the
+        operation left alone keeps the wrapper it already had, so
+        ``result.space.spaces[d] is field.space.spaces[d]`` holds under both backends.
+
+        The derived block starts cold, because :meth:`_take` is the only writer and it
+        replaces the block wholesale; a refined field shares no memo with the field it
+        came from.
+
+        Args:
+            impl (_Impl): The implementation to adopt, with no re-validation.
+            prior (~pantr.bspline.BsplineSpace): The space wrapper the operation
+                started from, whose direction wrappers are reused where ``impl`` still
+                holds their implementations.
+
+        Returns:
+            Bspline: A wrapper around ``impl``.
+        """
+        self = object.__new__(cls)
+        self._take(impl, _BsplineSpace._wrap_over(impl.space, prior.spaces))
+        return self
 
     def _take(self, impl: _Impl, space: BsplineSpace) -> None:
         """Adopt an implementation and the space wrapper in front of it.
@@ -1083,7 +1126,7 @@ class Bspline:
                 "At least one direction must have a non-empty array of knots to insert."
             )
 
-        return _insert_knots_bspline(self, new_knots_per_dim)
+        return insert_knots_into_field(self, new_knots_per_dim)
 
     def remove_knots(
         self,
@@ -1785,27 +1828,26 @@ class Bspline:
         if all(c is None or c == 1 for c in counts):
             raise ValueError("At least one direction must have n_subdivisions >= 2.")
 
-        # Validate regularity per active direction and compute per-direction new knots.
-        dtype = self.dtype
-        new_knots_per_dim: list[npt.NDArray[np.float32 | np.float64] | None] = []
+        # Validate regularity per active direction, in axis order. Turning the counts
+        # into knots is the backend's, so that the C++ half can reach for its own
+        # `uniform_subdivision_knots` instead of being handed the oracle's answer; what
+        # stays here is every refusal, which is what keeps the two backends refusing
+        # the same argument with the same message. The two loops were one before the
+        # C++ half existed, and splitting them changes nothing a caller can see:
+        # `_compute_uniform_subdivision_knots` raises nothing once its count and its
+        # regularity are in range.
         for i, c in enumerate(counts):
             if c is None or c == 1:
-                new_knots_per_dim.append(None)
-            else:
-                space_1d = self.space.spaces[i]
-                deg = space_1d.degree
-                eff_regularity = deg - 1 if regularity is None else regularity
-                if eff_regularity < -1 or eff_regularity > deg - 1:
-                    raise ValueError(
-                        f"regularity must be in [-1, degree - 1] = [-1, {deg - 1}] "
-                        f"for direction {i}, got {eff_regularity}"
-                    )
-                nk = _compute_uniform_subdivision_knots(
-                    space_1d.knots, space_1d.degree, space_1d.tolerance, c, eff_regularity
-                ).astype(dtype, copy=False)
-                new_knots_per_dim.append(nk)
+                continue
+            deg = self.space.spaces[i].degree
+            eff_regularity = deg - 1 if regularity is None else regularity
+            if eff_regularity < -1 or eff_regularity > deg - 1:
+                raise ValueError(
+                    f"regularity must be in [-1, degree - 1] = [-1, {deg - 1}] "
+                    f"for direction {i}, got {eff_regularity}"
+                )
 
-        return _insert_knots_bspline(self, new_knots_per_dim)
+        return subdivide_field(self, counts, regularity)
 
     def slice(self, axis: int, value: float) -> Bspline | npt.NDArray[np.float32 | np.float64]:
         """Slice the B-spline by fixing one parametric direction at a given value.

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -1103,6 +1103,9 @@ class Bspline:
             ValueError: If all directions have empty or ``None`` knot arrays.
             ValueError: If any knot lies outside its direction's domain.
             ValueError: If any insertion would exceed maximum multiplicity.
+            TypeError: If this field was built under the other backend. New with the
+                C++ dispatch: refinement crosses the boundary as a *field*, and
+                ``_cpp_handle`` refuses a foreign one rather than converting it.
 
         References:
             Knot insertion and refinement :cite:p:`piegl1997nurbs`.
@@ -1809,6 +1812,8 @@ class Bspline:
             ValueError: If no direction has a count >= 2.
             ValueError: If ``regularity`` is outside the valid range for any
                 active direction.
+            TypeError: If this field was built under the other backend, for the reason
+                :meth:`insert_knots` gives.
         """
         if isinstance(n_subdivisions, int):
             counts: list[int | None] = [n_subdivisions] * self.dim

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -648,6 +648,31 @@ class BsplineSpace1D:
             raise ValueError("degree must be non-negative")
         self._impl = _new_impl(_stored_knots(knots), degree, periodic, snap_knots)
 
+    @classmethod
+    def _wrap(cls, impl: _Impl) -> BsplineSpace1D:
+        """Wrap an implementation object that is already valid.
+
+        The path an operation takes when C++ built the space: refining a
+        :class:`~pantr.bspline.Bspline` under the C++ backend produces a
+        ``BsplineSpace1D<T>`` per refined direction, and the wrapper in front of it
+        must hold *that* handle rather than an equal-valued rebuild -- otherwise the
+        field's implementation and its space wrapper would be two computations of one
+        answer, which is a second truth about a value.
+
+        Going through the constructor instead would re-run the whole of it: the
+        non-decreasing scan, the tolerance, the snapping and the interval check, all on
+        a vector C++ has already validated, and it would allocate a second space.
+
+        Args:
+            impl (_Impl): The implementation object to adopt, with no re-validation.
+
+        Returns:
+            BsplineSpace1D: A wrapper around ``impl``.
+        """
+        self = object.__new__(cls)
+        self._impl = impl
+        return self
+
     def __reduce__(
         self,
     ) -> tuple[type[BsplineSpace1D], tuple[_Knots, int, bool, bool]]:

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -39,6 +39,7 @@ from numpy import typing as npt
 from .._backend import Backend, active_backend, available_backends
 from ._bspline_basis_multidim import _tabulate_Bspline_basis_impl
 from ._bspline_cell_supports import _cell_supports_impl
+from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_1d import _impl_class as _one_d_impl_class
 
 if TYPE_CHECKING:
@@ -47,7 +48,6 @@ if TYPE_CHECKING:
     from .._pantr_cpp import BsplineSpace32 as _CppSpace32
     from .._pantr_cpp import BsplineSpace64 as _CppSpace64
     from ..quad import PointsLattice
-    from ._bspline_space_1d import BsplineSpace1D
 
     _Impl: TypeAlias = "_BsplineSpaceNDPython | _CppSpace32 | _CppSpace64"
     """The implementation a :class:`BsplineSpace` holds: the oracle, or a handle.
@@ -413,6 +413,47 @@ class BsplineSpace:
         impl = _new_impl(validated, _stored_dtype(validated))
         object.__setattr__(self, "_impl", impl)
         object.__setattr__(self, "_spaces", validated)
+
+    @classmethod
+    def _wrap_over(cls, impl: _Impl, prior: Sequence[BsplineSpace1D]) -> BsplineSpace:
+        """Wrap an implementation, reusing any prior direction wrapper it still holds.
+
+        The path an operation takes when C++ built the space: refining a
+        :class:`~pantr.bspline.Bspline` produces a new tensor-product space, and the
+        wrapper in front of it must hold *that* implementation rather than an
+        equal-valued rebuild. See :meth:`BsplineSpace1D._wrap`.
+
+        ``prior`` is what keeps :attr:`spaces` an identity and not merely an equality.
+        An operation that leaves a direction alone -- knot insertion given no knots for
+        it -- carries that direction's implementation into the result unchanged, and the
+        oracle carries its *wrapper* along with it, so ``result.spaces[d] is
+        source.spaces[d]`` holds there. Comparing each implementation against the one
+        the caller already had is what makes that hold under the C++ backend too;
+        without it the two backends would disagree on an identity, which is the kind of
+        difference no value comparison would ever report.
+        ``pantr.grid.HierarchicalGrid._wrap_over`` exists for the same reason.
+
+        Args:
+            impl (_Impl): The implementation object to adopt, with no re-validation.
+            prior (Sequence[BsplineSpace1D]): The univariate wrappers the operation
+                started from, in axis order. May be shorter than ``impl``'s dimension
+                or empty; entries whose implementation ``impl`` no longer holds are
+                ignored.
+
+        Returns:
+            BsplineSpace: A wrapper around ``impl``.
+        """
+        spaces: list[BsplineSpace1D] = []
+        for direction, one_d in enumerate(impl.spaces):
+            reusable = prior[direction] if direction < len(prior) else None
+            if reusable is not None and reusable._impl is one_d:
+                spaces.append(reusable)
+            else:
+                spaces.append(BsplineSpace1D._wrap(one_d))
+        self = object.__new__(cls)
+        object.__setattr__(self, "_impl", impl)
+        object.__setattr__(self, "_spaces", tuple(spaces))
+        return self
 
     def __setattr__(self, name: str, value: object) -> NoReturn:
         """Refuse to set an attribute, because a space is immutable.

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -433,23 +433,39 @@ class BsplineSpace:
         difference no value comparison would ever report.
         ``pantr.grid.HierarchicalGrid._wrap_over`` exists for the same reason.
 
+        **The reuse is positional, so this method is only correct for an operation that
+        preserves the directions and their order.** Refinement does; a boundary
+        extraction or a permutation would not, and reusing direction ``d``'s wrapper
+        there would hand back a wrapper for a different direction while every value
+        comparison agreed. So the dimensions must match, and that is checked rather
+        than documented: it is the one precondition of this method a caller could get
+        wrong silently.
+
         Args:
             impl (_Impl): The implementation object to adopt, with no re-validation.
             prior (Sequence[BsplineSpace1D]): The univariate wrappers the operation
-                started from, in axis order. May be shorter than ``impl``'s dimension
-                or empty; entries whose implementation ``impl`` no longer holds are
-                ignored.
+                started from, in axis order, one per direction of ``impl``. Entries
+                whose implementation ``impl`` no longer holds are ignored.
 
         Returns:
             BsplineSpace: A wrapper around ``impl``.
+
+        Raises:
+            ValueError: If ``prior`` does not have one entry per direction of ``impl``,
+                which means the operation changed the directions and must not reuse
+                their wrappers positionally.
         """
+        one_d_spaces = tuple(impl.spaces)
+        if len(prior) != len(one_d_spaces):
+            raise ValueError(
+                f"_wrap_over reuses a direction's wrapper by position, so it needs one "
+                f"prior wrapper per direction; got {len(prior)} for a space of "
+                f"{len(one_d_spaces)}."
+            )
         spaces: list[BsplineSpace1D] = []
-        for direction, one_d in enumerate(impl.spaces):
-            reusable = prior[direction] if direction < len(prior) else None
-            if reusable is not None and reusable._impl is one_d:
-                spaces.append(reusable)
-            else:
-                spaces.append(BsplineSpace1D._wrap(one_d))
+        for direction, one_d in enumerate(one_d_spaces):
+            reusable = prior[direction]
+            spaces.append(reusable if reusable._impl is one_d else BsplineSpace1D._wrap(one_d))
         self = object.__new__(cls)
         object.__setattr__(self, "_impl", impl)
         object.__setattr__(self, "_spaces", tuple(spaces))

--- a/src/pantr/bspline/_refinement_backend.py
+++ b/src/pantr/bspline/_refinement_backend.py
@@ -144,9 +144,21 @@ def _cpp_handle(bspline: Bspline) -> _CppHandle:
 def _the_cpp_backend_can_take_it(bspline: Bspline, refined: Sequence[bool]) -> bool:
     """Report whether the C++ path covers this call.
 
-    Two conditions, and the second is the declared boundary the module docstring
-    argues: the C++ backend has to be the active one, and no direction being refined
-    may be periodic.
+    Three conditions. The C++ backend has to be the active one; no direction being
+    refined may be **periodic**, which is the declared boundary the module docstring
+    argues; and at least one direction has to be refined at all.
+
+    That third one looks redundant and is not. The two C++ entry points restate
+    :class:`pantr.bspline.Bspline`'s own "at least one direction" refusal for the
+    benefit of a C++ caller with no wrapper in front of them, while the oracle path
+    returns an unrefined copy for the same argument. Both are right where they sit and
+    they disagree, so a *dispatcher* that could reach either would be the one thing
+    that must not differ between the backends. Nothing above it can reach the case --
+    :meth:`~pantr.bspline.Bspline.insert_knots` and
+    :meth:`~pantr.bspline.Bspline.subdivide` both refuse it first -- but this module's
+    two entry points are private symbols in a package whose private symbols a
+    downstream consumer already imports, so the asymmetry is closed here rather than
+    left resting on the one caller staying the only one.
 
     Args:
         bspline (~pantr.bspline.Bspline): The field to refine.
@@ -166,6 +178,8 @@ def _the_cpp_backend_can_take_it(bspline: Bspline, refined: Sequence[bool]) -> b
         return False
     if Backend.CPP not in available_backends():
         raise RuntimeError("the CPP backend is not available in this installation")
+    if not any(refined):
+        return False
     spaces = bspline.space.spaces
     return not any(
         touched and spaces[direction].periodic for direction, touched in enumerate(refined)
@@ -225,9 +239,11 @@ def _cpp_insert_knots(bspline: Bspline, new_knots_per_dim: Sequence[_Knots | Non
         ~pantr.bspline.Bspline: The refined field, wrapping a C++ handle.
 
     Raises:
-        ValueError: If any array is not 1D, if every one is empty, if a knot lies
-            outside its direction's domain, or if a merge would exceed the maximum
-            multiplicity. Every message is the oracle's.
+        ValueError: If a non-empty array is not 1D, if a knot lies outside its
+            direction's domain, or if a merge would exceed the maximum multiplicity.
+            Every message is the oracle's. "Every direction empty" is not among them:
+            :func:`_the_cpp_backend_can_take_it` keeps that case on the oracle path,
+            where it returns an unrefined copy.
     """
     from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
 
@@ -290,9 +306,11 @@ def insert_knots_into_field(
     Raises:
         TypeError: If the C++ backend is active and the field was built under the
             other one.
-        ValueError: If an array is not 1D, if every direction is empty, if a knot lies
-            outside its direction's domain, or if a merge would exceed the maximum
-            multiplicity.
+        ValueError: If a non-empty array is not 1D, if a knot lies outside its
+            direction's domain, or if a merge would exceed the maximum multiplicity.
+            An all-empty argument is not refused here; it returns an unrefined copy, as
+            the oracle does. :meth:`~pantr.bspline.Bspline.insert_knots` is what refuses
+            it.
     """
     refined = [nk is not None and nk.size > 0 for nk in new_knots_per_dim]
     if _the_cpp_backend_can_take_it(bspline, refined):

--- a/src/pantr/bspline/_refinement_backend.py
+++ b/src/pantr/bspline/_refinement_backend.py
@@ -62,14 +62,28 @@ multiplicity(0), rank(1), ...``. A ``std::span`` has no rank, so the C++ path ca
 make that check and :func:`_flat_insertions` makes it here -- for every direction,
 before the call.
 
-What survives of that is a single shape of doubly-bad input: direction 0 well-shaped
-but out of domain, *and* a later direction not 1D. The oracle reports the domain, the
-C++ path reports the rank. Both texts are the oracle's, both refusals are
-``ValueError``, and ``tests/parity/test_bspline_refinement.py`` pins both orders rather
-than leaving the divergence to be met.
+What survives of that is doubly-bad input where an *earlier* direction fails a check
+the oracle makes **after** rank, and a *later* direction fails rank. The oracle reports
+the earlier direction's failure, the C++ path reports the later direction's rank. Both
+texts are the oracle's, both refusals are ``ValueError``, and
+``tests/parity/test_bspline_refinement.py`` pins them rather than leaving the
+divergence to be met.
 
-**It was not a single shape until a review round.** A *zero-size* non-1D array -- shape
-``(0, 3)`` -- is skipped by the oracle before its rank is ever looked at, and
+**Exactly which shapes those are, closed by enumeration.**
+``_compute_inserted_knot_vector_1d`` makes four checks, in order: rank, empty, domain,
+multiplicity. Rank is the check the C++ path hoists, so it cannot diverge. Empty cannot
+either: the caller skips a zero-size array before the per-direction loop is reached, so
+the later rank failure surfaces on both sides -- measured. That leaves **domain and
+multiplicity, and both diverge.**
+
+**This said "a single shape" and named only the domain one.** The multiplicity shape
+diverges identically and no test constructed it, so nothing in the suite could have
+distinguished the claim from the truth. Two reviewers found it independently; the count
+above is now settled by enumerating the oracle's checks rather than by inspection.
+
+**A third shape existed until a review round, and was a behaviour divergence rather
+than an order one.** A *zero-size* non-1D array -- shape ``(0, 3)`` -- is skipped by the
+oracle before its rank is ever looked at, and
 :func:`_flat_insertions` refused it: the port raising where the oracle returns, which
 is a divergence in behaviour rather than in a message and which no comparison of
 refusal texts could have found. It now skips on size first, in the oracle's own order.

--- a/src/pantr/bspline/_refinement_backend.py
+++ b/src/pantr/bspline/_refinement_backend.py
@@ -55,16 +55,24 @@ no C++ half in :mod:`pantr.bspline._extraction_backend`.
 A periodic direction that receives **no** knots is not affected: C++ carries its space
 handle into the result untouched, exactly as the oracle carries its wrapper.
 
-**The order of two refusals differs, in one input.** The oracle checks each insertion
-array's *rank* inside the per-direction loop, interleaved with that direction's domain
-and multiplicity checks, so its order is ``rank(0), domain(0), multiplicity(0),
-rank(1), ...``. A ``std::span`` has no rank, so the C++ path cannot make that check and
-:func:`_flat_insertions` makes it here -- for every direction, before the call. The two
-therefore disagree on exactly one shape of input: direction 0 well-shaped but out of
-domain, *and* a later direction not 1D. The oracle reports the domain, the C++ path
-reports the rank. Both texts are the oracle's, both refusals are ``ValueError``, and
-``tests/parity/test_bspline_refinement.py`` pins both orders rather than leaving the
-divergence to be met.
+**The order of two refusals differs, and only their order.** The oracle checks each
+insertion array's *rank* inside the per-direction loop, interleaved with that
+direction's domain and multiplicity checks, so its order is ``rank(0), domain(0),
+multiplicity(0), rank(1), ...``. A ``std::span`` has no rank, so the C++ path cannot
+make that check and :func:`_flat_insertions` makes it here -- for every direction,
+before the call.
+
+What survives of that is a single shape of doubly-bad input: direction 0 well-shaped
+but out of domain, *and* a later direction not 1D. The oracle reports the domain, the
+C++ path reports the rank. Both texts are the oracle's, both refusals are
+``ValueError``, and ``tests/parity/test_bspline_refinement.py`` pins both orders rather
+than leaving the divergence to be met.
+
+**It was not a single shape until a review round.** A *zero-size* non-1D array -- shape
+``(0, 3)`` -- is skipped by the oracle before its rank is ever looked at, and
+:func:`_flat_insertions` refused it: the port raising where the oracle returns, which
+is a divergence in behaviour rather than in a message and which no comparison of
+refusal texts could have found. It now skips on size first, in the oracle's own order.
 
 Cross-backend fields
 --------------------
@@ -170,6 +178,16 @@ def _flat_insertions(new_knots_per_dim: Sequence[_Knots | None], dtype: Any) -> 
     ``None`` becomes an empty array, which is how the binding spells "skip this
     direction"; see the module docstring on why no ``Optional`` crosses.
 
+    **A zero-size array is skipped before its rank is looked at**, and the order of
+    those two tests is the whole of what makes this function faithful. The oracle
+    skips on ``nk.size == 0`` in
+    :func:`~pantr.bspline._bspline_knot_insertion._insert_knots_bspline`, one level
+    above the rank check in ``_compute_inserted_knot_vector_1d``, so an array of shape
+    ``(0, 3)`` never reaches that check and the refinement succeeds. Testing the rank
+    first here refused it instead -- the port raising where the oracle returns, which is
+    the worse direction of divergence and the one a message comparison would never
+    surface.
+
     Args:
         new_knots_per_dim (Sequence[npt.NDArray | None]): One array of knots to insert
             per direction, or ``None``.
@@ -180,13 +198,13 @@ def _flat_insertions(new_knots_per_dim: Sequence[_Knots | None], dtype: Any) -> 
         direction.
 
     Raises:
-        ValueError: If any array is not 1D, with the oracle's message. The C++ path
-            cannot make this check and the order it lands in differs from the oracle's;
-            the module docstring says how and pins where.
+        ValueError: If a non-empty array is not 1D, with the oracle's message. The C++
+            path cannot make this check and the order it lands in differs from the
+            oracle's; the module docstring says how and pins where.
     """
     flat: list[_Knots] = []
     for new_knots in new_knots_per_dim:
-        if new_knots is None:
+        if new_knots is None or new_knots.size == 0:
             flat.append(np.empty(0, dtype=dtype))
             continue
         if new_knots.ndim != 1:

--- a/src/pantr/bspline/_refinement_backend.py
+++ b/src/pantr/bspline/_refinement_backend.py
@@ -1,0 +1,332 @@
+"""Which implementation refines a B-spline field: the Numba one or C++.
+
+:mod:`pantr._backend` owns the **policy**. This module owns the **catalogue** for the
+two field-refinement operations, exactly as :mod:`pantr.bspline._extraction_backend`
+and :mod:`pantr.bezier._bezier_backend` do for theirs, and for the same reason: a
+catalogue imports the implementations it hands out, so keeping each one beside its own
+is what stops the policy module from importing the library it must stay independent of.
+
+Two entry points rather than accessors
+--------------------------------------
+
+:func:`insert_knots_into_field` and :func:`subdivide_field` are functions that *do* the
+work, not accessors that return a callable. The rule
+``design/cross_backend_types.md`` states -- a record when the consumer needs more than
+one implementation at once, a bare callable when it does not -- is about kernels
+selected by a caller that then invokes them. These are not kernels: what crosses the
+seam is a :class:`~pantr.bspline.Bspline`, the branch is decided by more than the
+active backend, and there is exactly one consumer per entry point. A selector returning
+one of two callables would have to hand its caller the periodicity question as well.
+
+What crosses the boundary
+-------------------------
+
+**The field, not its arrays.** These are operations on a domain type that C++ has owned
+since the 2026-08-27 amendment to ``design/cross_backend_types.md``, so the adapter
+hands the binding the handle the wrapper already holds and wraps the handle that comes
+back. Unpacking a field into a knot vector and a control net on one side and
+reassembling it on the other is the shape that amendment forbids, and the rationality
+flag is exactly the invariant a reassembly drops. :mod:`pantr.bezier._bezier_backend`
+says the same of its own n-dimensional entry points.
+
+The *arguments* cross as arrays and scalars: one 1D knot array per direction, and the
+per-direction subdivision counts. ``None`` does not cross in either. An unrefined
+direction is an **empty array** for the insertion and a count of **1** for the
+subdivision, which are the two spellings the oracle already treats as identical to
+``None`` -- every branch of :meth:`pantr.bspline.Bspline.subdivide` reads ``None`` and
+``1`` the same way, and :func:`~pantr.bspline._bspline_knot_insertion._insert_knots_bspline`
+reads ``None`` and an empty array the same way.
+
+Where the two backends differ, and there are two places
+-------------------------------------------------------
+
+**A periodic direction that receives knots runs the oracle.** The oracle refines one by
+a round trip through the open representation --
+``_to_open_bspline_1d_impl``, insert, ``_to_periodic_bspline_1d_impl`` -- and those two
+are the *boundary and periodic conversions*, which
+``cpp/include/pantr/bspline/bspline.hpp`` lists as their own port and which no ticket in
+this milestone covers. ``cpp/include/pantr/bspline/refinement.hpp`` therefore refuses a
+periodic direction outright, and :func:`_the_cpp_backend_can_take_it` keeps the Python
+path for such a field rather than letting a caller meet that refusal. It is the same
+declared boundary ``cpp/include/pantr/bspline/space_1d.hpp`` draws around
+``get_cardinal_intervals``, and the same shape as the cardinal extraction builder having
+no C++ half in :mod:`pantr.bspline._extraction_backend`.
+
+A periodic direction that receives **no** knots is not affected: C++ carries its space
+handle into the result untouched, exactly as the oracle carries its wrapper.
+
+**The order of two refusals differs, in one input.** The oracle checks each insertion
+array's *rank* inside the per-direction loop, interleaved with that direction's domain
+and multiplicity checks, so its order is ``rank(0), domain(0), multiplicity(0),
+rank(1), ...``. A ``std::span`` has no rank, so the C++ path cannot make that check and
+:func:`_flat_insertions` makes it here -- for every direction, before the call. The two
+therefore disagree on exactly one shape of input: direction 0 well-shaped but out of
+domain, *and* a later direction not 1D. The oracle reports the domain, the C++ path
+reports the rank. Both texts are the oracle's, both refusals are ``ValueError``, and
+``tests/parity/test_bspline_refinement.py`` pins both orders rather than leaving the
+divergence to be met.
+
+Cross-backend fields
+--------------------
+
+:func:`_cpp_handle` refuses a field built under the other backend rather than
+converting it, which is what ``design/cross_backend_types.md`` forbids and what
+:meth:`pantr.bspline.Bspline._mutate` already refuses for the three ``in_place=``
+methods. The refusal is a property of *taking the C++ route*, so it fires under the C++
+backend and not under the Python one, where the oracle runs happily over a C++ field's
+read-only control points. That asymmetry is
+:func:`pantr.bezier._bezier_backend._cpp_handle`'s, unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+import numpy as np
+
+from .._backend import Backend, active_backend, available_backends
+from ._bspline_knot_insertion import (
+    _compute_uniform_subdivision_knots,
+    _insert_knots_bspline,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import numpy.typing as npt
+
+    from .._pantr_cpp import Bspline32 as _CppBspline32
+    from .._pantr_cpp import Bspline64 as _CppBspline64
+    from ._bspline import Bspline
+
+    _CppHandle: TypeAlias = "_CppBspline32 | _CppBspline64"
+    """A field's C++ implementation, of either storage format."""
+
+_Knots: TypeAlias = "npt.NDArray[np.float32 | np.float64]"
+"""A knot array in one of the two storage formats a B-spline may use."""
+
+
+def _cpp_handle(bspline: Bspline) -> _CppHandle:
+    """The C++ implementation a field holds, refusing a Python one.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field whose handle is wanted.
+
+    Returns:
+        _CppHandle: The ``Bspline32`` or ``Bspline64`` handle.
+
+    Raises:
+        TypeError: If the field holds the Python implementation. That means the active
+            backend changed after it was built, and converting one implementation into
+            the other is what ``design/cross_backend_types.md`` forbids.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    impl = bspline._impl  # same package; the wrapper exposes no public handle
+    if not isinstance(impl, _pantr_cpp.Bspline32 | _pantr_cpp.Bspline64):
+        raise TypeError(
+            f"Bspline: cannot refine a Bspline built under a different backend "
+            f"({type(impl).__name__} against the active C++ one); the backend is "
+            f"chosen per process, so this means the active one changed after this "
+            f"Bspline was built."
+        )
+    return impl
+
+
+def _the_cpp_backend_can_take_it(bspline: Bspline, refined: Sequence[bool]) -> bool:
+    """Report whether the C++ path covers this call.
+
+    Two conditions, and the second is the declared boundary the module docstring
+    argues: the C++ backend has to be the active one, and no direction being refined
+    may be periodic.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to refine.
+        refined (Sequence[bool]): Whether each direction receives knots, in axis order.
+
+    Returns:
+        bool: True when :func:`_cpp_insert_knots` or :func:`_cpp_subdivide` may run.
+
+    Raises:
+        RuntimeError: If the C++ backend is the active one and is not available. That
+            cannot happen through :func:`pantr._backend.active_backend`, which refuses
+            an unavailable backend at import; the check is here so that this module
+            states the never-fall-back rule rather than relying on where it was
+            enforced.
+    """
+    if active_backend() is Backend.PYTHON:
+        return False
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    spaces = bspline.space.spaces
+    return not any(
+        touched and spaces[direction].periodic for direction, touched in enumerate(refined)
+    )
+
+
+def _flat_insertions(new_knots_per_dim: Sequence[_Knots | None], dtype: Any) -> list[_Knots]:  # noqa: ANN401
+    """Normalize the per-direction insertions to the 1D arrays the binding takes.
+
+    ``None`` becomes an empty array, which is how the binding spells "skip this
+    direction"; see the module docstring on why no ``Optional`` crosses.
+
+    Args:
+        new_knots_per_dim (Sequence[npt.NDArray | None]): One array of knots to insert
+            per direction, or ``None``.
+        dtype (Any): The field's storage format, which the arrays already carry.
+
+    Returns:
+        list[npt.NDArray[np.float32 | np.float64]]: One contiguous 1D array per
+        direction.
+
+    Raises:
+        ValueError: If any array is not 1D, with the oracle's message. The C++ path
+            cannot make this check and the order it lands in differs from the oracle's;
+            the module docstring says how and pins where.
+    """
+    flat: list[_Knots] = []
+    for new_knots in new_knots_per_dim:
+        if new_knots is None:
+            flat.append(np.empty(0, dtype=dtype))
+            continue
+        if new_knots.ndim != 1:
+            raise ValueError(f"new_knots must be a 1D array-like, got shape {new_knots.shape}")
+        flat.append(np.ascontiguousarray(new_knots))
+    return flat
+
+
+def _cpp_insert_knots(bspline: Bspline, new_knots_per_dim: Sequence[_Knots | None]) -> Bspline:
+    """Insert knots through the C++ binding.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field, holding a C++ handle.
+        new_knots_per_dim (Sequence[npt.NDArray | None]): One array of knots to insert
+            per direction, already cast to the field's dtype.
+
+    Returns:
+        ~pantr.bspline.Bspline: The refined field, wrapping a C++ handle.
+
+    Raises:
+        ValueError: If any array is not 1D, if every one is empty, if a knot lies
+            outside its direction's domain, or if a merge would exceed the maximum
+            multiplicity. Every message is the oracle's.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bspline import Bspline as BsplineCls  # noqa: PLC0415  (cycle)
+
+    handle = _cpp_handle(bspline)
+    flat = _flat_insertions(new_knots_per_dim, bspline.dtype)
+    return BsplineCls._wrap_over(_pantr_cpp.insert_bspline_knots(handle, flat), bspline.space)
+
+
+def _cpp_subdivide(
+    bspline: Bspline, counts: Sequence[int | None], regularity: int | None
+) -> Bspline:
+    """Subdivide through the C++ binding.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field, holding a C++ handle.
+        counts (Sequence[int | None]): Equal sub-spans per existing span, one per
+            direction; ``None`` and 1 both skip.
+        regularity (int | None): The continuity at each inserted knot, or ``None`` for
+            ``degree - 1`` per direction.
+
+    Returns:
+        ~pantr.bspline.Bspline: The refined field, wrapping a C++ handle.
+
+    Raises:
+        ValueError: If a merge would exceed the maximum multiplicity. The count and
+            regularity refusals were made by
+            :meth:`pantr.bspline.Bspline.subdivide` above the branch, so both backends
+            refuse the same argument with the same message.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bspline import Bspline as BsplineCls  # noqa: PLC0415  (cycle)
+
+    handle = _cpp_handle(bspline)
+    return BsplineCls._wrap_over(
+        _pantr_cpp.subdivide_bspline(
+            handle, [1 if count is None else int(count) for count in counts], regularity
+        ),
+        bspline.space,
+    )
+
+
+def insert_knots_into_field(
+    bspline: Bspline, new_knots_per_dim: Sequence[_Knots | None]
+) -> Bspline:
+    """Insert knots into a B-spline field, on whichever backend covers the call.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to refine.
+        new_knots_per_dim (Sequence[npt.NDArray | None]): One array of knot values to
+            insert per direction, in axis order, already cast to the field's dtype.
+            ``None`` or an empty array skips that direction.
+
+    Returns:
+        ~pantr.bspline.Bspline: A field over the same geometry, with refined knot
+        vectors.
+
+    Raises:
+        TypeError: If the C++ backend is active and the field was built under the
+            other one.
+        ValueError: If an array is not 1D, if every direction is empty, if a knot lies
+            outside its direction's domain, or if a merge would exceed the maximum
+            multiplicity.
+    """
+    refined = [nk is not None and nk.size > 0 for nk in new_knots_per_dim]
+    if _the_cpp_backend_can_take_it(bspline, refined):
+        return _cpp_insert_knots(bspline, new_knots_per_dim)
+    return _insert_knots_bspline(bspline, list(new_knots_per_dim))
+
+
+def subdivide_field(
+    bspline: Bspline, counts: Sequence[int | None], regularity: int | None
+) -> Bspline:
+    """Uniformly subdivide a B-spline field, on whichever backend covers the call.
+
+    The counts and the regularity have already been validated by
+    :meth:`pantr.bspline.Bspline.subdivide`, so neither branch here re-derives which
+    arguments are legal.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to refine.
+        counts (Sequence[int | None]): Equal sub-spans per existing knot span, one per
+            direction. ``None`` and 1 both skip that direction.
+        regularity (int | None): The continuity at each inserted knot, applied to every
+            subdivided direction. ``None`` uses ``degree - 1`` per direction.
+
+    Returns:
+        ~pantr.bspline.Bspline: A field over the same geometry, with uniformly refined
+        knot vectors.
+
+    Raises:
+        TypeError: If the C++ backend is active and the field was built under the
+            other one.
+        ValueError: If a merge would exceed the maximum multiplicity.
+    """
+    refined = [count is not None and count > 1 for count in counts]
+    if _the_cpp_backend_can_take_it(bspline, refined):
+        return _cpp_subdivide(bspline, counts, regularity)
+
+    # The oracle's own path: turn each active count into the knots it stands for, then
+    # insert them. `_compute_uniform_subdivision_knots` cannot raise here -- the
+    # regularity is in range and the count is at least 2, both established above the
+    # branch -- which is what lets the validation live there instead of interleaved
+    # with this loop, as it was before the C++ half existed.
+    dtype = bspline.dtype
+    new_knots_per_dim: list[_Knots | None] = []
+    for direction, count in enumerate(counts):
+        if count is None or count == 1:
+            new_knots_per_dim.append(None)
+            continue
+        space_1d = bspline.space.spaces[direction]
+        effective = space_1d.degree - 1 if regularity is None else regularity
+        new_knots_per_dim.append(
+            _compute_uniform_subdivision_knots(
+                space_1d.knots, space_1d.degree, space_1d.tolerance, count, effective
+            ).astype(dtype, copy=False)
+        )
+    return _insert_knots_bspline(bspline, new_knots_per_dim)

--- a/tests/parity/test_bspline_refinement.py
+++ b/tests/parity/test_bspline_refinement.py
@@ -159,6 +159,7 @@ import pytest
 
 from pantr._backend import Backend, use_backend
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline._refinement_backend import insert_knots_into_field, subdivide_field
 from tests._parity_harness import (
     AccuracyClaim,
     Field,
@@ -1087,6 +1088,57 @@ def test_a_near_duplicate_insertion_is_snapped_but_refined_unsnapped(
         fields=_fields(1),
         context=f"a near-duplicate insertion at {resolved}",
     )
+
+
+def test_the_backend_entry_points_agree_when_nothing_is_refined() -> None:
+    """Called directly with nothing to refine, both branches return an unrefined copy.
+
+    Not reachable through the public methods, which refuse an all-empty argument first.
+    It is asserted because :mod:`pantr.bspline._refinement_backend`'s two entry points
+    are private symbols in a package whose private symbols a downstream consumer
+    already imports, and because the two branches would otherwise disagree: the C++
+    entry points restate the wrapper's "at least one direction" refusal for a C++
+    caller, while the oracle returns a copy.
+    :func:`~pantr.bspline._refinement_backend._the_cpp_backend_can_take_it` keeps the
+    case on the oracle path so that the dispatcher has one answer rather than two.
+    """
+    case = CASES[7]
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field, _ = _make_field(case, np.float64)
+            for result in (
+                insert_knots_into_field(field, [None, np.empty(0)]),
+                subdivide_field(field, [1, None], None),
+            ):
+                assert result.space.num_basis == field.space.num_basis
+                assert np.array_equal(result.control_points, field.control_points)
+                for direction in range(field.dim):
+                    assert result.space.spaces[direction] is field.space.spaces[direction]
+
+    # And the binding still refuses it, which is the asymmetry being routed around
+    # rather than removed: a C++ caller with no wrapper in front of it gets the
+    # wrapper's own message.
+    with use_backend(Backend.CPP):
+        field, _ = _make_field(case, np.float64)
+        with pytest.raises(ValueError, match="At least one direction"):
+            _binding().insert_bspline_knots(field._impl, [np.empty(0), np.empty(0)])
+
+
+def test_wrap_over_refuses_a_dimension_it_cannot_match_positionally() -> None:
+    """The space wrapper's reuse is positional, so a changed dimension is refused.
+
+    ``BsplineSpace._wrap_over`` reuses direction ``d``'s wrapper when the new
+    implementation still holds direction ``d``'s implementation, which is only sound
+    for an operation that preserves the directions and their order. Refinement does; a
+    later boundary extraction or permutation would not, and would otherwise hand back a
+    wrapper for a different direction while every value comparison agreed. The
+    precondition is checked, and this is the check.
+    """
+    with use_backend(Backend.CPP):
+        surface, _ = _make_field(CASES[7], np.float64)
+        one_d, _ = _make_field(CASES[2], np.float64)
+        with pytest.raises(ValueError, match="one prior wrapper per direction"):
+            BsplineSpace._wrap_over(surface.space._impl, one_d.space.spaces)
 
 
 def test_a_zero_size_insertion_is_skipped_whatever_its_rank() -> None:

--- a/tests/parity/test_bspline_refinement.py
+++ b/tests/parity/test_bspline_refinement.py
@@ -101,6 +101,10 @@ Every quantity compared is relative on non-negative data, so the bound is
 
 - **the oracle's own formation**, ``e_r`` by ``E_j <- E_j + x E_{j-1}``: two roundings
   per knot along the dominant chain, plus the division by ``C(p, r)``. ``2p + 1``;
+- **the cast into the field's storage**: :func:`_make_field` forms the closed form in
+  ``float64`` and stores it in the field's dtype, which at ``float32`` is a real
+  rounding on the *input* the sweep then propagates. It costs one, because a convex
+  combination does not amplify a relative perturbation. ``1``;
 - **one direction's band recurrence**: ``p`` levels, each committing two subtractions,
   a division, a multiplication and an addition on its dominant path. ``5p``;
 - **one direction's control-point sweep**: ``p + 1`` terms, each a multiplication and an
@@ -108,7 +112,7 @@ Every quantity compared is relative on non-negative data, so the bound is
 - relative errors compose sub-additively and ``gamma_a + gamma_b <= gamma_{a+b}``, so
   ``D`` refined directions cost ``D (7p + 2)``.
 
-``K = 2p + 2 + D (7p + 2)``, the extra 1 being the store into the result. The magnitude
+``K = 2p + 3 + D (7p + 2)``, the last 1 being the store into the result. The magnitude
 is ``prod_d max_i A^d_{i, r_d}`` per component: the discrete B-splines of a refinement
 are non-negative, so each output coefficient is a convex combination of coarse ones and
 no partial sum of it exceeds the largest. That non-negativity is a classical property
@@ -291,7 +295,7 @@ def _accuracy_claim(
         AccuracyClaim: The bound and its derivation.
     """
     degree = max(refined.degree)
-    roundings = 2 * degree + 2 + num_refined * (7 * degree + 2)
+    roundings = 2 * degree + 3 + num_refined * (7 * degree + 2)
     unit = unit_roundoff(refined.dtype)
     relative = roundings * unit / (1.0 - roundings * unit)
     return derived_accuracy(
@@ -301,7 +305,8 @@ def _accuracy_claim(
             f"refinement that does not move the field must reproduce it on the refined "
             f"knots. gamma_{roundings} at unit roundoff {unit:.3e}, times "
             f"prod_d max_i A^d_(i, r_d) per component: {2 * degree + 1} roundings form "
-            f"the closed form itself, {num_refined} refined direction(s) cost "
+            f"the closed form itself, one is the cast of that closed form into the "
+            f"field's storage, {num_refined} refined direction(s) cost "
             f"{7 * degree + 2} each -- {5 * degree} in the band recurrence and "
             f"{2 * degree + 2} in the control-point sweep -- and one is the store. The "
             f"magnitude is a bound because the discrete B-splines of a refinement are "

--- a/tests/parity/test_bspline_refinement.py
+++ b/tests/parity/test_bspline_refinement.py
@@ -1089,6 +1089,62 @@ def test_a_near_duplicate_insertion_is_snapped_but_refined_unsnapped(
     )
 
 
+def test_a_zero_size_insertion_is_skipped_whatever_its_rank() -> None:
+    """An empty array skips its direction even when its shape is not 1-D.
+
+    The regression test for a divergence a review round found, and the exact input that
+    elicited it: ``[np.empty((0, 3)), [0.5]]``. The oracle skips on ``nk.size == 0`` in
+    ``_insert_knots_bspline``, one level *above* the rank check in
+    ``_compute_inserted_knot_vector_1d``, so a zero-size array never reaches that check
+    and the refinement succeeds. ``_flat_insertions`` tested the rank first and refused
+    it -- the port raising where the oracle returns.
+
+    That direction of divergence is the worse one and it is invisible to a comparison of
+    refusal texts, which is why it needs its own test rather than a row in the refusal
+    table. Both orderings of the pair are exercised, because a fix that skipped on size
+    only in the leading position would still be wrong.
+    """
+    case = _Case(
+        (_QUADRATIC_THIRDS, _SHIFTED_LINEAR),
+        (2, 1),
+        (None, None),
+        (1, 1),
+        None,
+        False,
+        "the zero-size input",
+    )
+    for label, argument, refined_axis in (
+        ("leading", [np.empty((0, 3)), np.array([11.5])], 1),
+        ("trailing", [np.array([0.5]), np.empty((2, 0))], 0),
+    ):
+        shapes: list[tuple[int, ...]] = []
+        for backend in (Backend.PYTHON, Backend.CPP):
+            with use_backend(backend):
+                field, _ = _make_field(case, np.float64)
+                before = field.control_points.shape
+                refined = field.insert_knots(argument)
+                shapes.append(refined.control_points.shape)
+                assert (
+                    refined.space.spaces[1 - refined_axis] is field.space.spaces[1 - refined_axis]
+                ), f"{label}: the zero-size direction did not keep its wrapper"
+                assert refined.control_points.shape[refined_axis] == before[refined_axis] + 1, (
+                    f"{label}: the other direction was not refined"
+                )
+        assert shapes[0] == shapes[1], f"{label}: {shapes[0]} against {shapes[1]}"
+
+    # A zero-size array of any rank still counts as empty for the "at least one
+    # direction" refusal, so the two backends refuse the all-empty call identically.
+    messages: list[str] = []
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field, _ = _make_field(case, np.float64)
+            with pytest.raises(ValueError) as raised:
+                field.insert_knots([np.empty((0, 3)), np.empty(0)])
+            messages.append(str(raised.value))
+    assert messages[0] == messages[1], messages
+    assert "At least one direction" in messages[0]
+
+
 def test_the_refusal_order_divergence_is_exactly_one_input() -> None:
     """The two backends disagree on which of two bad arguments they report, and only there.
 

--- a/tests/parity/test_bspline_refinement.py
+++ b/tests/parity/test_bspline_refinement.py
@@ -1,0 +1,1418 @@
+"""Parity of the two field refinements: `Bspline.insert_knots` and `.subdivide`.
+
+What this file compares is a **computation**, which is what separates it from
+``tests/parity/test_bspline_type.py``: that one compares a value the two backends only
+copy, so a tolerance there would be hiding a transcription error. Here the control net
+is pushed through a two-scale matrix, so there is real arithmetic on every coefficient
+and the criterion has to be argued rather than assumed.
+
+It is argued **per quantity** in :func:`_fields`, not once in bulk: the coefficients,
+the merged knot vectors, the tolerance the refined space derives from them, the counts,
+the degrees and the flags are exact for six different reasons, and a shared ``why``
+would be one sentence quoted in six failure messages it does not fit.
+
+## The criterion, and the host it depends on
+
+**Bitwise, for the coefficients and the knots.** The C++ sweep accumulates in the
+storage format, in ascending band order, from an exact zero, skipping the off-band
+columns rather than adding their exact zeros -- which is
+``pantr/bspline/_bspline_knot_insertion_core.py``'s ``_insert_knots_1d_core`` operation
+for operation. ``design/backend_parity.md`` Rule 9 is why that had to be read off the
+kernel rather than inferred: the oracle allocates its accumulator in ``ctrl.dtype`` and
+never widens it, so a C++ side accumulating in ``double`` would be exact at ``float64``
+and quietly wrong at ``float32``.
+
+The band recurrence *does* widen three variables under numba -- ``saved``, ``to_left``
+and ``to_right`` are each seeded with the literal ``0.0`` and so unify to ``float64`` --
+and it changes nothing, because each then holds the value of a ``float32`` expression
+and the exact sum of two ``float32`` numbers is representable in ``float64``. There is
+no double rounding to inherit, which is why ``oslo_bands_1d`` computing entirely in
+``T`` matches. ``cpp/include/pantr/bspline/refinement.hpp`` carries the same argument
+beside the code.
+
+Bitwise is a claim about **this build**, per ``design/backend_parity.md`` Rule 7. The
+sweep's inner statement is ``row[k] + weight * source[k]``, which a target with a fused
+multiply-add would contract; on the baseline x86-64 this project compiles for there is
+no FMA to contract into. :func:`~tests._parity_harness.contraction_may_fuse` is the
+gate, and where it reports a fusing build the bitwise claim is skipped rather than
+weakened -- Rule 10's budget would apply and no host in this project can execute it to
+check.
+
+**The interpreted oracle makes no difference here, and that is a guarantee rather than
+an observation.** ``design/backend_parity.md`` Rule 12 names the three things that
+differ under ``NUMBA_DISABLE_JIT=1`` -- a widened storage width, ``pow``, and an integer
+accumulator that wraps when compiled -- and its complementary half says a kernel built
+from ``+``, ``-``, ``*``, ``/`` and ``sqrt`` reproduces its own bits by IEEE 754 rather
+than by luck. Both Oslo kernels are of that kind: no ``pow``, and the only integer they
+carry is a column index bounded by an array length. The one width that does move is the
+``saved`` unification named above, in the other direction -- interpreted, NEP 50 keeps it
+``float32`` -- and it is exact either way for the same reason. So no gate is needed, and
+running this file under that configuration confirms it at both storage formats.
+
+## The independent check, and why the obvious one was not available
+
+``design/backend_parity.md`` opens with the fact everything else there follows from:
+parity says the two backends agree and not that either is right, so a shared error is
+invisible to every parity test in this file.
+
+The natural invariant for knot insertion is that **it must not move the curve**, and
+the natural way to check that is to evaluate before and after. That needs
+``BsplineSpace1D.tabulate_basis``, which ``cpp/include/pantr/bspline/space_1d.hpp``
+keeps off this milestone, so it is not available. The invariant is, though, written in
+**coefficients** instead of in values.
+
+**Marsden's identity.** For a knot vector ``t`` and degree ``p``,
+
+    (u - y)^p = sum_i prod_{k=1}^{p} (t_{i+k} - y) N_{i,p}(u),
+
+and matching the coefficient of ``(-y)^{p-r}`` on both sides gives, for every ``r`` in
+``[0, p]``,
+
+    u^r = sum_i [ e_r(t_{i+1}, ..., t_{i+p}) / C(p, r) ] N_{i,p}(u),
+
+with ``e_r`` the elementary symmetric polynomial. So the B-spline coefficients of the
+monomial ``u^r`` are a closed form in the knots alone. A field whose control points are
+those numbers *is* the map ``u -> u^r``; refinement must not move it; therefore the
+refined coefficients must be the same closed form on the **refined** knot vector.
+
+Three things make it a real oracle rather than a restatement:
+
+- **It is complete.** ``r = 1`` alone is the Greville abscissa and says only that the
+  refinement preserves affine maps; ``r = 0`` alone is the partition of unity. Either
+  leaves a band of ``p + 1`` entries pinned by one linear functional. All of
+  ``r`` in ``[0, p]`` pins ``p + 1`` independent functionals per band, which determines
+  it.
+- **It is not a mirror.** Elementary symmetric polynomials of knots and a binomial
+  coefficient, computed in :func:`_marsden_column` in this file. Nothing in it consults
+  the Oslo recurrence, either backend, or the refinement matrix.
+- **It survives several directions.** The refinement is a tensor product of the
+  per-direction matrices, so the field ``prod_d u_d^{r_d}`` has control points
+  ``prod_d A^d_{i_d, r_d}``, and each component of the net below carries one power
+  multi-index. Refining direction ``d`` must move that direction's factor and leave the
+  others alone, which is what catches a sweep applied to the wrong axis.
+
+``cpp/tests/test_bspline_refinement.cpp`` runs the same oracle against the C++ side
+alone, so the two halves of the check are independent of the Python seam.
+
+## The accuracy bound
+
+Every quantity compared is relative on non-negative data, so the bound is
+``gamma_K * magnitude`` with ``K`` counted rather than fitted:
+
+- **the oracle's own formation**, ``e_r`` by ``E_j <- E_j + x E_{j-1}``: two roundings
+  per knot along the dominant chain, plus the division by ``C(p, r)``. ``2p + 1``;
+- **one direction's band recurrence**: ``p`` levels, each committing two subtractions,
+  a division, a multiplication and an addition on its dominant path. ``5p``;
+- **one direction's control-point sweep**: ``p + 1`` terms, each a multiplication and an
+  addition. ``2p + 2``;
+- relative errors compose sub-additively and ``gamma_a + gamma_b <= gamma_{a+b}``, so
+  ``D`` refined directions cost ``D (7p + 2)``.
+
+``K = 2p + 2 + D (7p + 2)``, the extra 1 being the store into the result. The magnitude
+is ``prod_d max_i A^d_{i, r_d}`` per component: the discrete B-splines of a refinement
+are non-negative, so each output coefficient is a convex combination of coarse ones and
+no partial sum of it exceeds the largest. That non-negativity is a classical property
+(Cohen, Lyche & Riesenfeld 1980) and ``cpp/tests/test_bspline_refinement.cpp`` asserts
+it rather than assuming it, because it is the premise this bound rests on.
+
+The relative term is not the whole bound. A coefficient of an exact zero -- ``e_p`` of a
+window containing the knot 0 -- has a relative bound of zero, and floating point does
+not: :func:`~tests._parity_harness.underflow_floor` is added ``K`` times, which is the
+absolute half of Higham's model the harness's own docstring says every tolerance here
+carries.
+
+The counts are charged at ``unit_roundoff(dtype)`` throughout, the oracle's included,
+even though the oracle is formed in ``float64`` whatever the field stores. That
+over-states the ``float32`` case and keeps one derivation for both.
+
+## The two places the backends do not meet
+
+Both are recorded in :mod:`pantr.bspline._refinement_backend` and both are pinned here
+rather than left to be met.
+
+- **A periodic direction that receives knots runs the oracle**, because refining one
+  needs the open-to-periodic conversions, which are their own port. The C++ half refuses
+  it outright and
+  :func:`test_a_periodic_direction_is_refused_by_the_binding_and_served_by_the_oracle`
+  pins both halves of that. Parity on such a case is **common mode** -- one
+  implementation ran twice -- which this file says out loud rather than counting as
+  evidence.
+- **One shape of bad input is refused in a different order.** The oracle checks an
+  insertion array's rank inside its per-direction loop; a ``std::span`` has no rank, so
+  the C++ path checks every rank before the call.
+  :func:`test_the_refusal_order_divergence_is_exactly_one_input` pins both orders.
+"""
+
+from __future__ import annotations
+
+import math
+import pickle
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from tests._parity_harness import (
+    AccuracyClaim,
+    Field,
+    assert_accuracy,
+    assert_object_parity,
+    bitwise_parity,
+    contraction_may_fuse,
+    derived_accuracy,
+    exact_parity,
+    underflow_floor,
+    unit_roundoff,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+pytestmark = pytest.mark.usefixtures("cpp_backend")
+
+DTYPES: Final = (np.float64, np.float32)
+"""Both storage formats: a field stores `float32` too, so the C++ side has two classes."""
+
+_FUSING: Final = (
+    "this build's target ISA has a fused multiply-add, so the sweep's "
+    "`row[k] + weight * source[k]` may contract and the bitwise claim does not hold. "
+    "design/backend_parity.md Rule 10's budget would apply; no host in this project "
+    "can execute that branch to check it, so it is skipped rather than written blind."
+)
+"""Skip reason for the bitwise claims on a build that can fuse."""
+
+
+# ---------------------------------------------------------------------------
+# The independent oracle: Marsden's identity
+# ---------------------------------------------------------------------------
+
+
+def _marsden_column(
+    knots: npt.NDArray[np.float32 | np.float64], degree: int, power: int
+) -> npt.NDArray[np.float64]:
+    """The B-spline coefficients of ``u ** power`` over one knot vector.
+
+    ``A_i = e_power(knots[i+1], ..., knots[i+degree]) / C(degree, power)``; see the
+    module docstring for the identity. Formed in ``float64`` whatever the knots are
+    stored in, by the elementary-symmetric recurrence, so nothing here re-runs either
+    backend.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): The knot vector.
+        degree (int): The polynomial degree.
+        power (int): The monomial power, in ``[0, degree]``.
+
+    Returns:
+        npt.NDArray[np.float64]: One coefficient per basis function,
+        ``len(knots) - degree - 1`` of them.
+    """
+    count = len(knots) - degree - 1
+    out = np.zeros(count, dtype=np.float64)
+    for i in range(count):
+        symmetric = np.zeros(degree + 1, dtype=np.float64)
+        symmetric[0] = 1.0
+        for k in range(1, degree + 1):
+            knot = float(knots[i + k])
+            for j in range(k, 0, -1):
+                symmetric[j] += knot * symmetric[j - 1]
+        out[i] = symmetric[power] / float(math.comb(degree, power))
+    return out
+
+
+class _Marsden(NamedTuple):
+    """The Marsden net over a set of directions, and the magnitude of each entry.
+
+    Attributes:
+        values (npt.NDArray[np.float64]): The coefficients, shape
+            ``(*num_basis, num_components)``. Component ``c`` decodes row-major into a
+            power multi-index, so one net carries every monomial the degrees admit.
+        magnitude (npt.NDArray[np.float64]): ``prod_d max_i A^d_{i, r_d}`` per entry,
+            the factor the relative bound multiplies. See the module docstring.
+    """
+
+    values: npt.NDArray[np.float64]
+    magnitude: npt.NDArray[np.float64]
+
+
+def _marsden_net(spaces: Sequence[BsplineSpace1D]) -> _Marsden:
+    """The Marsden net over the given directions, with its per-entry magnitude.
+
+    Args:
+        spaces (Sequence[BsplineSpace1D]): One univariate space per direction, in axis
+            order.
+
+    Returns:
+        _Marsden: The coefficients and their magnitudes.
+    """
+    tables = [
+        [_marsden_column(space.knots, space.degree, power) for power in range(space.degree + 1)]
+        for space in spaces
+    ]
+    largest = [
+        [float(np.abs(column).max()) for column in per_direction] for per_direction in tables
+    ]
+    counts = tuple(space.num_basis for space in spaces)
+    powers = tuple(space.degree + 1 for space in spaces)
+    num_components = math.prod(powers)
+
+    values = np.zeros((*counts, num_components), dtype=np.float64)
+    magnitude = np.zeros((*counts, num_components), dtype=np.float64)
+    for index in np.ndindex(*counts):
+        for component in range(num_components):
+            rest = component
+            value = 1.0
+            bound = 1.0
+            for direction in reversed(range(len(spaces))):
+                power = rest % powers[direction]
+                rest //= powers[direction]
+                value *= float(tables[direction][power][index[direction]])
+                bound *= largest[direction][power]
+            values[(*index, component)] = value
+            magnitude[(*index, component)] = bound
+    return _Marsden(values, magnitude)
+
+
+def _accuracy_claim(
+    refined: Bspline, magnitude: npt.NDArray[np.float64], num_refined: int
+) -> AccuracyClaim:
+    """The elementwise bound between a refined net and Marsden's closed form.
+
+    Args:
+        refined (~pantr.bspline.Bspline): The refined field, for its degrees and dtype.
+        magnitude (npt.NDArray[np.float64]): The per-entry magnitude from
+            :func:`_marsden_net`.
+        num_refined (int): How many directions received knots, the ``D`` of the
+            derivation.
+
+    Returns:
+        AccuracyClaim: The bound and its derivation.
+    """
+    degree = max(refined.degree)
+    roundings = 2 * degree + 2 + num_refined * (7 * degree + 2)
+    unit = unit_roundoff(refined.dtype)
+    relative = roundings * unit / (1.0 - roundings * unit)
+    return derived_accuracy(
+        bound=relative * magnitude + roundings * underflow_floor(refined.dtype),
+        why=(
+            f"Marsden's identity gives the coefficients of u**r in closed form, so a "
+            f"refinement that does not move the field must reproduce it on the refined "
+            f"knots. gamma_{roundings} at unit roundoff {unit:.3e}, times "
+            f"prod_d max_i A^d_(i, r_d) per component: {2 * degree + 1} roundings form "
+            f"the closed form itself, {num_refined} refined direction(s) cost "
+            f"{7 * degree + 2} each -- {5 * degree} in the band recurrence and "
+            f"{2 * degree + 2} in the control-point sweep -- and one is the store. The "
+            f"magnitude is a bound because the discrete B-splines of a refinement are "
+            f"non-negative, so no partial sum exceeds the largest coarse coefficient. "
+            f"{roundings} underflow floors are added for the components whose closed "
+            f"form is an exact zero, where a relative bound asserts bit-identity it has "
+            f"no grounds for."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The cases
+# ---------------------------------------------------------------------------
+
+
+class _Case(NamedTuple):
+    """One field to refine under both backends, and how.
+
+    The control net is always the Marsden net over the case's own directions, so one
+    case serves the field-by-field parity comparison and the independent accuracy check
+    without two nets to keep in step.
+
+    Attributes:
+        knots (tuple[tuple[float, ...], ...]): One knot vector per direction.
+        degrees (tuple[int, ...]): One degree per direction.
+        insertions (tuple[tuple[float, ...] | None, ...]): Knots to insert per
+            direction; ``None`` skips it.
+        counts (tuple[int | None, ...]): Subdivision factors per direction; ``None`` and
+            1 both skip it.
+        regularity (int | None): The continuity at every inserted knot, or ``None`` for
+            ``degree - 1`` per direction.
+        is_rational (bool): Whether the last stored component is declared a homogeneous
+            weight. It changes the rank and nothing else here: refinement is linear and
+            component-blind, and nothing in this file divides by a weight, so a
+            "weight" that is a Marsden coefficient is a legitimate net for it even
+            where it would be a degenerate NURBS.
+        label (str): A short name for the failure message.
+    """
+
+    knots: tuple[tuple[float, ...], ...]
+    degrees: tuple[int, ...]
+    insertions: tuple[tuple[float, ...] | None, ...]
+    counts: tuple[int | None, ...]
+    regularity: int | None
+    is_rational: bool
+    label: str
+
+
+_THIRD: Final = 1.0 / 3.0
+"""A knot no binary format represents, so a refinement through it cannot round nothing."""
+
+_CONSTANT: Final = (0.0, 0.5, 1.0)
+"""Degree 0, two intervals, three basis functions: the piecewise-constant case."""
+
+_LINEAR: Final = (0.0, 0.0, 0.5, 1.0, 1.0)
+"""Degree 1, two intervals, three basis functions."""
+
+_QUADRATIC: Final = (0.0, 0.0, 0.0, 0.25, 0.75, 1.0, 1.0, 1.0)
+"""Degree 2, three intervals, five basis functions, dyadic throughout."""
+
+_QUADRATIC_THIRDS: Final = (0.0, 0.0, 0.0, _THIRD, 1.0, 1.0, 1.0)
+"""Degree 2, two intervals, four basis functions, and one knot that is not dyadic."""
+
+_CUBIC: Final = (0.0, 0.0, 0.0, 0.0, 0.25, 3.0 / 7.0, 1.0, 1.0, 1.0, 1.0)
+"""Degree 3, three intervals, six basis functions, two of its knots non-dyadic."""
+
+_QUARTIC: Final = (0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.55, 1.0, 1.0, 1.0, 1.0, 1.0)
+"""Degree 4, three intervals, seven basis functions. Sweep only: the highest degree here,
+where the band is widest and the rounding budget largest."""
+
+_SHIFTED_LINEAR: Final = (10.0, 10.0, 11.0, 12.0, 12.0)
+"""Degree 1 on ``[10, 12]``: a different scale, so a scale-dependent slip shows."""
+
+_UNCLAMPED: Final = (-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+"""Strictly increasing and clamped at neither end: legal, and the case where a band is
+truncated because it addresses columns the coarse space does not have."""
+
+_PERIODIC_UNIFORM: Final = (-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+"""The same vector read periodically, for the direction the C++ half refuses."""
+
+CASES: Final = (
+    _Case((_CONSTANT,), (0,), ((0.25,),), (3,), None, False, "a piecewise-constant curve"),
+    _Case((_LINEAR,), (1,), ((0.25, _THIRD),), (4,), None, False, "a linear curve"),
+    _Case((_QUADRATIC,), (2,), ((0.5,),), (2,), None, False, "a dyadic quadratic curve"),
+    _Case(
+        (_QUADRATIC_THIRDS,),
+        (2,),
+        ((_THIRD, _THIRD, 0.9),),
+        (3,),
+        0,
+        False,
+        "a quadratic curve refined through a repeat",
+    ),
+    _Case((_CUBIC,), (3,), ((0.1, 0.6),), (3,), 1, False, "a cubic curve"),
+    _Case((_CUBIC,), (3,), ((0.1,),), (2,), -1, False, "a cubic curve cut to C^-1"),
+    _Case(
+        (_QUADRATIC_THIRDS, _SHIFTED_LINEAR),
+        (2, 1),
+        (None, (11.5,)),
+        (1, 3),
+        None,
+        False,
+        "a surface with one direction refined",
+    ),
+    _Case(
+        (_QUADRATIC_THIRDS, _SHIFTED_LINEAR),
+        (2, 1),
+        ((0.5,), (11.5, 11.5)),
+        (2, 3),
+        0,
+        False,
+        "a surface with both directions refined",
+    ),
+    _Case(
+        (_QUADRATIC_THIRDS, _SHIFTED_LINEAR, _CUBIC),
+        (2, 1, 3),
+        ((0.5,), None, (0.6,)),
+        (2, 1, 3),
+        None,
+        True,
+        "a rational volume with two directions refined",
+    ),
+    _Case((_UNCLAMPED,), (2,), ((0.5,),), (3,), None, False, "an unclamped curve"),
+)
+"""The shapes both backends must agree on, for both operations.
+
+Each multi-direction case differs between its directions in the degree, the basis
+count, the domain and the domain's width at once, so no permutation of the net's shape
+is another admissible shape for its space and a transposed sweep cannot pass.
+:func:`test_the_case_table_earns_its_keep` asserts every one of those rather than
+leaving this paragraph to be believed.
+"""
+
+
+def _make_space(case: _Case, dtype: npt.DTypeLike) -> BsplineSpace:
+    """Build ``case``'s space under whichever backend is active.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The knot storage format.
+
+    Returns:
+        ~pantr.bspline.BsplineSpace: The space, in the active backend's implementation.
+    """
+    return BsplineSpace(
+        [
+            BsplineSpace1D(np.asarray(knots, dtype=dtype), degree)
+            for knots, degree in zip(case.knots, case.degrees, strict=True)
+        ]
+    )
+
+
+def _make_field(case: _Case, dtype: npt.DTypeLike) -> tuple[Bspline, _Marsden]:
+    """Build ``case``'s Marsden field under whichever backend is active.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, _Marsden]: The field, and the closed form it was
+        built from.
+    """
+    space = _make_space(case, dtype)
+    marsden = _marsden_net(space.spaces)
+    return Bspline(space, marsden.values.astype(dtype), case.is_rational), marsden
+
+
+def _insert(case: _Case, dtype: npt.DTypeLike) -> Bspline:
+    """Refine ``case`` by :meth:`~pantr.bspline.Bspline.insert_knots`, active backend.
+
+    Args:
+        case (_Case): The shape and the knots to insert.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        ~pantr.bspline.Bspline: The refined field.
+    """
+    field, _ = _make_field(case, dtype)
+    if len(case.degrees) == 1:
+        # A one-direction field takes the flat array, not a sequence of one: the oracle
+        # runs `np.asarray(new_knots, dtype)` on it, which would read `[[0.25]]` as a
+        # `(1, 1)` array and refuse it. `tests/_patches.py` in the downstream consumer
+        # records the same asymmetry.
+        return field.insert_knots(np.asarray(case.insertions[0], dtype=dtype))
+    return field.insert_knots(
+        [None if values is None else np.asarray(values, dtype=dtype) for values in case.insertions]
+    )
+
+
+def _subdivide(case: _Case, dtype: npt.DTypeLike) -> Bspline:
+    """Refine ``case`` by :meth:`~pantr.bspline.Bspline.subdivide`, active backend.
+
+    Args:
+        case (_Case): The shape and the factors.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        ~pantr.bspline.Bspline: The refined field.
+    """
+    field, _ = _make_field(case, dtype)
+    return field.subdivide(list(case.counts), case.regularity)
+
+
+def _both(case: _Case, dtype: npt.DTypeLike, *, subdivide: bool) -> tuple[Bspline, Bspline]:
+    """Refine the same field under each backend.
+
+    Everything happens inside the ``use_backend`` block, the refinement included: the
+    branch :mod:`pantr.bspline._refinement_backend` takes is decided by the *active*
+    backend, so refining outside the block would measure the wrong path.
+
+    Args:
+        case (_Case): The shape to build and how to refine it.
+        dtype (npt.DTypeLike): The storage format.
+        subdivide (bool): Whether to subdivide rather than insert explicit knots.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, ~pantr.bspline.Bspline]: ``(py, cpp)``, in the
+        order :func:`~tests._parity_harness.assert_object_parity` names its arguments.
+    """
+    refine = _subdivide if subdivide else _insert
+    with use_backend(Backend.PYTHON):
+        py = refine(case, dtype)
+    with use_backend(Backend.CPP):
+        cpp = refine(case, dtype)
+    return py, cpp
+
+
+def _fields(dim: int) -> tuple[Field, ...]:
+    """Every piece of a refined field's state, one field each, with its own argument.
+
+    Args:
+        dim (int): The field's number of parametric directions, which decides how many
+            per-direction knot vectors there are to compare.
+
+    Returns:
+        tuple[Field, ...]: The field list for
+        :func:`~tests._parity_harness.assert_object_parity`.
+    """
+    per_direction: list[Field] = []
+    for direction in range(dim):
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].knots",
+                bitwise_parity(
+                    why=(
+                        "the merged knot vector. `inserted_knot_vector` concatenates the old "
+                        "vector with the insertions and stable-sorts it, so no arithmetic "
+                        "touches a knot at all on the insertion path and a difference could "
+                        "only be a lost value, a reordering or a narrowing cast. On the "
+                        "subdivision path each new knot is `j * ((hi - lo) / n) + lo`, which "
+                        "is numpy's own linspace expression reproduced rather than "
+                        "simplified and computed in `double` whatever the storage is, so it "
+                        "is the same three operations in the same order on both sides."
+                    )
+                ),
+                read=lambda field, d=direction: field.space.spaces[d].knots,  # type: ignore[misc]
+            )
+        )
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].tolerance",
+                bitwise_parity(
+                    why=(
+                        "the refined space derives its own tolerance from the merged vector, "
+                        "before snapping, so it is a *new* quantity of the result rather than "
+                        "one carried over -- and it is what every later domain and "
+                        "multiplicity comparison on that space will use. The knots above "
+                        "agree bit for bit and `knot_tolerance` is the same reduction over "
+                        "them on both sides, so this does too; a difference would mean the "
+                        "two backends disagree about which knots are the same knot, which no "
+                        "comparison of the knots themselves would reveal."
+                    )
+                ),
+                read=lambda field, d=direction: field.space.spaces[d].tolerance,  # type: ignore[misc]
+            )
+        )
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].periodic",
+                exact_parity(
+                    why=(
+                        "a flag, and the one the C++ half is allowed to be wrong about in "
+                        "principle: it refuses to refine a periodic direction and carries an "
+                        "unrefined one over whole, so a direction that came back "
+                        "non-periodic would mean it converted a representation instead of "
+                        "carrying it. Nothing in the coefficients or the knots would say so."
+                    )
+                ),
+                read=lambda field, d=direction: field.space.spaces[d].periodic,  # type: ignore[misc]
+            )
+        )
+    return (
+        Field(
+            "control_points",
+            bitwise_parity(
+                why=(
+                    "the refined coefficients, and the only quantity here that arithmetic "
+                    "touches. The two backends run the same IEEE-754 operations in the same "
+                    "order: the band recurrence forms its quotient before multiplying by the "
+                    "carried value, the sweep accumulates in the storage format in ascending "
+                    "band order from an exact zero, and an off-band column is skipped rather "
+                    "than added as an exact zero. See the module docstring for why the "
+                    "oracle's `float64` unification of `saved` does not break that, and for "
+                    "the build this claim depends on."
+                )
+            ),
+        ),
+        *per_direction,
+        Field(
+            "space.num_basis",
+            exact_parity(
+                why=(
+                    "the per-direction basis counts the refined net is laid out on. Exact "
+                    "integer counts, and the field's business rather than the space's: this "
+                    "is the tuple the C++ constructor checks the refined net's extents "
+                    "against, so a disagreement means the two backends laid one refinement "
+                    "out on two different grids. A count that moved with the knots agreeing "
+                    "would mean the sweep produced the wrong number of rows."
+                )
+            ),
+        ),
+        Field(
+            "degree",
+            exact_parity(
+                why=(
+                    "one integer per direction, in axis order, and refinement must not "
+                    "change any of them -- that is the whole point of inserting a knot "
+                    "rather than elevating. The order is the load-bearing part: nothing "
+                    "about a degree reveals a transposition on a field whose directions "
+                    "happen to agree, which is why every multi-direction case here differs "
+                    "in it."
+                )
+            ),
+        ),
+        Field(
+            "rank",
+            exact_parity(
+                why=(
+                    "the stored component count less the weight column. Refinement touches "
+                    "no component axis, so a rank that moved means the sweep consumed or "
+                    "produced an axis -- and it is the one field that folds the rationality "
+                    "flag against the shape, so it catches a refinement that preserved the "
+                    "coefficient count while moving which axis carries the components."
+                )
+            ),
+        ),
+        Field(
+            "is_rational",
+            exact_parity(
+                why=(
+                    "the flag is carried through, and nothing transforms it. It is named as "
+                    "its own field rather than left implicit because it is what `rank` "
+                    "subtracts, so a flag dropped in the refinement shows up here as well as "
+                    "one field away, and reading only `rank` could not say which moved."
+                )
+            ),
+        ),
+        Field(
+            "dtype",
+            exact_parity(
+                why=(
+                    "the storage format the refined field reports, carried by the class of "
+                    "the C++ handle. A disagreement means the refinement changed precision, "
+                    "which for a coefficient representable in both formats -- most of them -- "
+                    "the bitwise claim above would not see."
+                )
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The field-by-field comparison
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.label)
+@pytest.mark.parametrize("subdivide", [False, True], ids=["insert_knots", "subdivide"])
+def test_the_refinement_agrees_field_by_field(
+    case: _Case, dtype: npt.DTypeLike, subdivide: bool
+) -> None:
+    """Every piece of the refined field's state agrees, under its own claim.
+
+    Args:
+        case (_Case): The shape to build and how to refine it.
+        dtype (npt.DTypeLike): The storage format.
+        subdivide (bool): Whether to subdivide rather than insert explicit knots.
+    """
+    if contraction_may_fuse():
+        pytest.skip(_FUSING)
+    py, cpp = _both(case, dtype, subdivide=subdivide)
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=_fields(len(case.degrees)),
+        context=f"{'subdivide' if subdivide else 'insert_knots'} on {case.label} at {dtype}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The independent accuracy check
+# ---------------------------------------------------------------------------
+
+
+def _clamped(case: _Case) -> bool:
+    """Report whether every direction of ``case`` is clamped at both ends.
+
+    Marsden's identity describes every coefficient only where it is. On an unclamped
+    vector the leading and trailing bands address columns the coarse space does not
+    have, they are truncated, and their coefficients are not the closed form; see
+    ``cpp/tests/test_bspline_refinement.cpp``, which checks the interior rows of such a
+    vector with a vacuity guard on how many it found.
+
+    Args:
+        case (_Case): The shape.
+
+    Returns:
+        bool: True when the identity covers the whole net.
+    """
+    return all(
+        knots[0] == knots[degree] and knots[-1] == knots[-degree - 1]
+        for knots, degree in zip(case.knots, case.degrees, strict=True)
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.label)
+@pytest.mark.parametrize("subdivide", [False, True], ids=["insert_knots", "subdivide"])
+def test_marsden_s_identity_survives_the_refinement(
+    case: _Case, dtype: npt.DTypeLike, subdivide: bool
+) -> None:
+    """The refined coefficients are the closed form again, on the refined knots.
+
+    The independent check. It says the refinement did not move the field, which no
+    comparison between the two backends can say; see the module docstring for the
+    identity, for why it is complete rather than partial, and for the bound.
+
+    Run on the C++ result, which is the backend under test. The oracle is covered by
+    the bitwise claim above carrying the same numbers to it, and by
+    ``tests/test_bspline_knot_insertion.py``.
+
+    Args:
+        case (_Case): The shape to build and how to refine it.
+        dtype (npt.DTypeLike): The storage format.
+        subdivide (bool): Whether to subdivide rather than insert explicit knots.
+    """
+    if not _clamped(case):
+        pytest.skip(
+            "the identity does not describe a truncated band, so an unclamped vector is "
+            "checked row by row in cpp/tests/test_bspline_refinement.cpp instead"
+        )
+    with use_backend(Backend.CPP):
+        refined = _subdivide(case, dtype) if subdivide else _insert(case, dtype)
+    expected = _marsden_net(refined.space.spaces)
+    if subdivide:
+        num_refined = sum(1 for count in case.counts if count is not None and count > 1)
+    else:
+        num_refined = sum(1 for values in case.insertions if values)
+    assert_accuracy(
+        np.asarray(refined.control_points, dtype=np.float64),
+        expected.values,
+        _accuracy_claim(refined, expected.magnitude, num_refined),
+        context=f"{'subdivide' if subdivide else 'insert_knots'} on {case.label} at {dtype}",
+    )
+
+
+def test_the_marsden_oracle_is_not_vacuous() -> None:
+    """The closed form disagrees with a wrong net, so agreeing with it says something.
+
+    The control for the check above. Marsden's coefficients of ``u**r`` over the
+    *refined* knots differ from those over the *coarse* ones -- if they did not, a
+    refinement that returned its input unchanged would pass -- and they differ by far
+    more than the bound.
+    """
+    case = CASES[4]
+    with use_backend(Backend.CPP):
+        field, coarse = _make_field(case, np.float64)
+        refined = _insert(case, np.float64)
+    fine = _marsden_net(refined.space.spaces)
+    assert fine.values.shape != coarse.values.shape, (
+        "the refinement did not change the net's shape, so the two closed forms could "
+        "not be told apart by shape either"
+    )
+    # The coarse net padded with its own last row is the crudest wrong answer a
+    # refinement could give; the closed form must reject it.
+    missing = fine.values.shape[0] - coarse.values.shape[0]
+    padded = np.concatenate([coarse.values, np.repeat(coarse.values[-1:], missing, axis=0)])
+    worst = float(np.abs(padded - fine.values).max())
+    bound = float(np.asarray(_accuracy_claim(refined, fine.magnitude, 1).bound).max())
+    assert worst > 1.0e6 * bound, (
+        f"the wrong net is only {worst:.3e} from the closed form against a bound of "
+        f"{bound:.3e}, so the accuracy check would not have rejected it"
+    )
+    assert field.rank == refined.rank
+
+
+# ---------------------------------------------------------------------------
+# The wide sweep
+# ---------------------------------------------------------------------------
+
+
+def _sweep_cases() -> list[_Case]:
+    """Ten times the shipped case count, over the same claim.
+
+    Built rather than listed, from every combination of a knot vector, a subdivision
+    factor and a regularity the degree admits. Non-dyadic vectors and non-dyadic
+    factors are both present, which is what makes the accuracy bound bind: a dyadic
+    refinement of a dyadic vector rounds nothing at all, and a sweep of only those
+    would report agreement without ever asking the bound a question.
+
+    Returns:
+        list[_Case]: The sweep, in a fixed order.
+    """
+    vectors: tuple[tuple[tuple[float, ...], int], ...] = (
+        (_CONSTANT, 0),
+        (_LINEAR, 1),
+        (_QUADRATIC, 2),
+        (_QUADRATIC_THIRDS, 2),
+        (_CUBIC, 3),
+        (_QUARTIC, 4),
+        (_SHIFTED_LINEAR, 1),
+    )
+    cases: list[_Case] = []
+    for knots, degree in vectors:
+        lo = float(knots[degree])
+        hi = float(knots[-degree - 1])
+        for factor in (2, 3, 4, 5, 7):
+            for regularity in (*range(-1, degree), None):
+                # An interior value that is not a breakpoint and not representable.
+                inserted = lo + (hi - lo) * _THIRD
+                cases.append(
+                    _Case(
+                        (knots,),
+                        (degree,),
+                        ((inserted,),),
+                        (factor,),
+                        regularity,
+                        bool(len(cases) % 3 == 0) and degree > 0,
+                        f"degree {degree} by {factor} at regularity {regularity}",
+                    )
+                )
+    # A handful of surfaces, so the sweep is not one-dimensional throughout.
+    for factor in (2, 3):
+        for regularity in (0, None):
+            cases.append(
+                _Case(
+                    (_QUADRATIC_THIRDS, _SHIFTED_LINEAR),
+                    (2, 1),
+                    ((0.5,), (11.5,)),
+                    (factor, factor),
+                    regularity,
+                    False,
+                    f"a surface by {factor} at regularity {regularity}",
+                )
+            )
+    return cases
+
+
+@pytest.mark.slow
+def test_the_claims_hold_over_a_ten_times_sweep() -> None:
+    """Both claims hold over more than ten times the shipped parametrization.
+
+    FELIGN/pantr#398 asks that the bound be verified over a sweep at least ten times the
+    one that ships, on the reasoning that a bound checked only by its own shipped sweep
+    has not been checked. Two guards keep the sweep from passing trivially: it must be
+    ten times the shipped comparison count, and the accuracy bound must actually be
+    **approached** somewhere -- a sweep on which every coefficient is exact says nothing
+    about a bound.
+    """
+    if contraction_may_fuse():
+        pytest.skip(_FUSING)
+    shipped = len(CASES) * len(DTYPES) * 2  # the two operations
+    cases = _sweep_cases()
+    swept = len(cases) * len(DTYPES) * 2
+    assert swept >= 10 * shipped, (
+        f"the sweep is {swept} comparisons against {shipped} shipped, which is under "
+        f"the ten-times floor of {10 * shipped}"
+    )
+
+    differing_bits = 0
+    worst_ratio = 0.0
+    approached = 0
+    for case in cases:
+        for dtype in DTYPES:
+            for subdivide in (False, True):
+                py, cpp = _both(case, dtype, subdivide=subdivide)
+                if not np.array_equal(
+                    np.asarray(py.control_points).view(
+                        np.uint32 if np.dtype(dtype) == np.float32 else np.uint64
+                    ),
+                    np.asarray(cpp.control_points).view(
+                        np.uint32 if np.dtype(dtype) == np.float32 else np.uint64
+                    ),
+                ) or not np.array_equal(py.space.spaces[0].knots, cpp.space.spaces[0].knots):
+                    differing_bits += 1
+                expected = _marsden_net(cpp.space.spaces)
+                if subdivide:
+                    num_refined = sum(1 for c in case.counts if c is not None and c > 1)
+                else:
+                    num_refined = sum(1 for values in case.insertions if values)
+                claim = _accuracy_claim(cpp, expected.magnitude, num_refined)
+                deviation = assert_accuracy(
+                    np.asarray(cpp.control_points, dtype=np.float64),
+                    expected.values,
+                    claim,
+                    context=f"sweep: {case.label} at {dtype}",
+                )
+                worst_ratio = max(worst_ratio, deviation.max_ratio_to_bound)
+                approached += int(deviation.num_differing > 0)
+
+    assert differing_bits == 0, f"{differing_bits} of {swept} comparisons differed bitwise"
+    assert worst_ratio > 0.0, (
+        "no coefficient in the whole sweep differed from the closed form, so the "
+        "accuracy bound was never asked a question. Add a non-dyadic vector or factor."
+    )
+    assert approached > swept // 10, (
+        f"only {approached} of {swept} comparisons had any deviation from the closed "
+        f"form, so the sweep is mostly exact arithmetic and is not exercising the bound"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The declared boundaries
+# ---------------------------------------------------------------------------
+
+
+def _periodic_field(dtype: npt.DTypeLike) -> Bspline:
+    """A surface whose first direction is periodic and whose second is clamped.
+
+    Args:
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        ~pantr.bspline.Bspline: The field, in the active backend's implementation.
+    """
+    space = BsplineSpace(
+        [
+            BsplineSpace1D(np.asarray(_PERIODIC_UNIFORM, dtype=dtype), 2, periodic=True),
+            BsplineSpace1D(np.asarray(_SHIFTED_LINEAR, dtype=dtype), 1),
+        ]
+    )
+    net = np.arange(math.prod(space.num_basis) * 2, dtype=dtype).reshape(*space.num_basis, 2)
+    return Bspline(space, net)
+
+
+def _binding() -> Any:
+    """The compiled extension, imported late so a missing one skips rather than errors.
+
+    Returns:
+        Any: The :mod:`pantr._pantr_cpp` module.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    return _pantr_cpp
+
+
+def test_a_periodic_direction_is_refused_by_the_binding_and_served_by_the_oracle() -> None:
+    """The C++ half refuses a periodic direction; the public API still refines it.
+
+    The declared boundary in both halves. Refining a periodic direction needs the
+    open-to-periodic conversions, which ``cpp/include/pantr/bspline/bspline.hpp`` lists
+    as their own port; :mod:`pantr.bspline._refinement_backend` therefore keeps the
+    oracle for such a field.
+
+    The two assertions together are what say the routing happened: the binding refuses
+    the call, and the public method that would otherwise make it succeeds. Neither alone
+    would -- a result is a result whichever path produced it.
+    """
+    with use_backend(Backend.CPP):
+        field = _periodic_field(np.float64)
+        with pytest.raises(ValueError, match="open-to-periodic conversion"):
+            _binding().insert_bspline_knots(field._impl, [np.array([0.25]), np.empty(0)])
+        refined = field.insert_knots([[0.25], None])
+
+    assert refined.space.spaces[0].periodic, "the periodic direction lost its wrap"
+    assert refined.space.spaces[0].knots.size == field.space.spaces[0].knots.size + 1
+    # The clamped direction is untouched and shares its wrapper, which is the same
+    # contract the all-C++ path keeps.
+    assert refined.space.spaces[1] is field.space.spaces[1]
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_periodic_refinement_agrees_between_the_backends(dtype: npt.DTypeLike) -> None:
+    """A periodic direction refines identically under either backend -- common mode.
+
+    Said out loud rather than counted as evidence: both backends run the *same*
+    implementation here, since :mod:`pantr.bspline._refinement_backend` routes a
+    periodic direction to the oracle. What this pins is that the routing produces a
+    complete, correct field under the C++ backend -- the refined periodic space, the
+    carried-over clamped one and the coefficients -- and not that two implementations
+    agree.
+
+    Args:
+        dtype (npt.DTypeLike): The storage format.
+    """
+    with use_backend(Backend.PYTHON):
+        py = _periodic_field(dtype).insert_knots([[0.25], [11.5]])
+    with use_backend(Backend.CPP):
+        cpp = _periodic_field(dtype).insert_knots([[0.25], [11.5]])
+    assert_object_parity(
+        py=py, cpp=cpp, fields=_fields(2), context=f"a periodic surface at {dtype}"
+    )
+
+
+def test_an_unrefined_periodic_direction_goes_through_the_cpp_path() -> None:
+    """A periodic direction given no knots does not push the call onto the oracle.
+
+    The other half of the routing rule, and the one an over-broad condition would get
+    wrong: only a periodic direction *receiving* knots is a problem, so a field with an
+    untouched periodic direction still refines in C++. Pinned by the binding accepting
+    the same call the public method makes.
+    """
+    with use_backend(Backend.CPP):
+        field = _periodic_field(np.float64)
+        through_the_binding = _binding().insert_bspline_knots(
+            field._impl, [np.empty(0), np.array([11.5])]
+        )
+        refined = field.insert_knots([None, [11.5]])
+
+    assert np.array_equal(refined.control_points, through_the_binding.control_points)
+    assert refined.space.spaces[0] is field.space.spaces[0], (
+        "the untouched periodic direction did not keep its wrapper"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_a_near_duplicate_insertion_is_snapped_but_refined_unsnapped(
+    dtype: npt.DTypeLike,
+) -> None:
+    """A knot within tolerance of an existing one collapses onto it, after the sweep.
+
+    The one place the refined *space* and the vector the *matrix* was built from are
+    not the same array, and it is easy to get wrong in the tidy direction: the merged
+    vector carries the near-duplicate as its own distinct value, the two-scale matrix is
+    built from **that**, and only then does ``BsplineSpace1D`` snap it onto its class.
+    Building the matrix from the snapped vector instead would be a different matrix and
+    a different geometry, so the order is load-bearing rather than incidental.
+
+    A mutation that swapped the refined space's snapping for ``as_given`` survived the
+    rest of this file, because nothing else here inserts a knot close enough to an
+    existing one for snapping to do anything. This is that case, and it is the reason
+    the field list's ``knots`` claim is bitwise rather than bounded: one ulp is exactly
+    the difference at stake.
+
+    Args:
+        dtype (npt.DTypeLike): The storage format.
+    """
+    resolved = np.dtype(dtype)
+    knots = np.asarray((0.0, 0.0, 0.0, 0.25, 0.75, 1.0, 1.0, 1.0), dtype=resolved)
+    quarter = np.asarray(0.25, dtype=resolved)
+    near = np.nextafter(quarter, np.asarray(1.0, dtype=resolved))
+    net = np.arange(5 * 2, dtype=resolved).reshape(5, 2)
+
+    refined: list[Bspline] = []
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = BsplineSpace([BsplineSpace1D(knots, 2)])
+            assert float(near - quarter) < space.spaces[0].tolerance, (
+                "one ulp is not inside this space's tolerance, so nothing here is a "
+                "near duplicate and the test would assert snapping that cannot happen"
+            )
+            refined.append(Bspline(space, net).insert_knots(np.asarray([near], dtype=resolved)))
+
+    for field in refined:
+        stored = field.space.spaces[0].knots
+        assert np.count_nonzero(stored == quarter) == 2, (
+            f"the near duplicate was not collapsed onto its class: {stored!r}"
+        )
+        assert not np.any(stored == near), (
+            f"the refined space stored the near duplicate as its own knot: {stored!r}"
+        )
+    assert_object_parity(
+        py=refined[0],
+        cpp=refined[1],
+        fields=_fields(1),
+        context=f"a near-duplicate insertion at {resolved}",
+    )
+
+
+def test_the_refusal_order_divergence_is_exactly_one_input() -> None:
+    """The two backends disagree on which of two bad arguments they report, and only there.
+
+    The one divergence :mod:`pantr.bspline._refinement_backend` records. The oracle
+    checks an insertion array's rank inside its per-direction loop, so with direction 0
+    out of domain *and* direction 1 not 1D it reports the domain; the C++ path checks
+    every rank before the call, so it reports the rank. Both texts are the oracle's and
+    both are ``ValueError``.
+
+    Pinned in both directions rather than described, because a divergence nothing
+    asserts is a divergence that will be "fixed" by accident in either direction.
+    """
+    case = _Case(
+        (_QUADRATIC_THIRDS, _SHIFTED_LINEAR),
+        (2, 1),
+        (None, None),
+        (1, 1),
+        None,
+        False,
+        "the divergent input",
+    )
+    bad = [np.array([5.0]), np.array([[11.5, 11.5]])]
+
+    with use_backend(Backend.PYTHON):
+        field, _ = _make_field(case, np.float64)
+        with pytest.raises(ValueError, match="outside the domain") as oracle:
+            field.insert_knots(bad)
+    with use_backend(Backend.CPP):
+        field, _ = _make_field(case, np.float64)
+        with pytest.raises(ValueError, match="must be a 1D array-like") as port:
+            field.insert_knots(bad)
+
+    assert "1D array-like" not in str(oracle.value)
+    assert "outside the domain" not in str(port.value)
+
+    # With only the rank at fault the two agree, text for text, which is what says the
+    # divergence is the *order* and not the message.
+    only_rank = [None, np.array([[11.5, 11.5]])]
+    messages = []
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field, _ = _make_field(case, np.float64)
+            with pytest.raises(ValueError) as raised:
+                field.insert_knots(only_rank)
+            messages.append(str(raised.value))
+    assert messages[0] == messages[1], messages
+
+
+# ---------------------------------------------------------------------------
+# The refusals
+# ---------------------------------------------------------------------------
+
+
+def _split_rendered_list(message: str) -> tuple[str, list[float]]:
+    """Split a refusal that ends in a rendered list into its text and its numbers.
+
+    Args:
+        message (str): The refusal text, ending in ``": [a b c]"``.
+
+    Returns:
+        tuple[str, list[float]]: Everything before the list, and the values in it.
+    """
+    prefix, _, listed = message.rpartition(": ")
+    return prefix, [float(token) for token in listed.strip("[]").split()]
+
+
+class _Refusal(NamedTuple):
+    """One bad call and where its refusal comes from.
+
+    Attributes:
+        label (str): A short name for the failure message.
+        call (str): ``"insert_knots"`` or ``"subdivide"``.
+        argument (Any): What to pass.
+        regularity (int | None): The second argument to ``subdivide``.
+        common_mode (bool): Whether the refusal is
+            :class:`pantr.bspline.Bspline`'s own, above the backend branch, and
+            therefore not evidence that two implementations agree.
+        lists_values (bool): Whether the message ends in a rendered list of the
+            offending values. Those are compared as *numbers* plus the text in front
+            of them, because the oracle renders the list with ``numpy``'s repr --
+            which chooses a shared precision across the elements and pads them -- and
+            ``cpp/include/pantr/bspline/knot_insertion.hpp`` states that reproducing
+            that is a formatting port nobody needs. So ``[5.]`` against ``[5.0]`` is
+            the intended difference and the values behind them are the claim.
+    """
+
+    label: str
+    call: str
+    argument: Any
+    regularity: int | None
+    common_mode: bool
+    lists_values: bool = False
+
+
+_REFUSALS: Final = (
+    _Refusal("a sequence of the wrong length", "insert_knots", [[0.5]], None, True),
+    _Refusal("every direction empty", "insert_knots", [[], []], None, True),
+    _Refusal("a knot outside the domain", "insert_knots", [[5.0], None], None, False, True),
+    _Refusal("a knot array that is not 1D", "insert_knots", [[[0.5, 0.5]], None], None, False),
+    _Refusal(
+        "a multiplicity above degree + 1",
+        "insert_knots",
+        [[_THIRD, _THIRD, _THIRD, _THIRD], None],
+        None,
+        False,
+    ),
+    _Refusal("a count sequence of the wrong length", "subdivide", [2], None, True),
+    _Refusal("a count below one", "subdivide", [0, 2], None, True),
+    _Refusal("no direction above one", "subdivide", [1, 1], None, True),
+    _Refusal("a regularity above degree - 1", "subdivide", [2, 2], 2, True),
+    _Refusal("a regularity below minus one", "subdivide", [2, 2], -2, True),
+)
+"""Every refusal both operations can produce, and whether it is common mode.
+
+The four that are not are the ones a cross-backend comparison actually decides: the
+domain check, the multiplicity check and the rank check are made by
+``pantr/bspline/refinement.hpp`` and ``_refinement_backend`` on one side and by
+``_compute_inserted_knot_vector_1d`` on the other, so the texts really are two
+independent literals. The six marked common mode are
+:class:`pantr.bspline.Bspline`'s own, above the branch, and are compared anyway --
+cheaply, and so that a future cut that moves one below the branch does not silently
+stop being checked.
+"""
+
+
+@pytest.mark.parametrize("refusal", _REFUSALS, ids=lambda refusal: refusal.label)
+def test_the_refusals_read_the_same_under_both_backends(refusal: _Refusal) -> None:
+    """A bad call is refused with the same text on either backend.
+
+    Args:
+        refusal (_Refusal): The bad call.
+    """
+    case = _Case(
+        (_QUADRATIC_THIRDS, _SHIFTED_LINEAR),
+        (2, 1),
+        (None, None),
+        (1, 1),
+        None,
+        False,
+        "a surface",
+    )
+    messages: list[str] = []
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field, _ = _make_field(case, np.float64)
+            with pytest.raises(ValueError) as raised:
+                if refusal.call == "insert_knots":
+                    field.insert_knots(refusal.argument)
+                else:
+                    field.subdivide(refusal.argument, refusal.regularity)
+            messages.append(str(raised.value))
+    if refusal.lists_values:
+        oracle_prefix, oracle_values = _split_rendered_list(messages[0])
+        port_prefix, port_values = _split_rendered_list(messages[1])
+        assert oracle_prefix == port_prefix, (
+            f"{refusal.label}: the oracle says {oracle_prefix!r} and the port says {port_prefix!r}"
+        )
+        assert oracle_values == port_values, (
+            f"{refusal.label}: the oracle listed {oracle_values} and the port listed {port_values}"
+        )
+        return
+    assert messages[0] == messages[1], (
+        f"{refusal.label}: the oracle says {messages[0]!r} and the port says {messages[1]!r}"
+    )
+
+
+def test_a_field_from_the_other_backend_is_refused() -> None:
+    """Refining a Python-built field under the C++ backend refuses rather than converts.
+
+    ``design/cross_backend_types.md`` forbids reconciling two implementations of one
+    type by converting between them, and :meth:`pantr.bspline.Bspline._mutate` already
+    refuses the same mismatch for the three ``in_place=`` methods. The refusal is a
+    property of *taking the C++ route*, which is
+    :func:`pantr.bezier._bezier_backend._cpp_handle`'s asymmetry: it fires under the C++
+    backend and not under the Python one, where the oracle runs happily over a C++
+    field's read-only control points.
+    """
+    case = CASES[2]
+    with use_backend(Backend.PYTHON):
+        python_field, _ = _make_field(case, np.float64)
+    with use_backend(Backend.CPP):
+        cpp_field, _ = _make_field(case, np.float64)
+        with pytest.raises(TypeError, match="different backend"):
+            python_field.insert_knots([0.5])
+        with pytest.raises(TypeError, match="different backend"):
+            python_field.subdivide(2)
+
+    # The other direction is not a refusal, and that is the asymmetry rather than an
+    # oversight: the oracle can read a C++ field's coefficients.
+    with use_backend(Backend.PYTHON):
+        refined = cpp_field.insert_knots([0.5])
+    assert refined.control_points.shape[0] == cpp_field.control_points.shape[0] + 1
+
+
+# ---------------------------------------------------------------------------
+# The wire format and the wrapper contracts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", CASES[:4], ids=lambda case: case.label)
+def test_a_refined_field_survives_a_pickle_round_trip_across_the_backends(
+    case: _Case, dtype: npt.DTypeLike
+) -> None:
+    """A refined field pickles under either backend and loads under either.
+
+    The refined field is the new picklable object this cut introduces -- it is built by
+    ``Bspline._wrap_over`` rather than by the constructor, so its space wrapper comes
+    from ``BsplineSpace._wrap_over`` and its directions from ``BsplineSpace1D._wrap``,
+    none of which the existing round-trip tests reach. A pickle written under one
+    backend has to load under the other, or the backend switch would silently become a
+    data-format switch.
+
+    Args:
+        case (_Case): The shape to build and refine.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    for writer in (Backend.PYTHON, Backend.CPP):
+        with use_backend(writer):
+            refined = _insert(case, dtype)
+            wire = pickle.dumps(refined)
+        for reader in (Backend.PYTHON, Backend.CPP):
+            with use_backend(reader):
+                restored = pickle.loads(wire)
+            assert type(restored) is Bspline
+            assert restored.degree == refined.degree
+            assert restored.rank == refined.rank
+            assert restored.is_rational == refined.is_rational
+            assert np.dtype(restored.dtype) == np.dtype(refined.dtype)
+            assert np.array_equal(restored.control_points, refined.control_points), (
+                f"{writer.name} -> {reader.name}: the coefficients moved"
+            )
+            for direction in range(len(case.degrees)):
+                assert np.array_equal(
+                    restored.space.spaces[direction].knots,
+                    refined.space.spaces[direction].knots,
+                )
+
+
+def test_the_refined_field_shares_the_space_its_implementation_holds() -> None:
+    """The wrapper in front of a refined field presents its own implementation's space.
+
+    ``Bspline._wrap_over`` exists so that the field's implementation and the space
+    wrapper in front of it are one answer rather than two computations of one. Under the
+    C++ backend that is checkable directly: the handle the wrapper's space holds must be
+    the very handle the field's implementation holds.
+    """
+    with use_backend(Backend.CPP):
+        refined = _insert(CASES[7], np.float64)
+        assert refined.space._impl is refined._impl.space
+        for direction, one_d in enumerate(refined._impl.space.spaces):
+            assert refined.space.spaces[direction]._impl is one_d
+
+
+def test_a_refined_field_has_a_cold_derived_block() -> None:
+    """A refinement shares no memo with the field it came from.
+
+    ``design/bspline_derived_caches.md`` asks that the derived block be replaced
+    wholesale rather than invalidated piece by piece, and ``Bspline._take`` is the only
+    writer. A field built by ``_wrap_over`` goes through it, so both memos start cold --
+    which matters because a refined field is a *different geometry* and a Bézier
+    decomposition or a point-inversion context carried over from its parent would be
+    silently wrong rather than merely stale.
+    """
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            refined = _insert(CASES[2], np.float64)
+        assert refined._derived.beziers is None
+        assert refined._derived.locate is None
+
+
+def test_the_wrapper_is_still_immutable_after_a_refinement() -> None:
+    """A refined field refuses attribute assignment, like any other.
+
+    ``_wrap_over`` fills the slots through ``object.__setattr__``, which is the only
+    door; a wrapper that had somehow acquired a writable one would be a second way to
+    reseat a value.
+    """
+    with use_backend(Backend.CPP):
+        refined = _insert(CASES[2], np.float64)
+    with pytest.raises(AttributeError, match="immutable"):
+        refined._impl = None  # type: ignore[assignment]
+    with pytest.raises(AttributeError, match="immutable"):
+        refined.space = None  # type: ignore[misc, assignment]
+
+
+# ---------------------------------------------------------------------------
+# The case table
+# ---------------------------------------------------------------------------
+
+
+def test_the_case_table_earns_its_keep() -> None:
+    """Each case is asymmetric where a symmetric one would hide a defect.
+
+    Four properties the module docstring and ``CASES`` rely on, asserted rather than
+    believed: every multi-direction case differs between its directions in the degree,
+    the basis count and the domain; some case is rational; some carries a knot no binary
+    format represents; and the operations really do refine, i.e. no case is a no-op.
+    """
+    multi = [case for case in CASES if len(case.degrees) > 1]
+    assert multi, "no multi-direction case, so nothing here could see a transposition"
+    for case in multi:
+        assert len(set(case.degrees)) == len(case.degrees), f"{case.label}: repeated degree"
+        counts = [
+            len(knots) - degree - 1 for knots, degree in zip(case.knots, case.degrees, strict=True)
+        ]
+        assert len(set(counts)) == len(counts), f"{case.label}: repeated basis count"
+        # Not *all* distinct: what makes a transposition detectable is that no
+        # permutation of the net's shape is another admissible shape, which the
+        # distinct basis counts above already give. What a repeated domain would hide
+        # is a scale-dependent slip, so it is enough that the directions do not all
+        # share one.
+        domains = [
+            (knots[degree], knots[-degree - 1])
+            for knots, degree in zip(case.knots, case.degrees, strict=True)
+        ]
+        assert len(set(domains)) > 1, f"{case.label}: every direction has one domain"
+
+    assert any(case.is_rational for case in CASES), "no rational case"
+    assert any(not _clamped(case) for case in CASES), "no unclamped case"
+    assert any(
+        any(knot not in (0.0, 0.25, 0.5, 0.75, 1.0) for knots in case.knots for knot in knots)
+        for case in CASES
+    ), "every knot in the table is dyadic, so no refinement here has to round"
+
+    with use_backend(Backend.PYTHON):
+        for case in CASES:
+            field, _ = _make_field(case, np.float64)
+            for refined in (_insert(case, np.float64), _subdivide(case, np.float64)):
+                assert refined.control_points.size > field.control_points.size, (
+                    f"{case.label}: the refinement produced no new coefficients"
+                )

--- a/tests/parity/test_bspline_refinement.py
+++ b/tests/parity/test_bspline_refinement.py
@@ -81,7 +81,10 @@ Three things make it a real oracle rather than a restatement:
   refinement preserves affine maps; ``r = 0`` alone is the partition of unity. Either
   leaves a band of ``p + 1`` entries pinned by one linear functional. All of
   ``r`` in ``[0, p]`` pins ``p + 1`` independent functionals per band, which determines
-  it.
+  it. **The nonsingularity that "independent" rests on is argued, not proved here**: it
+  fails for a window over a collapsed span and holds for every window a refinement can
+  produce, which is Curry-Schoenberg local polynomial reproduction. Checked in exact
+  rational arithmetic over the reachable bands; see the C++ test's file comment.
 - **It is not a mirror.** Elementary symmetric polynomials of knots and a binomial
   coefficient, computed in :func:`_marsden_column` in this file. Nothing in it consults
   the Oslo recurrence, either backend, or the refinement matrix.
@@ -112,7 +115,10 @@ Every quantity compared is relative on non-negative data, so the bound is
 - relative errors compose sub-additively and ``gamma_a + gamma_b <= gamma_{a+b}``, so
   ``D`` refined directions cost ``D (7p + 2)``.
 
-``K = 2p + 3 + D (7p + 2)``, the last 1 being the store into the result. The magnitude
+``K = 2p + 3 + D (7p + 2)``: the oracle's ``e_r`` recurrence plus one rounding on each
+end, the cast in and the store out (the sweep accumulates in ``double`` and writes back
+into ``T``, a real rounding at ``float32``, symmetric to the cast). Every term names the
+operations it charges; none is a pad. The magnitude
 is ``prod_d max_i A^d_{i, r_d}`` per component: the discrete B-splines of a refinement
 are non-negative, so each output coefficient is a convex combination of coarse ones and
 no partial sum of it exceeds the largest. That non-negativity is a classical property
@@ -141,10 +147,12 @@ rather than left to be met.
   pins both halves of that. Parity on such a case is **common mode** -- one
   implementation ran twice -- which this file says out loud rather than counting as
   evidence.
-- **One shape of bad input is refused in a different order.** The oracle checks an
+- **Two shapes of bad input are refused in a different order.** The oracle checks an
   insertion array's rank inside its per-direction loop; a ``std::span`` has no rank, so
-  the C++ path checks every rank before the call.
-  :func:`test_the_refusal_order_divergence_is_exactly_one_input` pins both orders.
+  the C++ path checks every rank before the call. Both of the oracle's post-rank value
+  checks -- domain and multiplicity -- therefore lose to a later direction's rank.
+  :func:`test_the_refusal_order_diverges_on_both_of_the_oracles_value_checks` pins
+  both, in both directions.
 """
 
 from __future__ import annotations
@@ -904,7 +912,15 @@ def test_the_claims_hold_over_a_ten_times_sweep() -> None:
                     np.asarray(cpp.control_points).view(
                         np.uint32 if np.dtype(dtype) == np.float32 else np.uint64
                     ),
-                ) or not np.array_equal(py.space.spaces[0].knots, cpp.space.spaces[0].knots):
+                ) or any(
+                    # Every direction, not direction 0. The sweep carries surface cases,
+                    # and a defect confined to a later direction's knots would have
+                    # counted as agreement here while the per-quantity test caught it
+                    # elsewhere -- so the counter under-reported rather than the suite
+                    # missing it, which is still a self-description that is not true.
+                    not np.array_equal(a.knots, b.knots)
+                    for a, b in zip(py.space.spaces, cpp.space.spaces, strict=True)
+                ):
                     differing_bits += 1
                 expected = _marsden_net(cpp.space.spaces)
                 if subdivide:
@@ -1197,17 +1213,26 @@ def test_a_zero_size_insertion_is_skipped_whatever_its_rank() -> None:
     assert "At least one direction" in messages[0]
 
 
-def test_the_refusal_order_divergence_is_exactly_one_input() -> None:
-    """The two backends disagree on which of two bad arguments they report, and only there.
+def test_the_refusal_order_diverges_on_both_of_the_oracles_value_checks() -> None:
+    """The two backends disagree on which of two bad arguments they report, on both shapes.
 
-    The one divergence :mod:`pantr.bspline._refinement_backend` records. The oracle
-    checks an insertion array's rank inside its per-direction loop, so with direction 0
-    out of domain *and* direction 1 not 1D it reports the domain; the C++ path checks
-    every rank before the call, so it reports the rank. Both texts are the oracle's and
-    both are ``ValueError``.
+    The oracle checks an insertion array's rank inside its per-direction loop; a
+    ``std::span`` has no rank, so the C++ path checks every direction's rank before the
+    call. So whenever an *earlier* direction fails a check the oracle makes **after**
+    rank, and a *later* direction fails rank, the two report different refusals. Both
+    texts are the oracle's and both are ``ValueError``.
 
-    Pinned in both directions rather than described, because a divergence nothing
-    asserts is a divergence that will be "fixed" by accident in either direction.
+    **Which shapes those are, closed by enumeration rather than asserted.**
+    ``_compute_inserted_knot_vector_1d`` makes exactly four checks, in order: rank,
+    empty, domain, multiplicity. Rank is the one the C++ path hoists, so it cannot
+    diverge; empty cannot either, because the caller skips a zero-size array before the
+    per-direction loop is reached, so the later rank failure surfaces on both sides.
+    That leaves **domain and multiplicity, and both diverge** -- measured below.
+
+    An earlier version of this test pinned only the domain shape and was named for the
+    claim that it was the only one. It was not: the multiplicity shape diverges the same
+    way and nothing asserted it, which is the failure this milestone keeps paying for --
+    a claim nothing in the suite can distinguish. Two reviewers found it independently.
     """
     case = _Case(
         (_QUADRATIC_THIRDS, _SHIFTED_LINEAR),
@@ -1218,19 +1243,27 @@ def test_the_refusal_order_divergence_is_exactly_one_input() -> None:
         False,
         "the divergent input",
     )
-    bad = [np.array([5.0]), np.array([[11.5, 11.5]])]
+    late_bad_rank = np.array([[11.5, 11.5]])
+    # One entry per value check the oracle makes after rank. `_THIRD` three times
+    # exceeds multiplicity `degree + 1 = 3` on a knot that is inside the domain, so it
+    # reaches the multiplicity check rather than stopping at the domain one.
+    shapes = (
+        ("outside the domain", [np.array([5.0]), late_bad_rank]),
+        ("maximum multiplicity", [np.array([_THIRD, _THIRD, _THIRD]), late_bad_rank]),
+    )
 
-    with use_backend(Backend.PYTHON):
-        field, _ = _make_field(case, np.float64)
-        with pytest.raises(ValueError, match="outside the domain") as oracle:
-            field.insert_knots(bad)
-    with use_backend(Backend.CPP):
-        field, _ = _make_field(case, np.float64)
-        with pytest.raises(ValueError, match="must be a 1D array-like") as port:
-            field.insert_knots(bad)
+    for oracle_text, bad in shapes:
+        with use_backend(Backend.PYTHON):
+            field, _ = _make_field(case, np.float64)
+            with pytest.raises(ValueError, match=oracle_text) as oracle:
+                field.insert_knots(bad)
+        with use_backend(Backend.CPP):
+            field, _ = _make_field(case, np.float64)
+            with pytest.raises(ValueError, match="must be a 1D array-like") as port:
+                field.insert_knots(bad)
 
-    assert "1D array-like" not in str(oracle.value)
-    assert "outside the domain" not in str(port.value)
+        assert "1D array-like" not in str(oracle.value), oracle_text
+        assert oracle_text not in str(port.value), oracle_text
 
     # With only the rank at fault the two agree, text for text, which is what says the
     # divergence is the *order* and not the message.


### PR DESCRIPTION
Cut 2 of #398: `Bspline.insert_knots` and `Bspline.subdivide` now run in C++ under the C++ backend. Cut 1 (#439) ported the field's state; this ports the first two operations over it.

Eight commits: four building it, then four from a review round (see the last section).

## What landed, and where the boundary is

- `cpp/include/pantr/bspline/refinement.hpp` — `refine_along_axis`, `insert_knots(const Bspline<T>&, ...)` and `subdivide(const Bspline<T>&, ...)`, as free functions over a `const Bspline&`, which is the line `bspline.hpp` and `space_nd.hpp` already draw.
- `cpp/bindings/bspline_refinement.cpp` — `insert_bspline_knots` and `subdivide_bspline`, two registrations each.
- `src/pantr/bspline/_refinement_backend.py` — the catalogue, in the shape `_extraction_backend.py` and `_bezier_backend.py` use.
- `BsplineSpace1D._wrap`, `BsplineSpace._wrap_over`, `Bspline._wrap_over` — the wrapping primitives eleven other ported types already have.

**A periodic direction that receives knots is a declared boundary, not a defect.** The oracle refines one through the open representation, using `_to_open_bspline_1d_impl` and `_to_periodic_bspline_1d_impl`; `bspline.hpp` lists the boundary and periodic conversions as their own port and no ticket in this milestone covers them. The C++ half refuses such a direction outright and the backend module routes the field to the oracle. A periodic direction receiving *no* knots is carried across whole, handle and all — and still goes through C++.

`evaluate`, `evaluate_derivatives`, `to_beziers` and `locate` remain blocked on basis tabulation, which `space_1d.hpp` keeps off this milestone. Nothing here touches them.

## Reuse versus new code

The header is 448 lines, 181 of them code. The whole two-scale matrix, the merge and the subdivision-point formula are **three calls** into the already-ported `knot_insertion.hpp` — `oslo_bands_1d`, `inserted_knot_vector`, `uniform_subdivision_knots`. There is no second Oslo recurrence, no second merge and no second linspace expression.

The only genuinely new numerics is `refine_along_axis`, about 25 lines: the strided application of those bands to one axis of a control net. `knot_insertion.hpp` said of itself that "the control-point half of knot insertion is not here"; this is that half, and that comment now points at it.

Two things had to be written rather than reused, and both are `ControlNet`/`Bspline` plumbing rather than mathematics: the per-direction `outer`/`inner` extents, and the space-handle carry-over for an untouched direction.

## The parity criterion, quantity by quantity

Each is argued in `_fields()` rather than once in bulk.

| quantity | claim | why, in one line |
|---|---|---|
| `control_points` | bitwise | the only quantity arithmetic touches; same IEEE-754 operations in the same order, accumulating in the *storage* format |
| `space.spaces[d].knots` | bitwise | a concatenate-and-stable-sort on the insertion path; numpy's own linspace expression, in `double`, on the subdivision path |
| `space.spaces[d].tolerance` | bitwise | a *new* quantity of the result, derived from the merged vector before snapping; it is what every later comparison on that space uses |
| `space.spaces[d].periodic` | exact | the flag the C++ half is allowed to be wrong about in principle, since it refuses to refine a periodic direction and carries an unrefined one over |
| `space.num_basis` | exact | the grid the refined net is laid out on, and what the C++ constructor checks its extents against |
| `degree` | exact | refinement must not change one; the *order* is what reveals a transposition |
| `rank` | exact | folds the rationality flag against the shape |
| `is_rational` | exact | what `rank` subtracts, so a lost flag shows up twice |
| `dtype` | exact | a refinement that changed precision would be invisible to the bitwise claim on a representable coefficient |

**Rule 9 was read off this kernel, not inferred.** `_insert_knots_1d_core` allocates its accumulator in `ctrl.dtype` and never widens it, so the C++ sweep accumulates in `T`. Accumulating in `double` would have been exact at `float64` and quietly wrong at `float32` — mutation M1 below is that mistake, and it is red, which is the mutation test Rule 9 asks for rather than the argument.

The band recurrence *does* widen three variables under numba (`saved`, `to_left`, `to_right` are each seeded with `0.0` and unify to `float64`), and it changes nothing: each then holds the value of a `float32` expression, and the exact sum of two `float32` numbers is representable in `float64`, so there is no double rounding to inherit.

**Rule 7 gate.** The sweep's inner statement is `row[k] + weight * source[k]`, a multiply-add. On this build (`-ffp-contract=on`, no `-march`, `__fp_contract__ == unavailable-on-target-isa`) there is no FMA to contract into and the claim holds; `contraction_may_fuse()` skips it where there is.

**Rule 12** covers the interpreted oracle by its complementary half: both Oslo kernels are built only from `+`, `-`, `*`, `/`, no `pow` and no integer accumulator that wraps. Confirmed by running the parity file under `NUMBA_DISABLE_JIT=1` at both storage formats — no gate needed.

The `linspace` half of the `knots` claim is inherited from #438 and was checked here rather than taken on trust, discriminatingly: over 24 199 `(lo, hi, n, j)` samples, `j * ((hi - lo) / n) + lo` reproduces `numpy.linspace`'s interior on **all** of them, while the two tidier equivalents `lo + j * (hi - lo) / n` and `lo + (hi - lo) * j / n` each disagree on 9.3%. So the C++ side reproducing numpy's expression rather than simplifying it is load-bearing, not stylistic.

## The independent accuracy check

Parity says the backends agree, not that either is right. The natural invariant — *inserting knots must not move the curve* — is usually checked by evaluating before and after, and **evaluation is blocked** on basis tabulation. So the invariant is written in coefficients instead of in values.

**Marsden's identity.** Matching the coefficient of `(-y)^{p-r}` in

    (u - y)^p = sum_i prod_{k=1}^{p} (t_{i+k} - y) N_{i,p}(u)

gives, for every `r` in `[0, p]`,

    u^r = sum_i [ e_r(t_{i+1}, ..., t_{i+p}) / C(p, r) ] N_{i,p}(u).

So the coefficients of the monomial `u^r` are a closed form in the knots alone. A field whose control points are those numbers *is* that monomial; a refinement that does not move it must reproduce the same closed form on the refined knots.

**Why it is not a mirror:** elementary symmetric polynomials of knots and a binomial coefficient, computed in the test file. Nothing in it consults the Oslo recurrence, either backend, or the refinement matrix.

**Why it is complete rather than partial:** `r = 1` alone is the Greville abscissa and says only that affine maps survive; `r = 0` alone is the partition of unity. Either leaves a band of `p + 1` entries pinned by one linear functional, so a wrong matrix preserving affine maps would pass. All of `r` in `[0, p]` pins `p + 1` independent functionals per band. In several directions the tensor-product structure keeps it a closed form, so one net carries every monomial the degrees admit and one refinement checks all of them — which is what catches a sweep applied to the wrong axis.

Run at both the C++ level (`cpp/tests/test_bspline_refinement.cpp`) and the Python level, so the two halves are independent of the Python seam.

**The bound.** `gamma_K * prod_d max_i A^d_(i, r_d)` plus `K` underflow floors, with `K = 2p + 3 + D(7p + 2)`: `2p + 1` roundings form the closed form itself, one is the cast of that closed form into the field's storage (a real rounding on the *input* at `float32`), each of `D` refined directions costs `5p` in the band recurrence and `2p + 2` in the control-point sweep, and one is the store into the result. The magnitude is a bound because the discrete B-splines of a refinement are non-negative — asserted in the C++ test rather than assumed, since it is the premise the bound rests on. The underflow floors are the absolute half of Higham's model, needed because a component whose closed form is an exact zero would otherwise carry a bound of zero.

Three cheap checks on it:

- **scaling** (`x -> lambda x` carrying the tolerance): worst ratio to the bound stays in 0.063–0.094 across `lambda` from 1e-6 to 1e6 at both dtypes, while the coefficient magnitudes span 1 to 1e18. Scale-invariant.
- **dimensional consistency**: the bound is absolute (a dimensionless relative term times a magnitude, plus an absolute floor in the storage format's smallest subnormal) and is compared against an absolute difference.
- **claimed order versus observed**: worst ratio by degree is 0.000, 0.000, 0.087, 0.125, 0.098 for degrees 0 to 4 — no upward trend, so `K`'s degree dependence is not under-counted over the range exercised. Degrees 0 and 1 come out *exact*; that comparison is still live (a 1e-3 relative kick is rejected, one ulp is inside the bound).

## The sweep, at 13.9x the shipped one

Shipped: 10 cases x 2 dtypes x 2 operations = 40 comparisons. The wide sweep is 139 cases x 2 x 2 = **556**.

- **0 of 556** differed bitwise.
- worst ratio to the accuracy bound **0.125**.
- **356 of 556** had a non-zero deviation from the closed form, which is the guard that says the bound was asked a question rather than satisfied by exact arithmetic. Both guards are asserted in the test, not merely measured here.

Reproduce: `PANTR_BACKEND=cpp <interpreter> -m pytest tests/parity/test_bspline_refinement.py -q`.

## Mutation run, with its control

Each mutation applied to `refinement.hpp` alone, extension rebuilt, then `cpp/tests/test_bspline_refinement` and `tests/parity/test_bspline_refinement.py`.

| mutation | expected | observed |
|---|---|---|
| M1 accumulate in `double` rather than the storage format (Rule 9's trap) | red | **red** (parity) |
| M2 sweep the band in descending order | red | **red** (parity) |
| M3 swap the `outer` and `inner` extents (refine the wrong axis) | red | **red** (both) |
| M4 drop the component axis from the `inner` extent | red | **red** (both) |
| M5 build the space from the *snapped* rather than the merged vector | red | **red** (parity) |
| M6 rebuild an untouched direction's space instead of carrying its handle | red | **red** (both) |
| M7 default `regularity` to `degree` instead of `degree - 1` | red | **red** (both) |
| **M8 CONTROL** hoist the band pointer, changing no operation | green | **green** |

**M5 survived the first run**, and that is reported rather than smoothed over: nothing in the suite inserted a knot close enough to an existing one for snapping to do anything, so the one input where the refined space's knots and the vector the matrix was built from are different arrays was untested. `test_a_near_duplicate_insertion_is_snapped_but_refined_unsnapped` is that case; M5 is red against it at both dtypes.

An earlier mutation on the C++ test alone (drop the last band entry) produced 457 failures in that file, which is what says its own oracle bites. The three fixes of the review round each carry their own control: reverting the source makes the new test red.

## The extension moved aside

Mandatory check for any parity claim: with `_pantr_cpp*.so` moved aside, `tests/parity/test_bspline_refinement.py` reports **all skipped, none passed**. Nothing in the file can pass without the extension.

## Downstream consumer census, by symbol name

Census by *name*, not by `pantr.` prefix, over the consumer repository at `8b8329b`.

Nothing is deleted or reshaped by this change, so the census is about meaning rather than existence. Every private knot-insertion symbol scores **0**: `_insert_knots_bspline`, `_compute_uniform_subdivision_knots`, `_compute_inserted_knot_vector_1d`, `_insert_knots_bspline_1d_impl`, `_insert_knots_1d_core`, `_compute_oslo_rows_1d_core`, `_compute_oslo_matrix_1d_core`, `_bspline_knot_insertion_core`. So do `_wrap`, `_wrap_over`, `_impl`, `_take`, `_mutate`, `_BsplinePython`, `use_backend`, `active_backend`, `PANTR_BACKEND`, `_pantr_cpp` and `_backend`.

Two non-zero hits, both benign:

- `_bspline_knot_insertion` — **1**, in `docs/design/v2-plan.md`, a forward-looking prose pointer to the module family for a deferred milestone. The module still exists.
- `_derived` — **26**, all of them the consumer's own `SplineFunctionSpace._derived`, unrelated to `Bspline._derived`.

The public surface it does use is `insert_knots` (11) and `subdivide` (1). Every call shape it passes was run under both backends and agrees exactly, refusal text included: `[interior] * 1` on a 1D field (both refuse, `new_knots must be a 1D array-like, got shape (1, 1)`), a flat array on a 1D field, `[interior, interior]` on a surface, and `[[], interior]` on a surface. The consumer imports no private symbol this change touches and does not select a backend, so it cannot reach the one cross-backend refusal this adds.

## Verification

- `ruff check .` — clean. `ruff format --check .` — 344 files already formatted. `mypy --config-file mypy.ini src tests scripts` — no issues in 319 source files. (This branch's CI runs none of the three, so they were run by hand.)
- `ctest --preset gcc` — 51/51.
- Full suite under **both** backends, green, with `PANTR_BACKEND=cpp` and without.
- Doctests: 82 passed, 7 skipped. `lint-imports`: 2 contracts kept.

## The review round

Two `reviewer` passes, one per language half. Findings and what was done, all fixed in this PR:

- **The `clamped` flag on `check_marsden_survives` was dead and its docstring described behaviour it did not have** — every call site passed `true`, and the `false` branch computed a ratio and then asserted nothing. Removed; the assertion is unconditional and the unclamped case keeps its own row-by-row check with its vacuity guards. (`e9dfb98`)
- **`check_the_axis_sweep_addresses_the_right_fibres` compared against a tolerance while its own comment argued exact equality.** A tolerance would let a wrong stride landing near the right fibre pass, which is the one thing that check exists to refuse. Now asserts equality, with the reason it survives contraction. (`e9dfb98`)
- **The rounding budget did not charge the cast of the closed form into the field's storage**, a real rounding on the *input* at `float32`. `K` gains one, in both test files, and the bound gains `K` underflow floors so no entry carries a bound of zero. (`e9dfb98`)
- **A zero-size insertion array of non-1-D shape diverged in behaviour, not in a message.** `[np.empty((0, 3)), [0.5]]` succeeds on the oracle, which skips on `size == 0` above the rank check, and was refused by the port. That falsified this PR's own claim that the two backends disagreed on "exactly one shape of input". Fixed, with the exact input as a regression test in both positions of the pair. (`ff463d8`)
- **The two private entry points disagreed when nothing was to be refined** — the C++ side refuses, the oracle returns a copy. Unreachable through the public methods, closed anyway because these are private symbols in a package whose private symbols a downstream consumer imports. (`19c2e93`)
- **`BsplineSpace._wrap_over` advertised tolerating a shorter `prior`**, which nothing exercised and which would silently reuse the wrong direction's wrapper for a future dimension-changing operation. Now requires one per direction and says so. (`19c2e93`)

Both reviewers confirmed independently that the two load-bearing claims hold under a full operand trace: bit-identity of `refine_along_axis` against `_insert_knots_1d_core`, and the argument that the strided sweep is indistinguishable from the oracle's transpose. The C++ side also builds and passes clean under `gcc-debug` with ASan and UBSan.

## Two findings for the record

- **A false reachability claim in `cpp/tests/test_bspline_knot_insertion.cpp`** (merged in #438): it said the multiplicity refusal is reachable from a subdivision, because "`regularity = -1` does at degree 1" push a knot past `degree + 1`. It does not — that value lands on `degree + 1` exactly, and a span's interior points collide with nothing. Fixed in `fa4d1be`, comment only, with the positive half now pinned by a test.
- **`src/pantr/bspline/_bspline.py`'s docstring says "Two of those operations cannot follow"** and then names three methods; with `locate` (blocked indirectly through `spline.evaluate` at `_bspline_locate.py:823,849`) it is four. Pre-existing, left alone.
- The docs build fails `-W` on this branch with 34 pre-existing warnings, identically before and after this change. None names a file this change touches, and this branch's CI builds no docs.
