### PR TITLE
fix(scripts): add the repository root before the tests import

### DIFF
--- a/scripts/measure_bezier_fma_bound.py
+++ b/scripts/measure_bezier_fma_bound.py
@@ -90,6 +90,12 @@ from pantr._backend import Backend, available_backends, use_backend
 from pantr.bezier import Bezier
 from pantr.bezier import _bezier_backend as backend
 from pantr.bezier._bezier_degree import _interpolating_reduction_operator
+
+# `tests` is a package at the repository root, and running this file directly puts
+# `scripts/` on the path rather than the root, so the two imports below need the root
+# added first. `scripts/measure_hierarchical_refinement_parity.py` does the same.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from tests._parity_harness import (
     absolute_tolerance,
     build_provenance,

--- a/scripts/measure_hierarchical_refinement_parity.py
+++ b/scripts/measure_hierarchical_refinement_parity.py
@@ -49,8 +49,7 @@ from pantr.grid._hierarchical_grid import HierarchicalGrid, hierarchical_grid
 
 # `tests` is a package at the repository root, and running this file directly puts
 # `scripts/` on the path rather than the root, so the import below needs the root
-# added first. `scripts/measure_bezier_fma_bound.py` imports the same module without
-# doing this and cannot be run directly as a result.
+# added first. `scripts/measure_bezier_fma_bound.py` does the same.
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
 from tests._parity_harness import unit_roundoff

--- a/tests/test_measurement_scripts.py
+++ b/tests/test_measurement_scripts.py
@@ -1,0 +1,96 @@
+"""Guard that the measurement scripts under ``scripts/`` can be run directly.
+
+Several of them import from the ``tests`` package, which lives at the repository root.
+Running a file inside ``scripts/`` sets ``sys.path[0]`` to ``scripts/`` **instead of** the
+working directory, so a script that imports from ``tests`` has to put the root on the path
+itself. One of them did not, and
+``python scripts/measure_bezier_fma_bound.py`` died with
+``ModuleNotFoundError: No module named 'tests'`` -- while the same module imported fine
+under pytest, which has the root on the path for its own reasons. Nothing in the suite
+looked at the way the script's own docstring says to run it.
+
+The scripts are discovered rather than listed, so a new one that reaches for the ``tests``
+package is covered the day it is added instead of the day someone remembers this file. The
+predicate is a source match, so a script reaching that package through
+``importlib.import_module`` or ``__import__`` would not be found; none does today.
+
+Why the check is not "run it with ``--help``"
+---------------------------------------------
+
+Because that measures the wrong thing here, and expensively. Of the two scripts,
+``measure_hierarchical_refinement_parity.py`` has an ``argparse`` parser and exits on
+``--help``; ``measure_bezier_fma_bound.py`` has no parser at all and ignores ``argv``, so
+``--help`` runs its full contraction-bound measurement over tens of thousands of entries and
+exits ``0`` only because that bound holds on this build. A guard written that way costs
+seconds per run and would report *"add the repository root to sys.path"* on a day the
+numerical bound was exceeded, which is a misattribution rather than a failure.
+
+So the subprocess reproduces the *import* condition and stops there:
+:func:`runpy.run_path` puts the script's own directory on the path exactly as direct
+execution does, ``-P`` keeps the working directory off it (which is what makes the root
+absent, and is the whole condition), and a ``run_name`` other than ``__main__`` leaves the
+script's ``if __name__ == "__main__"`` guard unfired. Checked both ways: against the
+unfixed script it raises the ``ModuleNotFoundError`` above, and against the fixed one it
+returns without doing any of the work.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+
+_IMPORTS_TESTS_PACKAGE = re.compile(r"^\s*(?:from|import)\s+tests\b", re.MULTILINE)
+
+
+def _scripts_importing_the_tests_package() -> list[pathlib.Path]:
+    """Collect the scripts whose source imports the root-level ``tests`` package.
+
+    Returns:
+        list[pathlib.Path]: The matching scripts, sorted by name for a stable test id.
+    """
+    return sorted(
+        path
+        for path in _SCRIPTS_DIR.glob("*.py")
+        if _IMPORTS_TESTS_PACKAGE.search(path.read_text(encoding="utf-8"))
+    )
+
+
+def test_the_guard_has_something_to_guard() -> None:
+    # Without this the parametrization below can silently shrink to nothing -- a rename or
+    # a moved import would leave a green test covering no script at all.
+    assert _scripts_importing_the_tests_package(), (
+        f"no script under {_SCRIPTS_DIR.name}/ imports the tests package; either the "
+        f"pattern stopped matching or this guard is obsolete"
+    )
+
+
+@pytest.mark.parametrize(
+    "script", _scripts_importing_the_tests_package(), ids=lambda path: path.stem
+)
+def test_the_script_imports_as_a_direct_run_would(script: pathlib.Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-P",
+            "-c",
+            "import runpy, sys; runpy.run_path(sys.argv[1], run_name='_import_check_')",
+            str(script),
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"{script.name} does not import when run the way its docstring says to run it; a "
+        f"script that imports the tests package must put the repository root on sys.path "
+        f"before doing so\n{result.stderr}"
+    )


### PR DESCRIPTION
## The defect

`scripts/measure_bezier_fma_bound.py` cannot be run the way its own docstring says to run it:

```
$ python scripts/measure_bezier_fma_bound.py --help
ModuleNotFoundError: No module named 'tests'
```

`tests` is a package at the repository root. Running a file inside `scripts/` puts `scripts/`
on `sys.path`, not the root, so a script that imports from `tests` has to add the root itself.
Its sibling `scripts/measure_hierarchical_refinement_parity.py` does exactly that, and its
comment there **names this script as broken** -- so the defect was known, recorded next to the
fix for it, and left standing.

Root-caused, not guessed. Reproduced at `cddda4e` before touching anything.

## The fix

The sibling's four lines, and nothing else. Both scripts import the `tests` package; the
enumeration is complete -- of the sixteen scripts under `scripts/`, these two are the only ones
that reach for it.

The sibling's comment claiming this script is broken is corrected in the same commit. A fix that
leaves standing the sentence asserting the bug still exists is not finished, and that sentence
was the one thing in the repo that recorded the defect.

## The regression test, and why it is not `--help`

`tests/test_measurement_scripts.py` **discovers** the scripts that import the `tests` package
rather than listing them, so a third one added later is covered the day it is added instead of
the day someone remembers this file. It carries a non-vacuity test as well: a discovered
parametrization can silently shrink to nothing -- a rename, a moved import -- and a guard
covering zero scripts is green and worthless.

**The first version ran each script with `--help`, and review showed that measures the wrong
thing here.** `measure_bezier_fma_bound.py` has no `argparse` at all and ignores `argv`, so
`--help` runs its whole contraction-bound measurement over tens of thousands of entries -- 4.4 s
-- and exits `0` only because that bound holds on this build. A guard written that way charges
every test run for a numerical measurement, and on the day the bound was exceeded it would
report *"put the repository root on sys.path"*, which is a misattribution rather than a failure.

So the subprocess reproduces the **import** condition and stops there. `runpy.run_path` puts the
script's own directory on the path exactly as direct execution does; `python -P` keeps the
working directory off it, which is what makes the root absent and is the whole condition; and a
`run_name` other than `__main__` leaves the script's own `if __name__` guard unfired. `runpy`
alone does **not** work and I checked: from the repository root it leaves `''` on the path, so
`tests` resolves anyway and the defect does not reproduce. The `-P` is the load-bearing part.

**Red controls, in both directions.** Against the unfixed script the guard fails with the real
`ModuleNotFoundError: No module named 'tests'` (`1 failed, 2 passed`); with the fix, `3 passed`,
and the whole file runs in 2.5 s doing none of the measurement.

One known limit, stated in the module docstring: the discovery predicate is a source match, so a
script reaching that package through `importlib.import_module` or `__import__` would not be
found. None does today.

## Checks

All run from the branch, against the branch's own source: `ruff check` clean, `ruff format
--check` 345 files, `mypy` 320 files, `lint-imports` 2 kept / 0 broken, and the full `pytest`
suite. The documentation build's `-W` failure on this branch is the 35 pre-existing warnings
inherited from `proto/cpp`, unchanged by this diff and fixed separately in #443.

## No merge

Opened for review only. The merge authority granted on 4 September expired with the previous
stretch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
