### PR TITLE
fix(bspline): wait for the JIT warmup before an extraction kernel

### DIFF
--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -26,6 +26,7 @@ from typing import Any, Final, Literal, cast, get_args
 import numpy as np
 import numpy.typing as npt
 
+from .._numba_compat import wait_for_jit_warmup
 from ..basis._basis_utils import _allocate_or_validate_out
 from ._extraction_backend import _KERNELS as _catalogue_kernels
 from ._extraction_backend import _KERNELS_MANY as _catalogue_kernels_many
@@ -375,6 +376,15 @@ def _prepare_apply_call(  # noqa: PLR0913 -- each arg reflects a distinct kernel
         ValueError: If shapes, dtypes, writability, or length invariants fail.
         NotImplementedError: If ``d > 3``.
     """
+    # `__init__.py` compiles the kernels on a background thread, and numba's default
+    # workqueue layer is not safe against a concurrent `parallel=True` call from another
+    # thread: the process *aborts* rather than raising. Every kernel invocation in this
+    # module's contract goes through this function or its batch twin, so the barrier belongs
+    # here rather than in each caller -- see `pantr.basis._basis_1D` for the same call at the
+    # equivalent point, and `tests/test_bspline_locate.py` for why it is the call and not the
+    # crash that a test can pin. Once per process; every later call costs nothing.
+    wait_for_jit_warmup()
+
     _validate_op_kind(op_kind)
     d = len(ops_1d_per_cell)
     if len(is_identity_per_dir) != d:
@@ -537,6 +547,15 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913, PLR0915
         ValueError: If shapes, dtypes, writability, or index-range invariants fail.
         NotImplementedError: If ``d > 3``.
     """
+    # `__init__.py` compiles the kernels on a background thread, and numba's default
+    # workqueue layer is not safe against a concurrent `parallel=True` call from another
+    # thread: the process *aborts* rather than raising. Every kernel invocation in this
+    # module's contract goes through this function or its batch twin, so the barrier belongs
+    # here rather than in each caller -- see `pantr.basis._basis_1D` for the same call at the
+    # equivalent point, and `tests/test_bspline_locate.py` for why it is the call and not the
+    # crash that a test can pin. Once per process; every later call costs nothing.
+    wait_for_jit_warmup()
+
     _validate_op_kind(op_kind)
     d = len(ops_1d)
     if len(idx_maps_1d) != d:

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -29,6 +29,7 @@ Covers:
 
 from __future__ import annotations
 
+import sys
 from typing import Any, get_args
 
 import numpy as np
@@ -1833,3 +1834,83 @@ def test_factors_validation() -> None:
         ext.factors((0,))
     with pytest.raises(TypeError, match="must be int or sequence"):
         ext.factors("0")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------- numba warmup
+
+
+class TestNumbaWarmup:
+    """Both apply funnels wait for the import-time JIT warmup, as their siblings do."""
+
+    def test_the_single_cell_funnel_calls_the_barrier(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``apply`` reaches the warmup barrier before it reaches a kernel.
+
+        ``pantr/__init__.py`` compiles its kernels on a background thread, and numba's
+        default workqueue threading layer is not safe against a concurrent
+        ``parallel=True`` call from another thread: the process *aborts* rather than
+        raising, taking the whole session with it. Every other Layer 2 entry point over
+        parallel kernels calls :func:`pantr._numba_compat.wait_for_jit_warmup` first;
+        these two did not, and ``_extraction_kernels`` is fourteen ``parallel=True``
+        kernels reached from four public methods.
+
+        Asserting the *call* rather than the absence of the crash follows
+        ``tests/test_bspline_locate.py``, and for the reason given there: the barrier is
+        a once-per-process event, so by the time any in-process test runs the warmup is
+        long finished and nothing in-process can observe the race. What this pins is the
+        contract -- delete the call and this test fails.
+        """
+        calls: list[str] = []
+        module = sys.modules["pantr.bspline._extraction_helpers"]
+        real_dispatch = module._dispatch_apply
+
+        def _record_barrier() -> None:
+            calls.append("barrier")
+
+        def _record_dispatch(d: int, op_kind: Any) -> Any:
+            calls.append("dispatch")
+            return real_dispatch(d, op_kind)
+
+        monkeypatch.setattr(module, "wait_for_jit_warmup", _record_barrier)
+        monkeypatch.setattr(module, "_dispatch_apply", _record_dispatch)
+
+        ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+        v = RNG.standard_normal(ext.input_shape_per_dir[0] * ext.input_shape_per_dir[1])
+        ext.apply(v.astype(ext.dtype), 1)
+
+        assert "barrier" in calls, "apply must wait for the JIT warmup"
+        assert calls.index("barrier") < calls.index("dispatch"), (
+            f"the barrier must precede the kernel lookup; got {calls[:3]}"
+        )
+
+    def test_the_batch_funnel_calls_the_barrier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``apply_many`` reaches the barrier before it reaches a kernel.
+
+        The batch half is twelve further ``parallel=True`` kernels behind its own Layer 2
+        funnel, so it needs its own assertion rather than inheriting the one above; see
+        that test for why the call and not the crash is what a test can pin.
+        """
+        calls: list[str] = []
+        module = sys.modules["pantr.bspline._extraction_helpers"]
+        real_dispatch = module._dispatch_apply_many
+
+        def _record_barrier() -> None:
+            calls.append("barrier")
+
+        def _record_dispatch(d: int, op_kind: Any) -> Any:
+            calls.append("dispatch")
+            return real_dispatch(d, op_kind)
+
+        monkeypatch.setattr(module, "wait_for_jit_warmup", _record_barrier)
+        monkeypatch.setattr(module, "_dispatch_apply_many", _record_dispatch)
+
+        ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+        n_in = ext.input_shape_per_dir[0] * ext.input_shape_per_dir[1]
+        operand = RNG.standard_normal((2, n_in)).astype(ext.dtype)
+        ext.apply_many(operand, [0, 1])
+
+        assert "barrier" in calls, "apply_many must wait for the JIT warmup"
+        assert calls.index("barrier") < calls.index("dispatch"), (
+            f"the barrier must precede the kernel lookup; got {calls[:3]}"
+        )


### PR DESCRIPTION
## The defect

`pantr/__init__.py` compiles its kernels on a background thread, and numba's default
workqueue threading layer is not safe against a concurrent `parallel=True` call from another
thread: the process **aborts** rather than raising, taking the whole session with it.
`CLAUDE.md` states the rule that follows — a Layer 2 entry point over parallel kernels calls
`pantr._numba_compat.wait_for_jit_warmup()` first — and names the three modules that follow it:
`basis/_basis_1D.py`, `bspline/_bspline_roots.py`, `bezier/_find_roots.py`.

**The extraction path does not.** `src/pantr/bspline/spanwise_element_extraction.py` contains no
call to the barrier at all, and `_extraction_kernels.py` is **fourteen** `parallel=True` kernels,
reached from four public methods: `apply`, `apply_transpose`, `apply_MT_K_M`, `apply_M_K_MT`,
plus their batch counterparts.

## Where the barrier goes, and why not in the four methods

In `_prepare_apply_call` and `_prepare_apply_many_call`, the two Layer 2 helpers. Every kernel
invocation in this module's contract passes through one of them, so a future consumer of the
compact storage layout inherits the barrier instead of having to remember it — one edit each
rather than two per consumer.

Two things ruled out before writing it, not after:

- **No self-deadlock.** Nothing in `__init__.py`'s warmup path reaches either helper, so the
  warmup thread cannot end up waiting on itself. Checked by enumerating the modules whose
  `_warmup_numba_functions` the background thread calls.
- **The C++ path is unaffected.** `_extraction_backend.py:317` takes its kernel from the
  extension, so there is no numba in that path, and the barrier is a no-op once the warmup has
  finished.

## Two tests, one per funnel

The batch half gets its own assertion rather than inheriting the single-cell one: they are two
sets of kernels behind two entry points, and a barrier added to one proves nothing about the
other.

Both assert **the call**, and that it precedes the kernel lookup. That follows
`tests/test_bspline_locate.py:1840`, which established this for the same barrier and for the
reason given there: the barrier is a once-per-process event, so by the time any in-process test
runs the warmup is long finished and **nothing in-process can observe the race**. What is pinned
is the contract.

**Red control, in that direction:** with the barrier removed, both tests fail; with it, both
pass.

## Deliberately not widened

The twelve `apply_kron_apply_many_*` kernels still have no `_warmup_numba_functions` entry, so
they compile on first call. That is a compilation-time question, not a safety one — the barrier
closes the abort without it — and mixing the two would make this diff a performance change as
well as a correctness one.

## Checks

All run from the branch against its own source: `ruff check` clean, `ruff format --check` (344
files), `mypy` (319 files), `lint-imports` 2 kept / 0 broken, `make doctest` 82 passed / 7
skipped, and the full `pytest` suite **9879 passed, 57 skipped, 7 xfailed** — exactly two more than
the base's 9877, which are the two tests added here.

The documentation build fails under `-W` on this branch, and it is the base's failure unchanged:
36 problems, compared set against set with the paths normalised rather than counted, **identical**
to `proto/cpp`'s. #443 fixes them.

## No merge

Opened for review only. The merge authority granted on 4 September expired with the previous
stretch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
