### PR TITLE
docs(api): clear the 36 warnings that fail the -W build

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -319,7 +319,7 @@ class Bezier:
     **This class is a wrapper.** Since the 2026-08-27 amendment to
     ``design/cross_backend_types.md`` the value is owned by C++
     (``cpp/include/pantr/bezier/bezier.hpp``) and this class holds one
-    implementation of it, chosen by :func:`_impl_class`. The operations are still
+    implementation of it, chosen by ``_impl_class``. The operations are still
     Python and still live in the sibling ``_bezier_*`` modules; only the state
     moved.
 
@@ -332,7 +332,7 @@ class Bezier:
 
     Attributes:
         _impl (_Impl): The implementation this wrapper holds; see
-            :func:`_impl_class`.
+            ``_impl_class``.
     """
 
     __slots__ = ("_impl",)

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -408,7 +408,7 @@ class Bspline:
     which is the C++ type (``cpp/include/pantr/bspline/bspline.hpp``) or the oracle
     ``_BsplinePython``. Most operations below are still Python over numba kernels and
     numpy; :meth:`insert_knots` and :meth:`subdivide` dispatch to C++ through
-    :mod:`pantr.bspline._refinement_backend`, and the module docstring says what that
+    ``pantr.bspline._refinement_backend``, and the module docstring says what that
     costs.
 
     Instances are immutable *as attribute holders*, and that is enforced rather than

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -590,9 +590,9 @@ class BsplineSpace1D:
 
     **This class is a wrapper.** The value -- the knots, the degree, the
     periodicity and everything they fix -- is owned by an implementation chosen by
-    :func:`_impl_class`, which is the C++ type
+    ``_impl_class``, which is the C++ type
     (``cpp/include/pantr/bspline/space_1d.hpp``) or the oracle
-    :class:`_BsplineSpace1DPython`. The operations below are still Python over
+    ``_BsplineSpace1DPython``. The operations below are still Python over
     numba kernels and are unchanged; only the state moved.
 
     Instances are immutable, and ``__slots__`` is what says so: there is no
@@ -600,7 +600,7 @@ class BsplineSpace1D:
 
     Attributes:
         _impl (_Impl): The implementation this wrapper holds; see
-            :func:`_impl_class`.
+            ``_impl_class``.
     """
 
     __slots__ = ("_impl",)

--- a/src/pantr/geometry.py
+++ b/src/pantr/geometry.py
@@ -608,12 +608,8 @@ class AABB:
     one Python class in front of it, which is what keeps the roughly two dozen
     ``isinstance`` sites across the package working unchanged.
 
-    Under ``PANTR_BACKEND=python`` the thing held is :class:`_AABBPython`
+    Under ``PANTR_BACKEND=python`` the thing held is ``_AABBPython``
     instead, which is the port's oracle and is temporary; see that class.
-
-    Attributes:
-        lo (npt.NDArray[np.float64]): Lower corner, shape ``(ndim,)``, read-only.
-        hi (npt.NDArray[np.float64]): Upper corner, shape ``(ndim,)``, read-only.
     """
 
     __slots__ = ("_impl",)

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -667,14 +667,9 @@ class BVH:
     constructor but is mostly intended for tests and round-trip serialization.
 
     **This class is a wrapper**, holding a hierarchy owned by the C++ core (or, under
-    ``PANTR_BACKEND=python``, a :class:`_BVHPython`). See the module docstring for
+    ``PANTR_BACKEND=python``, a ``_BVHPython``). See the module docstring for
     the ownership rule, for where validation lives, and for what the overlap
     predicate actually tests.
-
-    Attributes:
-        ndim (int): Spatial dimension of the indexed AABBs (``>= 1``).
-        n_cells (int): Number of cells indexed (equal to the number of leaves).
-        n_nodes (int): Total number of nodes (``2 * n_cells - 1``, else ``0``).
     """
 
     __slots__ = ("_impl",)

--- a/src/pantr/grid/_partition.py
+++ b/src/pantr/grid/_partition.py
@@ -231,14 +231,8 @@ class Partition:
     :attr:`n_parts`, :attr:`n_cells`, and :attr:`active_mask` properties.
 
     **This class is a wrapper**, holding a partition owned by the C++ core (or, under
-    ``PANTR_BACKEND=python``, a :class:`_PartitionPython`). See the module docstring
+    ``PANTR_BACKEND=python``, a ``_PartitionPython``). See the module docstring
     for the ownership rule and for where validation lives.
-
-    Attributes:
-        cell_owner (npt.NDArray[np.int32]): Per-cell owners, read-only.
-        n_parts (int): Number of parts (ranks).
-        n_cells (int): Number of cells.
-        active_mask (npt.NDArray[np.bool_]): Which cells some rank owns.
     """
 
     __slots__ = ("_impl",)

--- a/src/pantr/grid/_tags.py
+++ b/src/pantr/grid/_tags.py
@@ -643,16 +643,12 @@ class CellTags:
     grid's cell count is exposed through the :attr:`num_cells` property.
 
     **This class is a wrapper**, holding a registry owned by the C++ core (or, under
-    ``PANTR_BACKEND=python``, a :class:`_CellTagsPython`). See the module docstring
+    ``PANTR_BACKEND=python``, a ``_CellTagsPython``). See the module docstring
     for the ownership rule and for where validation lives.
 
     Iteration order is insertion order, and a :meth:`set` that replaces an existing
     name leaves that name where it was. Both backends guarantee it, because
-    :meth:`__iter__` and :attr:`names` are public and a caller can see it.
-
-    Attributes:
-        num_cells (int): Number of cells in the owning grid.
-        names (tuple[str, ...]): Registered tag names, in insertion order.
+    ``__iter__`` and :attr:`names` are public and a caller can see it.
     """
 
     __slots__ = ("_impl",)
@@ -915,11 +911,6 @@ class FacetTags:
     :attr:`facets_per_cell` properties.
 
     **This class is a wrapper**; see :class:`CellTags` and the module docstring.
-
-    Attributes:
-        num_cells (int): Number of cells in the owning grid.
-        facets_per_cell (int): Number of local facets per cell.
-        names (tuple[str, ...]): Registered tag names, in insertion order.
     """
 
     __slots__ = ("_impl",)

--- a/src/pantr/quad/__init__.py
+++ b/src/pantr/quad/__init__.py
@@ -9,7 +9,7 @@ This module provides:
 - :class:`QuadratureRule`: a d-dimensional quadrature rule on the unit cube,
   with :func:`tensor_product_quadrature` and :func:`gauss_legendre_quadrature`
   factories; the reference rule consumed by :func:`pantr.grid.cell_quadrature`.
-  Owned by the C++ core and wrapped here; see :mod:`pantr.quad._rule_nd`.
+  Owned by the C++ core and wrapped here; see ``pantr.quad._rule_nd``.
 """
 
 from ._lattice import PointsLattice, create_lagrange_points_lattice

--- a/src/pantr/quad/_rule_nd.py
+++ b/src/pantr/quad/_rule_nd.py
@@ -259,13 +259,7 @@ class QuadratureRule:
     **This class is a wrapper.** The rule itself is owned by the C++ core
     (``cpp/include/pantr/quad/rule.hpp``) and this class holds one; see the module
     docstring. Under ``PANTR_BACKEND=python`` it holds
-    :class:`_QuadratureRulePython` instead.
-
-    Attributes:
-        ndim (int): Number of axes (``>= 1``).
-        num_points (int): Number of quadrature points (``>= 1``).
-        points (npt.NDArray[np.float64]): Read-only ``(num_points, ndim)`` array.
-        weights (npt.NDArray[np.float64]): Read-only ``(num_points,)`` array.
+    ``_QuadratureRulePython`` instead.
     """
 
     __slots__ = ("_impl", "_points", "_weights")

--- a/src/pantr/transform.py
+++ b/src/pantr/transform.py
@@ -605,14 +605,9 @@ class AffineTransform:
     an affine map and one Python class in front of it.
 
     Under ``PANTR_BACKEND=python`` the thing held is
-    :class:`_AffineTransformPython`, the port's oracle, which is temporary.
+    ``_AffineTransformPython``, the port's oracle, which is temporary.
 
     Instances are immutable: every factory and operator returns a new map.
-
-    Attributes:
-        dim (int): The spatial dimension ``n``.
-        matrix (npt.NDArray[np.float64]): Read-only ``(n, n)`` linear part.
-        offset (npt.NDArray[np.float64]): Read-only ``(n,)`` translation.
     """
 
     __slots__ = ("__dict__", "_impl")


### PR DESCRIPTION
## What this is

`docs` builds with `-W` on this branch fail on **36 pre-existing problems**. None names a file
any of the eight landed cuts touched, so they have been carried rather than caused, and they
will block the eventual `proto/cpp` → `main` merge. This clears all of them.

Measured before: `build finished with problems, 36 warnings`, exit 2.
Measured after: **0 warnings, build succeeded**, from a clean `docs/_build`.

**The count is 36 and not 35, and that correction came out of review.** One of the problems is
emitted with an `ERROR:` prefix rather than `WARNING:`, so `grep -c WARNING` sees 35 while
Sphinx's own summary line says 36. Take the tool's summary, not a grep for one severity word.

## Three families, all consequences of the wrapper pattern the port introduced

**21 × `duplicate object description`.** Seven wrapper classes -- `AffineTransform`, `AABB`,
`BVH`, `CellTags`, `FacetTags`, `Partition`, `QuadratureRule` -- listed names in their class
`Attributes:` block that are *also* `@property` with their own docstring. Without
`napoleon_use_ivar`, Napoleon emits an `.. attribute::` directive per entry, so the same object
gets described twice.

Removed from the `Attributes:` blocks, which is where the redundancy is: these are properties,
not instance variables. `CLAUDE.md`'s documentation table separates the two rows, and the drift
was already visible in the code -- `AABB.ndim` and five of `BVH`'s eight properties were already
outside the block, so the blocks were a stale partial list. The private slots these classes do
carry (`_impl` on all seven, plus `QuadratureRule`'s `_points`/`_weights` read-caches and the
`__dict__` behind `AffineTransform.inverse`) were never in those blocks and document themselves.

**Checked entry by entry that nothing is lost**, and independently re-checked in review: all 21
property docstrings say the same thing or more precisely. `BVH.n_nodes` is the sharpest case, its
property giving the ``n_cells > 0`` qualifier the block omitted.

**14 dangling cross-references.** Roles pointing at private symbols autodoc does not document:
`_impl_class` (×4), `_BsplineSpace1DPython`, `_AffineTransformPython`, `_AABBPython`,
`_BVHPython`, `_CellTagsPython`, `_PartitionPython`, `_QuadratureRulePython`,
`pantr.quad._rule_nd`, `pantr.bspline._refinement_backend`, and `__iter__`.

Rewritten as literals, which is **this project's own declared convention** -- `docs/conf.py` says
it in the comment above `nitpick_ignore`: *"a role that can never resolve is a broken link rather
than a suppressible one."* `Bspline`'s class docstring already writes ``_impl_class`` and
``_BsplinePython`` that way; the classes that warned are the ones that drifted from it. No new
`nitpick_ignore` entries, and every one of the 14 targets is private or a dunder, so none was a
role that could have resolved.

**1 × `ERROR: Unknown target name: "np.bool"`.** From `npt.NDArray[np.bool_]` written unescaped
in `Partition`'s `Attributes:` block -- RST reads the trailing underscore as a hyperlink
reference. It goes with the block. Worth recording rather than merely fixing: the `active_mask`
property beside it writes ``npt.NDArray[np.bool\_]`` in a raw docstring and does not warn, so the
property was already right and the block was not. A third piece of evidence that the block was
stale rather than a summary.

## The alternative, in case you prefer it

`napoleon_use_ivar = True` in `docs/conf.py` silences the 21 duplicates in one line with no
docstring edits, because `:ivar:` fields create no object description. It would not touch the
`np.bool_` error, and it keeps the drift: a partial, stale list of properties presented as
attributes. I went with the source fix; the one-line version is yours to impose if you disagree.

## Deliberate boundary

**Eleven** `_impl_class` roles survive across these files, in three kinds of place autodoc does
not render: private module docstrings, private `_impl` slot docstrings, and the class docstrings
of the private oracle classes themselves. (I first wrote "seven, in two kinds of place"; review
counted them.) They are broken links in nothing published today; they would surface the day
`:private-members:` is switched on.

## How it was verified, and why local is the only proof available

`.github/workflows/ci.yaml` -- the workflow with the `docs` job -- triggers only on
`pull_request: branches: [main]`. A PR onto `proto/cpp` runs `cpp.yaml`, whose three jobs build
no documentation. **So this branch's CI cannot check this fix**, and the local build is the
evidence:

```
rm -r docs/_build
NUMBA_DISABLE_JIT=1 make docs SPHINXOPTS="-W --keep-going -j 8"
  -> build succeeded, 0 warnings
```

Also run, all clean: `ruff check .`, `ruff format --check .` (344 files), `mypy` (319 files),
`lint-imports` (2 kept / 0 broken), `make doctest` (82 passed, 7 skipped), `ci_local.sh
discipline` (8 PASS), and the full `pytest` suite (9877 passed, 57 skipped, 7 xfailed). A review
pass reproduced the before-and-after builds independently.

One environment note, because it silently invalidates any check run from a worktree: the editable
install in the shared conda environment puts a `ScikitBuildRedirectingFinder` on `sys.meta_path`,
and a meta-path finder outranks `sys.path`, so neither `pytest.ini`'s `pythonpath = src` nor an
absolute `PYTHONPATH` can point a worktree at its own source. Every command above was run with
that finder removed for the process, against the live extension from `build/skbuild/`. The stale
copy that was sitting in `src/pantr/` is from 3 September and lacks `bezier_extraction_1d`; using
it produces a parity failure that reads exactly like a regression on this branch and is not one.

## No merge

Opened for review only. The merge authority granted on 4 September expired with the previous
stretch, so this waits for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
