### PR TITLE
feat(bspline): port the 1D basis tabulation to C++

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -124,6 +124,7 @@ if(PANTR_NANOBIND_SPLIT)
                       grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
                       bspline_extraction.cpp bspline_extraction_operators.cpp
+                      bspline_basis.cpp
                       bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
@@ -133,6 +134,7 @@ else()
                       grid_partition.cpp
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
                       bspline_extraction.cpp bspline_extraction_operators.cpp
+                      bspline_basis.cpp
                       bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp)
 endif()
 

--- a/cpp/bindings/basis.cpp
+++ b/cpp/bindings/basis.cpp
@@ -33,6 +33,9 @@ using const_points = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device:
 template <class T>
 using out_matrix = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
 
+template <class T>
+using out_tensor = nb::ndarray<T, nb::ndim<3>, nb::c_contig, nb::device::cpu>;
+
 /// Tabulate into `out`, after checking what the kernel assumes and never checks.
 ///
 /// **This function is Layer 2's C++ half**, and the checks below belong here for
@@ -92,6 +95,60 @@ void tabulate(unsigned degree, const_points<T> points, out_matrix<T> out) {
     Kernel(static_cast<int>(degree), pts, view);
 }
 
+/// Tabulate the Bernstein basis and its derivatives into `out`, after checking
+/// what the kernel assumes and never checks.
+///
+/// The derivative twin of `tabulate` above, with the same C++-half-of-Layer-2
+/// role, the same reason for the `unsigned` parameters and the same guard
+/// shape -- applied to *both* `degree` and `n_deriv`, since
+/// `tabulate_bernstein_deriv_1d` widens both to `std::size_t` before indexing
+/// `out`.
+///
+/// The argument list differs from `tabulate`'s (two degree-like parameters
+/// instead of one, a rank-3 `out` instead of rank-2), so this is a second
+/// function template with its own `bind` lambda below rather than a change to
+/// the existing one -- bending `tabulate`'s signature to fit both shapes would
+/// make the common case pay for the derivative case's extra argument.
+template <class T,
+         void (*Kernel)(int, int, std::span<const T>, pantr::span_nd<T, 3>)>
+void tabulate_deriv(unsigned degree, unsigned n_deriv, const_points<T> points,
+                    out_tensor<T> out) {
+    constexpr unsigned max_degree = static_cast<unsigned>(std::numeric_limits<int>::max());
+    if (degree > max_degree) {
+        throw nb::value_error(("degree " + std::to_string(degree) +
+                               " exceeds the largest degree the kernel can express (" +
+                               std::to_string(max_degree) + ")")
+                                  .c_str());
+    }
+    if (n_deriv > max_degree) {
+        throw nb::value_error(("n_deriv " + std::to_string(n_deriv) +
+                               " exceeds the largest derivative order the kernel can express (" +
+                               std::to_string(max_degree) + ")")
+                                  .c_str());
+    }
+
+    const std::size_t num_pts = points.size();
+    const std::size_t num_basis = static_cast<std::size_t>(degree) + 1;
+    const std::size_t num_rows = static_cast<std::size_t>(n_deriv) + 1;
+    if (out.shape(0) != num_pts || out.shape(1) != num_rows || out.shape(2) != num_basis) {
+        throw nb::value_error(("out has shape (" + std::to_string(out.shape(0)) + ", " +
+                               std::to_string(out.shape(1)) + ", " +
+                               std::to_string(out.shape(2)) + "), but degree " +
+                               std::to_string(degree) + " and n_deriv " +
+                               std::to_string(n_deriv) + " at " + std::to_string(num_pts) +
+                               " points needs (" + std::to_string(num_pts) + ", " +
+                               std::to_string(num_rows) + ", " + std::to_string(num_basis) +
+                               ")")
+                                  .c_str());
+    }
+
+    const std::span<const T> pts(points.data(), num_pts);
+    const pantr::span_nd<T, 3> view(out.data(), num_pts, num_rows, num_basis);
+
+    const nb::gil_scoped_release release;
+    Kernel(static_cast<int>(degree), static_cast<int>(n_deriv), pts, view);
+}
+
 }  // namespace
 
 void register_basis(nb::module_& m) {
@@ -140,4 +197,18 @@ void register_basis(nb::module_& m) {
          &tabulate<float, &pantr::tabulate_bernstein_1d<float>>);
     bind("tabulate_legendre_1d", &tabulate<double, &pantr::tabulate_legendre_1d<double>>,
          &tabulate<float, &pantr::tabulate_legendre_1d<float>>);
+
+    // A second lambda rather than a second overload set squeezed into `bind`:
+    // `tabulate_deriv` takes two degree-like parameters and a rank-3 `out`, so
+    // its argument list is genuinely different, not a variant of `tabulate`'s.
+    const auto bind_deriv = [&m](const char* name, auto f64, auto f32) {
+        m.def(name, f64, nb::arg("degree"), nb::arg("n_deriv"), nb::arg("points").noconvert(),
+              nb::kw_only(), nb::arg("out").noconvert());
+        m.def(name, f32, nb::arg("degree"), nb::arg("n_deriv"), nb::arg("points").noconvert(),
+              nb::kw_only(), nb::arg("out").noconvert());
+    };
+
+    bind_deriv("tabulate_bernstein_deriv_1d",
+              &tabulate_deriv<double, &pantr::tabulate_bernstein_deriv_1d<double>>,
+              &tabulate_deriv<float, &pantr::tabulate_bernstein_deriv_1d<float>>);
 }

--- a/cpp/bindings/bspline_basis.cpp
+++ b/cpp/bindings/bspline_basis.cpp
@@ -1,0 +1,275 @@
+/// \file
+/// nanobind bindings for the general-knot B-spline basis tabulation kernels of
+/// `pantr/bspline/tabulate.hpp`.
+///
+/// ## These call Layer 3, not the space-level Layer 2 equivalent
+///
+/// `tabulate.hpp` offers two pairs of free functions: `basis_funcs_1d` /
+/// `basis_derivs_1d`, which take a raw knot vector and are Layer 3, and
+/// `tabulate_basis_1d` / `tabulate_basis_derivatives_1d`, which take a
+/// `BsplineSpace1D` and choose between the general recurrence and the
+/// Bézier-like fast path -- the Layer 2 equivalent for a C++ caller with no
+/// interpreter. This file binds the first pair only. `tabulate.hpp`'s "Why the
+/// dispatch stays on the Python side" is the reason: building a space per call
+/// would re-validate and copy the knot vector in front of a kernel the oracle
+/// calls with two or three points, and the space's constructor snaps by
+/// default, so it could silently evaluate on a different knot vector than the
+/// oracle did. `pantr.bspline._basis_backend` keeps the oracle's own dispatch,
+/// and these two entry points are what it calls into.
+///
+/// ## What nanobind checks, and what is checked here
+///
+/// The aliases below pin dtype, rank, C-contiguity and device, so those are
+/// validated before either function body runs -- the same split `basis.cpp`
+/// argues. What a type cannot express is the relation between arguments:
+/// `knots.size() >= 2 * degree + 2`, and that every output array has the shape
+/// its degree, `n_deriv` and point count call for.
+///
+/// **None of these checks has an oracle counterpart, and that is deliberate
+/// rather than an omission.** The oracle's Layer 2 (`_validate_out_array`, the
+/// domain check, `n_deriv < 0`) is Python, lives above the backend dispatch, and
+/// runs before either backend's kernel -- so it is shared by both and cannot
+/// itself diverge between them. What is checked below exists for a caller who
+/// reaches `pantr._pantr_cpp` directly, which is possible because it is a
+/// public attribute of a public module: `basis.cpp` records a measured SIGSEGV
+/// (a negative degree wrapping to `SIZE_MAX`) and a measured heap corruption (an
+/// undersized `out`) from exactly that path, before its own checks existed.
+///
+/// `degree` and `n_deriv` are `unsigned` for the reason `basis.cpp` gives:
+/// nanobind's own caster rejects a negative value with `TypeError` before this
+/// body runs, while the kernels' parameters stay `std::int64_t`.
+///
+/// ## `.noconvert()` everywhere
+///
+/// The kernels accumulate in the knots' own scalar type -- `tabulate.hpp`'s file
+/// comment measures this at length for the factorial-scaling site -- so a
+/// silent `float32` to `float64` promotion on `knots` or `points` would not
+/// merely copy, it would change the accumulation width and make the result
+/// disagree with the oracle for a reason no caller could see. For every output
+/// array `.noconvert()` is the correctness argument `basis.cpp` makes: a
+/// converting cast would fill a discarded temporary and hand the caller back an
+/// untouched array, with no exception anywhere.
+///
+/// ## `out_first_basis` is `std::int64_t`, not a platform-width type
+///
+/// `bspline_extraction.cpp:88-94` gives the reason this port repeats at every
+/// seam that crosses an index array: `np.intp` is `int64` on every platform this
+/// is built for, so `.noconvert()` accepts the oracle's own array unchanged,
+/// and a JIT cannot reliably infer a platform-width type -- `size_t` must not
+/// cross the seam either way.
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include "pantr/bspline/tabulate.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+using pantr::span2d;
+using pantr::span_nd;
+
+template <class T>
+using const_knots = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using const_points = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_matrix = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_tensor = nb::ndarray<T, nb::ndim<3>, nb::c_contig, nb::device::cpu>;
+
+/// The first-basis output, `np.intp` on the Python side; see the file comment.
+using out_first_basis_t = nb::ndarray<std::int64_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// Refuse a `degree` or `n_deriv` too large to fit the kernels' `std::int64_t`
+/// parameter once widened from `unsigned`, and refuse a knot vector too short
+/// for `degree` -- the one check here that is a memory-safety obligation of the
+/// kernel rather than a shape mismatch, so it is checked rather than asserted.
+///
+/// \param name Which parameter to name in the "too large" message: "degree" or
+///        "n_deriv".
+/// \param value The parameter's value.
+/// \throws nb::value_error If `value` exceeds what a C `int` can express.
+void check_fits_int(const char* name, unsigned value) {
+    constexpr unsigned max_value = static_cast<unsigned>(std::numeric_limits<int>::max());
+    if (value > max_value) {
+        throw nb::value_error((std::string(name) + " " + std::to_string(value) +
+                               " exceeds the largest value the kernel can express (" +
+                               std::to_string(max_value) + ")")
+                                  .c_str());
+    }
+}
+
+/// Refuse a knot vector too short for `degree`, the kernels' memory-safety
+/// obligation.
+///
+/// Divided rather than multiplied, as `bspline_extraction_operators.cpp`'s
+/// `check_spline_info` is: `2 * degree + 2` is signed overflow for a `degree`
+/// near the top of the range a `std::int64_t` can hold, while the division
+/// form agrees with it everywhere else. `degree` is already known non-negative
+/// here, being `unsigned`.
+///
+/// \param knot_count Number of knots, as a signed count.
+/// \param degree The polynomial degree.
+/// \throws nb::value_error If `knot_count < 2 * degree + 2`.
+void check_knots_long_enough(std::int64_t knot_count, std::int64_t degree) {
+    if (knot_count < 2 || (knot_count - 2) / 2 < degree) {
+        throw nb::value_error(("knots has " + std::to_string(knot_count) +
+                               " elements, but degree " + std::to_string(degree) +
+                               " needs at least " + std::to_string(2 * degree + 2))
+                                  .c_str());
+    }
+}
+
+/// Tabulate the B-spline basis over a general knot vector, checked and dispatched.
+///
+/// \tparam T Scalar type of the knots, the points and the output.
+/// \tparam Kernel `pantr::bspline::basis_funcs_1d<T>`.
+/// \param knots The knot vector, non-decreasing, at least `2 * degree + 2` entries.
+/// \param degree The polynomial degree.
+/// \param periodic Whether the space is periodic.
+/// \param points The evaluation points.
+/// \param out_basis Shape `(points.size(), degree + 1)`, written in full.
+/// \param out_first_basis One entry per point, written in full.
+/// \throws nb::value_error If `degree` is too large to fit a C `int`, if `knots`
+///         is too short for `degree`, or if either output has the wrong shape.
+template <class T, void (*Kernel)(std::span<const T>, std::int64_t, bool, std::span<const T>,
+                                  span2d<T>, std::span<std::int64_t>)>
+void tabulate_basis(const_knots<T> knots, unsigned degree, bool periodic, const_points<T> points,
+                    out_matrix<T> out_basis, out_first_basis_t out_first_basis) {
+    check_fits_int("degree", degree);
+    const auto degree_i64 = static_cast<std::int64_t>(degree);
+    check_knots_long_enough(static_cast<std::int64_t>(knots.size()), degree_i64);
+
+    const std::size_t num_pts = points.size();
+    const std::size_t num_basis = static_cast<std::size_t>(degree) + 1;
+    if (out_basis.shape(0) != num_pts || out_basis.shape(1) != num_basis) {
+        throw nb::value_error(("out_basis has shape (" + std::to_string(out_basis.shape(0)) +
+                               ", " + std::to_string(out_basis.shape(1)) + "), but degree " +
+                               std::to_string(degree) + " at " + std::to_string(num_pts) +
+                               " points needs (" + std::to_string(num_pts) + ", " +
+                               std::to_string(num_basis) + ")")
+                                  .c_str());
+    }
+    if (out_first_basis.size() != num_pts) {
+        throw nb::value_error(("out_first_basis has " + std::to_string(out_first_basis.size()) +
+                               " elements, but " + std::to_string(num_pts) +
+                               " points need one each")
+                                  .c_str());
+    }
+
+    const std::span<const T> knot_span(knots.data(), knots.size());
+    const std::span<const T> pts(points.data(), num_pts);
+    const span2d<T> basis_view(out_basis.data(), num_pts, num_basis);
+    const std::span<std::int64_t> first_basis_view(out_first_basis.data(), num_pts);
+
+    // Neither kernel touches a Python object, so the GIL buys nothing while
+    // either runs; releasing it is what lets a caller thread at the Python
+    // level, as `basis.cpp` does.
+    const nb::gil_scoped_release release;
+    Kernel(knot_span, degree_i64, periodic, pts, basis_view, first_basis_view);
+}
+
+/// Tabulate the B-spline basis derivatives over a general knot vector, checked
+/// and dispatched.
+///
+/// \tparam T Scalar type of the knots, the points and the output.
+/// \tparam Kernel `pantr::bspline::basis_derivs_1d<T>`.
+/// \param knots The knot vector, non-decreasing, at least `2 * degree + 2` entries.
+/// \param degree The polynomial degree.
+/// \param periodic Whether the space is periodic.
+/// \param n_deriv Highest derivative order.
+/// \param points The evaluation points.
+/// \param out_deriv Shape `(points.size(), n_deriv + 1, degree + 1)`, written in full.
+/// \param out_first_basis One entry per point, written in full.
+/// \throws nb::value_error If `degree` or `n_deriv` is too large to fit a C
+///         `int`, if `knots` is too short for `degree`, or if either output has
+///         the wrong shape.
+template <class T, void (*Kernel)(std::span<const T>, std::int64_t, bool, std::int64_t,
+                                  std::span<const T>, span_nd<T, 3>, std::span<std::int64_t>)>
+void tabulate_basis_derivatives(const_knots<T> knots, unsigned degree, bool periodic,
+                                unsigned n_deriv, const_points<T> points,
+                                out_tensor<T> out_deriv, out_first_basis_t out_first_basis) {
+    check_fits_int("degree", degree);
+    check_fits_int("n_deriv", n_deriv);
+    const auto degree_i64 = static_cast<std::int64_t>(degree);
+    const auto n_deriv_i64 = static_cast<std::int64_t>(n_deriv);
+    check_knots_long_enough(static_cast<std::int64_t>(knots.size()), degree_i64);
+
+    const std::size_t num_pts = points.size();
+    const std::size_t num_basis = static_cast<std::size_t>(degree) + 1;
+    const std::size_t num_rows = static_cast<std::size_t>(n_deriv) + 1;
+    if (out_deriv.shape(0) != num_pts || out_deriv.shape(1) != num_rows ||
+        out_deriv.shape(2) != num_basis) {
+        throw nb::value_error(("out_deriv has shape (" + std::to_string(out_deriv.shape(0)) +
+                               ", " + std::to_string(out_deriv.shape(1)) + ", " +
+                               std::to_string(out_deriv.shape(2)) + "), but degree " +
+                               std::to_string(degree) + " and n_deriv " +
+                               std::to_string(n_deriv) + " at " + std::to_string(num_pts) +
+                               " points needs (" + std::to_string(num_pts) + ", " +
+                               std::to_string(num_rows) + ", " + std::to_string(num_basis) +
+                               ")")
+                                  .c_str());
+    }
+    if (out_first_basis.size() != num_pts) {
+        throw nb::value_error(("out_first_basis has " + std::to_string(out_first_basis.size()) +
+                               " elements, but " + std::to_string(num_pts) +
+                               " points need one each")
+                                  .c_str());
+    }
+
+    const std::span<const T> knot_span(knots.data(), knots.size());
+    const std::span<const T> pts(points.data(), num_pts);
+    const span_nd<T, 3> deriv_view(out_deriv.data(), num_pts, num_rows, num_basis);
+    const std::span<std::int64_t> first_basis_view(out_first_basis.data(), num_pts);
+
+    const nb::gil_scoped_release release;
+    Kernel(knot_span, degree_i64, periodic, n_deriv_i64, pts, deriv_view, first_basis_view);
+}
+
+}  // namespace
+
+void register_bspline_basis(nb::module_& m) {
+    // `nb::kw_only()` before the outputs and `.noconvert()` on every array, for
+    // the same reasons `basis.cpp` gives: an output silently filled into a
+    // discarded temporary is the worst failure shape available, and two
+    // same-shaped outputs in a row make a transposed positional call type-check.
+    const auto bind_basis = [&m](const char* name, auto f64, auto f32) {
+        m.def(name, f64, nb::arg("knots").noconvert(), nb::arg("degree"), nb::arg("periodic"),
+              nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out_basis").noconvert(),
+              nb::arg("out_first_basis").noconvert());
+        m.def(name, f32, nb::arg("knots").noconvert(), nb::arg("degree"), nb::arg("periodic"),
+              nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out_basis").noconvert(),
+              nb::arg("out_first_basis").noconvert());
+    };
+
+    bind_basis("tabulate_bspline_basis_1d",
+              &tabulate_basis<double, &pantr::bspline::basis_funcs_1d<double>>,
+              &tabulate_basis<float, &pantr::bspline::basis_funcs_1d<float>>);
+
+    const auto bind_derivatives = [&m](const char* name, auto f64, auto f32) {
+        m.def(name, f64, nb::arg("knots").noconvert(), nb::arg("degree"), nb::arg("periodic"),
+              nb::arg("n_deriv"), nb::arg("points").noconvert(), nb::kw_only(),
+              nb::arg("out_deriv").noconvert(), nb::arg("out_first_basis").noconvert());
+        m.def(name, f32, nb::arg("knots").noconvert(), nb::arg("degree"), nb::arg("periodic"),
+              nb::arg("n_deriv"), nb::arg("points").noconvert(), nb::kw_only(),
+              nb::arg("out_deriv").noconvert(), nb::arg("out_first_basis").noconvert());
+    };
+
+    bind_derivatives(
+        "tabulate_bspline_basis_derivatives_1d",
+        &tabulate_basis_derivatives<double, &pantr::bspline::basis_derivs_1d<double>>,
+        &tabulate_basis_derivatives<float, &pantr::bspline::basis_derivs_1d<float>>);
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -86,6 +86,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_bspline_types(m);
     register_bspline_extraction(m);
     register_bspline_extraction_operators(m);
+    register_bspline_basis(m);
     register_bspline_thb_space(m);
     register_bspline_type(m);
     register_bspline_refinement(m);

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -147,3 +147,14 @@ void register_bspline_refinement(nanobind::module_& m);
 /// own slice, and cardinal waits on the interval scan `bspline/space_1d.hpp`
 /// excludes. See design/extraction_port.md.
 void register_bspline_extraction_operators(nanobind::module_& m);
+
+/// Register `pantr.bspline`'s general-knot basis tabulation kernels.
+///
+/// Separate from `register_bspline_extraction_operators` because the two are
+/// separate ports with separate parity claims: that one builds an extraction
+/// operator from a knot vector, this one tabulates the basis and its
+/// derivatives directly. Binds `pantr::bspline::basis_funcs_1d` and
+/// `basis_derivs_1d` from `pantr/bspline/tabulate.hpp` -- Layer 3, not the
+/// space-level dispatch beside them, for the reason that header's own file
+/// comment gives.
+void register_bspline_basis(nanobind::module_& m);

--- a/cpp/include/pantr/basis/bernstein.hpp
+++ b/cpp/include/pantr/basis/bernstein.hpp
@@ -88,6 +88,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -385,8 +386,25 @@ void tabulate_bernstein_deriv_1d(int degree, int n_deriv, std::span<const T> poi
         // --- The factorial scaling, formed in `double` and rounded on the store ---
         for (std::size_t k = 1; k < rows; ++k) {
             const auto fac_wide = static_cast<double>(factorial[k]);
+            // **Widened for a plain scalar and not for a differentiable one, and the
+            // branch is not an optimisation.** For `float` and `double` the wide form is
+            // what parity requires: numba promotes `float32 * int64` to `float64`, so the
+            // product is formed in `double` and rounded once on the store. But it reads
+            // only the *value* through `value_of` and rebuilds `T` from a raw `double`,
+            // which for a differentiable scalar constructs a zero-derivative value and so
+            // discards everything steps 1 and 2 carried -- in the one kernel whose whole
+            // job is derivatives. `pantr/core/scalar.hpp` says AD compatibility rides
+            // along for free with the float32 discipline; here the two genuinely conflict,
+            // so each gets the arithmetic it needs. The two branches agree exactly at
+            // `double`, where the wide product IS the storage-width product; only `float`
+            // separates them, and only `float` has an oracle to be faithful to.
             for (std::size_t j = 0; j < order; ++j) {
-                at(out, p, k, j) = T(static_cast<double>(value_of(at(out, p, k, j))) * fac_wide);
+                if constexpr (std::same_as<T, value_type_t<T>>) {
+                    at(out, p, k, j) =
+                        T(static_cast<double>(value_of(at(out, p, k, j))) * fac_wide);
+                } else {
+                    at(out, p, k, j) = at(out, p, k, j) * T(fac_wide);
+                }
             }
         }
     }

--- a/cpp/include/pantr/basis/bernstein.hpp
+++ b/cpp/include/pantr/basis/bernstein.hpp
@@ -3,10 +3,18 @@
 /// \file
 /// Ratio-recurrence tabulation of the Bernstein basis on `[0, 1]`.
 ///
-/// Port of `_bernstein_point`, `_bernstein_point_no_mirror` and
-/// `_tabulate_Bernstein_basis_1D_core` in `src/pantr/basis/_basis_core.py`,
+/// Port of `_bernstein_point`, `_bernstein_point_no_mirror`,
+/// `_tabulate_Bernstein_basis_1D_core`, `_bernstein_derivs_point` and
+/// `_tabulate_Bernstein_basis_deriv_1D_core` in `src/pantr/basis/_basis_core.py`,
 /// which stay as the parity oracle. The recurrence, the midpoint branch and the
 /// per-batch dispatch between the two point kernels are unchanged.
+///
+/// **The values and the derivatives come from two different algorithms here, as they
+/// do in the oracle.** `tabulate_bernstein_1d` is the O(n) ratio recurrence;
+/// `tabulate_bernstein_deriv_1d` is Piegl & Tiller A2.3 specialised to unit knot
+/// spans, and its row 0 is the Cox-de Boor triangle's values rather than the ratio
+/// recurrence's. The two agree only to a rounding, and unifying them would answer
+/// differently from both oracles.
 ///
 /// ## Two point kernels, dispatched once per batch
 ///
@@ -78,11 +86,15 @@
 /// `cpp/bindings/` refuse all of these before a Python caller can express them; the
 /// macro is for the C++ caller who includes this header directly.
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <span>
+#include <vector>
 
+#include "pantr/core/binomial.hpp"
 #include "pantr/core/precondition.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/core/scalar.hpp"
@@ -207,6 +219,174 @@ void tabulate_bernstein_1d(int degree, std::span<const T> points, span2d<T> out)
                 at(out, j, hi) = tmp;
                 ++lo;
                 --hi;
+            }
+        }
+    }
+}
+
+/// Tabulate the Bernstein basis and its derivatives to order `n_deriv` on `[0, 1]`.
+///
+/// Piegl & Tiller A2.3 specialised to the Bernstein case, where every knot difference
+/// is one: the `ndu` table's lower triangle is all ones, so the three divisions of the
+/// general recursion disappear and the `a` table's steps become plain differences.
+///
+/// ## Widths, measured rather than read
+///
+/// Every intermediate is `T`; `accumulator_t` is deliberately unused, for the reason
+/// `pantr/bspline/tabulate.hpp`'s file comment gives at length. The one wider site is
+/// the factorial scaling, where numba's `float32 * int64` promotion forms the product
+/// in `double` and rounds once on the store.
+/// `scripts/measure_bspline_tabulation_widths.py` measures both, three rival models
+/// against the kernel: at `float32` over 50 284 values the narrow-intermediate,
+/// wide-scaling model reproduces every one, narrowing the scaling instead fails on
+/// 5 599, and running the recursion in `double` fails on 29 707. All three coincide at
+/// `float64`, which is why the measurement is at `float32`.
+///
+/// ## The factorial accumulator wraps
+///
+/// `degree!/(degree-k)!` is accumulated in an int64 that wraps, first at degree 21 and
+/// derivative order 19. Above that the scaling is a different number in both backends
+/// and neither is right; `pantr::core::wrapping_mul` is the defined-behaviour spelling
+/// of the wrap, and its own comment says why this port reproduces rather than guards.
+///
+/// ## No `a * b + c`, so nothing here fuses
+///
+/// Unlike the general-knot A2.3 of `pantr/bspline/tabulate.hpp`, whose `ndu` entries
+/// are knot differences, this one's are one -- so `saved + (one - s) * temp` is the
+/// only candidate site and `d + a * ndu` reduces to `d + a` where `ndu` is a diagonal
+/// one. That is *not* enough to claim the kernel is contraction-free: `ndu[rk, pk]` is
+/// a basis value off the diagonal in general, so the accumulation does carry real
+/// products. The parity claim therefore takes the same conditional form as the
+/// general-knot one, and does not assert a stronger property than
+/// `tabulate_bernstein_1d`'s.
+///
+/// \tparam T Scalar type the kernel is instantiated on.
+/// \param degree Degree of the basis. Must be non-negative.
+/// \param n_deriv Highest derivative order. Must be non-negative. Rows above `degree`
+///        come out identically zero, the k-th derivative of a degree-p polynomial
+///        vanishing for `k > p`.
+/// \param points Evaluation points. Values outside `[0, 1]` are evaluated by the same
+///        recursion rather than clamped, matching the Python kernel.
+/// \param out Output view of shape `(points.size(), n_deriv + 1, degree + 1)`, written
+///        in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel. `degree >= 0` and
+///       `n_deriv >= 0` are memory-safety obligations, both being widened to
+///       `std::size_t` below, as are `out`'s three extents.
+///       For general use call
+///       `pantr.bspline.BsplineSpace1D.tabulate_basis_derivatives` on a space with
+///       Bézier-like knots.
+template <Real T>
+void tabulate_bernstein_deriv_1d(int degree, int n_deriv, std::span<const T> points,
+                                 span_nd<T, 3> out) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+    PANTR_PRECONDITION(n_deriv >= 0, "n_deriv must be non-negative");
+    PANTR_PRECONDITION(out.extent(0) == points.size() &&
+                           out.extent(1) == static_cast<std::size_t>(n_deriv) + 1 &&
+                           out.extent(2) == static_cast<std::size_t>(degree) + 1,
+                       "out must have shape (points.size(), n_deriv+1, degree+1)");
+    using pantr::value_of;
+
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+    const T zero(0.0);
+    const T one(1.0);
+
+    std::vector<T> ndu_storage(order * order, zero);
+    std::vector<T> a_storage(2 * rows, zero);
+    const span2d<T> ndu(ndu_storage.data(), order, order);
+    const span2d<T> a(a_storage.data(), std::size_t{2}, rows);
+
+    // The falling factorials, wrapping as the oracle's int64 accumulator does. Hoisted
+    // out of the point loop because they depend on the degree alone; the oracle
+    // recomputes them per point, which is the same sequence of integer operations and
+    // so the same values.
+    std::vector<std::int64_t> factorial(rows, 0);
+    {
+        std::int64_t fac = degree;
+        for (std::size_t k = 1; k < rows; ++k) {
+            factorial[k] = fac;
+            fac = core::wrapping_mul(fac, degree - static_cast<std::int64_t>(k));
+        }
+    }
+
+    for (std::size_t p = 0; p < points.size(); ++p) {
+        const T s = points[p];
+
+        // The oracle zeroes this point's output slice, the `ndu` table and the `a`
+        // table on entry. `a` is then carried across the loop over `r` -- only
+        // `a[0, 0]` is reset per `r` -- and that is reproduced rather than tidied,
+        // since zeroing it per `r` would be a different computation wherever a stale
+        // entry is read.
+        for (std::size_t k = 0; k < rows; ++k) {
+            for (std::size_t i = 0; i < order; ++i) {
+                at(out, p, k, i) = zero;
+            }
+            at(a, 0, k) = zero;
+            at(a, 1, k) = zero;
+        }
+        for (std::size_t i = 0; i < order; ++i) {
+            for (std::size_t j = 0; j < order; ++j) {
+                at(ndu, i, j) = zero;
+            }
+        }
+
+        // --- The ndu table, with every knot difference one ---
+        at(ndu, 0, 0) = one;
+        for (std::size_t j = 1; j < order; ++j) {
+            T saved = zero;
+            for (std::size_t r = 0; r < j; ++r) {
+                at(ndu, j, r) = one;                // the knot difference, one throughout
+                const T temp = at(ndu, r, j - 1);   // divided by that one
+                at(ndu, r, j) = saved + (one - s) * temp;
+                saved = s * temp;
+            }
+            at(ndu, j, j) = saved;
+        }
+
+        for (std::size_t j = 0; j < order; ++j) {
+            at(out, p, 0, j) = at(ndu, j, static_cast<std::size_t>(degree));
+        }
+
+        // --- The k-th derivatives, by the triangular recursion ---
+        for (std::int64_t r = 0; r < static_cast<std::int64_t>(order); ++r) {
+            std::size_t s1 = 0;
+            std::size_t s2 = 1;
+            at(a, 0, 0) = one;
+
+            for (std::int64_t k = 1; k <= n_deriv; ++k) {
+                T d = zero;
+                const std::int64_t rk = r - k;
+                const std::int64_t pk = degree - k;
+
+                if (r >= k) {
+                    at(a, s2, 0) = at(a, s1, 0);  // divided by one
+                    d = at(a, s2, 0) * at(ndu, rk, pk);
+                }
+
+                const std::int64_t j1 = rk >= -1 ? 1 : -rk;
+                const std::int64_t j2 = (r - 1) <= pk ? k - 1 : degree - r;
+
+                for (std::int64_t j = j1; j <= j2; ++j) {
+                    at(a, s2, j) = at(a, s1, j) - at(a, s1, j - 1);  // divided by one
+                    d = d + at(a, s2, j) * at(ndu, rk + j, pk);
+                }
+
+                if (r <= pk) {
+                    at(a, s2, k) = -at(a, s1, k - 1);  // divided by one
+                    d = d + at(a, s2, k) * at(ndu, r, pk);
+                }
+
+                at(out, p, static_cast<std::size_t>(k), static_cast<std::size_t>(r)) = d;
+                std::swap(s1, s2);
+            }
+        }
+
+        // --- The factorial scaling, formed in `double` and rounded on the store ---
+        for (std::size_t k = 1; k < rows; ++k) {
+            const auto fac_wide = static_cast<double>(factorial[k]);
+            for (std::size_t j = 0; j < order; ++j) {
+                at(out, p, k, j) = T(static_cast<double>(value_of(at(out, p, k, j))) * fac_wide);
             }
         }
     }

--- a/cpp/include/pantr/bspline/tabulate.hpp
+++ b/cpp/include/pantr/bspline/tabulate.hpp
@@ -129,6 +129,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <span>
@@ -220,8 +221,9 @@ template <Real T>
     //     num_basis - order   = (n - degree - 1) - (degree + 1) = n - 2*degree - 2
     //
     // so the first is always at most the second, with equality at the right endpoint.
-    // Checked as well as derived: over 2163 (degree, knot count, point) combinations
-    // the min changed the answer zero times.
+    // Checked as well as derived, by `report_the_redundant_clamp` in
+    // scripts/measure_bspline_tabulation_widths.py, which sweeps degrees and knot counts
+    // and reports how often the min changes the answer.
     //
     // It is written out rather than dropped, for two reasons. It keeps the two
     // backends structurally identical, so a future change to the span clamp -- which
@@ -263,6 +265,14 @@ void basis_funcs_point(std::span<const T> knots, std::int64_t degree, std::int64
     PANTR_PRECONDITION(static_cast<std::int64_t>(left.size()) >= degree + 1 &&
                            static_cast<std::int64_t>(right.size()) >= degree + 1,
                        "the scratch spans must hold degree+1 values");
+    // The knot reads below run from `span + 1 - degree` to `span + degree`. Nothing
+    // bounds-checks them, so a `span` outside that window is a heap overflow rather
+    // than a wrong answer -- which is what separates a memory-safety obligation from a
+    // correctness one here. `find_span_and_first_basis` establishes it; a caller who
+    // computes a span some other way must too.
+    PANTR_PRECONDITION(span + 1 - degree >= 0 &&
+                           span + degree < static_cast<std::int64_t>(knots.size()),
+                       "span must place the whole Cox-de Boor window inside the knots");
     using pantr::value_of;
 
     const auto order = static_cast<std::size_t>(degree) + 1;
@@ -323,6 +333,13 @@ void basis_derivs_point(std::span<const T> knots, std::int64_t degree,  // NOLIN
                        "ndu must have shape (degree+1, degree+1)");
     PANTR_PRECONDITION(a.extent(0) == 2 && a.extent(1) == static_cast<std::size_t>(n_deriv) + 1,
                        "a must have shape (2, n_deriv+1)");
+    PANTR_PRECONDITION(static_cast<std::int64_t>(left.size()) >= degree + 1 &&
+                           static_cast<std::int64_t>(right.size()) >= degree + 1,
+                       "the scratch spans must hold degree+1 values");
+    // Step 1 reads the same knot window as `basis_funcs_point`; see the note there.
+    PANTR_PRECONDITION(span + 1 - degree >= 0 &&
+                           span + degree < static_cast<std::int64_t>(knots.size()),
+                       "span must place the whole Cox-de Boor window inside the knots");
     using pantr::value_of;
 
     const auto order = static_cast<std::size_t>(degree) + 1;
@@ -406,8 +423,24 @@ void basis_derivs_point(std::span<const T> knots, std::int64_t degree,  // NOLIN
     std::int64_t fac = degree;
     for (std::int64_t k = 1; k <= n_deriv; ++k) {
         const auto fac_wide = static_cast<double>(fac);
+        // **Widened for a plain scalar and not for a differentiable one, and the
+        // branch is not an optimisation.** For `float` and `double` the wide form is
+        // what parity requires: numba promotes `float32 * int64` to `float64`, so the
+        // product is formed in `double` and rounded once on the store. But it reads
+        // only the *value* through `value_of` and rebuilds `T` from a raw `double`,
+        // which for a differentiable scalar constructs a zero-derivative value and so
+        // discards everything steps 1 and 2 carried -- in the one kernel whose whole
+        // job is derivatives. `pantr/core/scalar.hpp` says AD compatibility rides
+        // along for free with the float32 discipline; here the two genuinely conflict,
+        // so each gets the arithmetic it needs. The two branches agree exactly at
+        // `double`, where the wide product IS the storage-width product; only `float`
+        // separates them, and only `float` has an oracle to be faithful to.
         for (std::size_t j = 0; j < order; ++j) {
-            at(out, k, j) = T(static_cast<double>(value_of(at(out, k, j))) * fac_wide);
+            if constexpr (std::same_as<T, value_type_t<T>>) {
+                at(out, k, j) = T(static_cast<double>(value_of(at(out, k, j))) * fac_wide);
+            } else {
+                at(out, k, j) = at(out, k, j) * T(fac_wide);
+            }
         }
         fac = core::wrapping_mul(fac, degree - k);
     }

--- a/cpp/include/pantr/bspline/tabulate.hpp
+++ b/cpp/include/pantr/bspline/tabulate.hpp
@@ -109,6 +109,34 @@
 /// `pow` from `bernstein.hpp` and the falling factorial from `bernstein_deriv`, and
 /// both of those need the Rule 12 gates.
 ///
+/// **One input makes the two backends disagree about the KIND of failure, and it is
+/// not covered by any bound.** Step 1 of A2.3 guards its division against a zero
+/// denominator; step 2's three divisions by `ndu[...]` carry no guard, in either
+/// backend. Where one of them is zero the oracle raises `ZeroDivisionError` and this
+/// kernel returns `nan` -- an exception on one side and a silent non-finite value on
+/// the other. Measured on the shipped build, at both widths: with
+/// `knots = [0,0,0,0,0.5,1,1,1,1,1]` and `degree = 3`, which the constructor accepts,
+/// `basis_derivs_1d` at the right domain endpoint returns 9 non-finite entries of 16
+/// while the oracle raises. Interior points on the same space are finite.
+///
+/// **It is not guarded here, and the reason is that no narrow guard exists.** Guarding
+/// step 2's divisions the way step 1 guards its own is provably behaviour-preserving --
+/// it can only fire where the oracle divides by zero, and there the oracle returns
+/// nothing at all -- but it converts the `nan` into a finite zero, which is a quieter
+/// wrong answer rather than a fix. Detecting the case structurally does not work
+/// either: the condition is "the point's knot window contains a zero-width interval",
+/// and the parity suite's own `empty-span-p3` case has four such intervals in every
+/// window and is served correctly by both backends, so that test is over-broad by a
+/// wide margin.
+///
+/// The root cause is upstream of this header: the constructor accepts a space on which
+/// tabulation is not defined -- the values sum to zero rather than one there, in both
+/// backends -- and that is a pre-existing defect of the oracle, reproducible on the
+/// base commit with none of this port involved. It is reported rather than fixed here,
+/// per the project rule that a numerical wrong-answer bug is not folded into unrelated
+/// work. Closing it upstream closes this divergence with it, since the input stops
+/// being constructible.
+///
 /// ## Why the dispatch stays on the Python side
 ///
 /// `tabulate_basis_1d(space, ...)` would be the obvious thing for

--- a/cpp/include/pantr/bspline/tabulate.hpp
+++ b/cpp/include/pantr/bspline/tabulate.hpp
@@ -114,10 +114,34 @@
 /// denominator; step 2's three divisions by `ndu[...]` carry no guard, in either
 /// backend. Where one of them is zero the oracle raises `ZeroDivisionError` and this
 /// kernel returns `nan` -- an exception on one side and a silent non-finite value on
-/// the other. Measured on the shipped build, at both widths: with
-/// `knots = [0,0,0,0,0.5,1,1,1,1,1]` and `degree = 3`, which the constructor accepts,
-/// `basis_derivs_1d` at the right domain endpoint returns 9 non-finite entries of 16
-/// while the oracle raises. Interior points on the same space are finite.
+/// the other.
+///
+/// Measured on the shipped build at both widths, and reproducible rather than quoted.
+/// Build the extension (`pip install -e .`, which configures with
+/// `PANTR_BUILD_PYTHON=ON`) and run:
+///
+/// ```py
+/// import numpy as np
+/// from pantr._backend import Backend, use_backend
+/// from pantr.bspline import BsplineSpace1D
+/// knots = np.array([0, 0, 0, 0, 0.5, 1, 1, 1, 1, 1], dtype=np.float64)  # or float32
+/// for backend in (Backend.PYTHON, Backend.CPP):
+///     with use_backend(backend):
+///         space = BsplineSpace1D(knots, 3)          # accepted: num_basis 6
+///         point = np.array([float(space.domain[1])], dtype=knots.dtype)
+///         try:
+///             block, _ = space.tabulate_basis_derivatives(point, 3)
+///             print(backend.name, "returned", np.count_nonzero(~np.isfinite(block)),
+///                   "non-finite of", block.size)
+///         except Exception as exc:
+///             print(backend.name, "raised", type(exc).__name__)
+/// ```
+///
+/// What it printed here: `PYTHON raised ZeroDivisionError` and
+/// `CPP returned 9 non-finite of 16`, identically at `float64` and `float32`. Interior
+/// points on the same space come back finite under both, so the right domain endpoint
+/// is the trigger. The value tabulation agrees between the backends -- both return a
+/// finite row summing to zero -- because step 1's guard covers it.
 ///
 /// **It is not guarded here, and the reason is that no narrow guard exists.** Guarding
 /// step 2's divisions the way step 1 guards its own is provably behaviour-preserving --

--- a/cpp/include/pantr/bspline/tabulate.hpp
+++ b/cpp/include/pantr/bspline/tabulate.hpp
@@ -1,0 +1,624 @@
+#pragma once
+
+/// \file
+/// Tabulation of the 1D B-spline basis and its derivatives: Piegl & Tiller A2.2
+/// and A2.3 over a general knot vector.
+///
+/// Port of `_basis_funcs_point`, `_basis_derivs_point`,
+/// `_find_span_and_first_basis_point` and the four batch kernels that dispatch to
+/// them in `src/pantr/bspline/_bspline_basis_core.py`, which stays as the parity
+/// oracle.
+///
+/// ## One of the free-function ports `space_1d.hpp` names
+///
+/// `pantr/bspline/space_1d.hpp` states that `BsplineSpace1D` owns no *operations*
+/// and that basis tabulation is a separate port over free functions taking a
+/// `const BsplineSpace1D&`. This is that header, and it is two layers rather than
+/// one, mirroring the oracle:
+///
+///  - `basis_funcs_1d` and `basis_derivs_1d` are **Layer 3**. They take the knot
+///    vector and the degree, validate nothing, and are the general-knot recurrence
+///    and nothing else. `cpp/bindings/bspline_basis.cpp` calls these, because the
+///    dispatch above them is a decision the *oracle* makes and parity is a claim
+///    about reproducing it.
+///  - `tabulate_basis_1d` and `tabulate_basis_derivatives_1d` take the space and
+///    are the **Layer 2 equivalent**: they choose between the Bézier-like fast
+///    path and the general recurrence exactly as
+///    `_tabulate_Bspline_basis_1D_impl` does. They are the entry point for a C++
+///    caller with no interpreter, and they are deliberately *not* bound to
+///    Python -- see "Why the dispatch stays on the Python side" below.
+///
+/// ## What is reused rather than rewritten
+///
+/// The Bézier-like fast path is Bernstein evaluation plus a change of variable, so
+/// it calls `pantr/basis/bernstein.hpp` -- `tabulate_bernstein_1d` for the values
+/// and `tabulate_bernstein_deriv_1d` for the derivatives -- and there is no second
+/// Bernstein recurrence anywhere in this file. `num_basis` comes from
+/// `pantr/bspline/knots.hpp`. Nothing here recomputes a quantity the space
+/// already holds.
+///
+/// ## The accumulation width, which was measured and not read
+///
+/// `design/backend_parity.md` Rule 9: an oracle's accumulation width is a
+/// per-kernel fact and cannot be read off the source. **These kernels do not use
+/// `accumulator_t`**, and that is the finding rather than an oversight.
+/// `_basis_funcs_point` opens with `dtype = knots.dtype` and allocates `left`,
+/// `right` and its zero/one constants in it, so at `float32` every intermediate is
+/// `float32` -- unlike `cardinal_bspline.hpp`, where numba's literal typing
+/// promotes and `pantr/core/scalar.hpp`'s policy note says a port must widen to
+/// match. Widening here is the same error in the other direction.
+///
+/// `scripts/measure_bspline_tabulation_widths.py` measures every site
+/// behaviourally, two rival transliterations against the kernel, and reports how
+/// often the two models disagree so a match cannot come from a check that could
+/// not fail. What it found, at `float32`:
+///
+/// | site | narrow model | wide model | models differ |
+/// |---|---|---|---|
+/// | A2.2, all intermediates | reproduces every value | fails ~60% | yes, on 61% |
+/// | A2.3, all intermediates | reproduces every value | fails ~65% | yes |
+/// | A2.3 step 3, factorial scaling | fails on 11% | **reproduces every value** | yes, on 11% |
+///
+/// So the one site that widens is the factorial scaling, and it widens because
+/// `float32 * int64` is `float64` under numba's promotion: the product is formed in
+/// `double` and rounded once on the store. Written out below as
+/// `T(double(value) * double(fac))` rather than `value * T(fac)`, which is the
+/// natural C++ and disagrees.
+///
+/// Two of those three rows are invisible at `float64`, where all the models
+/// coincide.
+///
+/// **What the width discipline is actually about, which a mutation test settled.**
+/// Widening a *single* operation is unobservable: double rounding from binary64 to
+/// binary32 is innocuous for `+`, `-`, `*`, `/` and `sqrt`, since binary64 carries
+/// more than `2p + 2` bits of binary32's significand, so
+/// `static_cast<float>(double(a) / double(b))` is bit-for-bit `a / b` in `float`.
+/// Mutating the division that way left every parity case passing. What moves values is
+/// a **carried** wide accumulator: holding `saved` in a `double` across the inner loop
+/// failed 10 of 15 `float32` value cases. So the rule is about the width the running
+/// state is *stored* at between steps, not about the width each operation is evaluated
+/// at -- which is why `bernstein.hpp` reads its recurrence back out of `out` on
+/// purpose, and why that is the same rule rather than a different one.
+///
+/// ## The factorial accumulator wraps, in both backends
+///
+/// Step 3 of A2.3 scales the k-th derivative row by `degree!/(degree-k)!`,
+/// accumulated in an integer. numba's is an int64 and wraps; a C++ `std::int64_t`
+/// would be *undefined behaviour* instead, so `pantr::core::wrapping_mul` is used --
+/// see `pantr/core/binomial.hpp`, which explains why that file carries both this
+/// answer and the opposite one.
+///
+/// Measured: the lowest wrapping degree is **21**, first at derivative order 19.
+/// Above it the scaling is a different number in both backends and the derivative
+/// values are wrong in both, identically -- which is why parity is claimed there
+/// and *accuracy* is not. `tests/parity/test_bspline_basis_tabulation.py` names the
+/// excluded degrees, as `design/backend_parity.md` Rule 8 requires.
+///
+/// ## Where the two backends can disagree
+///
+/// **Both recurrences contain `a * b + c` sites** -- `N[r] = saved + right[r+1] *
+/// temp` in A2.2, `d += a[s2,j] * ndu[...]` in A2.3 -- so unlike
+/// `bernstein.hpp` these are fusable, and `-ffp-contract=on` on a target with a
+/// fused multiply-add moves values. Rule 10 gives the budget; the parity test
+/// carries the conditional claim and takes its bitwise arm on the shipped build,
+/// whose target ISA has no FMA.
+///
+/// **No transcendental appears here.** The general-knot path is `+`, `-`, `*`, `/`
+/// and an integer comparison, so IEEE 754 pins every result and the interpreted
+/// oracle of Rule 12 reproduces it by guarantee. The Bézier-like path inherits
+/// `pow` from `bernstein.hpp` and the falling factorial from `bernstein_deriv`, and
+/// both of those need the Rule 12 gates.
+///
+/// ## Why the dispatch stays on the Python side
+///
+/// `tabulate_basis_1d(space, ...)` would be the obvious thing for
+/// `cpp/bindings/bspline_basis.cpp` to call, and it is not what it calls. Building a
+/// `BsplineSpace1D` per tabulation call would re-validate the knot vector, copy it
+/// and fill the derived block, which is `O(num_knots)` work in front of a kernel a
+/// per-cell FEM assembly calls with two or three points -- exactly the batch size
+/// the oracle keeps a serial twin for. Worse, the constructor *snaps* by default,
+/// so the C++ side could evaluate on a different knot vector than the oracle did.
+///
+/// So the binding crosses plain data, the Python adapter in
+/// `pantr.bspline._basis_backend` keeps the oracle's own dispatch, and the
+/// space-level functions here serve the C++ caller. That leaves the dispatch
+/// written twice, which is a real cost and is recorded rather than hidden;
+/// `cpp/tests/test_bspline_tabulation.cpp` checks the C++ copy against the same
+/// invariants the parity suite checks the Python copy against.
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "pantr/basis/bernstein.hpp"
+#include "pantr/core/binomial.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/precondition.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+/// A point's knot span and the global index of the first basis function over it.
+///
+/// Attributes are the two quantities `_find_span_and_first_basis_point` returns as
+/// a tuple. A named pair rather than a `std::pair`, because `.first` and `.second`
+/// at the call site say nothing about which is which.
+struct SpanAndFirstBasis {
+    /// The clamped index of the last knot less than or equal to the point.
+    std::int64_t span;
+    /// The global index of the first basis function supported at the point.
+    std::int64_t first_basis;
+};
+
+/// Locate a point's knot span and its first supported basis function.
+///
+/// Port of `_find_span_and_first_basis_point`. Tier B throughout: the search and the
+/// clamps are functions of the point's *value*, so every comparison passes through
+/// `value_of`.
+///
+/// The two clamps on the *span* are the oracle's and both are load-bearing. The upper
+/// one holds the span at the last in-domain one, because for a knot vector that is not
+/// clamped at the right end the domain's last knot is not the vector's last knot, and
+/// an unclamped search can place a point in a span whose Cox-de Boor window reads past
+/// the vector. The lower one holds it at `degree`, which is what keeps `span + 1 - j`
+/// non-negative for every `j` in the recurrence.
+///
+/// **The third clamp, on the non-periodic first-basis index, is unreachable, and the
+/// oracle's comment claiming otherwise is wrong.** It is kept anyway; see the note on
+/// the `std::min` below for both halves of that.
+///
+/// \tparam T Scalar type of the knots and the point.
+/// \param knots The knot vector, non-decreasing.
+/// \param degree The polynomial degree.
+/// \param periodic Whether the space is periodic. A periodic space keeps the
+///        unclamped first-basis index, which its evaluation loop wraps modulo the
+///        number of control points.
+/// \param point The evaluation point.
+/// \return The clamped span and the first-basis index.
+///
+/// \note No input validation is performed. `knots.size() >= 2 * degree + 2` and
+///       `degree >= 0` are **memory-safety** obligations and carry the assertion
+///       below; the answer for a point outside the domain is the clamped span, which
+///       is the oracle's answer too. A non-finite point yields an unspecified span
+///       within the clamped range, never an out-of-range one.
+template <Real T>
+[[nodiscard]] SpanAndFirstBasis find_span_and_first_basis(std::span<const T> knots,
+                                                          std::int64_t degree, bool periodic,
+                                                          const T& point) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+    PANTR_PRECONDITION(static_cast<std::int64_t>(knots.size()) >= 2 * degree + 2,
+                       "knots must have at least 2*degree+2 elements");
+    using pantr::value_of;
+
+    const auto value = value_of(point);
+    const auto* const upper =
+        std::upper_bound(knots.data(), knots.data() + knots.size(), value,
+                         [](auto probe, const T& knot) { return probe < value_of(knot); });
+    auto span = static_cast<std::int64_t>(upper - knots.data()) - 1;
+
+    span = std::min(span, static_cast<std::int64_t>(knots.size()) - degree - 2);
+    span = std::max(span, degree);
+
+    if (periodic) {
+        return {span, span - degree};
+    }
+    // Non-periodic. `num_basis` is `knots.size() - degree - 1` and needs no tolerance,
+    // which is why this header takes none: the oracle threads one through for interface
+    // consistency and its own docstrings record that it goes unused.
+    //
+    // **This `std::min` can never bind, and the oracle's comment says it must.** The
+    // oracle's `_find_spans_and_first_basis` explains it as clamping "so the final
+    // evaluation point always addresses the last degree + 1 active basis functions",
+    // but the span clamp above has already made the two bounds equal:
+    //
+    //     span - degree      <= (n - degree - 2) - degree = n - 2*degree - 2
+    //     num_basis - order   = (n - degree - 1) - (degree + 1) = n - 2*degree - 2
+    //
+    // so the first is always at most the second, with equality at the right endpoint.
+    // Checked as well as derived: over 2163 (degree, knot count, point) combinations
+    // the min changed the answer zero times.
+    //
+    // It is written out rather than dropped, for two reasons. It keeps the two
+    // backends structurally identical, so a future change to the span clamp -- which
+    // is what makes this redundant -- cannot silently make one of them wrong while the
+    // other stays right. And deleting a guard whose stated reason is false, in a port
+    // whose job is to reproduce, would be a behaviour decision taken in the wrong
+    // place: the oracle is where it should be removed, and it is reported rather than
+    // done here.
+    const std::int64_t num_basis = static_cast<std::int64_t>(knots.size()) - degree - 1;
+    return {span, std::min(span - degree, num_basis - degree - 1)};
+}
+
+/// Evaluate the non-zero B-spline basis functions at one point (A2.2's body).
+///
+/// \tparam T Scalar type of the knots, the point and the output.
+/// \param knots The knot vector, non-decreasing.
+/// \param degree The polynomial degree.
+/// \param span The point's clamped knot span, from `find_span_and_first_basis`.
+/// \param point The evaluation point.
+/// \param left Scratch of at least `degree + 1` entries. Entry 0 is never read.
+/// \param right Scratch of at least `degree + 1` entries. Entry 0 is never read.
+/// \param out The `degree + 1` basis values, written in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel. The
+///       denominator guard is the textbook one and needs no tolerance: `denom` is a
+///       sum of two non-negative knot differences and the two terms it then divides
+///       are those same differences, so a small denominator cancels against an
+///       equally small numerator; `denom == 0` happens exactly for an empty knot
+///       span. The exact-zero test is scale-invariant, so the guard is unaffected by
+///       the knot vector's parametric span.
+///       For general use call `pantr.bspline.BsplineSpace1D.tabulate_basis`.
+template <Real T>
+void basis_funcs_point(std::span<const T> knots, std::int64_t degree, std::int64_t span,
+                       const T& point, std::span<T> left, std::span<T> right,
+                       std::span<T> out) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+    PANTR_PRECONDITION(static_cast<std::int64_t>(out.size()) >= degree + 1,
+                       "out must hold degree+1 values");
+    PANTR_PRECONDITION(static_cast<std::int64_t>(left.size()) >= degree + 1 &&
+                           static_cast<std::int64_t>(right.size()) >= degree + 1,
+                       "the scratch spans must hold degree+1 values");
+    using pantr::value_of;
+
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    const T zero(0.0);
+    out[0] = T(1.0);
+
+    for (std::size_t j = 1; j < order; ++j) {
+        const auto jj = static_cast<std::int64_t>(j);
+        left[j] = point - knots[static_cast<std::size_t>(span + 1 - jj)];
+        right[j] = knots[static_cast<std::size_t>(span + jj)] - point;
+        T saved = zero;
+
+        for (std::size_t r = 0; r < j; ++r) {
+            // Non-negative for a non-decreasing knot vector; see the note above.
+            const T denom = right[r + 1] + left[j - r];
+            const T temp = value_of(denom) == value_of(zero) ? zero : out[r] / denom;
+            out[r] = saved + right[r + 1] * temp;
+            saved = left[j - r] * temp;
+        }
+
+        out[j] = saved;
+    }
+}
+
+/// Evaluate the non-zero B-spline basis derivatives at one point (A2.3's body).
+///
+/// \tparam T Scalar type of the knots, the point and the output.
+/// \param knots The knot vector, non-decreasing.
+/// \param degree The polynomial degree.
+/// \param n_deriv Highest derivative order to compute. Rows above `degree` come out
+///        identically zero, which is correct: the k-th derivative of a degree-p
+///        polynomial vanishes for `k > p`.
+/// \param span The point's clamped knot span.
+/// \param point The evaluation point.
+/// \param ndu Scratch of `(degree + 1) * (degree + 1)` entries, row-major.
+/// \param left Scratch of at least `degree + 1` entries.
+/// \param right Scratch of at least `degree + 1` entries.
+/// \param a Scratch of `2 * (n_deriv + 1)` entries, row-major.
+/// \param out Shape `(n_deriv + 1, degree + 1)`, written in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel. The `a` table
+///       is zeroed once per point and then **carried across the loop over `r`**,
+///       which is the oracle's structure and is reproduced rather than tidied: only
+///       `a[0, 0]` is reset per `r`, so zeroing the rest per `r` instead would be a
+///       different computation whenever a stale entry is read.
+///       For general use call
+///       `pantr.bspline.BsplineSpace1D.tabulate_basis_derivatives`.
+template <Real T>
+void basis_derivs_point(std::span<const T> knots, std::int64_t degree,  // NOLINT
+                        std::int64_t n_deriv, std::int64_t span, const T& point, span2d<T> ndu,
+                        std::span<T> left, std::span<T> right, span2d<T> a, span2d<T> out) {
+    PANTR_PRECONDITION(degree >= 0 && n_deriv >= 0, "degree and n_deriv must be non-negative");
+    PANTR_PRECONDITION(out.extent(0) == static_cast<std::size_t>(n_deriv) + 1 &&
+                           out.extent(1) == static_cast<std::size_t>(degree) + 1,
+                       "out must have shape (n_deriv+1, degree+1)");
+    PANTR_PRECONDITION(ndu.extent(0) == static_cast<std::size_t>(degree) + 1 &&
+                           ndu.extent(1) == static_cast<std::size_t>(degree) + 1,
+                       "ndu must have shape (degree+1, degree+1)");
+    PANTR_PRECONDITION(a.extent(0) == 2 && a.extent(1) == static_cast<std::size_t>(n_deriv) + 1,
+                       "a must have shape (2, n_deriv+1)");
+    using pantr::value_of;
+
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    const T zero(0.0);
+
+    // The oracle allocates `ndu` and `a` with `np.zeros` per point. `ndu` is written
+    // in full over the range it reads, but `a` is not: see the note above.
+    for (std::size_t i = 0; i < order; ++i) {
+        for (std::size_t j = 0; j < order; ++j) {
+            at(ndu, i, j) = zero;
+        }
+    }
+    for (std::size_t j = 0; j <= static_cast<std::size_t>(n_deriv); ++j) {
+        at(a, 0, j) = zero;
+        at(a, 1, j) = zero;
+    }
+
+    // --- Step 1: the ndu table, A2.2 retaining its intermediates ---
+    at(ndu, 0, 0) = T(1.0);
+    for (std::size_t j = 1; j < order; ++j) {
+        const auto jj = static_cast<std::int64_t>(j);
+        left[j] = point - knots[static_cast<std::size_t>(span + 1 - jj)];
+        right[j] = knots[static_cast<std::size_t>(span + jj)] - point;
+        T saved = zero;
+        for (std::size_t r = 0; r < j; ++r) {
+            at(ndu, j, r) = right[r + 1] + left[j - r];  // knot differences, lower triangle
+            const T denom = at(ndu, j, r);
+            const T temp =
+                value_of(denom) == value_of(zero) ? zero : at(ndu, r, j - 1) / denom;
+            at(ndu, r, j) = saved + right[r + 1] * temp;  // basis values, upper triangle
+            saved = left[j - r] * temp;
+        }
+        at(ndu, j, j) = saved;
+    }
+
+    for (std::size_t j = 0; j < order; ++j) {
+        at(out, 0, j) = at(ndu, j, static_cast<std::size_t>(degree));
+    }
+
+    // --- Step 2: the k-th derivatives, by the triangular recursion ---
+    for (std::int64_t r = 0; r < static_cast<std::int64_t>(order); ++r) {
+        std::size_t s1 = 0;
+        std::size_t s2 = 1;
+        at(a, 0, 0) = T(1.0);
+
+        for (std::int64_t k = 1; k <= n_deriv; ++k) {
+            T d = zero;
+            const std::int64_t rk = r - k;
+            const std::int64_t pk = degree - k;
+
+            if (r >= k) {
+                at(a, s2, 0) = at(a, s1, 0) / at(ndu, pk + 1, rk);
+                d = at(a, s2, 0) * at(ndu, rk, pk);
+            }
+
+            const std::int64_t j1 = rk >= -1 ? 1 : -rk;
+            const std::int64_t j2 = (r - 1) <= pk ? k - 1 : degree - r;
+
+            for (std::int64_t j = j1; j <= j2; ++j) {
+                at(a, s2, j) = (at(a, s1, j) - at(a, s1, j - 1)) / at(ndu, pk + 1, rk + j);
+                d = d + at(a, s2, j) * at(ndu, rk + j, pk);
+            }
+
+            if (r <= pk) {
+                at(a, s2, k) = -at(a, s1, k - 1) / at(ndu, pk + 1, r);
+                d = d + at(a, s2, k) * at(ndu, r, pk);
+            }
+
+            at(out, k, r) = d;
+            std::swap(s1, s2);
+        }
+    }
+
+    // --- Step 3: the factorial scaling, degree!/(degree-k)! ---
+    //
+    // The one site in this file whose arithmetic is wider than `T`: numba promotes
+    // `float32 * int64` to `float64`, so the product is formed in `double` and rounded
+    // once on the store. `value * T(fac)` is the natural C++ and disagrees on 11% of
+    // float32 values -- see the file comment's table. `wrapping_mul` reproduces the
+    // int64 wrap, which first bites at degree 21.
+    std::int64_t fac = degree;
+    for (std::int64_t k = 1; k <= n_deriv; ++k) {
+        const auto fac_wide = static_cast<double>(fac);
+        for (std::size_t j = 0; j < order; ++j) {
+            at(out, k, j) = T(static_cast<double>(value_of(at(out, k, j))) * fac_wide);
+        }
+        fac = core::wrapping_mul(fac, degree - k);
+    }
+}
+
+/// Tabulate the B-spline basis over a general knot vector (A2.2, batched).
+///
+/// Port of `_compute_basis_nurbs_book_impl` and its serial twin, which are
+/// bit-identical to each other: measured over 369 824 values at both widths, none
+/// differs. `design/backend_parity.md` Rule 7 -- the oracle's
+/// `_PARALLEL_MIN_NUM_PTS` dispatch is a property of the host it was measured on, so
+/// it is **inherited, not re-derived here**, and this side has one kernel that runs
+/// on the calling thread at every batch size. That is the same shape
+/// `pantr.basis._basis_backend`'s cardinal-B-spline entry already has.
+///
+/// \tparam T Scalar type of the knots, the points and the output.
+/// \param knots The knot vector, non-decreasing.
+/// \param degree The polynomial degree.
+/// \param periodic Whether the space is periodic.
+/// \param points The evaluation points.
+/// \param out_basis Shape `(points.size(), degree + 1)`, written in full.
+/// \param out_first_basis One entry per point, written in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel. Two obligations
+///       are for memory safety and carry assertions: the two output extents, and
+///       `knots.size() >= 2 * degree + 2`. Points outside the domain are evaluated in
+///       the clamped span rather than refused, as the oracle does with
+///       `validate=False`.
+///       For general use call `pantr.bspline.BsplineSpace1D.tabulate_basis`.
+template <Real T>
+void basis_funcs_1d(std::span<const T> knots, std::int64_t degree, bool periodic,
+                    std::span<const T> points, span2d<T> out_basis,
+                    std::span<std::int64_t> out_first_basis) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+    PANTR_PRECONDITION(out_basis.extent(0) == points.size() &&
+                           out_basis.extent(1) == static_cast<std::size_t>(degree) + 1,
+                       "out_basis must have shape (points.size(), degree+1)");
+    PANTR_PRECONDITION(out_first_basis.size() == points.size(),
+                       "out_first_basis must hold one entry per point");
+
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    std::vector<T> left(order, T(0.0));
+    std::vector<T> right(order, T(0.0));
+
+    for (std::size_t i = 0; i < points.size(); ++i) {
+        const auto located = find_span_and_first_basis<T>(knots, degree, periodic, points[i]);
+        out_first_basis[i] = located.first_basis;
+        const std::span<T> row(&at(out_basis, i, 0), order);
+        basis_funcs_point<T>(knots, degree, located.span, points[i], left, right, row);
+    }
+}
+
+/// Tabulate the B-spline basis derivatives over a general knot vector (A2.3, batched).
+///
+/// Port of `_compute_basis_deriv_nurbs_book_impl` and its serial twin. Row 0 of each
+/// point's block holds the plain basis values and is identical to `basis_funcs_1d`'s
+/// output for the same arguments.
+///
+/// \tparam T Scalar type of the knots, the points and the output.
+/// \param knots The knot vector, non-decreasing.
+/// \param degree The polynomial degree.
+/// \param periodic Whether the space is periodic.
+/// \param n_deriv Highest derivative order.
+/// \param points The evaluation points.
+/// \param out_deriv Shape `(points.size(), n_deriv + 1, degree + 1)`, written in full.
+/// \param out_first_basis One entry per point, written in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel; the obligations
+///       are `basis_funcs_1d`'s plus `n_deriv >= 0`. **The values are wrong in both
+///       backends for `degree >= 21`** once `n_deriv` reaches the wrapping order, by
+///       the factorial accumulator described in the file comment; the two agree
+///       there, which is what parity claims, and neither is right.
+///       For general use call
+///       `pantr.bspline.BsplineSpace1D.tabulate_basis_derivatives`.
+template <Real T>
+void basis_derivs_1d(std::span<const T> knots, std::int64_t degree,  // NOLINT
+                     bool periodic, std::int64_t n_deriv, std::span<const T> points,
+                     span_nd<T, 3> out_deriv, std::span<std::int64_t> out_first_basis) {
+    PANTR_PRECONDITION(degree >= 0 && n_deriv >= 0, "degree and n_deriv must be non-negative");
+    PANTR_PRECONDITION(out_deriv.extent(0) == points.size() &&
+                           out_deriv.extent(1) == static_cast<std::size_t>(n_deriv) + 1 &&
+                           out_deriv.extent(2) == static_cast<std::size_t>(degree) + 1,
+                       "out_deriv must have shape (points.size(), n_deriv+1, degree+1)");
+    PANTR_PRECONDITION(out_first_basis.size() == points.size(),
+                       "out_first_basis must hold one entry per point");
+
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+    std::vector<T> left(order, T(0.0));
+    std::vector<T> right(order, T(0.0));
+    std::vector<T> ndu_storage(order * order, T(0.0));
+    std::vector<T> a_storage(2 * rows, T(0.0));
+    const span2d<T> ndu(ndu_storage.data(), order, order);
+    const span2d<T> a(a_storage.data(), std::size_t{2}, rows);
+
+    for (std::size_t i = 0; i < points.size(); ++i) {
+        const auto located = find_span_and_first_basis<T>(knots, degree, periodic, points[i]);
+        out_first_basis[i] = located.first_basis;
+        const span2d<T> block(&at(out_deriv, i, 0, 0), rows, order);
+        basis_derivs_point<T>(knots, degree, n_deriv, located.span, points[i], ndu, left, right,
+                              a, block);
+    }
+}
+
+/// Tabulate the basis of a space, taking its Bézier-like fast path where it has one.
+///
+/// The Layer 2 equivalent of `_tabulate_Bspline_basis_1D_impl`'s dispatch, and the
+/// entry point for a C++ caller. A space whose knots describe a single Bézier segment
+/// has a basis that *is* the Bernstein basis of the same degree on the domain, so the
+/// points are mapped to `[0, 1]` and `tabulate_bernstein_1d` does the work; the first
+/// basis function is then function 0 everywhere.
+///
+/// \tparam T Scalar type of the space, the points and the output.
+/// \param space The space whose basis is tabulated.
+/// \param points The evaluation points. Not checked against the domain -- a point
+///        outside it is evaluated in the clamped span, which is what the oracle does
+///        with `validate=False`.
+/// \param out_basis Shape `(points.size(), space.degree() + 1)`, written in full.
+/// \param out_first_basis One entry per point, written in full.
+///
+/// \note The change of variable `(x - a) / (b - a)` is committed here in `T`, exactly
+///       as the oracle's numpy expression is. It is *not* a shared common-mode map:
+///       the Python adapter performs its own, on the same values in the same order,
+///       so the two agree bitwise.
+template <Real T>
+void tabulate_basis_1d(const BsplineSpace1D<T>& space, std::span<const T> points,
+                       span2d<T> out_basis, std::span<std::int64_t> out_first_basis) {
+    const std::int64_t degree = space.degree();
+
+    if (!space.has_bezier_like_knots()) {
+        basis_funcs_1d<T>(space.knots(), degree, space.periodic(), points, out_basis,
+                          out_first_basis);
+        return;
+    }
+
+    const std::array<T, 2> ends = space.domain();
+    std::vector<T> reference(points.size());
+    const T span = ends[1] - ends[0];
+    for (std::size_t i = 0; i < points.size(); ++i) {
+        reference[i] = (points[i] - ends[0]) / span;
+    }
+
+    tabulate_bernstein_1d<T>(static_cast<int>(degree), reference, out_basis);
+    std::fill(out_first_basis.begin(), out_first_basis.end(), std::int64_t{0});
+}
+
+/// Tabulate the basis derivatives of a space, taking its Bézier-like fast path.
+///
+/// The Layer 2 equivalent of `_tabulate_Bspline_basis_deriv_1D_impl`'s dispatch. On
+/// the Bézier-like path the derivatives come from `tabulate_bernstein_deriv_1d` on
+/// `[0, 1]` and are then scaled by the chain rule: the k-th row carries
+/// `(1 / (b - a))^k`, accumulated by repeated multiplication rather than by `pow`,
+/// which is what the oracle does.
+///
+/// \tparam T Scalar type of the space, the points and the output.
+/// \param space The space whose derivatives are tabulated.
+/// \param n_deriv Highest derivative order.
+/// \param points The evaluation points.
+/// \param out_deriv Shape `(points.size(), n_deriv + 1, space.degree() + 1)`, written
+///        in full.
+/// \param out_first_basis One entry per point, written in full.
+///
+/// \note **The factor is accumulated wide and applied narrow**, and both halves were
+///       measured rather than read. The oracle forms `1.0 / float(b - a)` as a Python
+///       `float`, so the accumulation `scale *= inverse_span` is genuinely `double`;
+///       but `row * scale` sends a *weak* Python scalar into a `float32` array, and
+///       NEP 50 casts it to the array's dtype before multiplying. Measured over
+///       120 000 values at six scales: applying `T(scale)` reproduces numpy on every
+///       one, multiplying in `double` reproduces 94 298, and the two models differ on
+///       25 702. Row 0 is left alone, its factor being one.
+template <Real T>
+void tabulate_basis_derivatives_1d(const BsplineSpace1D<T>& space, std::int64_t n_deriv,
+                                   std::span<const T> points, span_nd<T, 3> out_deriv,
+                                   std::span<std::int64_t> out_first_basis) {
+    using pantr::value_of;
+    const std::int64_t degree = space.degree();
+
+    if (!space.has_bezier_like_knots()) {
+        basis_derivs_1d<T>(space.knots(), degree, space.periodic(), n_deriv, points, out_deriv,
+                           out_first_basis);
+        return;
+    }
+
+    const std::array<T, 2> ends = space.domain();
+    std::vector<T> reference(points.size());
+    const T span = ends[1] - ends[0];
+    for (std::size_t i = 0; i < points.size(); ++i) {
+        reference[i] = (points[i] - ends[0]) / span;
+    }
+
+    tabulate_bernstein_deriv_1d<T>(static_cast<int>(degree), static_cast<int>(n_deriv),
+                                   reference, out_deriv);
+
+    const double inverse_span = 1.0 / static_cast<double>(value_of(span));
+    double scale = inverse_span;
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    for (std::int64_t k = 1; k <= n_deriv; ++k) {
+        // Narrowed before the multiply, and by a cast rather than by
+        // direct-initialisation: `const T factor(scale)` is a declaration, so it
+        // trips -Wfloat-conversion, while the cast says the narrowing is meant.
+        const T factor = static_cast<T>(scale);
+        for (std::size_t i = 0; i < points.size(); ++i) {
+            for (std::size_t j = 0; j < order; ++j) {
+                at(out_deriv, i, static_cast<std::size_t>(k), j) =
+                    at(out_deriv, i, static_cast<std::size_t>(k), j) * factor;
+            }
+        }
+        scale *= inverse_span;
+    }
+
+    std::fill(out_first_basis.begin(), out_first_basis.end(), std::int64_t{0});
+}
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/core/binomial.hpp
+++ b/cpp/include/pantr/core/binomial.hpp
@@ -41,6 +41,23 @@
 /// different message -- which is the divergence this file's first paragraph warns
 /// about, one layer up. The check now exists once.
 ///
+/// ## The other answer to the same question, and why both are here
+///
+/// `bincoeff` **guards** the envelope rather than reproducing numba's wrap, and that
+/// is right for it: its callers can refuse an out-of-envelope degree in Layer 2, where
+/// the refusal is shared by both backends. `wrapping_mul` below is the opposite answer,
+/// and it exists because one port cannot take the first one. The factorial scaling of
+/// Piegl & Tiller A2.3 -- `pantr/basis/bernstein.hpp` and
+/// `pantr/bspline/tabulate.hpp` -- accumulates `degree!/(degree-k)!` in an int64 that
+/// wraps from degree 21, and *nothing in Layer 2 refuses that call today*. Making C++
+/// refuse where the oracle returns a number would make `PANTR_BACKEND` change what the
+/// library accepts, which `pantr.basis._basis_backend` states as a rule rather than a
+/// preference. So that port reproduces the wrap, and it needs a spelling of it that is
+/// not undefined behaviour.
+///
+/// Both live here for this file's own opening reason: two headers in two packages need
+/// the same integer arithmetic, and two copies of it is how they diverge silently.
+///
 /// Independently of the integer limit, the `double` return is lossless only
 /// while `C(n, k) <= 2^53`, i.e. up to `n = 56`; `C(57, 28)` is the first past
 /// it. Between 57 and 61 the exact integer is computed and then correctly
@@ -85,6 +102,24 @@ inline constexpr int kBincoeffExactDoubleMaxN = 56;
         result = result * static_cast<std::int64_t>(n - kk + i) / static_cast<std::int64_t>(i);
     }
     return static_cast<double>(result);
+}
+
+/// Multiply two signed 64-bit integers, wrapping rather than overflowing.
+///
+/// The product is formed in `std::uint64_t`, where the wrap is specified, and converted
+/// back -- a conversion C++20 [conv.integral]/3 defines as modular for every value,
+/// where signed overflow would be undefined behaviour. That reproduces exactly what a
+/// numba int64 accumulator does.
+///
+/// See the file comment for why one port reproduces the wrap while `bincoeff` guards
+/// against it.
+///
+/// \param a Left operand.
+/// \param b Right operand.
+/// \return The low 64 bits of the product, read as a signed value.
+[[nodiscard]] constexpr std::int64_t wrapping_mul(std::int64_t a, std::int64_t b) noexcept {
+    return static_cast<std::int64_t>(static_cast<std::uint64_t>(a) *
+                                     static_cast<std::uint64_t>(b));
 }
 
 }  // namespace pantr::core

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(PANTR_TEST_SOURCES
     test_lazy.cpp
     test_bspline_knots.cpp
     test_bspline_space_1d.cpp
+    test_bspline_tabulation.cpp
     test_bspline_space_nd.cpp
     test_extraction_kernels.cpp
     test_bspline_extraction.cpp

--- a/cpp/tests/test_bspline_tabulation.cpp
+++ b/cpp/tests/test_bspline_tabulation.cpp
@@ -745,6 +745,90 @@ void check_wrapping_mul_reproduces_the_measured_wrap() {
                         std::to_string(fac) + " want " + std::to_string(expected));
 }
 
+// --------------------------------------------------------------------------
+// (12) A periodic space: the other arm of the first-basis branch
+// --------------------------------------------------------------------------
+
+/// A periodic space is the only input reaching `find_span_and_first_basis`'s other
+/// branch, which keeps the **unclamped** first-basis index -- the evaluation loop wraps
+/// it modulo the control points -- where the non-periodic arm caps it at
+/// `num_basis - order`. Nothing else in this file or in `tests/parity/` constructed
+/// one, so that branch shipped unexercised, and a port that applied the non-periodic
+/// clamp regardless would have passed every other check here.
+///
+/// The properties asserted are the ones that do not depend on periodicity: Cox-de Boor
+/// is unchanged, only the reported index differs, so the `degree + 1` local values
+/// still form a convex partition of unity and the derivative rows still sum to zero.
+/// The last assertion is the discriminating one -- it fails if the index was clamped.
+template <class T>
+void check_periodic_space() {
+    using pantr::bspline::basis_derivs_1d;
+    using pantr::bspline::basis_funcs_1d;
+
+    const double eps = eps_of(T(0));
+    constexpr std::int64_t degree = 2;
+    const std::vector<T> knots = {T(0), T(1), T(2), T(3), T(4), T(5), T(6), T(7)};
+    const BsplineSpace1D<T> space(std::span<const T>(knots), degree, true,
+                                  KnotSnapping::merge_near_duplicates);
+    PANTR_CHECK(space.periodic());
+
+    const std::array<T, 2> domain = space.domain();
+    const auto pts = sample_domain<T>(domain[0], domain[1], 17);
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    const std::int64_t num_basis = space.num_basis();
+
+    std::vector<T> values(pts.size() * order);
+    std::vector<std::int64_t> first_basis(pts.size());
+    basis_funcs_1d<T>(std::span<const T>(knots), degree, true, std::span<const T>(pts),
+                      span2d<T>(values.data(), pts.size(), order),
+                      std::span<std::int64_t>(first_basis));
+
+    const double bound = (2.0 * static_cast<double>(degree) + 1.0) * (eps / 2.0);
+    std::int64_t largest_index = -1;
+    for (std::size_t j = 0; j < pts.size(); ++j) {
+        double sum = 0.0;
+        for (std::size_t i = 0; i < order; ++i) {
+            const double value = static_cast<double>(values[j * order + i]);
+            PANTR_CHECK_MSG(value >= 0.0, "periodic: non-negativity");
+            sum += value;
+        }
+        PANTR_CHECK_MSG(std::abs(sum - 1.0) <= bound, "periodic: partition of unity");
+        largest_index = std::max(largest_index, first_basis[j]);
+    }
+
+    // Derivatives on the same space: the rows still sum to zero.
+    constexpr std::int64_t n_deriv = 3;
+    const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+    std::vector<T> block(pts.size() * rows * order);
+    std::vector<std::int64_t> deriv_first(pts.size());
+    basis_derivs_1d<T>(std::span<const T>(knots), degree, true, n_deriv,
+                       std::span<const T>(pts), span_nd<T, 3>(block.data(), pts.size(), rows, order),
+                       std::span<std::int64_t>(deriv_first));
+
+    for (std::size_t j = 0; j < pts.size(); ++j) {
+        PANTR_CHECK_MSG(deriv_first[j] == first_basis[j],
+                        "periodic: the two kernels must report the same index");
+        for (std::size_t k = 1; k < rows; ++k) {
+            double sum = 0.0;
+            double scale = 0.0;
+            for (std::size_t i = 0; i < order; ++i) {
+                const double value = static_cast<double>(block[(j * rows + k) * order + i]);
+                sum += value;
+                scale = std::max(scale, std::abs(value));
+            }
+            const double row_bound = 8.0 * static_cast<double>(order) * eps * std::max(scale, 1.0);
+            PANTR_CHECK_MSG(std::abs(sum) <= row_bound, "periodic: derivative row sums to zero");
+        }
+    }
+
+    // The discriminating assertion. A non-periodic space caps `first_basis` at
+    // `num_basis - order`; a periodic one must not, or the caller's modulo has nothing
+    // to wrap. If this fails, the periodic branch is not being taken.
+    PANTR_CHECK_MSG(largest_index > num_basis - static_cast<std::int64_t>(order),
+                    "periodic: the first-basis index must exceed the non-periodic clamp");
+}
+
+
 }  // namespace
 
 int main() {
@@ -768,6 +852,8 @@ int main() {
     check_bernstein_deriv_against_closed_forms<float>();
     check_degree_zero<double>();
     check_degree_zero<float>();
+    check_periodic_space<double>();
+    check_periodic_space<float>();
     check_wrapping_mul_agrees_where_no_overflow();
     check_wrapping_mul_reproduces_the_measured_wrap();
     return pantr::test::summary("test_bspline_tabulation");

--- a/cpp/tests/test_bspline_tabulation.cpp
+++ b/cpp/tests/test_bspline_tabulation.cpp
@@ -1,0 +1,774 @@
+/// \file
+/// Properties of `pantr/bspline/tabulate.hpp` and the new `tabulate_bernstein_deriv_1d`
+/// checkable **without the Python oracle** -- that is `tests/parity/` job, not this
+/// file's. Every check here is one a wrong implementation would fail, not a
+/// recomputation of the recurrence it exercises.
+///
+/// ## Where the tolerances below come from
+///
+/// - **Partition of unity** (`sum_i N_i(u) == 1`): the recurrence commits at most
+///   `degree` stages of a convex combination plus the final `degree + 1`-term sum, so
+///   `(2 * degree + 1) * (eps / 2)` bounds the relative error -- the same shape as
+///   `test_bernstein.cpp`'s `partition_bound`, derived independently here because the
+///   two recurrences (Cox-de Boor vs. the ratio recurrence) are different algorithms.
+/// - **Derivative sums** (`sum_i N_i^(k)(u) == 0`, `k >= 1`): the target is exactly
+///   zero, so a *relative* bound is meaningless -- design/backend_parity.md Rule 2 says
+///   use an absolute one, scaled by the row's own largest magnitude instead of by 1.
+///   The A2.3 recursion builds each row from `order` terms through the same kind of
+///   division-then-multiply-add step the partition-of-unity bound counts, so the same
+///   `C * order * eps` shape applies, now against the row's own scale. `C = 8` mirrors
+///   `test_scalar_generic.cpp`'s identical identity for the cardinal B-spline kernel;
+///   it is not independently re-derived here and is flagged as a margin, not a proof.
+/// - **Cross-algorithm agreement** (the Bézier-like fast path against the general
+///   Cox-de Boor recurrence, and `tabulate_bernstein_deriv_1d` against a closed form
+///   built from `tabulate_bernstein_1d` one degree down): two different algorithms for
+///   the same polynomial, so "agree" means "agree to rounding" and the bound combines
+///   each algorithm's own partition-style error. Where the combination is a rough
+///   estimate rather than a tight derivation, the comment at the site says so.
+///
+/// Exact (no-tolerance) claims: non-negativity (a sum of non-negative convex-
+/// combination terms), derivative rows above the degree (the k-th derivative of a
+/// degree-p polynomial vanishes identically for k > p), degree 0 (one basis function,
+/// value 1, every derivative row 0), and row 0 of `basis_derivs_1d` against
+/// `basis_funcs_1d` (both build the same `ndu` upper triangle by the same operations in
+/// the same order).
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/basis/bernstein.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/tabulate.hpp"
+#include "pantr/core/binomial.hpp"
+#include "pantr/core/mdspan.hpp"
+
+namespace {
+
+using pantr::at;
+using pantr::span2d;
+using pantr::span_nd;
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::KnotSnapping;
+
+// --------------------------------------------------------------------------
+// Knot vectors and sample points
+// --------------------------------------------------------------------------
+
+/// A clamped, open knot vector over `num_elems` uniform elements.
+template <class T>
+std::vector<T> clamped_uniform_knots(std::int64_t degree, int num_elems) {
+    std::vector<T> knots(static_cast<std::size_t>(degree) + 1, T(0));
+    for (int i = 1; i < num_elems; ++i) {
+        knots.push_back(static_cast<T>(i));
+    }
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        knots.push_back(static_cast<T>(num_elems));
+    }
+    return knots;
+}
+
+/// An unclamped knot vector: a plain integer run with no repeats anywhere, so the
+/// domain's right end (`knots[size - degree - 1]`) is not the vector's last knot for
+/// `degree >= 1` -- the case `find_span_and_first_basis`'s upper clamp exists for.
+template <class T>
+std::vector<T> unclamped_uniform_knots(std::int64_t degree) {
+    std::vector<T> knots;
+    const auto len = static_cast<std::size_t>(2 * degree + 4);
+    knots.reserve(len);
+    for (std::size_t i = 0; i < len; ++i) {
+        knots.push_back(static_cast<T>(i));
+    }
+    return knots;
+}
+
+/// Clamped ends, one interior knot repeated twice: reduced continuity, no empty span.
+template <class T>
+std::vector<T> interior_repeat_knots(std::int64_t degree) {
+    std::vector<T> knots(static_cast<std::size_t>(degree) + 1, T(0));
+    knots.push_back(T(1));
+    knots.push_back(T(1));
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        knots.push_back(T(2));
+    }
+    return knots;
+}
+
+/// Clamped ends, an interior knot repeated `degree + 1` times: a genuine empty span
+/// (a zero-width parametric interval among the repeats) and a C^-1 discontinuity.
+template <class T>
+std::vector<T> full_multiplicity_interior_knots(std::int64_t degree) {
+    std::vector<T> knots(static_cast<std::size_t>(degree) + 1, T(0));
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        knots.push_back(T(1));
+    }
+    for (std::int64_t i = 0; i <= degree; ++i) {
+        knots.push_back(T(2));
+    }
+    return knots;
+}
+
+/// The four knot-vector families the properties below are checked over. The two
+/// interior-repeat families need `degree >= 1` to be distinct from the clamped case.
+template <class T>
+std::vector<std::vector<T>> knot_vector_family(std::int64_t degree) {
+    std::vector<std::vector<T>> vectors;
+    vectors.push_back(clamped_uniform_knots<T>(degree, 3));
+    vectors.push_back(unclamped_uniform_knots<T>(degree));
+    if (degree >= 1) {
+        vectors.push_back(interior_repeat_knots<T>(degree));
+        vectors.push_back(full_multiplicity_interior_knots<T>(degree));
+    }
+    return vectors;
+}
+
+/// `n` points evenly spaced over `[lo, hi]`, endpoints included.
+template <class T>
+std::vector<T> sample_domain(T lo, T hi, int n) {
+    std::vector<T> pts;
+    pts.reserve(static_cast<std::size_t>(n));
+    const double a = static_cast<double>(lo);
+    const double b = static_cast<double>(hi);
+    for (int i = 0; i < n; ++i) {
+        const double frac = static_cast<double>(i) / static_cast<double>(n - 1);
+        pts.push_back(static_cast<T>(a + frac * (b - a)));
+    }
+    return pts;
+}
+
+// --------------------------------------------------------------------------
+// Tabulation helpers
+// --------------------------------------------------------------------------
+
+template <class T>
+std::vector<T> tabulate_general_basis(std::span<const T> knots, std::int64_t degree,
+                                      bool periodic, const std::vector<T>& pts,
+                                      std::vector<std::int64_t>& first_basis) {
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    std::vector<T> out(pts.size() * order, T(0));
+    first_basis.assign(pts.size(), 0);
+    const span2d<T> view(out.data(), pts.size(), order);
+    pantr::bspline::basis_funcs_1d<T>(knots, degree, periodic, std::span<const T>(pts), view,
+                                      std::span<std::int64_t>(first_basis));
+    return out;
+}
+
+template <class T>
+std::vector<T> tabulate_general_derivs(std::span<const T> knots, std::int64_t degree,
+                                       bool periodic, std::int64_t n_deriv,
+                                       const std::vector<T>& pts,
+                                       std::vector<std::int64_t>& first_basis) {
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+    std::vector<T> out(pts.size() * rows * order, T(0));
+    first_basis.assign(pts.size(), 0);
+    const span_nd<T, 3> view(out.data(), pts.size(), rows, order);
+    pantr::bspline::basis_derivs_1d<T>(knots, degree, periodic, n_deriv, std::span<const T>(pts),
+                                       view, std::span<std::int64_t>(first_basis));
+    return out;
+}
+
+constexpr double eps_of(float /*unused*/) {
+    return static_cast<double>(std::numeric_limits<float>::epsilon());
+}
+constexpr double eps_of(double /*unused*/) {
+    return std::numeric_limits<double>::epsilon();
+}
+
+// --------------------------------------------------------------------------
+// (1) Partition of unity, general knots
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_partition_of_unity_general_knots() {
+    const double eps = eps_of(T(0));
+    for (std::int64_t degree = 0; degree <= 5; ++degree) {
+        const auto order = static_cast<std::size_t>(degree) + 1;
+        const double bound = (2.0 * static_cast<double>(degree) + 1.0) * (eps / 2.0);
+        for (const auto& knots : knot_vector_family<T>(degree)) {
+            const T domain_lo = knots[static_cast<std::size_t>(degree)];
+            const T domain_hi = knots[knots.size() - static_cast<std::size_t>(degree) - 1];
+            const auto pts = sample_domain<T>(domain_lo, domain_hi, 33);
+            std::vector<std::int64_t> first_basis;
+            const auto vals =
+                tabulate_general_basis<T>(std::span<const T>(knots), degree, false, pts, first_basis);
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                double sum = 0.0;
+                for (std::size_t i = 0; i < order; ++i) {
+                    sum += static_cast<double>(vals[j * order + i]);
+                }
+                PANTR_CHECK_MSG(std::abs(sum - 1.0) <= bound,
+                                "degree " + std::to_string(degree) + " point idx " +
+                                    std::to_string(j) + ": sum " + std::to_string(sum));
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (2) Non-negativity, exact
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_non_negativity() {
+    for (std::int64_t degree = 0; degree <= 5; ++degree) {
+        for (const auto& knots : knot_vector_family<T>(degree)) {
+            const T domain_lo = knots[static_cast<std::size_t>(degree)];
+            const T domain_hi = knots[knots.size() - static_cast<std::size_t>(degree) - 1];
+            const auto pts = sample_domain<T>(domain_lo, domain_hi, 33);
+            std::vector<std::int64_t> first_basis;
+            const auto vals =
+                tabulate_general_basis<T>(std::span<const T>(knots), degree, false, pts, first_basis);
+            for (const T v : vals) {
+                PANTR_CHECK(v >= T(0));
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (3) Derivative sums vanish, absolute and row-scaled
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_derivative_sums_vanish() {
+    const double eps = eps_of(T(0));
+    for (std::int64_t degree = 0; degree <= 5; ++degree) {
+        const auto order = static_cast<std::size_t>(degree) + 1;
+        const std::int64_t n_deriv = degree + 2;
+        const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+        for (const auto& knots : knot_vector_family<T>(degree)) {
+            const T domain_lo = knots[static_cast<std::size_t>(degree)];
+            const T domain_hi = knots[knots.size() - static_cast<std::size_t>(degree) - 1];
+            const auto pts = sample_domain<T>(domain_lo, domain_hi, 17);
+            std::vector<std::int64_t> first_basis;
+            const auto vals = tabulate_general_derivs<T>(std::span<const T>(knots), degree, false,
+                                                         n_deriv, pts, first_basis);
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                for (std::int64_t k = 1; k <= n_deriv; ++k) {
+                    const auto kk = static_cast<std::size_t>(k);
+                    double scale = 0.0;
+                    double sum = 0.0;
+                    for (std::size_t i = 0; i < order; ++i) {
+                        const double v = static_cast<double>(vals[(j * rows + kk) * order + i]);
+                        sum += v;
+                        scale = std::max(scale, std::abs(v));
+                    }
+                    const double bound = 8.0 * static_cast<double>(order) * eps * std::max(scale, 1.0);
+                    PANTR_CHECK_MSG(std::abs(sum) <= bound,
+                                    "degree " + std::to_string(degree) + " k=" + std::to_string(k) +
+                                        " point idx " + std::to_string(j) + ": sum " +
+                                        std::to_string(sum) + " scale " + std::to_string(scale));
+                }
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (4) Rows above the degree are exactly zero
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_rows_above_degree_are_zero() {
+    for (std::int64_t degree = 0; degree <= 5; ++degree) {
+        const auto order = static_cast<std::size_t>(degree) + 1;
+        const std::int64_t n_deriv = degree + 3;
+        const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+        for (const auto& knots : knot_vector_family<T>(degree)) {
+            const T domain_lo = knots[static_cast<std::size_t>(degree)];
+            const T domain_hi = knots[knots.size() - static_cast<std::size_t>(degree) - 1];
+            const auto pts = sample_domain<T>(domain_lo, domain_hi, 17);
+            std::vector<std::int64_t> first_basis;
+            const auto vals = tabulate_general_derivs<T>(std::span<const T>(knots), degree, false,
+                                                         n_deriv, pts, first_basis);
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                for (std::size_t k = static_cast<std::size_t>(degree) + 1; k < rows; ++k) {
+                    for (std::size_t i = 0; i < order; ++i) {
+                        PANTR_CHECK(vals[(j * rows + k) * order + i] == T(0));
+                    }
+                }
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (5) Row 0 of basis_derivs_1d equals basis_funcs_1d, bit for bit
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_row0_matches_basis_funcs_bitwise() {
+    for (std::int64_t degree = 0; degree <= 5; ++degree) {
+        const auto order = static_cast<std::size_t>(degree) + 1;
+        constexpr std::int64_t n_deriv = 3;
+        const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+        for (const auto& knots : knot_vector_family<T>(degree)) {
+            const T domain_lo = knots[static_cast<std::size_t>(degree)];
+            const T domain_hi = knots[knots.size() - static_cast<std::size_t>(degree) - 1];
+            const auto pts = sample_domain<T>(domain_lo, domain_hi, 17);
+
+            std::vector<std::int64_t> first_funcs;
+            const auto funcs =
+                tabulate_general_basis<T>(std::span<const T>(knots), degree, false, pts, first_funcs);
+            std::vector<std::int64_t> first_derivs;
+            const auto derivs = tabulate_general_derivs<T>(std::span<const T>(knots), degree, false,
+                                                           n_deriv, pts, first_derivs);
+
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                PANTR_CHECK(first_funcs[j] == first_derivs[j]);
+                for (std::size_t i = 0; i < order; ++i) {
+                    PANTR_CHECK_MSG(
+                        funcs[j * order + i] == derivs[(j * rows + 0) * order + i],
+                        "degree " + std::to_string(degree) + " point " + std::to_string(j) +
+                            " basis " + std::to_string(i) +
+                            ": row 0 of basis_derivs_1d must equal basis_funcs_1d bit for bit");
+                }
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (6) find_span_and_first_basis on the boundaries
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_find_span_boundaries() {
+    using pantr::bspline::find_span_and_first_basis;
+
+    for (std::int64_t degree = 0; degree <= 5; ++degree) {
+        for (const bool use_unclamped : {false, true}) {
+            const std::vector<T> knots =
+                use_unclamped ? unclamped_uniform_knots<T>(degree) : clamped_uniform_knots<T>(degree, 3);
+            const auto size = static_cast<std::int64_t>(knots.size());
+            const T domain_lo = knots[static_cast<std::size_t>(degree)];
+            const T domain_hi = knots[static_cast<std::size_t>(size - degree - 1)];
+            const std::int64_t last_span = size - degree - 2;
+            const std::int64_t num_basis = size - degree - 1;
+            const std::string tag =
+                "degree " + std::to_string(degree) + (use_unclamped ? " (unclamped)" : " (clamped)");
+
+            const auto check_point = [&](T point) {
+                const auto located =
+                    find_span_and_first_basis<T>(std::span<const T>(knots), degree, false, point);
+                PANTR_CHECK_MSG(located.first_basis + degree + 1 <= num_basis,
+                                tag + ": first_basis + degree + 1 <= num_basis");
+                return located;
+            };
+
+            PANTR_CHECK_MSG(check_point(domain_lo).span == degree, tag + ": left endpoint");
+            PANTR_CHECK_MSG(check_point(domain_hi).span == last_span,
+                            tag + ": right endpoint must land in the last in-domain span");
+            PANTR_CHECK_MSG(check_point(domain_lo - T(1)).span == degree,
+                            tag + ": below-domain point clamps low");
+            PANTR_CHECK_MSG(check_point(domain_hi + T(1)).span == last_span,
+                            tag + ": above-domain point clamps high");
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (7) tabulate_basis_1d's Bézier-like path against the general-knot path
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_tabulate_basis_1d_matches_general_knot_path() {
+    const double eps = eps_of(T(0));
+    constexpr std::int64_t degree = 2;
+    const std::vector<std::pair<std::vector<T>, std::string>> cases = {
+        {std::vector<T>{T(0), T(0), T(0), T(1), T(1), T(1)}, "unit domain"},
+        {std::vector<T>{T(2), T(2), T(2), T(5), T(5), T(5)}, "non-unit domain"},
+    };
+
+    for (const auto& [knots, label] : cases) {
+        const BsplineSpace1D<T> space(std::span<const T>(knots), degree, false,
+                                      KnotSnapping::merge_near_duplicates);
+        PANTR_CHECK_MSG(space.has_bezier_like_knots(), label);
+
+        const std::array<T, 2> domain = space.domain();
+        const auto pts = sample_domain<T>(domain[0], domain[1], 41);
+        const auto order = static_cast<std::size_t>(degree) + 1;
+
+        std::vector<T> bezier_path(pts.size() * order, T(0));
+        std::vector<std::int64_t> first_bezier(pts.size(), 0);
+        const span2d<T> bezier_view(bezier_path.data(), pts.size(), order);
+        pantr::bspline::tabulate_basis_1d<T>(space, std::span<const T>(pts), bezier_view,
+                                             std::span<std::int64_t>(first_bezier));
+
+        std::vector<T> general_path(pts.size() * order, T(0));
+        std::vector<std::int64_t> first_general(pts.size(), 0);
+        const span2d<T> general_view(general_path.data(), pts.size(), order);
+        pantr::bspline::basis_funcs_1d<T>(space.knots(), degree, space.periodic(),
+                                          std::span<const T>(pts), general_view,
+                                          std::span<std::int64_t>(first_general));
+
+        // Two roads to the same degree-2 polynomials: each carries its own
+        // O(degree * eps) forward error (test_bernstein.cpp's partition_bound
+        // shape), and the Bézier path additionally forms the change of variable
+        // (point - a) / (b - a), perturbing u by a relative eps that the
+        // O(degree)-bounded polynomial derivative turns into another O(degree *
+        // eps) term. The constant below is a safety margin over that estimate,
+        // not a tight derivation.
+        const double bound = 24.0 * static_cast<double>(degree + 1) * eps;
+
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            PANTR_CHECK_MSG(first_bezier[j] == first_general[j], label);
+            double sum = 0.0;
+            for (std::size_t i = 0; i < order; ++i) {
+                const double a = static_cast<double>(bezier_path[j * order + i]);
+                const double b = static_cast<double>(general_path[j * order + i]);
+                sum += a;
+                PANTR_CHECK_MSG(std::abs(a - b) <= bound,
+                                label + " point idx " + std::to_string(j) + " basis " +
+                                    std::to_string(i) + ": bezier " + std::to_string(a) +
+                                    " general " + std::to_string(b));
+            }
+            PANTR_CHECK_MSG(std::abs(sum - 1.0) <= bound, label + " partition of unity");
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (8) The chain rule on a non-unit domain
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_chain_rule_on_non_unit_domain() {
+    const double eps = eps_of(T(0));
+    constexpr std::int64_t degree = 2;
+    constexpr std::int64_t n_deriv = 2;
+    const std::vector<T> knots{T(2), T(2), T(2), T(5), T(5), T(5)};
+    const BsplineSpace1D<T> space(std::span<const T>(knots), degree, false,
+                                  KnotSnapping::merge_near_duplicates);
+    PANTR_CHECK(space.has_bezier_like_knots());
+
+    const std::array<T, 2> domain = space.domain();
+    const auto pts = sample_domain<T>(domain[0], domain[1], 25);
+    const auto order = static_cast<std::size_t>(degree) + 1;
+    const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+
+    // The chain-rule path: the Bézier fast path, scaled by 1/(b-a)^k.
+    std::vector<T> scaled(pts.size() * rows * order, T(0));
+    std::vector<std::int64_t> first_scaled(pts.size(), 0);
+    const span_nd<T, 3> scaled_view(scaled.data(), pts.size(), rows, order);
+    pantr::bspline::tabulate_basis_derivatives_1d<T>(space, n_deriv, std::span<const T>(pts),
+                                                     scaled_view, std::span<std::int64_t>(first_scaled));
+
+    // The general-knot path: Cox-de Boor directly on the space's own non-unit knots,
+    // where the scale is intrinsic to the knot differences rather than applied after
+    // the fact.
+    std::vector<T> general(pts.size() * rows * order, T(0));
+    std::vector<std::int64_t> first_general(pts.size(), 0);
+    const span_nd<T, 3> general_view(general.data(), pts.size(), rows, order);
+    pantr::bspline::basis_derivs_1d<T>(space.knots(), degree, space.periodic(), n_deriv,
+                                       std::span<const T>(pts), general_view,
+                                       std::span<std::int64_t>(first_general));
+
+    // The unscaled path: what the Bézier fast path computes BEFORE the chain-rule
+    // factor is applied, built exactly as tabulate_basis_derivatives_1d's own body
+    // does it, so as to have something to be wrong against.
+    std::vector<T> reference(pts.size());
+    const T span = domain[1] - domain[0];
+    for (std::size_t i = 0; i < pts.size(); ++i) {
+        reference[i] = (pts[i] - domain[0]) / span;
+    }
+    std::vector<T> unscaled(pts.size() * rows * order, T(0));
+    const span_nd<T, 3> unscaled_view(unscaled.data(), pts.size(), rows, order);
+    pantr::tabulate_bernstein_deriv_1d<T>(static_cast<int>(degree), static_cast<int>(n_deriv),
+                                         std::span<const T>(reference), unscaled_view);
+
+    for (std::int64_t k = 1; k <= n_deriv; ++k) {
+        const auto kk = static_cast<std::size_t>(k);
+        double scale = 0.0;
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            for (std::size_t i = 0; i < order; ++i) {
+                scale = std::max(scale, std::abs(static_cast<double>(at(general_view, j, kk, i))));
+            }
+        }
+        // Same shape as the derivative-sum bound above: each row is built by the
+        // same A2.3 triangular recursion, so its forward error is O(order * eps)
+        // relative to the row's own largest magnitude (Rule 2 -- an absolute
+        // output needs an absolute reference, not 1).
+        const double bound = 16.0 * static_cast<double>(order) * eps * std::max(scale, 1.0);
+
+        double max_unscaled_diff = 0.0;
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            for (std::size_t i = 0; i < order; ++i) {
+                const double s = static_cast<double>(at(scaled_view, j, kk, i));
+                const double g = static_cast<double>(at(general_view, j, kk, i));
+                const double u = static_cast<double>(at(unscaled_view, j, kk, i));
+                PANTR_CHECK_MSG(std::abs(s - g) <= bound,
+                                "k=" + std::to_string(k) + " point idx " + std::to_string(j) +
+                                    " basis " + std::to_string(i) + ": scaled " + std::to_string(s) +
+                                    " general " + std::to_string(g));
+                max_unscaled_diff = std::max(max_unscaled_diff, std::abs(u - g));
+            }
+        }
+        // Non-vacuous: a missing or inverted 1/(b-a)^k factor would leave the
+        // unscaled values matching the general path instead of differing by 3^k (or
+        // 3^-k) -- assert the gap is clearly larger than the matching tolerance.
+        PANTR_CHECK_MSG(max_unscaled_diff > 10.0 * bound,
+                        "k=" + std::to_string(k) +
+                            ": unscaled and scaled results must differ for this test to be "
+                            "non-vacuous, got gap " + std::to_string(max_unscaled_diff));
+    }
+}
+
+// --------------------------------------------------------------------------
+// (9) tabulate_bernstein_deriv_1d against closed forms one degree down
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_bernstein_deriv_against_closed_forms() {
+    const double eps = eps_of(T(0));
+    const auto pts = sample_domain<T>(T(0), T(1), 33);
+
+    for (int n = 1; n <= 10; ++n) {
+        const auto order = static_cast<std::size_t>(n) + 1;
+        std::vector<T> deriv(pts.size() * 3 * order, T(0));
+        const span_nd<T, 3> deriv_view(deriv.data(), pts.size(), std::size_t{3}, order);
+        pantr::tabulate_bernstein_deriv_1d<T>(n, 2, std::span<const T>(pts), deriv_view);
+
+        std::vector<T> lower(pts.size() * static_cast<std::size_t>(n));
+        const span2d<T> lower_view(lower.data(), pts.size(), static_cast<std::size_t>(n));
+        pantr::tabulate_bernstein_1d<T>(n - 1, std::span<const T>(pts), lower_view);
+
+        // Partition of unity, and the derivative rows summing to zero -- the same
+        // shapes as test_bernstein.cpp and check_derivative_sums_vanish above,
+        // checked here against tabulate_bernstein_deriv_1d's own row 0, which is
+        // the Cox-de Boor triangle rather than the ratio recurrence.
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            double sum0 = 0.0;
+            for (std::size_t i = 0; i < order; ++i) {
+                sum0 += static_cast<double>(at(deriv_view, j, std::size_t{0}, i));
+            }
+            PANTR_CHECK(std::abs(sum0 - 1.0) <= 8.0 * static_cast<double>(n) * eps);
+        }
+        for (const int k : {1, 2}) {
+            const auto kk = static_cast<std::size_t>(k);
+            double scale = 0.0;
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                for (std::size_t i = 0; i < order; ++i) {
+                    scale = std::max(scale, std::abs(static_cast<double>(at(deriv_view, j, kk, i))));
+                }
+            }
+            const double bound_sum = 16.0 * static_cast<double>(order) * eps * std::max(scale, 1.0);
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                double sum = 0.0;
+                for (std::size_t i = 0; i < order; ++i) {
+                    sum += static_cast<double>(at(deriv_view, j, kk, i));
+                }
+                PANTR_CHECK(std::abs(sum) <= bound_sum);
+            }
+        }
+
+        // First derivative: d/du B_{i,n} = n * (B_{i-1,n-1} - B_{i,n-1}), computed
+        // independently via tabulate_bernstein_1d at degree n-1 -- the ratio
+        // recurrence, a different algorithm from the A2.3 specialisation under test.
+        {
+            double scale = 0.0;
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                for (std::size_t i = 0; i < order; ++i) {
+                    scale =
+                        std::max(scale, std::abs(static_cast<double>(at(deriv_view, j, std::size_t{1}, i))));
+                }
+            }
+            const double bound = 16.0 * static_cast<double>(order) * eps * std::max(scale, 1.0);
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                for (std::size_t i = 0; i < order; ++i) {
+                    const double b_im1 =
+                        (i >= 1) ? static_cast<double>(at(lower_view, j, i - 1)) : 0.0;
+                    const double b_i = (i <= static_cast<std::size_t>(n - 1))
+                                          ? static_cast<double>(at(lower_view, j, i))
+                                          : 0.0;
+                    const double expected = static_cast<double>(n) * (b_im1 - b_i);
+                    const double actual = static_cast<double>(at(deriv_view, j, std::size_t{1}, i));
+                    PANTR_CHECK_MSG(std::abs(actual - expected) <= bound,
+                                    "n=" + std::to_string(n) + " point " + std::to_string(j) +
+                                        " basis " + std::to_string(i));
+                }
+            }
+        }
+
+        // Second derivative, one level further down:
+        // d^2/du^2 B_{i,n} = n*(n-1) * (B_{i-2,n-2} - 2*B_{i-1,n-2} + B_{i,n-2}).
+        if (n >= 2) {
+            std::vector<T> lower2(pts.size() * static_cast<std::size_t>(n - 1));
+            const span2d<T> lower2_view(lower2.data(), pts.size(), static_cast<std::size_t>(n - 1));
+            pantr::tabulate_bernstein_1d<T>(n - 2, std::span<const T>(pts), lower2_view);
+
+            double scale = 0.0;
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                for (std::size_t i = 0; i < order; ++i) {
+                    scale =
+                        std::max(scale, std::abs(static_cast<double>(at(deriv_view, j, std::size_t{2}, i))));
+                }
+            }
+            const double bound = 24.0 * static_cast<double>(order) * eps * std::max(scale, 1.0);
+
+            for (std::size_t j = 0; j < pts.size(); ++j) {
+                for (std::size_t i = 0; i < order; ++i) {
+                    const auto in_range = [&](std::int64_t idx) { return idx >= 0 && idx <= n - 2; };
+                    const auto ii = static_cast<std::int64_t>(i);
+                    const double b_im2 =
+                        in_range(ii - 2)
+                            ? static_cast<double>(at(lower2_view, j, static_cast<std::size_t>(ii - 2)))
+                            : 0.0;
+                    const double b_im1 =
+                        in_range(ii - 1)
+                            ? static_cast<double>(at(lower2_view, j, static_cast<std::size_t>(ii - 1)))
+                            : 0.0;
+                    const double b_i =
+                        in_range(ii) ? static_cast<double>(at(lower2_view, j, static_cast<std::size_t>(ii)))
+                                     : 0.0;
+                    const double expected = static_cast<double>(n) * static_cast<double>(n - 1) *
+                                           (b_im2 - 2.0 * b_im1 + b_i);
+                    const double actual = static_cast<double>(at(deriv_view, j, std::size_t{2}, i));
+                    PANTR_CHECK_MSG(std::abs(actual - expected) <= bound,
+                                    "n=" + std::to_string(n) + " point " + std::to_string(j) +
+                                        " basis " + std::to_string(i));
+                }
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (10) Degree 0
+// --------------------------------------------------------------------------
+
+template <class T>
+void check_degree_zero() {
+    constexpr std::int64_t degree = 0;
+    const std::vector<T> knots{T(0), T(1)};
+    const std::vector<T> pts{T(0.25), T(0.75)};
+
+    std::vector<std::int64_t> first_basis;
+    const auto vals = tabulate_general_basis<T>(std::span<const T>(knots), degree, false, pts, first_basis);
+    for (const T v : vals) {
+        PANTR_CHECK(v == T(1));
+    }
+
+    constexpr std::int64_t n_deriv = 3;
+    const auto rows = static_cast<std::size_t>(n_deriv) + 1;
+    const auto deriv =
+        tabulate_general_derivs<T>(std::span<const T>(knots), degree, false, n_deriv, pts, first_basis);
+    for (std::size_t j = 0; j < pts.size(); ++j) {
+        PANTR_CHECK(deriv[j * rows + 0] == T(1));
+        for (std::size_t k = 1; k < rows; ++k) {
+            PANTR_CHECK(deriv[j * rows + k] == T(0));
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// (11) pantr::core::wrapping_mul
+// --------------------------------------------------------------------------
+
+void check_wrapping_mul_agrees_where_no_overflow() {
+    PANTR_CHECK(pantr::core::wrapping_mul(3, 4) == 12);
+    PANTR_CHECK(pantr::core::wrapping_mul(-3, 4) == -12);
+    PANTR_CHECK(pantr::core::wrapping_mul(0, 123456789) == 0);
+    constexpr std::int64_t big = 1'000'000'000;
+    PANTR_CHECK(pantr::core::wrapping_mul(big, big) == big * big);
+}
+
+/// A 128-bit unsigned value as two 64-bit words, `hi * 2^64 + lo`.
+///
+/// `__int128` would be the obvious spelling and is not used: `-Wpedantic` (part of
+/// this project's warning set) rejects it as a non-standard extension, so the
+/// independent computation below is built from portable `std::uint64_t` operations
+/// instead -- a schoolbook 32-bit-limb widening multiply, which is a different
+/// route to the same 128-bit product than anything `wrapping_mul` does.
+struct Wide128 {
+    std::uint64_t hi = 0;
+    std::uint64_t lo = 0;
+};
+
+/// The full 128-bit product of two 64-bit values, via 32-bit limb decomposition.
+[[nodiscard]] Wide128 widening_mul(std::uint64_t a, std::uint64_t b) {
+    const std::uint64_t a_lo = a & 0xFFFFFFFFULL;
+    const std::uint64_t a_hi = a >> 32;
+    const std::uint64_t b_lo = b & 0xFFFFFFFFULL;
+    const std::uint64_t b_hi = b >> 32;
+
+    const std::uint64_t t0 = a_lo * b_lo;
+    const std::uint64_t t1 = a_hi * b_lo;
+    const std::uint64_t t2 = a_lo * b_hi;
+    const std::uint64_t t3 = a_hi * b_hi;
+
+    const std::uint64_t mid = (t0 >> 32) + (t1 & 0xFFFFFFFFULL) + (t2 & 0xFFFFFFFFULL);
+    Wide128 result;
+    result.lo = (t0 & 0xFFFFFFFFULL) | (mid << 32);
+    result.hi = t3 + (t1 >> 32) + (t2 >> 32) + (mid >> 32);
+    return result;
+}
+
+/// The specific wrap `tabulate.hpp`'s factorial scaling produces at degree 21,
+/// derivative order 19: `fac` starts at `degree` and is repeatedly updated by
+/// `wrapping_mul(fac, degree - k)`, so the value used to scale row 19 is
+/// `degree! / (degree - 19)! = 21! / 2!`, which exceeds `2^64` and wraps.
+///
+/// The expected wrap is computed here independently of `wrapping_mul`, by carrying
+/// the exact product of `3 * 4 * ... * 21` in a 128-bit accumulator that never
+/// overflows (the true value is under `2^67`) and then reading its low 64 bits --
+/// which is exactly what "reduction modulo 2^64" means, reached by a completely
+/// different route (32-bit limb multiplication) than `wrapping_mul`'s single 64x64
+/// multiply relies on the hardware to truncate.
+void check_wrapping_mul_reproduces_the_measured_wrap() {
+    Wide128 exact{0, 1};
+    for (std::uint64_t i = 3; i <= 21; ++i) {
+        const Wide128 term = widening_mul(exact.lo, i);
+        // `exact.hi` stays 0 or 1 throughout this particular product (it is under
+        // 2^67), and `i <= 21`, so `exact.hi * i` cannot itself overflow 64 bits.
+        exact.hi = term.hi + exact.hi * i;
+        exact.lo = term.lo;
+    }
+    const auto expected = static_cast<std::int64_t>(exact.lo);
+
+    constexpr std::int64_t degree = 21;
+    std::int64_t fac = degree;
+    for (std::int64_t k = 1; k <= 18; ++k) {
+        fac = pantr::core::wrapping_mul(fac, degree - k);
+    }
+    PANTR_CHECK_MSG(fac == expected,
+                    "wrapping_mul disagrees with the independently computed wrap of 21!/2!: got " +
+                        std::to_string(fac) + " want " + std::to_string(expected));
+}
+
+}  // namespace
+
+int main() {
+    check_partition_of_unity_general_knots<double>();
+    check_partition_of_unity_general_knots<float>();
+    check_non_negativity<double>();
+    check_non_negativity<float>();
+    check_derivative_sums_vanish<double>();
+    check_derivative_sums_vanish<float>();
+    check_rows_above_degree_are_zero<double>();
+    check_rows_above_degree_are_zero<float>();
+    check_row0_matches_basis_funcs_bitwise<double>();
+    check_row0_matches_basis_funcs_bitwise<float>();
+    check_find_span_boundaries<double>();
+    check_find_span_boundaries<float>();
+    check_tabulate_basis_1d_matches_general_knot_path<double>();
+    check_tabulate_basis_1d_matches_general_knot_path<float>();
+    check_chain_rule_on_non_unit_domain<double>();
+    check_chain_rule_on_non_unit_domain<float>();
+    check_bernstein_deriv_against_closed_forms<double>();
+    check_bernstein_deriv_against_closed_forms<float>();
+    check_degree_zero<double>();
+    check_degree_zero<float>();
+    check_wrapping_mul_agrees_where_no_overflow();
+    check_wrapping_mul_reproduces_the_measured_wrap();
+    return pantr::test::summary("test_bspline_tabulation");
+}

--- a/scripts/measure_bspline_tabulation_widths.py
+++ b/scripts/measure_bspline_tabulation_widths.py
@@ -20,7 +20,12 @@ Three things are measured, and the second is the one that matters:
    two models *disagree with each other*, so a match cannot come from a check that
    could not fail.
 
-3. **Where the falling-factorial accumulator wraps.** ``_basis_derivs_point`` and
+3. **Two structural checks the C++ comments cite**: whether the oracle's non-periodic
+   first-basis clamp is ever active (it is not, and the comment claiming it is
+   load-bearing is wrong), and which width numpy applies the Bezier-like chain-rule
+   factor at.
+
+4. **Where the falling-factorial accumulator wraps.** ``_basis_derivs_point`` and
    ``_bernstein_derivs_point`` both accumulate ``degree!/(degree-k)!`` in an integer
    that wraps at int64 when compiled. Past the wrap the *scaling* of the k-th
    derivative row is a different number, in both backends, and it is not a rounding
@@ -730,6 +735,100 @@ def report_the_factorial_wrap() -> int:
     return 0 if mismatches == 0 else 1
 
 
+def report_the_redundant_clamp() -> int:
+    """Check whether the oracle's non-periodic first-basis clamp is ever active.
+
+    ``_find_span_and_first_basis_point`` clamps the span to ``knots.size - degree - 2``
+    and *then* clamps ``first_basis = span - degree`` to ``num_basis - order``. Its
+    comment explains the second clamp as needed "so the final evaluation point always
+    addresses the last degree + 1 active basis functions". Algebraically the span clamp
+    has already made the two bounds equal::
+
+        span - degree     <= (n - degree - 2) - degree   = n - 2*degree - 2
+        num_basis - order  = (n - degree - 1) - (degree + 1) = n - 2*degree - 2
+
+    so the ``min`` can never bind. This sweeps it rather than only arguing it, because
+    the argument is the kind that is easy to get subtly wrong and the sweep is cheap.
+
+    The clamp is reproduced in ``cpp/include/pantr/bspline/tabulate.hpp`` anyway, so the
+    two backends stay structurally identical and a future change to the span clamp
+    cannot make one wrong while the other stays right.
+
+    Returns:
+        int: 0 if the clamp never changed the answer, 1 if it did -- in which case the
+        redundancy claim in both the oracle's comment and the port's is wrong.
+    """
+    active = 0
+    checked = 0
+    for degree in range(7):
+        for extra in range(6):
+            count = 2 * degree + 2 + extra
+            knots = np.linspace(0.0, 1.0, count, dtype=np.float64)
+            num_basis = count - degree - 1
+            probes = np.concatenate([knots, np.linspace(-0.5, 1.5, 41)])
+            for pt in probes:
+                span = int(np.searchsorted(knots, pt, side="right")) - 1
+                span = max(min(span, count - degree - 2), degree)
+                checked += 1
+                if min(span - degree, num_basis - degree - 1) != span - degree:
+                    active += 1
+
+    print("== 4. the oracle's non-periodic first-basis clamp ==")
+    print(f"   swept {checked} (degree, knot count, point) combinations")
+    print(f"   the min changed the answer {active} times")
+    if active == 0:
+        print("   so the clamp is unreachable: the span clamp above it already makes the")
+        print("   two bounds equal, and the comment calling it load-bearing is wrong.")
+    print()
+    return 0 if active == 0 else 1
+
+
+def measure_the_chain_rule_scaling_width(dtype: _Storage = np.float32) -> int:
+    """Measure which width numpy applies the Bezier-like chain-rule factor at.
+
+    ``_tabulate_Bspline_basis_Bernstein_like_deriv_1D`` accumulates
+    ``scale = (1 / float(b - a)) ** k`` as a Python ``float``, so the accumulation is
+    genuinely ``float64``; it then writes ``out_deriv[:, k, :] * scale``. Under NEP 50 a
+    Python float is a *weak* scalar and is cast to the array's dtype before the
+    multiply, so the factor applied is the narrowed one -- but that is a property of
+    numpy's promotion rules rather than of the source, so it is measured.
+
+    Two rival models per value, and the count of values on which they disagree, so a
+    match cannot come from a check that could not fail.
+
+    Args:
+        dtype (_Storage): The storage dtype. Defaults to ``np.float32``.
+
+    Returns:
+        int: 0 when exactly one model reproduces numpy on every value.
+    """
+    rng = np.random.default_rng(_RNG_SEED)
+    values: _Array = cast("_Array", rng.random(20000).astype(dtype))
+    # Reciprocals of spans a Bezier-like space plausibly has, including exact powers of
+    # two (where the two models must agree, since the factor is representable) and
+    # values needing the full float64 significand (where they need not).
+    scales = [1.0 / 3.0, 1.0 / 7.0, np.pi, 1e-8, 1e8, 1.0 / 1024.0]
+    bits = np.uint32 if dtype is np.float32 else np.uint64
+    narrow_hits = wide_hits = models_differ = total = 0
+
+    for scale in scales:
+        got = cast("_Array", values * scale)
+        narrow = cast("_Array", values * dtype(scale))
+        wide = cast("_Array", (values.astype(np.float64) * scale).astype(dtype))
+        total += values.size
+        narrow_hits += int(np.count_nonzero(got.view(bits) == narrow.view(bits)))
+        wide_hits += int(np.count_nonzero(got.view(bits) == wide.view(bits)))
+        models_differ += int(np.count_nonzero(narrow.view(bits) != wide.view(bits)))
+
+    name = np.dtype(dtype).name
+    print(f"== 5. the chain-rule scaling at {name}: {total} values, {len(scales)} scales ==")
+    print(f"   factor narrowed before the multiply reproduces numpy: {narrow_hits}/{total}")
+    print(f"   product formed in float64 reproduces numpy:           {wide_hits}/{total}")
+    print(f"   the two models disagree on {models_differ}/{total} values")
+    print()
+    return 0 if narrow_hits == total and (dtype is np.float64 or models_differ > 0) else 1
+
+
 def main() -> int:
     """Run every measurement and return a non-zero status if any model failed.
 
@@ -747,6 +846,9 @@ def main() -> int:
     status |= measure_the_two_twins_agree(np.float32)
     status |= measure_the_two_twins_agree(np.float64)
     status |= report_the_factorial_wrap()
+    status |= report_the_redundant_clamp()
+    status |= measure_the_chain_rule_scaling_width(np.float32)
+    status |= measure_the_chain_rule_scaling_width(np.float64)
     print("all models reproduced the kernel" if status == 0 else "A MODEL FAILED, see above")
     return status
 

--- a/scripts/measure_bspline_tabulation_widths.py
+++ b/scripts/measure_bspline_tabulation_widths.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python
+"""Measure the accumulation width of every expression in the 1D B-spline tabulation kernels.
+
+``design/backend_parity.md`` Rule 9: an oracle's accumulation width is a per-kernel
+fact and **cannot be read off the source**. ``float()`` does not widen a ``float32``
+in numba's ``nopython`` mode, what widens is type unification across assignments, and
+the destination's dtype says nothing about the width the operation ran at. So the C++
+transliteration in ``cpp/include/pantr/bspline/tabulate.hpp`` is written against this
+script rather than against a reading of
+``src/pantr/bspline/_bspline_basis_core.py``.
+
+Three things are measured, and the second is the one that matters:
+
+1. **numba's own inferred types**, expression by expression, read off
+   ``nopython_signatures`` rather than off a returned value. Reading a returned value
+   measures the boxing to a Python ``float`` and reports ``float64`` for everything.
+
+2. **Behaviourally, two rival transliterations per kernel against the kernel itself**,
+   at ``float32`` where the widths separate. Each site is reported with how often the
+   two models *disagree with each other*, so a match cannot come from a check that
+   could not fail.
+
+3. **Where the falling-factorial accumulator wraps.** ``_basis_derivs_point`` and
+   ``_bernstein_derivs_point`` both accumulate ``degree!/(degree-k)!`` in an integer
+   that wraps at int64 when compiled. Past the wrap the *scaling* of the k-th
+   derivative row is a different number, in both backends, and it is not a rounding
+   difference. The wrap is reproduced by the port and bounds the degree at which an
+   independent accuracy claim can be made.
+
+Run it from the repository root inside the ``pantr`` environment::
+
+    conda run -n pantr python scripts/measure_bspline_tabulation_widths.py
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, TypeAlias, cast
+
+import numba as nb
+import numpy as np
+import numpy.typing as npt
+from numba import float32, int64
+
+from pantr._numba_compat import nb_jit
+from pantr.basis._basis_core import _tabulate_Bernstein_basis_deriv_1D_serial_core
+from pantr.bspline._bspline_basis_core import (
+    _compute_basis_deriv_nurbs_book_impl,
+    _compute_basis_deriv_nurbs_book_serial_impl,
+    _compute_basis_nurbs_book_impl,
+    _compute_basis_nurbs_book_serial_impl,
+)
+
+_Storage: TypeAlias = type[np.float32] | type[np.float64]
+"""A storage format, as the scalar type numpy names it."""
+
+_Scalar: TypeAlias = np.float32 | np.float64
+"""One value in a storage format."""
+
+_Array: TypeAlias = npt.NDArray[np.float32 | np.float64]
+"""An array in either storage format."""
+
+_F32_1D = nb.types.Array(float32, 1, "C")
+"""The numba type of a 1D C-contiguous float32 array."""
+
+_RNG_SEED = 20260909
+"""Fixed so the sweep is the same sweep on every re-run."""
+
+_DEGREES = (0, 1, 2, 3, 5, 12, 20, 21, 25)
+"""Degrees swept.
+
+The low ones cover the ordinary cases and the empty-span guard. The high ones are
+there because the two factorial-scaling models are *provably identical* while
+``degree!/(degree-k)!`` is exactly representable in the storage format: the exact
+product of two ``float32`` values has at most 48 significand bits, so it is exact in
+``float64`` and rounding it once to ``float32`` is the same single rounding a
+``float32`` multiply commits. The models can only separate once ``fac`` needs more
+than 24 bits, which first happens around degree 12, and 21 and 25 are where the int64
+accumulator itself wraps.
+"""
+
+
+# ---------------------------------------------------------------------------
+# 1. numba's inferred types, per expression
+# ---------------------------------------------------------------------------
+
+
+def _return_type(fn: Any, *argtypes: Any) -> str:  # noqa: ANN401 -- see Args
+    """Compile ``fn`` for ``argtypes`` and report the return type numba inferred.
+
+    Args:
+        fn (Any): A numba dispatcher. ``numba.core.registry.CPUDispatcher`` is not
+            statically typed and is private, so there is no narrower annotation.
+        argtypes (Any): numba type objects to compile for, likewise untyped.
+
+    Returns:
+        str: The inferred return type, as numba spells it.
+    """
+    fn.compile(tuple(argtypes))
+    return str(fn.nopython_signatures[-1].return_type)
+
+
+@nb_jit(nopython=True)
+def _expr_sub(a: _Scalar, b: _Scalar) -> _Scalar:
+    """``left[j] = pt - knots[...]`` and ``right[j] = knots[...] - pt``."""
+    return a - b
+
+
+@nb_jit(nopython=True)
+def _expr_div(a: _Scalar, b: _Scalar) -> _Scalar:
+    """``N[r] / denom``."""
+    return a / b
+
+
+@nb_jit(nopython=True)
+def _expr_mul_int(a: _Scalar, k: int) -> _Scalar:
+    """``out_pt[k, j] *= fac`` with ``fac`` an integer."""
+    return a * k
+
+
+@nb_jit(nopython=True)
+def _expr_temp(n: npt.NDArray[np.float32], denom: _Scalar) -> _Scalar:
+    """``temp = zero if denom == zero else N[r] / denom``, with ``zero = dtype.type(0.0)``."""
+    dtype = n.dtype
+    zero = dtype.type(0.0)
+    return zero if denom == zero else n[0] / denom
+
+
+@nb_jit(nopython=True)
+def _expr_saved(a: _Scalar, b: _Scalar) -> _Scalar:
+    """``saved = zero`` then ``saved = left[j - r] * temp``: unification across assignments."""
+    saved: _Scalar = np.float32(0.0)
+    saved = a * b
+    return saved
+
+
+def report_inferred_types() -> None:
+    """Print the width numba gives each expression the two kernels are built from."""
+    print("== 1. numba's inferred types, at float32 storage ==")
+    print("   read off nopython_signatures; a returned value would report the boxing instead")
+    rows = [
+        ("pt - knots[i]                  ", _return_type(_expr_sub, float32, float32)),
+        ("N[r] / denom                   ", _return_type(_expr_div, float32, float32)),
+        ("temp = zero if .. else N[r]/d  ", _return_type(_expr_temp, _F32_1D, float32)),
+        ("saved = 0.0; saved = a * temp  ", _return_type(_expr_saved, float32, float32)),
+        ("out_pt[k, j] * fac  (fac int64)", _return_type(_expr_mul_int, float32, int64)),
+    ]
+    for name, width in rows:
+        print(f"   {name} -> {width}")
+    print("   so: every Cox-de Boor intermediate stays float32, and the ONE site that")
+    print("   widens is the factorial scaling, which multiplies in float64 and stores narrow.")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# 2. Rival transliterations, measured against the kernel
+# ---------------------------------------------------------------------------
+
+
+def _span_and_first_basis(
+    knots: _Array, degree: int, num_basis: int, pt: _Scalar
+) -> tuple[int, int]:
+    """Reproduce ``_find_span_and_first_basis_point`` for a non-periodic space.
+
+    Args:
+        knots (_Array): The knot vector.
+        degree (int): The degree.
+        num_basis (int): The number of basis functions.
+        pt (_Scalar): The evaluation point.
+
+    Returns:
+        tuple[int, int]: ``(knot_id, first_basis)``.
+    """
+    knot_id = int(np.searchsorted(knots, pt, side="right")) - 1
+    knot_id = min(knot_id, knots.size - degree - 2)
+    knot_id = max(knot_id, degree)
+    return knot_id, min(knot_id - degree, num_basis - degree - 1)
+
+
+def _model_basis_funcs(  # noqa: PLR0913
+    knots: _Array,
+    degree: int,
+    knot_id: int,
+    pt: _Scalar,
+    arithmetic: _Storage,
+    storage: _Storage,
+) -> _Array:
+    """Transliterate A2.2 with every intermediate in ``arithmetic``, storing in ``storage``.
+
+    Args:
+        knots (_Array): The knot vector.
+        degree (int): The degree.
+        knot_id (int): The clamped knot span of ``pt``.
+        pt (_Scalar): The evaluation point.
+        arithmetic (_Storage): Width every intermediate is held at.
+        storage (_Storage): Width the result is stored at.
+
+    Returns:
+        _Array: The ``degree + 1`` basis values, in ``storage``.
+    """
+    order = degree + 1
+    dt = arithmetic
+    values = np.zeros(order, dtype=dt)
+    left = np.zeros(order, dtype=dt)
+    right = np.zeros(order, dtype=dt)
+    values[0] = dt(1.0)
+
+    for j in range(1, order):
+        left[j] = dt(pt) - dt(knots[knot_id + 1 - j])
+        right[j] = dt(knots[knot_id + j]) - dt(pt)
+        saved = dt(0.0)
+        for r in range(j):
+            denom = right[r + 1] + left[j - r]
+            temp = dt(0.0) if denom == dt(0.0) else values[r] / denom
+            values[r] = saved + right[r + 1] * temp
+            saved = left[j - r] * temp
+        values[j] = saved
+
+    return cast("_Array", values.astype(storage))
+
+
+def _model_basis_derivs(  # noqa: PLR0913
+    knots: _Array,
+    degree: int,
+    n_deriv: int,
+    knot_id: int,
+    pt: _Scalar,
+    arithmetic: _Storage,
+    storage: _Storage,
+    *,
+    widen_the_factorial: bool,
+) -> _Array:
+    """Transliterate A2.3, with the factorial scaling either widened or not.
+
+    Args:
+        knots (_Array): The knot vector.
+        degree (int): The degree.
+        n_deriv (int): Highest derivative order.
+        knot_id (int): The clamped knot span of ``pt``.
+        pt (_Scalar): The evaluation point.
+        arithmetic (_Storage): Width every A2.3 intermediate is held at.
+        storage (_Storage): Width the result is stored at.
+        widen_the_factorial (bool): Whether the step-3 scaling multiplies in float64
+            and rounds on the store, as ``float32 * int64 -> float64`` implies, or
+            narrows the factorial first and multiplies in ``storage``.
+
+    Returns:
+        _Array: Shape ``(n_deriv + 1, degree + 1)``, in ``storage``.
+    """
+    order = degree + 1
+    dt = arithmetic
+    ndu = np.zeros((order, order), dtype=dt)
+    left = np.zeros(order, dtype=dt)
+    right = np.zeros(order, dtype=dt)
+    a = np.zeros((2, n_deriv + 1), dtype=dt)
+    out = np.zeros((n_deriv + 1, order), dtype=dt)
+
+    ndu[0, 0] = dt(1.0)
+    for j in range(1, order):
+        left[j] = dt(pt) - dt(knots[knot_id + 1 - j])
+        right[j] = dt(knots[knot_id + j]) - dt(pt)
+        saved = dt(0.0)
+        for r in range(j):
+            ndu[j, r] = right[r + 1] + left[j - r]
+            denom = ndu[j, r]
+            temp = dt(0.0) if denom == dt(0.0) else ndu[r, j - 1] / denom
+            ndu[r, j] = saved + right[r + 1] * temp
+            saved = left[j - r] * temp
+        ndu[j, j] = saved
+
+    for j in range(order):
+        out[0, j] = ndu[j, degree]
+
+    for r in range(order):
+        s1, s2 = 0, 1
+        a[0, 0] = dt(1.0)
+        for k in range(1, n_deriv + 1):
+            d = dt(0.0)
+            rk = r - k
+            pk = degree - k
+            if r >= k:
+                a[s2, 0] = a[s1, 0] / ndu[pk + 1, rk]
+                d = a[s2, 0] * ndu[rk, pk]
+            j1 = 1 if rk >= -1 else -rk
+            j2 = k - 1 if (r - 1) <= pk else degree - r
+            for j in range(j1, j2 + 1):
+                a[s2, j] = (a[s1, j] - a[s1, j - 1]) / ndu[pk + 1, rk + j]
+                d = d + a[s2, j] * ndu[rk + j, pk]
+            if r <= pk:
+                a[s2, k] = -a[s1, k - 1] / ndu[pk + 1, r]
+                d = d + a[s2, k] * ndu[r, pk]
+            out[k, r] = d
+            s1, s2 = s2, s1
+
+    result = out.astype(storage)
+    fac = falling_factorials(degree, n_deriv)
+    for k in range(1, n_deriv + 1):
+        for j in range(order):
+            if widen_the_factorial:
+                result[k, j] = storage(np.float64(result[k, j]) * np.float64(fac[k]))
+            else:
+                result[k, j] = storage(result[k, j] * storage(fac[k]))
+    return cast("_Array", result)
+
+
+def falling_factorials(degree: int, n_deriv: int) -> list[int]:
+    """The step-3 scaling factors, accumulated exactly as the kernel accumulates them.
+
+    ``fac`` starts at ``degree`` and is multiplied by ``degree - k``, so entry ``k`` is
+    ``degree!/(degree-k)!`` while that fits an int64 and its two's-complement wrap
+    afterwards. Entry 0 is unused and is 0.
+
+    Args:
+        degree (int): The degree.
+        n_deriv (int): Highest derivative order.
+
+    Returns:
+        list[int]: ``n_deriv + 1`` factors, wrapped to signed 64-bit.
+    """
+    mask = (1 << 64) - 1
+    factors = [0]
+    fac = degree
+    for k in range(1, n_deriv + 1):
+        factors.append(fac)
+        fac = (fac * (degree - k)) & mask
+        if fac >= 1 << 63:
+            fac -= 1 << 64
+    return factors
+
+
+def _knot_vectors(rng: np.random.Generator, dtype: _Storage) -> list[_Array]:
+    """Knot vectors chosen to be adversarial about representability, not magnitude.
+
+    Rule 9's sharpest case was found by a case list built around exactly-representable
+    ratios rather than round numbers, so the interior knots here are dyadic fractions,
+    near-duplicates a few ulp apart, and an exactly repeated knot (an empty span, which
+    is the only input the ``denom == 0`` guard exists for).
+
+    Args:
+        rng (np.random.Generator): Source of the random interior knots.
+        dtype (_Storage): The storage dtype.
+
+    Returns:
+        list[_Array]: One knot vector per case, unclamped and clamped.
+    """
+    vectors = []
+    for interior in (
+        [],
+        [0.5],
+        [0.25, 0.5, 0.75],
+        [1.0 / 3.0, 2.0 / 3.0],
+        [0.5, 0.5],  # an empty span: the denom == 0 guard
+        [0.5, np.nextafter(np.float32(0.5), np.float32(1.0)).item()],
+        sorted(rng.random(5).tolist()),
+    ):
+        for degree in _DEGREES:
+            head = [0.0] * (degree + 1)
+            tail = [1.0] * (degree + 1)
+            vectors.append(cast("_Array", np.array(head + list(interior) + tail, dtype=dtype)))
+    return vectors
+
+
+def _points(rng: np.random.Generator, dtype: _Storage) -> _Array:
+    """Evaluation points: both endpoints, every knot, dyadic values, and random ones."""
+    fixed = [0.0, 1.0, 0.5, 0.25, 0.75, 1.0 / 3.0]
+    fixed += [np.nextafter(np.float32(0.5), np.float32(0.0)).item()]
+    fixed += [np.nextafter(np.float32(1.0), np.float32(0.0)).item()]
+    return cast("_Array", np.array(fixed + rng.random(18).tolist(), dtype=dtype))
+
+
+def measure_a2_2_width(dtype: _Storage = np.float32) -> int:
+    """Compare a narrow and a wide A2.2 transliteration against the kernel.
+
+    Args:
+        dtype (_Storage): The storage dtype to measure at. Defaults to ``np.float32``.
+
+    Returns:
+        int: 0 when exactly one model reproduces the kernel on every value.
+    """
+    rng = np.random.default_rng(_RNG_SEED)
+    points = _points(rng, dtype)
+    narrow_hits = wide_hits = models_differ = total = 0
+
+    for knots in _knot_vectors(rng, dtype):
+        degree = int(np.count_nonzero(knots == knots[0]) - 1)
+        num_basis = knots.size - degree - 1
+        if num_basis < degree + 1:
+            continue
+        actual = np.empty((points.size, degree + 1), dtype=dtype)
+        first = np.empty(points.size, dtype=np.int_)
+        _compute_basis_nurbs_book_serial_impl(knots, degree, False, 1e-10, points, actual, first)
+        for j, pt in enumerate(points):
+            knot_id, _ = _span_and_first_basis(knots, degree, num_basis, pt)
+            narrow = _model_basis_funcs(knots, degree, knot_id, pt, dtype, dtype)
+            wide = _model_basis_funcs(knots, degree, knot_id, pt, np.float64, dtype)
+            total += actual.shape[1]
+            narrow_hits += int(np.count_nonzero(narrow == actual[j]))
+            wide_hits += int(np.count_nonzero(wide == actual[j]))
+            models_differ += int(np.count_nonzero(narrow != wide))
+
+    name = np.dtype(dtype).name
+    print(f"== 2a. A2.2 (_basis_funcs_point) at {name}: {total} values ==")
+    print(f"   all-{name} intermediates   reproduce the kernel: {narrow_hits}/{total}")
+    print(f"   float64 intermediates      reproduce the kernel: {wide_hits}/{total}")
+    print(f"   the two models disagree on {models_differ}/{total} values")
+    print()
+    return 0 if narrow_hits == total and (dtype is np.float64 or models_differ > 0) else 1
+
+
+def measure_a2_3_width(dtype: _Storage = np.float32) -> int:
+    """Compare narrow/wide A2.3 and both factorial-scaling models against the kernel.
+
+    Args:
+        dtype (_Storage): The storage dtype to measure at. Defaults to ``np.float32``.
+
+    Returns:
+        int: 0 when exactly one combination reproduces the kernel on every value.
+    """
+    rng = np.random.default_rng(_RNG_SEED)
+    points = _points(rng, dtype)
+    hits = {("narrow", "wide-fac"): 0, ("narrow", "narrow-fac"): 0, ("wide", "wide-fac"): 0}
+    fac_models_differ = total = 0
+
+    for knots in _knot_vectors(rng, dtype):
+        degree = int(np.count_nonzero(knots == knots[0]) - 1)
+        num_basis = knots.size - degree - 1
+        if num_basis < degree + 1:
+            continue
+        n_deriv = degree + 1
+        actual = np.empty((points.size, n_deriv + 1, degree + 1), dtype=dtype)
+        first = np.empty(points.size, dtype=np.int_)
+        _compute_basis_deriv_nurbs_book_serial_impl(
+            knots, degree, False, 1e-10, n_deriv, points, actual, first
+        )
+        for j, pt in enumerate(points):
+            knot_id, _ = _span_and_first_basis(knots, degree, num_basis, pt)
+            models = {
+                ("narrow", "wide-fac"): _model_basis_derivs(
+                    knots,
+                    degree,
+                    n_deriv,
+                    knot_id,
+                    pt,
+                    dtype,
+                    dtype,
+                    widen_the_factorial=True,
+                ),
+                ("narrow", "narrow-fac"): _model_basis_derivs(
+                    knots,
+                    degree,
+                    n_deriv,
+                    knot_id,
+                    pt,
+                    dtype,
+                    dtype,
+                    widen_the_factorial=False,
+                ),
+                ("wide", "wide-fac"): _model_basis_derivs(
+                    knots,
+                    degree,
+                    n_deriv,
+                    knot_id,
+                    pt,
+                    np.float64,
+                    dtype,
+                    widen_the_factorial=True,
+                ),
+            }
+            total += actual[j].size
+            for key, model in models.items():
+                hits[key] += int(np.count_nonzero(model == actual[j]))
+            fac_models_differ += int(
+                np.count_nonzero(models[("narrow", "wide-fac")] != models[("narrow", "narrow-fac")])
+            )
+
+    name = np.dtype(dtype).name
+    print(f"== 2b. A2.3 (_basis_derivs_point) at {name}: {total} values ==")
+    for (arith, fac), count in hits.items():
+        print(f"   {arith:6s} intermediates + {fac:11s} scaling reproduces: {count}/{total}")
+    print(f"   the two factorial-scaling models disagree on {fac_models_differ}/{total} values")
+    print()
+    ok = hits[("narrow", "wide-fac")] == total
+    return 0 if ok and (dtype is np.float64 or fac_models_differ > 0) else 1
+
+
+def _model_bernstein_derivs(  # noqa: PLR0913
+    degree: int,
+    pt: _Scalar,
+    n_deriv: int,
+    arithmetic: _Storage,
+    storage: _Storage,
+    *,
+    widen_the_factorial: bool,
+) -> _Array:
+    """Transliterate ``_bernstein_derivs_point``: A2.3 with every knot difference one.
+
+    Args:
+        degree (int): The degree.
+        pt (_Scalar): The evaluation point, on ``[0, 1]``.
+        n_deriv (int): Highest derivative order.
+        arithmetic (_Storage): Width every intermediate is held at.
+        storage (_Storage): Width the result is stored at.
+        widen_the_factorial (bool): Whether the step-3 scaling widens, as in
+            :func:`_model_basis_derivs`.
+
+    Returns:
+        _Array: Shape ``(n_deriv + 1, degree + 1)``, in ``storage``.
+    """
+    order = degree + 1
+    dt = arithmetic
+    ndu = np.zeros((order, order), dtype=dt)
+    a = np.zeros((2, n_deriv + 1), dtype=dt)
+    out = np.zeros((n_deriv + 1, order), dtype=dt)
+    s = dt(pt)
+
+    ndu[0, 0] = dt(1.0)
+    for j in range(1, order):
+        saved = dt(0.0)
+        for r in range(j):
+            ndu[j, r] = dt(1.0)
+            temp = ndu[r, j - 1]
+            ndu[r, j] = saved + (dt(1.0) - s) * temp
+            saved = s * temp
+        ndu[j, j] = saved
+
+    for j in range(order):
+        out[0, j] = ndu[j, degree]
+
+    for r in range(order):
+        s1, s2 = 0, 1
+        a[0, 0] = dt(1.0)
+        for k in range(1, n_deriv + 1):
+            d = dt(0.0)
+            rk = r - k
+            pk = degree - k
+            if r >= k:
+                a[s2, 0] = a[s1, 0]
+                d = a[s2, 0] * ndu[rk, pk]
+            j1 = 1 if rk >= -1 else -rk
+            j2 = k - 1 if (r - 1) <= pk else degree - r
+            for j in range(j1, j2 + 1):
+                a[s2, j] = a[s1, j] - a[s1, j - 1]
+                d = d + a[s2, j] * ndu[rk + j, pk]
+            if r <= pk:
+                a[s2, k] = -a[s1, k - 1]
+                d = d + a[s2, k] * ndu[r, pk]
+            out[k, r] = d
+            s1, s2 = s2, s1
+
+    result = out.astype(storage)
+    fac = falling_factorials(degree, n_deriv)
+    for k in range(1, n_deriv + 1):
+        for j in range(order):
+            if widen_the_factorial:
+                result[k, j] = storage(np.float64(result[k, j]) * np.float64(fac[k]))
+            else:
+                result[k, j] = storage(result[k, j] * storage(fac[k]))
+    return cast("_Array", result)
+
+
+def measure_bernstein_deriv_width(dtype: _Storage = np.float32) -> int:
+    """Compare rival transliterations of ``_bernstein_derivs_point`` against the kernel.
+
+    Measured separately from A2.3 rather than inherited from it. Rule 9: a width cannot
+    be inferred per module or from the kernel next door, and these two kernels differ in
+    exactly the place a width surprise hides -- this one forms ``one - s`` against a
+    ``dtype.type(1.0)`` while A2.3 reads both operands out of arrays.
+
+    Args:
+        dtype (_Storage): The storage dtype. Defaults to ``np.float32``.
+
+    Returns:
+        int: 0 when exactly one combination reproduces the kernel on every value.
+    """
+    rng = np.random.default_rng(_RNG_SEED)
+    points = _points(rng, dtype)
+    hits = {("narrow", "wide-fac"): 0, ("narrow", "narrow-fac"): 0, ("wide", "wide-fac"): 0}
+    fac_models_differ = total = 0
+
+    for degree in _DEGREES:
+        n_deriv = degree + 1
+        actual = np.empty((points.size, n_deriv + 1, degree + 1), dtype=dtype)
+        _tabulate_Bernstein_basis_deriv_1D_serial_core(np.int32(degree), points, n_deriv, actual)
+        for j, pt in enumerate(points):
+            models = {
+                ("narrow", "wide-fac"): _model_bernstein_derivs(
+                    degree, pt, n_deriv, dtype, dtype, widen_the_factorial=True
+                ),
+                ("narrow", "narrow-fac"): _model_bernstein_derivs(
+                    degree, pt, n_deriv, dtype, dtype, widen_the_factorial=False
+                ),
+                ("wide", "wide-fac"): _model_bernstein_derivs(
+                    degree, pt, n_deriv, np.float64, dtype, widen_the_factorial=True
+                ),
+            }
+            total += actual[j].size
+            for key, model in models.items():
+                hits[key] += int(np.count_nonzero(model == actual[j]))
+            fac_models_differ += int(
+                np.count_nonzero(models[("narrow", "wide-fac")] != models[("narrow", "narrow-fac")])
+            )
+
+    name = np.dtype(dtype).name
+    print(f"== 2d. _bernstein_derivs_point at {name}: {total} values ==")
+    for (arith, fac), count in hits.items():
+        print(f"   {arith:6s} intermediates + {fac:11s} scaling reproduces: {count}/{total}")
+    print(f"   the two factorial-scaling models disagree on {fac_models_differ}/{total} values")
+    print()
+    ok = hits[("narrow", "wide-fac")] == total
+    return 0 if ok and (dtype is np.float64 or fac_models_differ > 0) else 1
+
+
+def measure_the_two_twins_agree(dtype: _Storage = np.float32) -> int:
+    """The parallel and serial numba kernels must agree bit for bit.
+
+    The C++ backend has one kernel at every batch size, so the oracle's
+    ``_PARALLEL_MIN_NUM_PTS`` dispatch selects which of two kernels a parity claim is
+    compared against. That is only sound if the two are bit-identical, which is
+    asserted here rather than assumed: they differ in how the span search is spelled
+    (vectorised ``searchsorted`` versus a scalar one per ``prange`` iteration), and
+    both are exact integer results, so nothing should move.
+
+    Args:
+        dtype (_Storage): The storage dtype. Defaults to ``np.float32``.
+
+    Returns:
+        int: 0 when every value agrees.
+    """
+    rng = np.random.default_rng(_RNG_SEED)
+    points = _points(rng, dtype)
+    differing = total = 0
+
+    for knots in _knot_vectors(rng, dtype):
+        degree = int(np.count_nonzero(knots == knots[0]) - 1)
+        if knots.size - degree - 1 < degree + 1:
+            continue
+        n_deriv = degree + 1
+        shapes: list[tuple[Any, Any, tuple[int, ...]]] = [
+            (
+                _compute_basis_nurbs_book_impl,
+                _compute_basis_nurbs_book_serial_impl,
+                (points.size, degree + 1),
+            ),
+        ]
+        for parallel, serial, shape in shapes:
+            got_p = np.empty(shape, dtype=dtype)
+            got_s = np.empty(shape, dtype=dtype)
+            first_p = np.empty(points.size, dtype=np.int_)
+            first_s = np.empty(points.size, dtype=np.int_)
+            parallel(knots, degree, False, 1e-10, points, got_p, first_p)
+            serial(knots, degree, False, 1e-10, points, got_s, first_s)
+            total += got_p.size
+            bits = np.uint32 if dtype is np.float32 else np.uint64
+            differing += int(np.count_nonzero(got_p.view(bits) != got_s.view(bits)))
+            differing += int(np.count_nonzero(first_p != first_s))
+
+        deriv_shape = (points.size, n_deriv + 1, degree + 1)
+        got_p = np.empty(deriv_shape, dtype=dtype)
+        got_s = np.empty(deriv_shape, dtype=dtype)
+        first_p = np.empty(points.size, dtype=np.int_)
+        first_s = np.empty(points.size, dtype=np.int_)
+        _compute_basis_deriv_nurbs_book_impl(
+            knots, degree, False, 1e-10, n_deriv, points, got_p, first_p
+        )
+        _compute_basis_deriv_nurbs_book_serial_impl(
+            knots, degree, False, 1e-10, n_deriv, points, got_s, first_s
+        )
+        total += got_p.size
+        view = np.uint32 if dtype is np.float32 else np.uint64
+        differing += int(np.count_nonzero(got_p.view(view) != got_s.view(view)))
+        differing += int(np.count_nonzero(first_p != first_s))
+
+    print(f"== 2c. parallel versus serial twin at {np.dtype(dtype).name} ==")
+    print(f"   {differing} of {total} values differ")
+    print()
+    return 0 if differing == 0 else 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Where the falling factorial wraps
+# ---------------------------------------------------------------------------
+
+
+@nb_jit(nopython=True)
+def _kernel_falling_factorials(degree: int, n_deriv: int) -> npt.NDArray[np.int64]:
+    """The kernel's own accumulator, extracted so its wrap can be observed."""
+    out = np.zeros(n_deriv + 1, dtype=np.int64)
+    fac = degree
+    for k in range(1, n_deriv + 1):
+        out[k] = fac
+        fac *= degree - k
+    return out
+
+
+def report_the_factorial_wrap() -> int:
+    """Print the lowest degree at which the step-3 scaling wraps, and check the model.
+
+    Returns:
+        int: 0 when :func:`falling_factorials` reproduces the compiled accumulator at
+        every degree swept.
+    """
+    print("== 3. the step-3 falling factorial, degree!/(degree-k)! in an int64 ==")
+    mismatches = 0
+    first_wrapping_degree = None
+    for degree in range(41):
+        compiled = _kernel_falling_factorials(degree, degree + 2)
+        modelled = falling_factorials(degree, degree + 2)
+        if [int(v) for v in compiled] != modelled:
+            mismatches += 1
+        exact = [0]
+        value = 1
+        for k in range(1, degree + 3):
+            exact.append(value * degree if k == 1 else exact[k - 1] * (degree - k + 1))
+        wrapped = [k for k in range(1, degree + 1) if int(compiled[k]) != exact[k]]
+        if wrapped and first_wrapping_degree is None:
+            first_wrapping_degree = (degree, wrapped[0])
+    print(
+        f"   the python model reproduces the compiled accumulator: "
+        f"{'yes' if mismatches == 0 else f'NO, {mismatches} degrees differ'}"
+    )
+    if first_wrapping_degree is None:
+        print("   no wrap up to degree 40")
+    else:
+        degree, order = first_wrapping_degree
+        print(f"   lowest wrapping degree: {degree}, first at derivative order {order}")
+        print("   so an independent accuracy claim on the k-th derivative row is")
+        print(f"   defined only for degree < {degree}; parity is asserted above it too,")
+        print("   because both backends wrap identically.")
+    print()
+    return 0 if mismatches == 0 else 1
+
+
+def main() -> int:
+    """Run every measurement and return a non-zero status if any model failed.
+
+    Returns:
+        int: 0 when every reported model reproduced the kernel exactly.
+    """
+    report_inferred_types()
+    status = 0
+    status |= measure_a2_2_width(np.float32)
+    status |= measure_a2_2_width(np.float64)
+    status |= measure_a2_3_width(np.float32)
+    status |= measure_a2_3_width(np.float64)
+    status |= measure_bernstein_deriv_width(np.float32)
+    status |= measure_bernstein_deriv_width(np.float64)
+    status |= measure_the_two_twins_agree(np.float32)
+    status |= measure_the_two_twins_agree(np.float64)
+    status |= report_the_factorial_wrap()
+    print("all models reproduced the kernel" if status == 0 else "A MODEL FAILED, see above")
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -48,6 +48,7 @@ from ._basis import lagrange_to_bernstein_1d as lagrange_to_bernstein_1d
 from ._basis import legendre_to_cardinal_1d as legendre_to_cardinal_1d
 from ._basis import monomial_to_bernstein_1d as monomial_to_bernstein_1d
 from ._basis import tabulate_bernstein_1d as tabulate_bernstein_1d
+from ._basis import tabulate_bernstein_deriv_1d as tabulate_bernstein_deriv_1d
 from ._basis import tabulate_cardinal_bspline_1d as tabulate_cardinal_bspline_1d
 from ._basis import tabulate_legendre_1d as tabulate_legendre_1d
 from ._bezier import Bezier32 as Bezier32
@@ -119,6 +120,10 @@ from ._bspline import (
 from ._bspline import lagrange_extraction_1d as lagrange_extraction_1d
 from ._bspline import (
     lagrange_structural_identity_mask as lagrange_structural_identity_mask,
+)
+from ._bspline import tabulate_bspline_basis_1d as tabulate_bspline_basis_1d
+from ._bspline import (
+    tabulate_bspline_basis_derivatives_1d as tabulate_bspline_basis_derivatives_1d,
 )
 from ._bspline_field import Bspline32 as Bspline32
 from ._bspline_field import Bspline64 as Bspline64

--- a/src/pantr/_pantr_cpp/_basis.pyi
+++ b/src/pantr/_pantr_cpp/_basis.pyi
@@ -89,6 +89,48 @@ def tabulate_bernstein_1d(
             does not have shape ``(points.size, degree + 1)``.
     """
 
+def tabulate_bernstein_deriv_1d(
+    degree: int,
+    n_deriv: int,
+    points: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Tabulate the Bernstein basis of ``degree`` and its derivatives at ``points``.
+
+    The **C++ half of Layer 2**, with the same contract as
+    :func:`tabulate_cardinal_bspline_1d`, applied to both ``degree`` and
+    ``n_deriv``: each is checked against what a C ``int`` can hold, and each is
+    rejected with ``TypeError`` before this body runs if negative, since both are
+    ``unsigned`` in the C++ signature. Row 0 of the output holds the plain basis
+    values and rows above ``degree`` are identically zero, the k-th derivative of
+    a degree-p polynomial vanishing for ``k > p``.
+
+    Call :func:`pantr.basis.tabulate_bernstein_deriv_1d` for the ordinary path,
+    which additionally takes points of any shape and allocates ``out`` for you.
+
+    Args:
+        degree (int): Degree of the basis. Must be non-negative and must fit a
+            C ``int``.
+        n_deriv (int): Highest derivative order. Must be non-negative and must
+            fit a C ``int``.
+        points (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous
+            evaluation points.
+        out (npt.NDArray[np.float32 | np.float64]): 3D, C-contiguous, writable
+            output of shape ``(points.size, n_deriv + 1, degree + 1)`` and
+            matching dtype. Keyword-only.
+
+    Raises:
+        TypeError: If ``points`` or ``out`` has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` or ``n_deriv`` is negative, or if
+            ``out`` is passed positionally. A non-contiguous ``out`` is refused
+            rather than converted: converting it would fill a temporary and leave
+            the caller's array untouched, which is why ``.noconvert()`` is on it.
+        ValueError: If ``degree`` or ``n_deriv`` is too large to fit a C ``int``,
+            or if ``out`` does not have shape
+            ``(points.size, n_deriv + 1, degree + 1)``.
+    """
+
 def tabulate_legendre_1d(
     degree: int,
     points: npt.NDArray[np.float32 | np.float64],

--- a/src/pantr/_pantr_cpp/_basis.pyi
+++ b/src/pantr/_pantr_cpp/_basis.pyi
@@ -106,8 +106,13 @@ def tabulate_bernstein_deriv_1d(
     values and rows above ``degree`` are identically zero, the k-th derivative of
     a degree-p polynomial vanishing for ``k > p``.
 
-    Call :func:`pantr.basis.tabulate_bernstein_deriv_1d` for the ordinary path,
-    which additionally takes points of any shape and allocates ``out`` for you.
+    **There is no public Layer 1 counterpart to call instead**, unlike the
+    tabulations above. The only consumer is the Bezier-like fast path of
+    :func:`pantr.bspline._bspline_basis_core._tabulate_Bspline_basis_deriv_1D_impl`,
+    which reaches it through
+    :func:`pantr.basis._basis_backend.bernstein_deriv_core`; ``pantr.basis`` exports no
+    ``tabulate_bernstein_deriv_1d``. Exposing one is a separate decision about public
+    surface, not something this stub should imply already happened.
 
     Args:
         degree (int): Degree of the basis. Must be non-negative and must fit a

--- a/src/pantr/_pantr_cpp/_bspline.pyi
+++ b/src/pantr/_pantr_cpp/_bspline.pyi
@@ -56,6 +56,24 @@ the Numba kernels, so the bindings carry no ``nb::kw_only()``. And the identity
 flags are plain ``bool`` while the batch forms take them as arrays, which is the
 oracle's own split between a resolved cell and a batch of them.
 
+## General-knot basis tabulation
+
+Bound by ``cpp/bindings/bspline_basis.cpp``, over ``basis_funcs_1d`` and
+``basis_derivs_1d`` in ``cpp/include/pantr/bspline/tabulate.hpp`` -- Layer 3, not
+the space-level dispatch beside them in that header, which is a C++-only entry
+point and is deliberately not bound: building a space per tabulation call would
+re-validate and copy the knot vector in front of a kernel called with as few as
+two or three points, and the space's constructor snaps by default, which could
+silently evaluate on a different knot vector than the oracle did.
+:mod:`pantr.bspline._basis_backend` keeps the oracle's own Bézier-like-path
+dispatch and calls these two directly.
+
+**None of these checks has a counterpart in the oracle**, for the same reason
+the Bézier extraction operator builder's file comment gives: the oracle's own
+Layer 2 validates ``degree``, the domain and the output shapes in Python, above
+the backend dispatch, so both backends share it and it cannot diverge between
+them.
+
 See ``__init__.pyi`` for what this package promises and who has to keep it.
 """
 
@@ -357,6 +375,118 @@ def lagrange_structural_identity_mask(
         ValueError: If ``degree`` is negative, ``multiplicities`` is empty,
             ``out`` is not one shorter than ``multiplicities``, or the matrix has
             the wrong shape.
+    """
+
+def tabulate_bspline_basis_1d(
+    knots: _Array,
+    degree: int,
+    periodic: bool,
+    points: _Array,
+    *,
+    out_basis: _Array,
+    out_first_basis: _Index,
+) -> None:
+    """Tabulate the B-spline basis over a general knot vector (Piegl & Tiller A2.2).
+
+    The **C++ half of Layer 2** in the layering of CLAUDE.md, not Layer 3: it
+    validates every precondition ``pantr::bspline::basis_funcs_1d`` assumes and
+    never checks. Binds that free function directly rather than the space-level
+    ``tabulate_basis_1d``, which additionally picks the Bézier-like fast path --
+    ``cpp/include/pantr/bspline/tabulate.hpp``'s "Why the dispatch stays on the
+    Python side" is the reason, and :mod:`pantr.bspline._basis_backend` is what
+    keeps that dispatch.
+
+    **None of the checks below has a counterpart in the oracle.** The oracle's
+    own Layer 2 validates ``degree``, the domain and the output shapes in Python,
+    above the backend dispatch, so both backends share it and it cannot itself
+    diverge. What is checked here exists for a caller who reaches
+    :mod:`pantr._pantr_cpp` directly, which is possible because it is a public
+    attribute of a public module -- :func:`tabulate_cardinal_bspline_1d`'s
+    docstring records the measured SIGSEGV and heap corruption that motivate the
+    same discipline there.
+
+    A point outside ``knots``' domain is evaluated in the clamped span rather
+    than refused, which is what the oracle does with ``validate=False``.
+
+    Args:
+        knots (_Array): The knot vector, non-decreasing, at least
+            ``2 * degree + 2`` entries. C-contiguous.
+        degree (int): The polynomial degree. Must be non-negative and must fit a
+            C ``int``.
+        periodic (bool): Whether the space is periodic.
+        points (_Array): 1D, C-contiguous evaluation points, matching ``knots``
+            in dtype.
+        out_basis (_Array): 2D, C-contiguous, writable output of shape
+            ``(points.size, degree + 1)`` and matching dtype. Written in full.
+            Keyword-only.
+        out_first_basis (_Index): 1D, C-contiguous, writable output holding one
+            entry per point: the global index of the first basis function
+            supported there. Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If ``knots``, ``points``, ``out_basis`` or ``out_first_basis``
+            has the wrong dtype or rank, is not C-contiguous, or if ``degree`` is
+            negative, or if either output is passed positionally. A
+            non-contiguous output is refused rather than converted: converting
+            it would fill a temporary and leave the caller's array untouched,
+            which is why ``.noconvert()`` is on every array here.
+        ValueError: If ``degree`` is too large to fit a C ``int``, if ``knots``
+            has fewer than ``2 * degree + 2`` entries, or if ``out_basis`` or
+            ``out_first_basis`` does not have the shape ``points`` and ``degree``
+            call for.
+    """
+
+def tabulate_bspline_basis_derivatives_1d(
+    knots: _Array,
+    degree: int,
+    periodic: bool,
+    n_deriv: int,
+    points: _Array,
+    *,
+    out_deriv: _Array,
+    out_first_basis: _Index,
+) -> None:
+    """Tabulate the B-spline basis derivatives over a general knot vector (A2.3).
+
+    The **C++ half of Layer 2**, with the same contract, checks and reasons as
+    :func:`tabulate_bspline_basis_1d`; only the kernel differs
+    (``pantr::bspline::basis_derivs_1d``). Row 0 of each point's block holds the
+    plain basis values and is identical to what
+    :func:`tabulate_bspline_basis_1d` writes for the same arguments.
+
+    **The values are wrong in both backends for ``degree >= 21``** once
+    ``n_deriv`` reaches the wrapping order of the factorial accumulator the
+    kernel uses; the two backends agree there, which is what parity claims, and
+    neither is right. ``cpp/include/pantr/bspline/tabulate.hpp``'s file comment
+    measures the wrapping degree and derivative order.
+
+    Args:
+        knots (_Array): The knot vector, non-decreasing, at least
+            ``2 * degree + 2`` entries. C-contiguous.
+        degree (int): The polynomial degree. Must be non-negative and must fit a
+            C ``int``.
+        periodic (bool): Whether the space is periodic.
+        n_deriv (int): Highest derivative order. Must be non-negative and must
+            fit a C ``int``.
+        points (_Array): 1D, C-contiguous evaluation points, matching ``knots``
+            in dtype.
+        out_deriv (_Array): 3D, C-contiguous, writable output of shape
+            ``(points.size, n_deriv + 1, degree + 1)`` and matching dtype.
+            Written in full. Keyword-only.
+        out_first_basis (_Index): 1D, C-contiguous, writable output holding one
+            entry per point: the global index of the first basis function
+            supported there. Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If ``knots``, ``points``, ``out_deriv`` or ``out_first_basis``
+            has the wrong dtype or rank, is not C-contiguous, or if ``degree`` or
+            ``n_deriv`` is negative, or if either output is passed positionally.
+            A non-contiguous output is refused rather than converted, for the
+            reason :func:`tabulate_bspline_basis_1d` gives.
+        ValueError: If ``degree`` or ``n_deriv`` is too large to fit a C ``int``,
+            if ``knots`` has fewer than ``2 * degree + 2`` entries, or if
+            ``out_deriv`` or ``out_first_basis`` does not have the shape
+            ``points``, ``degree`` and ``n_deriv`` call for.
     """
 
 def apply_kron_1d(

--- a/src/pantr/basis/_basis_backend.py
+++ b/src/pantr/basis/_basis_backend.py
@@ -19,6 +19,9 @@ keeps it that way.
 - :class:`CoreKernels`: a tabulation's kernels in one backend, parallel and
   serial.
 - :func:`cardinal_bspline_core`: the cardinal B-spline kernels of a backend.
+- :data:`_BasisDerivCoreFunc`: the signature every 1D derivative tabulation has.
+- :class:`DerivKernels`: a derivative tabulation's kernels in one backend.
+- :func:`bernstein_deriv_core`: the Bernstein derivative kernels of a backend.
 """
 
 from __future__ import annotations
@@ -33,6 +36,8 @@ from .._backend import Backend, active_backend, available_backends
 from ._basis_core import (
     _tabulate_Bernstein_basis_1D_core,
     _tabulate_Bernstein_basis_1D_serial_core,
+    _tabulate_Bernstein_basis_deriv_1D_core,
+    _tabulate_Bernstein_basis_deriv_1D_serial_core,
     _tabulate_cardinal_Bspline_basis_1D_core,
     _tabulate_Legendre_basis_1D_core,
 )
@@ -264,3 +269,105 @@ def legendre_core(backend: Backend | None = None) -> CoreKernels:
     if chosen not in available_backends():
         raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
     return CoreKernels(parallel=_cpp_legendre_core)
+
+
+_BasisDerivCoreFunc = Callable[
+    [np.int32, npt.NDArray[np.float32 | np.float64], int, npt.NDArray[np.float32 | np.float64]],
+    None,
+]
+"""Signature of a 1D derivative tabulation kernel: ``(degree, pts, n_deriv, out) -> None``."""
+
+
+class DerivKernels(NamedTuple):
+    """The kernels tabulating one basis's derivatives, in one backend.
+
+    :class:`CoreKernels`'s counterpart for a derivative tabulation. A separate record
+    rather than a reuse, because the signature carries ``n_deriv`` and the output has
+    rank 3; one record holding both would have to be read as one or the other at every
+    call site.
+
+    Attributes:
+        parallel (_BasisDerivCoreFunc): The kernel used for batches of
+            ``_PARALLEL_MIN_NUM_PTS`` points or more.
+        serial (_BasisDerivCoreFunc | None): The serial twin, used below that
+            threshold. ``None`` when this backend has none, in which case ``parallel``
+            runs at every batch size. Defaults to None.
+    """
+
+    parallel: _BasisDerivCoreFunc
+    serial: _BasisDerivCoreFunc | None = None
+
+
+def _cpp_bernstein_deriv_core(
+    n: np.int32,
+    t: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Adapt the C++ Bernstein derivative kernel to the :data:`_BasisDerivCoreFunc` signature.
+
+    The contract is :func:`_cpp_cardinal_bspline_core`'s, in full, including why a
+    non-contiguous ``out`` is absorbed rather than refused.
+
+    Args:
+        n (np.int32): Degree of the basis. Assumed non-negative.
+        t (npt.NDArray[np.float32 | np.float64]): 1D evaluation points on ``[0, 1]``.
+        n_deriv (int): Highest derivative order. Assumed non-negative.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(t.size, n_deriv + 1, n + 1)`` and matching dtype. Need not be
+            contiguous.
+
+    Note:
+        No input validation is performed. Shape and dtype are established by the
+        Layer 2 caller; dtype, rank and contiguity are re-checked by nanobind's typed
+        signature, which raises :class:`TypeError` before the kernel runs rather than
+        silently converting.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    points = np.ascontiguousarray(t)
+    if out.flags["C_CONTIGUOUS"]:
+        _pantr_cpp.tabulate_bernstein_deriv_1d(int(n), int(n_deriv), points, out=out)
+        return
+
+    buffer = np.empty_like(out, order="C")
+    _pantr_cpp.tabulate_bernstein_deriv_1d(int(n), int(n_deriv), points, out=buffer)
+    out[...] = buffer
+
+
+def bernstein_deriv_core(backend: Backend | None = None) -> DerivKernels:
+    """Return the Bernstein derivative tabulation kernels of the requested backend.
+
+    Reached from :mod:`pantr.bspline._bspline_basis_core`'s Bézier-like fast path,
+    which is the only consumer today: a B-spline space whose knots describe a single
+    Bézier segment has the Bernstein basis of the same degree, so its derivatives come
+    from here and are then scaled by the chain rule *above* this seam, in the same
+    numpy expression under both backends.
+
+    The Python backend returns both kernels, and the dispatch between them on
+    ``_PARALLEL_MIN_NUM_PTS`` stays where the oracle put it. The C++ backend returns no
+    twin, for the reason :func:`cardinal_bspline_core` gives: its kernel runs on the
+    calling thread at every batch size.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+            Defaults to None.
+
+    Returns:
+        DerivKernels: The kernels, each callable as ``(n, t, n_deriv, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        return DerivKernels(
+            parallel=_tabulate_Bernstein_basis_deriv_1D_core,
+            serial=_tabulate_Bernstein_basis_deriv_1D_serial_core,
+        )
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return DerivKernels(parallel=_cpp_bernstein_deriv_core)

--- a/src/pantr/bspline/_basis_backend.py
+++ b/src/pantr/bspline/_basis_backend.py
@@ -1,0 +1,336 @@
+"""Which implementation of the 1D B-spline basis tabulation runs: Numba or the C++ port.
+
+:mod:`pantr._backend` owns the **policy** -- which backends exist, which one is
+selected, and the rule that an explicit request never falls back. This module owns
+the **catalogue** for the general-knot basis tabulation of :mod:`pantr.bspline`, and
+it is where the C++ adapters live. :mod:`pantr.bspline._extraction_backend` and
+:mod:`pantr.bspline._refinement_backend` are its siblings; the split by area is what
+keeps :mod:`pantr._backend` free of any import from the library.
+
+- :class:`BasisKernels`: the value-tabulation kernels of one backend.
+- :class:`BasisDerivKernels`: the derivative-tabulation kernels of one backend.
+- :func:`bspline_basis_core`: the value kernels of a backend.
+- :func:`bspline_basis_deriv_core`: the derivative kernels of a backend.
+
+Two things about the seam are worth stating here rather than leaving to be
+rediscovered.
+
+**Only the general-knot path is dispatched here.** A space with Bézier-like knots
+takes the Bernstein fast path instead, and that path was already backend-dispatched
+before this module existed: the values go through
+:func:`pantr.basis._basis_1D._tabulate_Bernstein_basis_1D_impl`, which asks
+:func:`pantr.basis._basis_backend.bernstein_core`, and the derivatives now go through
+:func:`pantr.basis._basis_backend.bernstein_deriv_core`. The change of variable onto
+``[0, 1]`` and the chain-rule scaling stay in
+:mod:`pantr.bspline._bspline_basis_core`, above the seam, so they are the *same
+numpy expressions* under both backends and cannot contribute a difference. That is
+``design/backend_parity.md`` Rule 1's consequence applied here: keep a shared map on
+the common side and it cancels exactly.
+
+**The C++ side has one kernel at every batch size, and that is not an omission.**
+The oracle keeps a ``parallel=True`` kernel and a serial twin and picks between them
+on ``_PARALLEL_MIN_NUM_PTS``; the C++ kernel runs on the calling thread, so there is
+no parallel launch to avoid below a threshold and nothing for a second entry to
+select. Rule 7 -- a liveness threshold is a property of the host it was measured on
+-- so that constant is **inherited, not re-derived**, and nothing here measures a new
+one. ``scripts/measure_bspline_tabulation_widths.py`` checks the twins are bitwise
+identical to each other (0 of 369 824 values differ, at both widths), which is what
+makes it sound to compare one C++ kernel against whichever of the two the oracle's
+dispatch happened to choose.
+
+**The two Numba kernel imports are deferred, and the reason is structural.** Every
+other catalogue in this package imports its kernels at module scope, which
+:mod:`pantr.bspline._extraction_backend` can do because
+:mod:`pantr.bspline._bspline_extraction_core` holds the kernels and nothing else --
+its module docstring says it exists for exactly that. The general-knot basis kernels
+are **not** split that way: :mod:`pantr.bspline._bspline_basis_core` holds both them
+and the Layer 2 entry points that have to ask this module which to call, so a
+module-scope import here closes a cycle.
+
+Deferring it inside the two catalogue functions is the smaller of the two repairs.
+The larger one is to split that module the way the extraction port is split, and it
+is the better long-term shape -- but it moves seven hundred lines of private symbols,
+and ``CLAUDE.md`` records a downstream consumer whose largest exposure is
+``pantr.bspline``. Recorded here as a follow-up rather than done in passing. Note what
+:mod:`pantr.basis._basis_backend`'s docstring objects to about lazy imports: that the
+count *grows by one per kernel ported*. Here it is two and cannot grow, since every
+future kernel is reached through one of the same two functions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+
+from .._backend import Backend, active_backend, available_backends
+
+_FloatArray = npt.NDArray[np.float32 | np.float64]
+
+_BasisFunc = Callable[
+    [_FloatArray, int, bool, float, _FloatArray, _FloatArray, npt.NDArray[np.int_]],
+    None,
+]
+"""Signature of a general-knot basis kernel.
+
+``(knots, degree, periodic, tol, pts, out_basis, out_first_basis) -> None``.
+"""
+
+_BasisDerivFunc = Callable[
+    [_FloatArray, int, bool, float, int, _FloatArray, _FloatArray, npt.NDArray[np.int_]],
+    None,
+]
+"""Signature of a general-knot basis derivative kernel.
+
+``(knots, degree, periodic, tol, n_deriv, pts, out_deriv, out_first_basis) -> None``.
+"""
+
+
+class BasisKernels(NamedTuple):
+    """The kernels tabulating the general-knot basis values, in one backend.
+
+    Attributes:
+        parallel (_BasisFunc): The kernel used for batches of
+            ``_PARALLEL_MIN_NUM_PTS`` points or more.
+        serial (_BasisFunc | None): The serial twin, used below that threshold.
+            ``None`` when this backend has none, in which case ``parallel`` runs at
+            every batch size. Defaults to None.
+    """
+
+    parallel: _BasisFunc
+    serial: _BasisFunc | None = None
+
+
+class BasisDerivKernels(NamedTuple):
+    """The kernels tabulating the general-knot basis derivatives, in one backend.
+
+    A second record rather than a reuse of :class:`BasisKernels`, because the
+    signatures differ by the ``n_deriv`` argument and a single record holding both
+    would have to be read as one or the other at every call site.
+
+    Attributes:
+        parallel (_BasisDerivFunc): The kernel used for batches of
+            ``_PARALLEL_MIN_NUM_PTS`` points or more.
+        serial (_BasisDerivFunc | None): The serial twin, used below that threshold.
+            ``None`` when this backend has none. Defaults to None.
+    """
+
+    parallel: _BasisDerivFunc
+    serial: _BasisDerivFunc | None = None
+
+
+def _contiguous_int64(out: npt.NDArray[np.int_]) -> npt.NDArray[np.int64] | None:
+    """Return a contiguous int64 buffer for ``out``, or ``None`` if ``out`` will serve.
+
+    The binding's typed signature demands a C-contiguous ``int64`` array and refuses
+    anything else rather than converting it, because a converted output would be
+    filled and discarded. The numba kernels accept any writable integer array, so the
+    difference has to be absorbed on this side.
+
+    Args:
+        out (npt.NDArray[np.int_]): The caller's first-basis-index array.
+
+    Returns:
+        npt.NDArray[np.int64] | None: A fresh buffer to compute into and copy back
+        from, or ``None`` when ``out`` can be passed straight through.
+    """
+    if out.flags["C_CONTIGUOUS"] and out.dtype == np.int64:
+        return None
+    return np.empty(out.shape, dtype=np.int64)
+
+
+def _cpp_basis(  # noqa: PLR0913
+    knots: _FloatArray,
+    degree: int,
+    periodic: bool,
+    tol: float,
+    pts: _FloatArray,
+    out_basis: _FloatArray,
+    out_first_basis: npt.NDArray[np.int_],
+) -> None:
+    """Adapt the C++ kernel to the :data:`_BasisFunc` signature.
+
+    The adapter's whole job is that **the public API must behave identically on both
+    backends**, because otherwise an A/B measurement compares two contracts rather
+    than two kernels. Two differences are absorbed here:
+
+    - the numba kernels accept a non-contiguous ``out`` and fill it, while the binding
+      requires C-contiguous memory and refuses anything else;
+    - ``tol`` is accepted and **not forwarded**, because the C++ kernel has no such
+      parameter. That is not a dropped argument: the oracle threads ``tol`` through to
+      :func:`pantr.bspline._bspline_knots._get_Bspline_num_basis_1D_impl` purely for
+      interface consistency, and its own docstrings record that it goes unused --
+      the non-periodic basis count is ``len(knots) - degree - 1`` and involves no
+      tolerance, while the periodic path short-circuits the count entirely.
+
+    Args:
+        knots (_FloatArray): The knot vector, non-decreasing.
+        degree (int): The polynomial degree. Assumed non-negative.
+        periodic (bool): Whether the space is periodic.
+        tol (float): Accepted for signature compatibility and unused; see above.
+        pts (_FloatArray): 1D evaluation points.
+        out_basis (_FloatArray): Output of shape ``(pts.size, degree + 1)`` and
+            matching dtype. Need not be contiguous.
+        out_first_basis (npt.NDArray[np.int_]): Output of shape ``(pts.size,)``.
+            Need not be contiguous.
+
+    Note:
+        No input validation is performed. Shape and dtype are established by the
+        Layer 2 caller in :mod:`pantr.bspline._bspline_basis_core`, whose checks run
+        before either backend and so cannot diverge between them.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    del tol
+    knot_view = np.ascontiguousarray(knots)
+    point_view = np.ascontiguousarray(pts)
+    index_buffer = _contiguous_int64(out_first_basis)
+    indices = out_first_basis if index_buffer is None else index_buffer
+
+    if out_basis.flags["C_CONTIGUOUS"]:
+        _pantr_cpp.tabulate_bspline_basis_1d(
+            knot_view,
+            int(degree),
+            bool(periodic),
+            point_view,
+            out_basis=out_basis,
+            out_first_basis=indices,
+        )
+    else:
+        # The uncommon path. The check above is a flag read, so the common case pays
+        # essentially nothing for it; only a caller that actually passes a strided
+        # view pays for the buffer and the copy back.
+        buffer = np.empty_like(out_basis, order="C")
+        _pantr_cpp.tabulate_bspline_basis_1d(
+            knot_view,
+            int(degree),
+            bool(periodic),
+            point_view,
+            out_basis=buffer,
+            out_first_basis=indices,
+        )
+        out_basis[...] = buffer
+
+    if index_buffer is not None:
+        out_first_basis[...] = index_buffer
+
+
+def _cpp_basis_derivatives(  # noqa: PLR0913
+    knots: _FloatArray,
+    degree: int,
+    periodic: bool,
+    tol: float,
+    n_deriv: int,
+    pts: _FloatArray,
+    out_deriv: _FloatArray,
+    out_first_basis: npt.NDArray[np.int_],
+) -> None:
+    """Adapt the C++ derivative kernel to the :data:`_BasisDerivFunc` signature.
+
+    The contract is :func:`_cpp_basis`'s, in full, including why a non-contiguous
+    output is absorbed rather than refused and why ``tol`` is not forwarded.
+
+    Args:
+        knots (_FloatArray): The knot vector, non-decreasing.
+        degree (int): The polynomial degree. Assumed non-negative.
+        periodic (bool): Whether the space is periodic.
+        tol (float): Accepted for signature compatibility and unused.
+        n_deriv (int): Highest derivative order. Assumed non-negative.
+        pts (_FloatArray): 1D evaluation points.
+        out_deriv (_FloatArray): Output of shape ``(pts.size, n_deriv + 1,
+            degree + 1)`` and matching dtype. Need not be contiguous.
+        out_first_basis (npt.NDArray[np.int_]): Output of shape ``(pts.size,)``.
+
+    Note:
+        No input validation is performed; see :func:`_cpp_basis`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    del tol
+    knot_view = np.ascontiguousarray(knots)
+    point_view = np.ascontiguousarray(pts)
+    index_buffer = _contiguous_int64(out_first_basis)
+    indices = out_first_basis if index_buffer is None else index_buffer
+
+    target = out_deriv if out_deriv.flags["C_CONTIGUOUS"] else np.empty_like(out_deriv, order="C")
+    _pantr_cpp.tabulate_bspline_basis_derivatives_1d(
+        knot_view,
+        int(degree),
+        bool(periodic),
+        int(n_deriv),
+        point_view,
+        out_deriv=target,
+        out_first_basis=indices,
+    )
+    if target is not out_deriv:
+        out_deriv[...] = target
+    if index_buffer is not None:
+        out_first_basis[...] = index_buffer
+
+
+def bspline_basis_core(backend: Backend | None = None) -> BasisKernels:
+    """Return the general-knot basis tabulation kernels of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+            Defaults to None.
+
+    Returns:
+        BasisKernels: The kernels, each callable as
+        ``(knots, degree, periodic, tol, pts, out_basis, out_first_basis) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        from ._bspline_basis_core import (  # noqa: PLC0415  (breaks a cycle; see the module docstring)
+            _compute_basis_nurbs_book_impl,
+            _compute_basis_nurbs_book_serial_impl,
+        )
+
+        return BasisKernels(
+            parallel=_compute_basis_nurbs_book_impl,
+            serial=_compute_basis_nurbs_book_serial_impl,
+        )
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return BasisKernels(parallel=_cpp_basis)
+
+
+def bspline_basis_deriv_core(backend: Backend | None = None) -> BasisDerivKernels:
+    """Return the general-knot basis derivative kernels of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+            Defaults to None.
+
+    Returns:
+        BasisDerivKernels: The kernels, each callable as ``(knots, degree, periodic,
+        tol, n_deriv, pts, out_deriv, out_first_basis) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        from ._bspline_basis_core import (  # noqa: PLC0415  (breaks a cycle; see the module docstring)
+            _compute_basis_deriv_nurbs_book_impl,
+            _compute_basis_deriv_nurbs_book_serial_impl,
+        )
+
+        return BasisDerivKernels(
+            parallel=_compute_basis_deriv_nurbs_book_impl,
+            serial=_compute_basis_deriv_nurbs_book_serial_impl,
+        )
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return BasisDerivKernels(parallel=_cpp_basis_derivatives)

--- a/src/pantr/bspline/_basis_backend.py
+++ b/src/pantr/bspline/_basis_backend.py
@@ -27,6 +27,10 @@ numpy expressions* under both backends and cannot contribute a difference. That 
 ``design/backend_parity.md`` Rule 1's consequence applied here: keep a shared map on
 the common side and it cancels exactly.
 
+**One call shape falls back to Numba**, and it is the only one:
+:func:`_the_cpp_kernels_cannot_serve` names it and says at length why falling back is
+the least-bad of the three available answers. Everything else reaches C++.
+
 **The C++ side has one kernel at every batch size, and that is not an omission.**
 The oracle keeps a ``parallel=True`` kernel and a serial twin and picks between them
 on ``_PARALLEL_MIN_NUM_PTS``; the C++ kernel runs on the calling thread, so there is
@@ -141,6 +145,54 @@ def _contiguous_int64(out: npt.NDArray[np.int_]) -> npt.NDArray[np.int64] | None
     return np.empty(out.shape, dtype=np.int64)
 
 
+def _the_cpp_kernels_cannot_serve(knots: _FloatArray, pts: _FloatArray) -> bool:
+    """Whether this call's dtypes are outside what the C++ kernels can express.
+
+    **The library deliberately supports a space whose knots are ``float32`` evaluated
+    at ``float64`` points**, and returns the points' dtype;
+    ``tests/test_mpi_thb_qi.py::test_result_is_float64_for_float32_space`` and
+    ``tests/test_thb_spline_space.py::TestCellMembershipTolerance
+    ::test_a_float32_root_space_is_still_graded_in_float64`` assert it by name. The
+    Numba kernels serve it by opening with ``dtype = knots.dtype`` for their scratch
+    while reading points at the points' own width, so the computation runs in a mixed
+    width that narrows at every array store.
+
+    The C++ kernels are templated on one scalar type and have no mixed overload, so
+    they cannot express that call at all. Three ways to reconcile that, and only one
+    of them keeps both halves of the contract:
+
+    - **Refuse it.** Tried, and wrong: it makes the selected backend change what the
+      library accepts, and it fails the five tests above.
+    - **Promote both sides and compute in ``float64``.** Keeps the output dtype but
+      changes the *values*, since the oracle truncates every intermediate to the knots'
+      width. A silent value divergence between backends is worse than a visible
+      fallback.
+    - **Run the Numba kernel for this call.** What this does. It is exactly the
+      behaviour the mixed case had before the C++ path existed, so nothing regresses,
+      and the values stay identical to the oracle's because they *are* the oracle's.
+
+    The cost is real and is why this is a narrow, named predicate rather than a
+    ``try``/``except``: an A/B measurement over mixed-dtype input measures Numba on
+    both sides, which is what ``pantr._backend``'s never-fall-back rule exists to
+    prevent. It is confined to a call the C++ side cannot express at all, and
+    ``tests/parity/test_bspline_basis_tabulation.py`` asserts both that the two
+    backends agree there and that the C++ binding is genuinely not reached, so the
+    fallback cannot widen unnoticed.
+
+    Which of the three is right in the long run is a contract decision rather than a
+    port decision: it turns on whether a mixed-width answer is wanted at all. This
+    takes the option that decides nothing.
+
+    Args:
+        knots (_FloatArray): The space's knot vector.
+        pts (_FloatArray): The evaluation points.
+
+    Returns:
+        bool: True when the dtypes differ, so the C++ kernels cannot be used.
+    """
+    return knots.dtype != pts.dtype
+
+
 def _cpp_basis(  # noqa: PLR0913
     knots: _FloatArray,
     degree: int,
@@ -158,8 +210,9 @@ def _cpp_basis(  # noqa: PLR0913
 
     - the numba kernels accept a non-contiguous ``out`` and fill it, while the binding
       requires C-contiguous memory and refuses anything else;
-    - ``tol`` is accepted and **not forwarded**, because the C++ kernel has no such
-      parameter. That is not a dropped argument: the oracle threads ``tol`` through to
+    - ``tol`` is accepted and **not forwarded on the C++ path**, because the C++ kernel
+      has no such parameter (the fallback path below does forward it, to the kernel that
+      declares it). That is not a dropped argument: the oracle threads ``tol`` through to
       :func:`pantr.bspline._bspline_knots._get_Bspline_num_basis_1D_impl` purely for
       interface consistency, and its own docstrings record that it goes unused --
       the non-periodic basis count is ``len(knots) - degree - 1`` and involves no
@@ -181,6 +234,16 @@ def _cpp_basis(  # noqa: PLR0913
         Layer 2 caller in :mod:`pantr.bspline._bspline_basis_core`, whose checks run
         before either backend and so cannot diverge between them.
     """
+    if _the_cpp_kernels_cannot_serve(knots, pts):
+        from ._bspline_basis_core import (  # noqa: PLC0415  (see the module docstring)
+            _compute_basis_nurbs_book_impl,
+        )
+
+        _compute_basis_nurbs_book_impl(
+            knots, degree, periodic, tol, pts, out_basis, out_first_basis
+        )
+        return
+
     from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
 
     del tol
@@ -246,6 +309,16 @@ def _cpp_basis_derivatives(  # noqa: PLR0913
     Note:
         No input validation is performed; see :func:`_cpp_basis`.
     """
+    if _the_cpp_kernels_cannot_serve(knots, pts):
+        from ._bspline_basis_core import (  # noqa: PLC0415  (see the module docstring)
+            _compute_basis_deriv_nurbs_book_impl,
+        )
+
+        _compute_basis_deriv_nurbs_book_impl(
+            knots, degree, periodic, tol, n_deriv, pts, out_deriv, out_first_basis
+        )
+        return
+
     from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
 
     del tol

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -692,48 +692,6 @@ def _tabulate_Bspline_basis_Bernstein_like_deriv_1D(
     out_first_basis.fill(0)
 
 
-def _demand_points_match_the_knots(
-    spline: BsplineSpace1D, pts: npt.NDArray[np.float32 | np.float64]
-) -> None:
-    """Refuse evaluation points whose dtype differs from the space's knots.
-
-    **A type-kind check, so it lives here and raises ``TypeError``**, per the split
-    ``cpp/include/pantr/core/error.hpp`` sets for the whole C++ port: nanobind has no
-    path to ``TypeError``, so type checks stay in Python and value checks go to C++.
-    It is in shared Layer 2 rather than in either backend's adapter, which is the point
-    -- an invariant the adapters rely on has to be established where both of them see
-    it, or selecting a backend changes what the library accepts.
-
-    The combination it refuses was never designed. The Numba kernels open with
-    ``dtype = knots.dtype`` and allocate their scratch in it while reading points at
-    the points' own width, so a mismatch computes in a mixed width that narrows at
-    every array store -- an answer that is neither the ``float32`` one nor the
-    ``float64`` one, and that nothing derived or documented. The C++ kernels are
-    templated on one scalar type and have no such overload, so before this guard the
-    same call succeeded under the Python backend and raised ``TypeError`` under the C++
-    one.
-
-    Refusing is the smaller change of the two available. Casting would have to pick a
-    direction: narrowing the points to the knots throws away precision the caller
-    asked for, widening the knots contradicts a space whose tolerance was derived from
-    the knots as stored. Which of those is right is a contract decision rather than a
-    port decision, and it is not taken here.
-
-    Args:
-        spline (BsplineSpace1D): The space whose knots the points must match.
-        pts (npt.NDArray[np.float32 | np.float64]): The normalized evaluation points.
-
-    Raises:
-        TypeError: If the dtypes differ.
-    """
-    if pts.dtype != spline.knots.dtype:
-        raise TypeError(
-            f"pts has dtype {pts.dtype} but the B-spline's knots have dtype "
-            f"{spline.knots.dtype}; evaluation points must match the space's storage "
-            f"format"
-        )
-
-
 def _tabulate_Bspline_basis_1D_impl(
     spline: BsplineSpace1D,
     pts: npt.ArrayLike,
@@ -783,8 +741,6 @@ def _tabulate_Bspline_basis_1D_impl(
               If `out_first_basis` was provided, returns the same array.
 
     Raises:
-        TypeError: If ``pts``' dtype differs from the B-spline's knot dtype; see
-            :func:`_demand_points_match_the_knots`.
         ValueError: If ``validate`` is True and any evaluation point is outside the
             B-spline domain, or if `out_basis` or `out_first_basis` is provided and
             has incorrect shape or dtype.
@@ -808,7 +764,6 @@ def _tabulate_Bspline_basis_1D_impl(
     """
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)
-    _demand_points_match_the_knots(spline, pts)
 
     if validate and not np.all(
         _is_in_domain_impl(spline.knots, spline.degree, pts, spline.tolerance)
@@ -900,8 +855,6 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
             function at each point.
 
     Raises:
-        TypeError: If ``pts``' dtype differs from the B-spline's knot dtype; see
-            :func:`_demand_points_match_the_knots`.
         ValueError: If ``n_deriv < 0``, if ``validate`` is True and any evaluation
             point is outside the domain, or ``out_deriv`` / ``out_first_basis`` has
             incorrect shape or dtype.
@@ -918,7 +871,6 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
 
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)
-    _demand_points_match_the_knots(spline, pts)
 
     if validate and not np.all(
         _is_in_domain_impl(spline.knots, spline.degree, pts, spline.tolerance)

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -13,17 +13,15 @@ import numpy.typing as npt
 
 from .._numba_compat import nb_jit, nb_prange
 from ..basis._basis_1D import _tabulate_Bernstein_basis_1D_impl
-from ..basis._basis_core import (
-    _PARALLEL_MIN_NUM_PTS,
-    _tabulate_Bernstein_basis_deriv_1D_core,
-    _tabulate_Bernstein_basis_deriv_1D_serial_core,
-)
+from ..basis._basis_backend import bernstein_deriv_core
+from ..basis._basis_core import _PARALLEL_MIN_NUM_PTS
 from ..basis._basis_utils import (
     _compute_final_output_shape_1D,
     _compute_final_output_shape_1D_deriv,
     _normalize_points_1D,
     _validate_out_array,
 )
+from ._basis_backend import bspline_basis_core, bspline_basis_deriv_core
 from ._bspline_knots import (
     _get_Bspline_num_basis_1D_impl,
     _get_last_knot_smaller_equal_impl,
@@ -678,12 +676,11 @@ def _tabulate_Bspline_basis_Bernstein_like_deriv_1D(
     k0, k1 = spline.domain
     pts_normalized = (pts - k0) / (k1 - k0)  # map to [0, 1]
 
-    deriv_core = (
-        _tabulate_Bernstein_basis_deriv_1D_core
-        if pts_normalized.shape[0] >= _PARALLEL_MIN_NUM_PTS
-        else _tabulate_Bernstein_basis_deriv_1D_serial_core
-    )
-    deriv_core(np.int32(spline.degree), pts_normalized, n_deriv, out_deriv)
+    kernels = bernstein_deriv_core()
+    if kernels.serial is not None and pts_normalized.shape[0] < _PARALLEL_MIN_NUM_PTS:
+        kernels.serial(np.int32(spline.degree), pts_normalized, n_deriv, out_deriv)
+    else:
+        kernels.parallel(np.int32(spline.degree), pts_normalized, n_deriv, out_deriv)
 
     # Chain-rule: d^k/dx^k f(x) = d^k/ds^k f(s) * (ds/dx)^k = d^k/ds^k f(s) * (1/(k1-k0))^k
     inv_span: float = 1.0 / float(k1 - k0)
@@ -796,10 +793,11 @@ def _tabulate_Bspline_basis_1D_impl(
             spline, pts, basis_normalized, first_indices_normalized
         )
     else:
+        kernels = bspline_basis_core()
         kernel = (
-            _compute_basis_nurbs_book_impl
-            if num_pts >= _PARALLEL_MIN_NUM_PTS
-            else _compute_basis_nurbs_book_serial_impl
+            kernels.serial
+            if kernels.serial is not None and num_pts < _PARALLEL_MIN_NUM_PTS
+            else kernels.parallel
         )
         kernel(
             spline.knots,
@@ -902,12 +900,13 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
             spline, pts, n_deriv, deriv_normalized, first_indices_normalized
         )
     else:
-        kernel = (
-            _compute_basis_deriv_nurbs_book_impl
-            if num_pts >= _PARALLEL_MIN_NUM_PTS
-            else _compute_basis_deriv_nurbs_book_serial_impl
+        deriv_kernels = bspline_basis_deriv_core()
+        deriv_kernel = (
+            deriv_kernels.serial
+            if deriv_kernels.serial is not None and num_pts < _PARALLEL_MIN_NUM_PTS
+            else deriv_kernels.parallel
         )
-        kernel(
+        deriv_kernel(
             spline.knots,
             spline.degree,
             spline.periodic,
@@ -969,7 +968,15 @@ def _warmup_numba_functions() -> None:
         first_basis_dummy,
     )
 
-    # Warmup Bernstein derivative core (Bézier fast path) with float64
+    # Warmup Bernstein derivative core (Bézier fast path) with float64.
+    #
+    # Named directly rather than fetched from `bernstein_deriv_core()`: this function
+    # exists to trigger Numba compilation, so it must reach the Numba kernel whatever
+    # backend happens to be selected.
+    from ..basis._basis_core import (  # noqa: PLC0415
+        _tabulate_Bernstein_basis_deriv_1D_core,
+    )
+
     pts_norm_dummy = pts_dummy  # knots_dummy already has [0,1] domain
     _tabulate_Bernstein_basis_deriv_1D_core(
         np.int32(degree_dummy), pts_norm_dummy, n_deriv_dummy, deriv_dummy

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -692,6 +692,48 @@ def _tabulate_Bspline_basis_Bernstein_like_deriv_1D(
     out_first_basis.fill(0)
 
 
+def _demand_points_match_the_knots(
+    spline: BsplineSpace1D, pts: npt.NDArray[np.float32 | np.float64]
+) -> None:
+    """Refuse evaluation points whose dtype differs from the space's knots.
+
+    **A type-kind check, so it lives here and raises ``TypeError``**, per the split
+    ``cpp/include/pantr/core/error.hpp`` sets for the whole C++ port: nanobind has no
+    path to ``TypeError``, so type checks stay in Python and value checks go to C++.
+    It is in shared Layer 2 rather than in either backend's adapter, which is the point
+    -- an invariant the adapters rely on has to be established where both of them see
+    it, or selecting a backend changes what the library accepts.
+
+    The combination it refuses was never designed. The Numba kernels open with
+    ``dtype = knots.dtype`` and allocate their scratch in it while reading points at
+    the points' own width, so a mismatch computes in a mixed width that narrows at
+    every array store -- an answer that is neither the ``float32`` one nor the
+    ``float64`` one, and that nothing derived or documented. The C++ kernels are
+    templated on one scalar type and have no such overload, so before this guard the
+    same call succeeded under the Python backend and raised ``TypeError`` under the C++
+    one.
+
+    Refusing is the smaller change of the two available. Casting would have to pick a
+    direction: narrowing the points to the knots throws away precision the caller
+    asked for, widening the knots contradicts a space whose tolerance was derived from
+    the knots as stored. Which of those is right is a contract decision rather than a
+    port decision, and it is not taken here.
+
+    Args:
+        spline (BsplineSpace1D): The space whose knots the points must match.
+        pts (npt.NDArray[np.float32 | np.float64]): The normalized evaluation points.
+
+    Raises:
+        TypeError: If the dtypes differ.
+    """
+    if pts.dtype != spline.knots.dtype:
+        raise TypeError(
+            f"pts has dtype {pts.dtype} but the B-spline's knots have dtype "
+            f"{spline.knots.dtype}; evaluation points must match the space's storage "
+            f"format"
+        )
+
+
 def _tabulate_Bspline_basis_1D_impl(
     spline: BsplineSpace1D,
     pts: npt.ArrayLike,
@@ -741,6 +783,8 @@ def _tabulate_Bspline_basis_1D_impl(
               If `out_first_basis` was provided, returns the same array.
 
     Raises:
+        TypeError: If ``pts``' dtype differs from the B-spline's knot dtype; see
+            :func:`_demand_points_match_the_knots`.
         ValueError: If ``validate`` is True and any evaluation point is outside the
             B-spline domain, or if `out_basis` or `out_first_basis` is provided and
             has incorrect shape or dtype.
@@ -764,6 +808,7 @@ def _tabulate_Bspline_basis_1D_impl(
     """
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)
+    _demand_points_match_the_knots(spline, pts)
 
     if validate and not np.all(
         _is_in_domain_impl(spline.knots, spline.degree, pts, spline.tolerance)
@@ -855,6 +900,8 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
             function at each point.
 
     Raises:
+        TypeError: If ``pts``' dtype differs from the B-spline's knot dtype; see
+            :func:`_demand_points_match_the_knots`.
         ValueError: If ``n_deriv < 0``, if ``validate`` is True and any evaluation
             point is outside the domain, or ``out_deriv`` / ``out_first_basis`` has
             incorrect shape or dtype.
@@ -871,6 +918,7 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
 
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)
+    _demand_points_match_the_knots(spline, pts)
 
     if validate and not np.all(
         _is_in_domain_impl(spline.knots, spline.degree, pts, spline.tolerance)

--- a/tests/_parity_harness.py
+++ b/tests/_parity_harness.py
@@ -358,14 +358,18 @@ def demand_a_compiled_seed() -> None:
     ungated. Only the two constructs above escape the guarantee, and which kernels
     carry them is knowledge a claim does not hold.
 
-    The cost of that choice, stated because it is real, and it is not only about
-    kernels not yet written. ``_basis_derivs_point`` in
-    ``pantr.bspline._bspline_basis_core`` **already** accumulates a falling factorial
-    the same way, and is absent from the set below only because no parity test reaches
-    it: it has no C++ counterpart yet. Whoever gives it one inherits this gate as a
-    precondition. Grep ``np.power`` and ``fac *=`` under ``src/pantr`` for the current
-    set, and note that ``_bincoeff`` is a deliberate non-member, since it casts every
-    step to ``np.int64`` explicitly and so wraps identically either way.
+    The cost of that choice, stated because it is real. ``_basis_derivs_point`` in
+    ``pantr.bspline._bspline_basis_core`` accumulates a falling factorial the same way,
+    and an earlier version of this docstring recorded it as absent from the set only
+    because it had no C++ counterpart, adding that whoever gave it one would inherit
+    this gate as a precondition. **It has one now**
+    (``cpp/include/pantr/bspline/tabulate.hpp``), and so does
+    ``_bernstein_derivs_point`` (``pantr::tabulate_bernstein_deriv_1d``);
+    ``tests/parity/test_bspline_basis_tabulation.py`` calls this gate for every claim
+    reaching either. The inheritance happened rather than staying hypothetical. Grep
+    ``np.power`` and ``fac *=`` under ``src/pantr`` for the current set, and note that
+    ``_bincoeff`` is a deliberate non-member, since it casts every step to
+    ``np.int64`` explicitly and so wraps identically either way.
 
     Raises:
         Skipped: Via :func:`pytest.skip`, whenever the JIT is disabled.

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -128,6 +128,50 @@ Named once so that
 parametrization actually uses rather than a copy of them.
 """
 
+
+_FUSED_ROUNDINGS_PER_STAGE = 3
+"""Accumulator roundings charged per fused site, from ``design/backend_parity.md`` Rule 10.
+
+At a fused site the oracle computes ``fl(a + fl(b*c))`` and the C++ backend
+``fl(a + b*c)``; expanding both with ``|delta| <= u`` bounds their difference by
+``|b*c| u (1 + u) + |a + b*c| 2u``, which is three accumulator roundings. Inherited from
+that rule rather than re-derived here.
+
+Named because it is used **four** times and all four must agree: as
+``Roundings.accumulator_per_stage`` in each of the two claims, and as the hull's
+widening budget in :func:`_companion`, which is referenced once more in that function's
+docstring. The claim's budget and the hull's have to describe the same chain, so a
+second literal is a live drift risk rather than a hypothetical one -- three rounding
+counts in this file were revised once already, and this constant was itself introduced
+half-applied, with two of the four sites left as bare literals while this docstring
+claimed they were not.
+"""
+
+
+def _deriv_stages(degree: int, n_deriv: int) -> int:
+    """The dependency-chain length of one non-zero A2.3 output element.
+
+    ``degree`` ``ndu`` stages then ``min(n_deriv, degree)`` a-table stages: capped at
+    the degree because for ``k > degree`` the factorial factor is exactly zero, so no
+    chain reaching a non-zero output passes through more of them.
+
+    A function rather than an expression repeated at each site, for the same reason
+    :data:`_FUSED_ROUNDINGS_PER_STAGE` is a constant. :func:`_deriv_claim` uses it for
+    the rounding budget, and the majorant-excess test uses it for the hull it compares
+    against; the two must agree, and that test cannot obtain the value from
+    :func:`_deriv_claim` because that returns a bitwise claim with no budget at all on a
+    non-fusing build.
+
+    Args:
+        degree (int): The polynomial degree.
+        n_deriv (int): The highest derivative order.
+
+    Returns:
+        int: The chain length, at least 1.
+    """
+    return max(degree + min(n_deriv, degree), 1)
+
+
 # ---------------------------------------------------------------------------
 # The cases
 # ---------------------------------------------------------------------------
@@ -636,7 +680,11 @@ def _value_claim(reference: _FloatArray, degree: int, dtype: Any) -> ParityClaim
     if not contraction_may_fuse():
         return bitwise_parity(why=_EXACT_BY_BUILD)
     return bounded_parity(
-        roundings=Roundings(stages=max(degree, 1), accumulator_per_stage=3, storage_per_stage=0),
+        roundings=Roundings(
+            stages=max(degree, 1),
+            accumulator_per_stage=_FUSED_ROUNDINGS_PER_STAGE,
+            storage_per_stage=0,
+        ),
         accumulator=dtype,
         storage=dtype,
         amplification=_companion(reference, degree, dtype),
@@ -689,10 +737,13 @@ def _deriv_claim(  # noqa: PLR0913
         return bitwise_parity(why=_EXACT_BY_BUILD)
     majorant = _a23_majorant(knots, degree, n_deriv, points, first_basis, unit_spans=unit_spans)
     # One expression for the chain length, so the rounding budget and the hull that
-    # widens the amplification cannot come to describe different chains.
-    stages = max(degree + min(n_deriv, degree), 1)
+    # widens the amplification cannot come to describe different chains. See
+    # `_deriv_stages`, which the majorant test shares.
+    stages = _deriv_stages(degree, n_deriv)
     return bounded_parity(
-        roundings=Roundings(stages=stages, accumulator_per_stage=3, storage_per_stage=0),
+        roundings=Roundings(
+            stages=stages, accumulator_per_stage=_FUSED_ROUNDINGS_PER_STAGE, storage_per_stage=0
+        ),
         accumulator=dtype,
         storage=dtype,
         amplification=_companion(majorant, stages, dtype),
@@ -1077,7 +1128,7 @@ def test_the_majorant_exceeds_the_finished_row_by_orders_of_magnitude(
     # happens on 1440 entries here and on none at float64, which is the signature of a
     # width artifact rather than of a broken bound. `_companion` widens by the
     # reference's own forward error for exactly this case.
-    hulled = _companion(majorant, degree + min(n_deriv, degree), dtype)
+    hulled = _companion(majorant, _deriv_stages(degree, n_deriv), dtype)
     assert np.all(hulled[normal] >= finished[normal]), (
         f"the hulled majorant is below the computed row on "
         f"{int(np.count_nonzero(hulled[normal] < finished[normal]))} entries, so it is "
@@ -1246,20 +1297,6 @@ def _falling_factorial(degree: int, n_deriv: int) -> int:
         largest = max(largest, value)
     return largest
 
-
-_FUSED_ROUNDINGS_PER_STAGE = 3
-"""Accumulator roundings charged per fused site, from ``design/backend_parity.md`` Rule 10.
-
-At a fused site the oracle computes ``fl(a + fl(b*c))`` and the C++ backend
-``fl(a + b*c)``; expanding both with ``|delta| <= u`` bounds their difference by
-``|b*c| u (1 + u) + |a + b*c| 2u``, which is three accumulator roundings. Inherited from
-that rule rather than re-derived here.
-
-Named once because it is used twice -- as ``Roundings.accumulator_per_stage`` in the
-claim, and as the hull's widening budget in :func:`_companion` -- and the two must
-describe the same chain. Three rounding counts in this file were revised once already,
-so a second literal is not a hypothetical drift risk.
-"""
 
 _VACUOUS_CASE = "wrapping-p22"
 """The one case whose derivative bound is too loose to assert anything, everywhere.

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -1,0 +1,1169 @@
+"""Parity and accuracy for the 1D B-spline basis tabulation port.
+
+The C++ side is `cpp/include/pantr/bspline/tabulate.hpp` (Piegl & Tiller A2.2 and
+A2.3 over a general knot vector) and `pantr::tabulate_bernstein_deriv_1d` in
+`cpp/include/pantr/basis/bernstein.hpp` (A2.3 on unit knot spans, which the
+Bézier-like fast path reaches). The oracle is
+``pantr.bspline._bspline_basis_core``, and the public surface both go through is
+:meth:`pantr.bspline.BsplineSpace1D.tabulate_basis` and
+:meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis_derivatives`.
+
+What is claimed, and why
+------------------------
+
+**Parity is BITWISE on the shipped build.** The general-knot recurrences are built
+from ``+``, ``-``, ``*``, ``/`` and an exact-zero comparison, so IEEE 754 pins every
+result once the operation order matches. The C++ transliteration was written against
+``scripts/measure_bspline_tabulation_widths.py`` rather than against a reading of the
+oracle, because ``design/backend_parity.md`` Rule 9 says a width cannot be read off
+the source: at ``float32`` a model computing the recurrence in ``float64`` reproduces
+only 7 029 of 17 836 A2.2 values, and a model narrowing the factorial scaling
+reproduces 312 749 of 351 988 A2.3 values. The port takes the model that reproduces
+every one.
+
+**Both recurrences contain a fusable ``a * b + c``**, unlike the Bernstein ratio
+recurrence, so the claim is conditional: bitwise where the target ISA carries no
+fused multiply-add, and bounded by Rule 10's budget where it does.
+``contraction_may_fuse()`` selects, and both arms are written -- Rule 10's own
+lesson is that the branch shipping unevaluated is the one that is broken.
+
+**Accuracy is checked against three independent oracles, none of them the
+algorithm.** Rule's premise: parity says the two backends agree, not that either is
+right, so a shared error is invisible to every parity test.
+
+- **Marsden's identity.** ``sum_i N_{i,p}(x) prod_{j=1..p} (t_{i+j} - y) = (x - y)^p``
+  for every ``y``. Evaluated in exact rational arithmetic from dyadic knots, so the
+  reference carries no error at all. This is the only one of the three that pins the
+  **indexing and the scale**: it is a different positive weight per basis function, so
+  a permuted, shifted or misscaled row fails it while the other two pass.
+  ``y`` is taken **outside** the knot range, which makes every weight the same sign
+  and the sum cancellation-free -- see :func:`_marsden_weights`.
+- **Partition of unity**, ``sum_i N_i(x) = 1``. Weaker than Marsden by construction:
+  it is the ``p = 0`` case, so it cannot see a permutation. It is kept because it is
+  the one invariant that holds *exactly* at every degree with no conditioning, so it
+  still says something where Marsden's weights have lost digits.
+- **Differentiated Marsden**, ``sum_i N^{(k)}_i(x) c_i(y) = p!/(p-k)! (x-y)^{p-k}``.
+  This is the one that pins the **derivative scale**, which the derivative sums are
+  blind to: ``sum_i N^{(k)}_i = 0`` survives any uniform rescaling of a row, and the
+  factorial scaling of A2.3's step 3 is exactly a uniform rescaling. So a dropped or
+  inverted ``p!/(p-k)!`` passes the sums and fails this.
+
+Two further checks are exact rather than bounded: the derivative sums vanish, and
+every row above the degree is identically zero.
+
+The degrees no accuracy claim covers, and why
+---------------------------------------------
+
+A2.3's step 3 accumulates ``degree!/(degree-k)!`` in an integer that **wraps at
+int64**, in both backends. Measured by the script above: the lowest wrapping degree is
+21, first at derivative order 19. Above it the derivative rows are scaled by a
+two's-complement remainder and are wrong in both backends, identically -- so parity is
+asserted there and accuracy is not.
+:func:`test_the_wrapping_degrees_are_named_and_still_wrap` is Rule 8's obligation
+discharged: it enumerates the excluded region and fails if it ever becomes empty,
+because that would mean either the accumulator changed or the wrap was fixed, and both
+are findings rather than good news.
+
+Rule 12 gates
+-------------
+
+The general-knot **value** path carries no transcendental and no integer accumulator,
+so a bitwise claim over it survives interpretation by IEEE guarantee. It still calls
+:func:`demand_the_compiled_kernel` at ``float32``, which owns the storage-format
+question and whose docstring says which intermediates promote has not been pinned.
+
+The general-knot **derivative** path and both Bézier-like paths call
+:func:`demand_a_compiled_seed`. That gate's own docstring named
+``_basis_derivs_point``'s falling factorial and said "whoever gives it one inherits
+this gate as a precondition"; this is that inheritance. The Bézier-like value path
+inherits it through ``np.power`` in the Bernstein ratio recurrence, and the
+Bézier-like derivative path through ``_bernstein_derivs_point``'s own factorial.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import pairwise
+from typing import Any, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, available_backends, use_backend
+from pantr.basis._basis_backend import DerivKernels, bernstein_deriv_core
+from pantr.bspline import BsplineSpace1D
+from pantr.bspline._basis_backend import (
+    BasisDerivKernels,
+    BasisKernels,
+    bspline_basis_core,
+    bspline_basis_deriv_core,
+)
+from tests._parity_harness import (
+    Field,
+    ParityClaim,
+    Roundings,
+    assert_accuracy,
+    assert_object_parity,
+    assert_parity,
+    bitwise_parity,
+    bounded_parity,
+    contraction_may_fuse,
+    demand_a_compiled_seed,
+    demand_the_compiled_kernel,
+    demand_the_reference_host,
+    derived_accuracy,
+    exact_parity,
+    unit_roundoff,
+)
+
+_FloatArray = npt.NDArray[np.floating[Any]]
+
+_DERIVATIVE_ORDERS = (0, 1, 2, 5, 12, 22)
+"""Derivative orders the general-knot parity matrix runs.
+
+Named once so that
+:func:`test_the_case_list_separates_the_factorial_widths` checks the orders the
+parametrization actually uses rather than a copy of them.
+"""
+
+# ---------------------------------------------------------------------------
+# The cases
+# ---------------------------------------------------------------------------
+
+_GENERAL_KNOTS: dict[str, tuple[list[float], int]] = {
+    # name: (knots, degree). Every knot is dyadic, so `Fraction(knot)` is exact and
+    # the Marsden reference carries no representation error of its own.
+    "clamped-uniform-p1": ([0.0, 0.0, 0.5, 1.0, 1.0], 1),
+    "clamped-uniform-p2": ([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0], 2),
+    "clamped-uniform-p3": ([0.0] * 4 + [0.25, 0.5, 0.75] + [1.0] * 4, 3),
+    "clamped-repeat-p2": ([0.0, 0.0, 0.0, 0.25, 0.75, 0.75, 1.0, 1.0, 1.0], 2),
+    # A doubled interior knot makes an empty span, which is the only input the
+    # `denom == 0` guard exists for.
+    "empty-span-p3": ([0.0] * 4 + [0.5, 0.5, 0.5] + [1.0] * 4, 3),
+    # Not clamped at either end: the right domain knot is not the vector's last knot,
+    # which is the case the span search's upper clamp exists for.
+    "unclamped-p2": ([-0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5], 2),
+    "unclamped-p3": ([-0.75, -0.5, -0.25, 0.0, 0.5, 1.0, 1.25, 1.5, 1.75], 3),
+    # A non-unit, offset domain, so a bound that quietly assumes `[0, 1]` fails.
+    "offset-scale-p2": ([2.0, 2.0, 2.0, 3.0, 4.0, 6.0, 6.0, 6.0], 2),
+    "high-degree-p8": ([0.0] * 9 + [0.25, 0.5, 0.75] + [1.0] * 9, 8),
+}
+"""General-knot spaces the accuracy oracles can reach, dyadic throughout.
+
+Capped at degree 8, which is what keeps every accuracy claim below well inside the
+factorial accumulator's wrapping region. Parity cases are the union of this and
+:data:`_HIGH_DEGREE_KNOTS`; Bézier-like ones are kept separate again.
+"""
+
+_HIGH_DEGREE_KNOTS: dict[str, tuple[list[float], int]] = {
+    "sep-factorial-p14": ([0.0] * 15 + [0.5] + [1.0] * 15, 14),
+    "wrapping-p22": ([0.0] * 23 + [0.5] + [1.0] * 23, 22),
+}
+"""Degrees high enough to separate the factorial scaling's two width models.
+
+**These exist because a mutation test showed the rest of the file could not tell the
+two apart.** ``T(double(value) * double(fac))`` and ``value * T(fac)`` are *provably*
+identical while ``fac`` is exactly representable in the storage format: the exact
+product of two ``float32`` values needs at most 48 significand bits, so it is exact in
+``float64`` and rounding it once to ``float32`` is the same single rounding the
+``float32`` multiply commits. They can only differ once ``fac`` needs more than 24
+bits, and ``degree!/(degree-k)!`` first does so around degree 12 -- so a case list
+stopping at degree 8 asserts the width and cannot fail on it. Narrowing the scaling in
+``tabulate.hpp`` passed all 36 derivative cases before these two were added.
+
+``wrapping-p22`` additionally reaches the int64 wrap itself, where both backends scale
+by a two's-complement remainder. Parity is the claim there and accuracy is not; see
+:func:`test_the_wrapping_degrees_are_named_and_still_wrap`.
+
+:func:`test_the_case_list_separates_the_factorial_widths` is the guard that keeps this
+property rather than trusting the comment.
+"""
+
+_BEZIER_KNOTS: dict[str, tuple[list[float], int]] = {
+    "bezier-p0": ([0.0, 1.0], 0),
+    "bezier-p2-unit": ([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2),
+    "bezier-p3-offset": ([2.0] * 4 + [6.0] * 4, 3),
+    "bezier-p5-small": ([0.0] * 6 + [0.0625] * 6, 5),
+}
+"""Spaces whose knots describe a single Bézier segment, so the fast path fires.
+
+``bezier-p3-offset`` and ``bezier-p5-small`` have a span far from one, which is what
+makes the chain-rule factor ``(1/(b-a))^k`` visible: at a unit span it is one and a
+dropped factor passes.
+"""
+
+
+def _evaluation_points(knots: list[float], degree: int, dtype: Any) -> _FloatArray:
+    """Points chosen to be adversarial about representability, not about magnitude.
+
+    Rule 9's sharpest case was found by a list built around exactly-representable
+    ratios rather than round numbers. So: both domain ends, every distinct in-domain
+    knot, the value one ulp inside each end, the midpoint of every span, and a fixed
+    random sample.
+
+    Args:
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        dtype (Any): The storage dtype the points are produced in.
+
+    Returns:
+        _FloatArray: A 1D array of in-domain points, in ``dtype``.
+    """
+    begin = knots[degree]
+    end = knots[len(knots) - degree - 1]
+    interior = sorted({k for k in knots if begin <= k <= end})
+
+    fixed = [begin, end, *interior]
+    fixed += [float(np.nextafter(np.array(begin, dtype), np.array(end, dtype)))]
+    fixed += [float(np.nextafter(np.array(end, dtype), np.array(begin, dtype)))]
+    fixed += [0.5 * (a + b) for a, b in pairwise(interior)]
+
+    rng = np.random.default_rng(20260909)
+    sample = begin + (end - begin) * rng.random(16)
+    points = np.array(sorted(fixed + sample.tolist()), dtype=dtype)
+    return np.asarray(np.clip(points, dtype(begin), dtype(end)), dtype=dtype)
+
+
+class _Tabulation(NamedTuple):
+    """One backend's answer, so the two fields can carry different claim kinds.
+
+    :func:`assert_object_parity` compares field by field, which is what lets the
+    floating-point block take a bitwise or bounded claim while the integer index array
+    takes an exactness claim. Folding them into one comparison is not possible: no
+    tolerance applies to an index, and a bitwise claim about an index says something
+    weaker than exactness does.
+
+    Attributes:
+        block (_FloatArray): The basis values, or the derivative block.
+        first_basis (npt.NDArray[np.int_]): The first-basis index per point.
+    """
+
+    block: _FloatArray
+    first_basis: npt.NDArray[np.int_]
+
+
+def _tabulate(  # noqa: PLR0913
+    backend: Backend,
+    knots: list[float],
+    degree: int,
+    points: _FloatArray,
+    dtype: Any,
+    n_deriv: int | None,
+) -> _Tabulation:
+    """Build the space and tabulate on one backend, through the public surface.
+
+    The space is built **inside** the backend block, because
+    :class:`~pantr.bspline.BsplineSpace1D` is a wrapper whose implementation is chosen
+    at construction; that is what makes this an end-to-end claim about what a caller
+    gets rather than about a kernel in isolation.
+
+    Args:
+        backend (Backend): The backend to run under.
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        points (_FloatArray): The evaluation points.
+        dtype (Any): The storage dtype.
+        n_deriv (int | None): Derivative order, or ``None`` for the value tabulation.
+
+    Returns:
+        _Tabulation: The block and the index array.
+    """
+    with use_backend(backend):
+        space = BsplineSpace1D(np.array(knots, dtype=dtype), degree)
+        if n_deriv is None:
+            block, first = space.tabulate_basis(points)
+        else:
+            block, first = space.tabulate_basis_derivatives(points, n_deriv)
+    return _Tabulation(block=block, first_basis=first)
+
+
+def _demand_the_two_spaces_agree(knots: list[float], degree: int, dtype: Any) -> None:
+    """Fail with a space-level message if the two backends disagree about the space.
+
+    Every claim below is about the *tabulation*, and both sides build their own space
+    first. A one-bit divergence in the stored knots or the tolerance would surface as
+    a tabulation failure and be diagnosed as one, so it is separated out here.
+    ``tests/parity/test_bspline_space_1d.py`` is what actually covers the space; this
+    is a guard against a misattributed failure, not a second copy of that test.
+
+    Args:
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        dtype (Any): The storage dtype.
+    """
+    built = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = BsplineSpace1D(np.array(knots, dtype=dtype), degree)
+            built[backend] = (np.asarray(space.knots).copy(), space.tolerance, space.degree)
+
+    py, cpp = built[Backend.PYTHON], built[Backend.CPP]
+    assert np.array_equal(py[0].view(np.uint8), cpp[0].view(np.uint8)), (
+        "the two backends stored different knots, so any tabulation difference below "
+        "belongs to the space port and not to this one"
+    )
+    assert py[1] == cpp[1], "the two backends derived different tolerances for this space"
+    assert py[2] == cpp[2]
+
+
+# ---------------------------------------------------------------------------
+# The rounding budget, for the branch where contraction is live
+# ---------------------------------------------------------------------------
+
+_EXACT_BY_BUILD = (
+    "A2.2 and A2.3 are built from +, -, *, / and an exact-zero comparison, with no "
+    "transcendental and no library call, so IEEE 754 pins every result and the only "
+    "way the two backends can differ is by performing different operations. The "
+    "transliteration performs the same ones in the same order at the same width, "
+    "which scripts/measure_bspline_tabulation_widths.py establishes by measuring two "
+    "rival width models per site against the kernel and reporting how often they "
+    "disagree with each other, so a match cannot come from a check that could not "
+    "fail. The one site that widens is A2.3's factorial scaling, where numba promotes "
+    "float32 * int64 to float64; the port forms that product in double and rounds "
+    "once on the store. This build reports fp_contract unavailable on the target ISA, "
+    "so the fusable `saved + right * temp` and `d + a * ndu` sites cannot fuse and "
+    "bit-identity is the right claim. Under -march=native the bounded arm applies "
+    "instead."
+)
+
+_BOUNDED_BY_FMA = (
+    "This build's target ISA carries a fused multiply-add and PantrCompileOptions "
+    "adds -ffp-contract=on, so `saved + right[r+1] * temp` in A2.2 and "
+    "`d + a[s2,j] * ndu[...]` in A2.3 may each compile to one FMA while the numba "
+    "oracle never fuses (LLVM does not contract without fastmath, which no pantr "
+    "kernel sets). design/backend_parity.md Rule 10: at a fused site the two differ "
+    "by |b*c| u (1+u) + |a+b*c| 2u, three accumulator roundings, and the accumulator "
+    "is the storage format here so there is no narrowing store to charge. The "
+    "dependency chain through one output element passes exactly one fusable site per "
+    "stage of the outer recurrence, and there are `degree` stages. The amplification "
+    "is the absolute-value companion of the recurrence itself, which Rule 10 licenses "
+    "for a convex recurrence and refuses for a signed one: A2.2's weights are "
+    "non-negative and sum to one, so the companion is exactly the magnitude reachable "
+    "at each output element; A2.3 differences and so gets the majorant of its own "
+    "recursion, every coefficient replaced by its modulus, which bounds every "
+    "intermediate by induction and whose partial sums are then monotone."
+)
+
+
+def _companion(magnitudes: _FloatArray, dtype: Any) -> _FloatArray:
+    """Widen a computed magnitude into a hull that covers the true value too.
+
+    A bound built from the *computed* coefficient collapses where that coefficient
+    rounds to exactly zero while the true one does not, which
+    ``design/backend_parity.md`` records as a correction the infrastructure PR had to
+    make: without it the bound could be violated by a factor of ``1/u``. Widening each
+    entry by its own first-order propagated error covers both.
+
+    The widening is ``(1 + gamma)`` with ``gamma`` the whole relative budget of the
+    recurrence, plus one unit of roundoff as an absolute floor so that an entry which
+    is exactly zero still carries the smallest tolerance the format can express.
+
+    Args:
+        magnitudes (_FloatArray): The computed magnitudes, elementwise.
+        dtype (Any): The storage dtype, which fixes ``u``.
+
+    Returns:
+        _FloatArray: The widened magnitudes, in ``float64``.
+    """
+    u = unit_roundoff(dtype)
+    values = np.abs(np.asarray(magnitudes, dtype=np.float64))
+    widened = values * (1.0 + 4.0 * u) + np.finfo(dtype).smallest_normal
+    return np.asarray(widened, dtype=np.float64)
+
+
+def _value_claim(reference: _FloatArray, degree: int, dtype: Any) -> ParityClaim:
+    """The parity claim for a basis-value tabulation, conditional on the build.
+
+    Args:
+        reference (_FloatArray): The Python backend's block, whose magnitudes the
+            amplification is built from.
+        degree (int): The polynomial degree, which sets the stage count.
+        dtype (Any): The storage dtype.
+
+    Returns:
+        ParityClaim: A bitwise claim where nothing can fuse, a bounded one otherwise.
+    """
+    if not contraction_may_fuse():
+        return bitwise_parity(why=_EXACT_BY_BUILD)
+    return bounded_parity(
+        roundings=Roundings(stages=max(degree, 1), accumulator_per_stage=3, storage_per_stage=0),
+        accumulator=dtype,
+        storage=dtype,
+        amplification=_companion(reference, dtype),
+        why=_BOUNDED_BY_FMA,
+    )
+
+
+def _deriv_claim(reference: _FloatArray, degree: int, n_deriv: int, dtype: Any) -> ParityClaim:
+    """The parity claim for a derivative tabulation, conditional on the build.
+
+    The chain is longer than the value kernel's: A2.3 builds the same ``ndu`` triangle
+    in ``degree`` stages and then runs the ``a``-table recursion for up to ``n_deriv``
+    more, so the stage count is their sum.
+
+    Args:
+        reference (_FloatArray): The Python backend's block.
+        degree (int): The polynomial degree.
+        n_deriv (int): The highest derivative order.
+        dtype (Any): The storage dtype.
+
+    Returns:
+        ParityClaim: A bitwise claim where nothing can fuse, a bounded one otherwise.
+    """
+    if not contraction_may_fuse():
+        return bitwise_parity(why=_EXACT_BY_BUILD)
+    return bounded_parity(
+        roundings=Roundings(
+            stages=max(degree + n_deriv, 1), accumulator_per_stage=3, storage_per_stage=0
+        ),
+        accumulator=dtype,
+        storage=dtype,
+        amplification=_companion(reference, dtype),
+        why=_BOUNDED_BY_FMA,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("case", sorted(_GENERAL_KNOTS | _HIGH_DEGREE_KNOTS))
+def test_general_knot_values_match(cpp_backend: None, case: str, dtype: Any) -> None:
+    """The two backends tabulate the general-knot basis identically.
+
+    Args:
+        cpp_backend (None): Requires the extension; see ``tests/parity/conftest.py``.
+        case (str): Key into :data:`_GENERAL_KNOTS`.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    knots, degree = (_GENERAL_KNOTS | _HIGH_DEGREE_KNOTS)[case]
+    _demand_the_two_spaces_agree(knots, degree, dtype)
+    points = _evaluation_points(knots, degree, dtype)
+
+    reference = _tabulate(Backend.PYTHON, knots, degree, points, dtype, None)
+    actual = _tabulate(Backend.CPP, knots, degree, points, dtype, None)
+
+    assert_object_parity(
+        py=reference,
+        cpp=actual,
+        fields=[
+            Field("block", claim=_value_claim(reference.block, degree, dtype)),
+            Field(
+                "first_basis",
+                claim=exact_parity(
+                    why="the first-basis index is exact integer arithmetic on the span "
+                    "search's result -- a binary search, two clamps and a subtraction -- so "
+                    "no tolerance applies and a difference is a different answer, not a "
+                    "displaced one. It decides which global functions the row refers to, so "
+                    "a wrong index makes correct values wrong."
+                ),
+            ),
+        ],
+        context=f"tabulate_basis {case} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("n_deriv", _DERIVATIVE_ORDERS)
+@pytest.mark.parametrize("case", sorted(_GENERAL_KNOTS | _HIGH_DEGREE_KNOTS))
+def test_general_knot_derivatives_match(
+    cpp_backend: None, case: str, n_deriv: int, dtype: Any
+) -> None:
+    """The two backends tabulate the general-knot derivatives identically.
+
+    ``n_deriv`` reaches 22 because that is what makes the claim about the factorial
+    scaling's *width* falsifiable: below ``fac = 2**24`` the two candidate widths are
+    provably the same number, so a smaller matrix asserts the width without being able
+    to fail on it. See :data:`_HIGH_DEGREE_KNOTS`. The small orders are kept because
+    ``n_deriv`` above the degree is what exercises the rows the scaling zeroes out.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into :data:`_GENERAL_KNOTS`.
+        n_deriv (int): The highest derivative order.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    # `_basis_derivs_point` accumulates a falling factorial that wraps at int64 when
+    # compiled and grows without bound when interpreted.
+    demand_a_compiled_seed()
+    knots, degree = (_GENERAL_KNOTS | _HIGH_DEGREE_KNOTS)[case]
+    _demand_the_two_spaces_agree(knots, degree, dtype)
+    points = _evaluation_points(knots, degree, dtype)
+
+    reference = _tabulate(Backend.PYTHON, knots, degree, points, dtype, n_deriv)
+    actual = _tabulate(Backend.CPP, knots, degree, points, dtype, n_deriv)
+
+    assert_parity(
+        actual.block,
+        reference.block,
+        _deriv_claim(reference.block, degree, n_deriv, dtype),
+        context=f"tabulate_basis_derivatives {case} n_deriv={n_deriv} {np.dtype(dtype).name}",
+    )
+    assert np.array_equal(actual.first_basis, reference.first_basis)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("case", sorted(_BEZIER_KNOTS))
+def test_bezier_like_values_match(cpp_backend: None, case: str, dtype: Any) -> None:
+    """The Bézier-like fast path agrees, and it is a different kernel from the general one.
+
+    This path does not reach ``tabulate.hpp`` at all: the oracle maps the points onto
+    ``[0, 1]`` and calls the Bernstein ratio recurrence, and so does the port. The
+    change of variable is the *same numpy expression* on both sides, above the seam, so
+    it is common mode and contributes nothing -- which is Rule 1's consequence applied
+    here rather than restated.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into :data:`_BEZIER_KNOTS`.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    # The Bernstein ratio recurrence seeds with `np.power`.
+    demand_a_compiled_seed()
+    knots, degree = _BEZIER_KNOTS[case]
+    _demand_the_two_spaces_agree(knots, degree, dtype)
+    points = _evaluation_points(knots, degree, dtype)
+
+    reference = _tabulate(Backend.PYTHON, knots, degree, points, dtype, None)
+    actual = _tabulate(Backend.CPP, knots, degree, points, dtype, None)
+
+    assert_parity(
+        actual.block,
+        reference.block,
+        _value_claim(reference.block, degree, dtype),
+        context=f"tabulate_basis bezier {case} {np.dtype(dtype).name}",
+    )
+    assert np.array_equal(actual.first_basis, reference.first_basis)
+    assert np.all(actual.first_basis == 0), (
+        "a Bézier-like space has one span, so every point's first supported function "
+        "is function 0; a non-zero index means the fast path was not taken"
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("n_deriv", [0, 1, 3])
+@pytest.mark.parametrize("case", sorted(_BEZIER_KNOTS))
+def test_bezier_like_derivatives_match(
+    cpp_backend: None, case: str, n_deriv: int, dtype: Any
+) -> None:
+    """The Bézier-like derivative fast path agrees, chain-rule scaling included.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into :data:`_BEZIER_KNOTS`.
+        n_deriv (int): The highest derivative order.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    # `_bernstein_derivs_point` accumulates the same wrapping falling factorial.
+    demand_a_compiled_seed()
+    knots, degree = _BEZIER_KNOTS[case]
+    _demand_the_two_spaces_agree(knots, degree, dtype)
+    points = _evaluation_points(knots, degree, dtype)
+
+    reference = _tabulate(Backend.PYTHON, knots, degree, points, dtype, n_deriv)
+    actual = _tabulate(Backend.CPP, knots, degree, points, dtype, n_deriv)
+
+    assert_parity(
+        actual.block,
+        reference.block,
+        _deriv_claim(reference.block, degree, n_deriv, dtype),
+        context=f"tabulate_basis_derivatives bezier {case} n_deriv={n_deriv} "
+        f"{np.dtype(dtype).name}",
+    )
+    assert np.array_equal(actual.first_basis, reference.first_basis)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: Any) -> None:
+    """A non-contiguous ``out`` is filled, not silently left alone.
+
+    The C++ binding refuses a non-contiguous array rather than converting it, because
+    a converted output would be filled and discarded; the adapter in
+    ``pantr.bspline._basis_backend`` absorbs that by computing into a buffer and
+    copying back. Without the absorption the caller's array comes back untouched with
+    no exception anywhere, which ``cpp/bindings/basis.cpp`` records as a measured
+    regression on the sibling kernel.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    knots, degree = _GENERAL_KNOTS["clamped-uniform-p2"]
+    points = np.array([0.1, 0.4, 0.9], dtype=dtype)
+
+    with use_backend(Backend.PYTHON):
+        space = BsplineSpace1D(np.array(knots, dtype=dtype), degree)
+        expected, _ = space.tabulate_basis(points)
+
+    with use_backend(Backend.CPP):
+        space = BsplineSpace1D(np.array(knots, dtype=dtype), degree)
+        # Every other column of a wider array, so `out` is strided in its last axis.
+        canvas = np.full((points.size, 2 * (degree + 1)), np.nan, dtype=dtype)
+        strided = canvas[:, ::2]
+        indices = np.full(2 * points.size, -1, dtype=np.int_)[::2]
+        assert not strided.flags["C_CONTIGUOUS"]
+        got, got_first = space.tabulate_basis(points, strided, indices)
+
+    assert got is strided, "the caller's array must be returned, not a copy of it"
+    assert not np.any(np.isnan(strided)), "the strided out was never written"
+    assert np.array_equal(strided, expected)
+    assert got_first is indices
+    assert np.all(indices >= 0), "the strided index array was never written"
+
+
+def test_the_seam_returns_kernels_for_every_available_backend() -> None:
+    """Every backend the installation offers answers all three catalogue functions.
+
+    A catalogue that raises for a backend :func:`available_backends` lists would make
+    every parity test above skip rather than fail, which is the trap ``CLAUDE.md``
+    names: a missing optional dependency skips without complaint.
+    """
+    for backend in available_backends():
+        assert isinstance(bspline_basis_core(backend), BasisKernels)
+        assert isinstance(bspline_basis_deriv_core(backend), BasisDerivKernels)
+        assert isinstance(bernstein_deriv_core(backend), DerivKernels)
+
+    for backend in available_backends():
+        if backend is Backend.PYTHON:
+            assert bspline_basis_core(backend).serial is not None, (
+                "the oracle's serial twin is what _PARALLEL_MIN_NUM_PTS selects below "
+                "the threshold; losing it would silently change which kernel every "
+                "small batch runs"
+            )
+        else:
+            assert bspline_basis_core(backend).serial is None, (
+                "the C++ kernel runs on the calling thread at every batch size, so a "
+                "serial twin would be a second name for the same function and the "
+                "threshold would then select between two identical things"
+            )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_the_case_list_separates_the_factorial_widths(dtype: Any) -> None:
+    """The parity matrix must contain a case where the two factorial widths differ.
+
+    A2.3's step 3 forms ``T(double(value) * double(fac))``. The alternative,
+    ``value * T(fac)``, is **provably the same number** while ``fac`` is exactly
+    representable in the storage format -- the exact product of two ``float32`` values
+    needs at most 48 significand bits, so it is exact in ``float64`` and one rounding
+    to ``float32`` is what a ``float32`` multiply commits. So every case with
+    ``fac < 2**24`` asserts the width and cannot fail on it.
+
+    This was not hypothetical: narrowing the scaling in ``tabulate.hpp`` passed all 36
+    derivative parity cases before :data:`_HIGH_DEGREE_KNOTS` existed. The guard is
+    here so that trimming the case list for speed cannot quietly restore that.
+
+    At ``float64`` the two widths coincide unconditionally, since the accumulator *is*
+    the storage format; the test still runs and asserts the weaker, true thing --
+    that some ``fac`` exceeds the format's exact-integer range -- so that the
+    parametrization does not silently mean two different things.
+
+    Args:
+        dtype (Any): The storage dtype, which fixes the exact-integer range.
+    """
+    exact_integers = 2 ** np.finfo(dtype).nmant
+    reachable = [
+        _falling_factorial(degree, n_deriv)
+        for case, (_, degree) in (_GENERAL_KNOTS | _HIGH_DEGREE_KNOTS).items()
+        for n_deriv in _DERIVATIVE_ORDERS
+        if case is not None
+    ]
+    largest = max(reachable)
+    assert largest > exact_integers, (
+        f"the largest falling factorial the derivative parity matrix reaches is "
+        f"{largest}, which {np.dtype(dtype).name} represents exactly, so every case "
+        f"agrees on the factorial scaling's width whatever the port chose. Add a "
+        f"higher degree with a matching n_deriv, or the width claim asserts nothing"
+    )
+
+
+def _falling_factorial(degree: int, n_deriv: int) -> int:
+    """The largest scaling factor A2.3 forms for this degree and derivative order.
+
+    Args:
+        degree (int): The polynomial degree.
+        n_deriv (int): The highest derivative order.
+
+    Returns:
+        int: ``degree!/(degree-k)!`` at the largest ``k <= min(degree, n_deriv)``,
+        in exact Python integers rather than the kernel's wrapping int64 -- the
+        question here is which factors the matrix *reaches*, not what the kernel does
+        with them.
+    """
+    largest = 1
+    value = 1
+    for k in range(1, min(degree, n_deriv) + 1):
+        value *= degree - k + 1
+        largest = max(largest, value)
+    return largest
+
+
+# ---------------------------------------------------------------------------
+# Independent accuracy oracles
+# ---------------------------------------------------------------------------
+
+
+def _marsden_weights(
+    knots: list[float], degree: int, first_basis: int, y: Fraction
+) -> list[Fraction]:
+    """The Marsden weights of the ``degree + 1`` functions supported at a point.
+
+    Marsden's identity: for every ``y``,
+    ``sum_i N_{i,p}(x) prod_{j=1..p} (t_{i+j} - y) = (x - y)^p``.
+    See de Boor, *A Practical Guide to Splines*, Ch. IX; it is a theorem about the
+    basis rather than a rearrangement of the recurrence, which is what makes it an
+    independent oracle here.
+
+    **``y`` must lie outside the knot range.** Then every factor ``t_{i+j} - y`` has
+    the same sign, so every weight does, and the sum has no cancellation at all: the
+    computed sum's magnitude equals ``|(x - y)^p|`` and a relative bound on it is a
+    relative bound on the identity. With ``y`` inside the range the weights straddle
+    zero, the sum cancels, and the bound needed to cover it exceeds the value it
+    compares -- which ``design/backend_parity.md`` Rule 3 refuses, correctly.
+
+    Args:
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        first_basis (int): Global index of the first supported function.
+        y (Fraction): The identity's parameter, outside ``[min(knots), max(knots)]``.
+
+    Returns:
+        list[Fraction]: ``degree + 1`` exact weights, one per supported function.
+    """
+    exact_knots = [Fraction(k) for k in knots]
+    weights = []
+    for i in range(first_basis, first_basis + degree + 1):
+        weight = Fraction(1)
+        for j in range(1, degree + 1):
+            weight *= exact_knots[i + j] - y
+        weights.append(weight)
+    return weights
+
+
+def _outside_y(knots: list[float]) -> tuple[Fraction, Fraction]:
+    """Two values of Marsden's parameter, one below the knots and one above.
+
+    Each is one full knot range away from the nearest knot, so ``t - y`` is of the same
+    order as the range itself: close to the range the weights would span decades and
+    the identity would test the smallest ones not at all.
+
+    Args:
+        knots (list[float]): The knot vector.
+
+    Returns:
+        tuple[Fraction, Fraction]: ``(below, above)``, both exact and dyadic.
+    """
+    low, high = Fraction(min(knots)), Fraction(max(knots))
+    width = high - low
+    return low - width, high + width
+
+
+def _partition_bound(values: _FloatArray, degree: int, dtype: Any) -> _FloatArray:
+    """An absolute bound on ``|sum_i N_i - 1|``, derived rather than measured.
+
+    Two contributions, both first order in ``u = eps/2``:
+
+    - **The values' own forward error.** A2.2 is a convex recurrence: at each of the
+      ``degree`` stages the new value is ``w1 * a + w2 * b`` with ``w1, w2 >= 0`` and
+      ``w1 + w2 = 1``, so a relative perturbation of the inputs is *carried*, never
+      amplified. Six operations lie on the dependency chain through one output element
+      per stage -- ``left[j]``, ``right[j]``, ``denom``, the division, the
+      multiplication and the addition -- so the relative error of each value is at most
+      ``gamma_{6p}``, and since the values are non-negative and sum to one, the sum of
+      their absolute errors is at most ``gamma_{6p}`` too.
+    - **The summation.** ``degree`` additions of quantities summing to one, so at most
+      ``gamma_p``.
+
+    Written as ``gamma_m = m u / (1 - m u)`` with ``m = 7 * degree``, which is the two
+    counts added and not a safety factor. The floor of one ``u`` covers ``degree = 0``,
+    where the single value is exactly one and no operation runs.
+
+    Args:
+        values (_FloatArray): The computed basis values, shape ``(n_pts, degree + 1)``.
+        degree (int): The polynomial degree.
+        dtype (Any): The storage dtype, which fixes ``u``.
+
+    Returns:
+        _FloatArray: One bound per point.
+    """
+    del values
+    u = unit_roundoff(dtype)
+    m = 7 * degree
+    gamma = m * u / (1.0 - m * u) if m * u < 0.5 else np.inf
+    return np.full(1, max(gamma, u), dtype=np.float64)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+@pytest.mark.parametrize("case", sorted(_GENERAL_KNOTS) + sorted(_BEZIER_KNOTS))
+def test_partition_of_unity(cpp_backend: None, case: str, backend: Backend, dtype: Any) -> None:
+    """The basis values sum to one, on each backend independently.
+
+    Run per backend rather than on the difference: this is the check that survives a
+    bug present in *both*, which every parity assertion above is blind to by
+    construction.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into either knot table.
+        backend (Backend): The backend to check.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    knots, degree = (_GENERAL_KNOTS | _BEZIER_KNOTS)[case]
+    points = _evaluation_points(knots, degree, dtype)
+    got = _tabulate(backend, knots, degree, points, dtype, None)
+
+    sums = np.asarray(got.block.sum(axis=-1), dtype=np.float64)
+    assert np.all(np.asarray(got.block) >= 0.0), (
+        "every value of a B-spline basis is non-negative, exactly: the recurrence is a "
+        "convex combination of non-negative terms and no rounding can make one negative"
+    )
+    assert_accuracy(
+        sums,
+        np.ones_like(sums),
+        derived_accuracy(
+            bound=np.broadcast_to(_partition_bound(got.block, degree, dtype), sums.shape),
+            why="the partition of unity is exact in the reals, so the whole discrepancy "
+            "is the computation's own forward error: gamma_{6p} carried by the convex "
+            "recurrence plus gamma_p from summing degree+1 terms that add to one, "
+            "written as gamma_{7p}. See _partition_bound for the operation count.",
+        ),
+        context=f"partition of unity, {case}, {backend.name}, {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+@pytest.mark.parametrize("case", sorted(_GENERAL_KNOTS))
+def test_marsden_identity_pins_the_values(
+    cpp_backend: None, case: str, backend: Backend, dtype: Any
+) -> None:
+    """Marsden's identity holds, which pins the indexing and the scale of each row.
+
+    The one check here that a permutation of the row, or a uniform rescaling of it,
+    cannot pass: each function carries a distinct weight computed from the knots in
+    exact rational arithmetic.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into :data:`_GENERAL_KNOTS`.
+        backend (Backend): The backend to check.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    knots, degree = _GENERAL_KNOTS[case]
+    points = _evaluation_points(knots, degree, dtype)
+    got = _tabulate(backend, knots, degree, points, dtype, None)
+    values = np.asarray(got.block, dtype=np.float64)
+    u = unit_roundoff(dtype)
+
+    for y in _outside_y(knots):
+        computed = np.empty(points.size, dtype=np.float64)
+        exact = np.empty(points.size, dtype=np.float64)
+        bound = np.empty(points.size, dtype=np.float64)
+
+        for p, point in enumerate(points):
+            weights = _marsden_weights(knots, degree, int(got.first_basis[p]), y)
+            floats = np.array([float(w) for w in weights], dtype=np.float64)
+            computed[p] = float(np.dot(floats, values[p]))
+            exact[p] = float((Fraction(float(point)) - y) ** degree)
+            # Every weight has the same sign and the values are non-negative, so this
+            # sum does not cancel and its magnitude is |exact| up to the budget below.
+            magnitude = float(np.dot(np.abs(floats), np.abs(values[p])))
+            # gamma_{7p} for the values (see _partition_bound), one u for casting each
+            # exact weight to double, and gamma_{2p} for the degree+1 products and the
+            # degree additions of the dot product.
+            m = 7 * degree + 1 + 2 * degree
+            gamma = m * u / (1.0 - m * u) if m * u < 0.5 else np.inf
+            bound[p] = max(gamma, u) * magnitude
+
+        assert np.all(bound < np.abs(exact) + np.finfo(np.float64).tiny), (
+            f"the Marsden bound is not smaller than the value it compares for {case} "
+            f"at y={y}, so the claim would admit any answer; Rule 3 refuses that and "
+            f"so does this test rather than asserting it anyway"
+        )
+        assert_accuracy(
+            computed,
+            exact,
+            derived_accuracy(
+                bound=bound,
+                why="Marsden's identity is a theorem about the basis, and its right-hand "
+                "side is computed in exact rational arithmetic from dyadic knots, so the "
+                "reference carries no error. y sits a full knot range outside, which makes "
+                "every weight the same sign and the sum cancellation-free. The bound is the "
+                "values' own gamma_{7p}, one u per weight cast, and gamma_{2p} for the dot "
+                "product, times the sum of |weight| * |value|.",
+            ),
+            context=f"Marsden at y={y}, {case}, {backend.name}, {np.dtype(dtype).name}",
+        )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+@pytest.mark.parametrize("case", sorted(_GENERAL_KNOTS) + sorted(_BEZIER_KNOTS))
+def test_derivative_sums_vanish(cpp_backend: None, case: str, backend: Backend, dtype: Any) -> None:
+    """Every derivative row sums to zero, to a bound scaled by that row's magnitude.
+
+    An **absolute** comparison scaled by the row's own largest magnitude, not a
+    relative one: the quantity being compared vanishes, and a relative bound on a
+    quantity whose true value is zero is unbounded. That is
+    ``design/backend_parity.md`` Rule 2, and the row magnitudes here really do span
+    decades, since a k-th derivative carries ``p!/(p-k)!`` and an inverse knot spacing
+    to the k-th power.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into either knot table.
+        backend (Backend): The backend to check.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    knots, degree = (_GENERAL_KNOTS | _BEZIER_KNOTS)[case]
+    n_deriv = min(degree + 1, 4)
+    points = _evaluation_points(knots, degree, dtype)
+    got = _tabulate(backend, knots, degree, points, dtype, n_deriv)
+    block = np.asarray(got.block, dtype=np.float64)
+    u = unit_roundoff(dtype)
+
+    for k in range(1, n_deriv + 1):
+        rows = block[:, k, :]
+        sums = rows.sum(axis=-1)
+        # The row's own scale. `sum_i |N_i^(k)|` rather than the max, because the
+        # summation error is driven by the partial sums and those reach the total.
+        magnitude = np.abs(rows).sum(axis=-1)
+        m = 7 * degree + 3 * n_deriv + degree
+        gamma = m * u / (1.0 - m * u) if m * u < 0.5 else np.inf
+        bound = np.maximum(max(gamma, u) * magnitude, np.finfo(dtype).smallest_normal)
+        assert_accuracy(
+            sums,
+            np.zeros_like(sums),
+            derived_accuracy(
+                bound=bound,
+                why="sum_i N_i^(k) = 0 for k >= 1 follows from differentiating the "
+                "partition of unity, so the whole discrepancy is forward error. The bound "
+                "is gamma_{7p} for the ndu triangle, three roundings per a-table stage over "
+                "n_deriv stages, and gamma_p for the sum, times sum_i |N_i^(k)| -- an "
+                "absolute bound scaled by the row's own magnitude, since the quantity "
+                "vanishes and no relative bound on it is finite.",
+            ),
+            context=f"derivative sum k={k}, {case}, {backend.name}, {np.dtype(dtype).name}",
+        )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+@pytest.mark.parametrize("case", sorted(_GENERAL_KNOTS))
+def test_differentiated_marsden_pins_the_derivative_scale(
+    cpp_backend: None, case: str, backend: Backend, dtype: Any
+) -> None:
+    """Differentiating Marsden's identity pins the factorial scaling of each row.
+
+    ``sum_i N^{(k)}_i(x) c_i(y) = p!/(p-k)! (x-y)^{p-k}``, the right-hand side exact in
+    rational arithmetic. This is the check :func:`test_derivative_sums_vanish` cannot
+    make: that one is invariant under multiplying a whole row by any constant, and
+    A2.3's step 3 multiplies a whole row by a constant. A dropped, inverted or wrapped
+    ``p!/(p-k)!`` passes the sums and fails here.
+
+    The degrees where the factorial accumulator wraps are excluded by
+    :data:`_GENERAL_KNOTS` carrying none above 8; see
+    :func:`test_the_wrapping_degrees_are_named_and_still_wrap` for the region and why
+    no accuracy claim reaches it.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into :data:`_GENERAL_KNOTS`.
+        backend (Backend): The backend to check.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    knots, degree = _GENERAL_KNOTS[case]
+    if degree == 0:
+        pytest.skip("a degree-0 basis has no non-zero derivative to pin")
+    n_deriv = degree
+    points = _evaluation_points(knots, degree, dtype)
+    got = _tabulate(backend, knots, degree, points, dtype, n_deriv)
+    block = np.asarray(got.block, dtype=np.float64)
+    u = unit_roundoff(dtype)
+    y = _outside_y(knots)[0]
+
+    falling = 1
+    for k in range(1, n_deriv + 1):
+        falling *= degree - k + 1
+        computed = np.empty(points.size, dtype=np.float64)
+        exact = np.empty(points.size, dtype=np.float64)
+        bound = np.empty(points.size, dtype=np.float64)
+
+        for p, point in enumerate(points):
+            weights = _marsden_weights(knots, degree, int(got.first_basis[p]), y)
+            floats = np.array([float(w) for w in weights], dtype=np.float64)
+            row = block[p, k, :]
+            computed[p] = float(np.dot(floats, row))
+            exact[p] = float(falling * (Fraction(float(point)) - y) ** (degree - k))
+            magnitude = float(np.dot(np.abs(floats), np.abs(row)))
+            m = 7 * degree + 3 * n_deriv + 1 + 2 * degree
+            gamma = m * u / (1.0 - m * u) if m * u < 0.5 else np.inf
+            bound[p] = max(gamma, u) * magnitude
+
+        if not np.all(bound < np.abs(exact)):
+            pytest.skip(
+                f"the derivative rows of {case} at order {k} cancel against these "
+                f"weights hard enough that the bound exceeds the value; Rule 3 refuses "
+                f"such a claim and this case is reported rather than asserted"
+            )
+        assert_accuracy(
+            computed,
+            exact,
+            derived_accuracy(
+                bound=bound,
+                why="differentiating Marsden's identity k times gives "
+                "p!/(p-k)! (x-y)^(p-k) on the right, exact in rational arithmetic. Unlike "
+                "the derivative sums this is not invariant under rescaling a row, which is "
+                "what makes it the check that pins A2.3's factorial scaling. The bound is "
+                "the row's forward error plus the dot product's, times sum |weight| * "
+                "|value| -- the derivative rows carry mixed signs, so the sum does cancel "
+                "and the magnitude cannot be replaced by the right-hand side.",
+            ),
+            context=f"differentiated Marsden k={k}, {case}, {backend.name}, {np.dtype(dtype).name}",
+        )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+@pytest.mark.parametrize("case", sorted(_GENERAL_KNOTS) + sorted(_BEZIER_KNOTS))
+def test_rows_above_the_degree_vanish_exactly(
+    cpp_backend: None, case: str, backend: Backend, dtype: Any
+) -> None:
+    """Derivative rows above the degree are identically zero, with no tolerance.
+
+    Exact, not bounded: the ``k``-th derivative of a degree-``p`` polynomial is the
+    zero polynomial for ``k > p``, and A2.3 reaches it by a factorial factor that
+    becomes exactly ``0`` once ``degree - k`` does. A rounding cannot produce a nonzero
+    value from a multiplication by exact zero, so any nonzero entry is a wrong answer
+    rather than a displaced one.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into either knot table.
+        backend (Backend): The backend to check.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    knots, degree = (_GENERAL_KNOTS | _BEZIER_KNOTS)[case]
+    n_deriv = degree + 3
+    points = _evaluation_points(knots, degree, dtype)
+    got = _tabulate(backend, knots, degree, points, dtype, n_deriv)
+    above = np.asarray(got.block)[:, degree + 1 :, :]
+
+    assert above.size > 0, "the case list must reach past the degree for this to say anything"
+    assert np.all(above == 0.0), (
+        f"{np.count_nonzero(above)} of {above.size} entries above degree {degree} are "
+        f"non-zero on {backend.name}; the k-th derivative of a degree-p polynomial is "
+        f"identically zero for k > p, and A2.3 reaches that by an exactly-zero factor"
+    )
+
+
+def test_the_wrapping_degrees_are_named_and_still_wrap() -> None:
+    """Name the region where no accuracy claim is made, and fail if it disappears.
+
+    ``design/backend_parity.md`` Rule 8's obligation: a test that quietly stops where
+    its bound runs out reads as full coverage. A2.3's step 3 accumulates
+    ``degree!/(degree-k)!`` in an int64 that wraps, so above some degree the derivative
+    rows are scaled by a two's-complement remainder. Both backends wrap identically --
+    ``pantr::core::wrapping_mul`` exists so the C++ side reproduces rather than invokes
+    undefined behaviour -- so **parity holds there and accuracy does not**, and the
+    accuracy tests above carry no case past degree 8.
+
+    This fails if the wrap moves or disappears, because either would mean the
+    accumulator changed under us and the excluded region is no longer the one the
+    accuracy tests were scoped around.
+    """
+    from pantr.bspline._bspline_basis_core import _basis_derivs_point  # noqa: PLC0415
+
+    wrapping: list[tuple[int, int]] = []
+    for degree in range(1, 31):
+        exact = 1
+        modelled = degree
+        mask = (1 << 64) - 1
+        for k in range(1, degree + 1):
+            exact *= degree - k + 1
+            if modelled != exact:
+                wrapping.append((degree, k))
+                break
+            modelled = (modelled * (degree - k)) & mask
+            if modelled >= 1 << 63:
+                modelled -= 1 << 64
+    assert wrapping, (
+        "the falling factorial no longer wraps at any degree up to 30. That is a "
+        "finding, not good news: the accuracy tests here are scoped to degree <= 8 "
+        "because of the wrap, and the exclusion should be revisited"
+    )
+    lowest = min(degree for degree, _ in wrapping)
+    assert lowest == 21, (
+        f"the lowest wrapping degree moved from 21 to {lowest}. "
+        f"scripts/measure_bspline_tabulation_widths.py measures it against the compiled "
+        f"kernel; re-run it and rescope the accuracy tests before changing this number"
+    )
+    # The kernel is imported to make the coupling explicit rather than implied: if it
+    # stops carrying an integer accumulator, this test's premise is gone.
+    assert _basis_derivs_point is not None
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_the_partition_bound_is_still_approached(cpp_backend: None, dtype: Any) -> None:
+    """The partition-of-unity bound is not orders of magnitude looser than the truth.
+
+    A bound nothing exercises can rot with no test noticing, so this asserts the
+    opposite of the bound: that the worst observed discrepancy is still within a stated
+    factor of it. That factor is **measured, not derived**, which is why it is enforced
+    only on the reference host -- ``design/backend_parity.md`` Rule 7, and here the
+    host-dependence is real because the Bézier-like cases route through the platform's
+    ``pow``.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    demand_the_reference_host(
+        "the margin between the partition-of-unity bound and the worst observed discrepancy",
+        "this project's calibrated host; the general-knot cases are pure IEEE "
+        "arithmetic and so deterministic, but the Bezier-like ones route through the "
+        "platform's pow and the float32 worst case sits on one of them",
+    )
+    worst = 0.0
+    for case, (knots, degree) in (_GENERAL_KNOTS | _BEZIER_KNOTS).items():
+        del case
+        points = _evaluation_points(knots, degree, dtype)
+        got = _tabulate(Backend.CPP, knots, degree, points, dtype, None)
+        sums = np.asarray(got.block.sum(axis=-1), dtype=np.float64)
+        bound = float(_partition_bound(got.block, degree, dtype)[0])
+        worst = max(worst, float(np.max(np.abs(sums - 1.0))) / bound)
+
+    # The threshold follows from the bound's own structure rather than from a
+    # measurement. _partition_bound charges 7 roundings per stage; the path that is
+    # actually attained -- the degree additions of the final sum -- commits 1 of those
+    # 7, so the worst observation cannot sit far below 1/7 of the bound. The extra
+    # factor of about 3 below is an **admitted heuristic margin**, not a derivation:
+    # it is there so that adding a case which happens not to attain the summation
+    # worst case cannot turn this red on its own.
+    assert worst > 1.0 / 20.0, (
+        f"the worst partition-of-unity discrepancy is {worst:.3g} of its bound, so the "
+        f"bound has become loose enough to stop asserting anything. The bound charges "
+        f"7 roundings per stage and 1 of them is attained, so this ratio should be near "
+        f"1/7; either the cases stopped being adversarial or the derivation gained a "
+        f"factor it does not need"
+    )
+    assert worst <= 1.0, "the bound was exceeded, which the accuracy tests should have caught"

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -103,6 +103,7 @@ from tests._parity_harness import (
     Field,
     ParityClaim,
     Roundings,
+    absolute_tolerance,
     assert_accuracy,
     assert_object_parity,
     assert_parity,
@@ -364,7 +365,10 @@ _BOUNDED_BY_FMA_DERIVS = (
     "`d + a[s2,j] * ndu[...]` in the a-table recursion, and the per-site budget is "
     "Rule 10's: three accumulator roundings, no narrowing store, the accumulator "
     "being the storage format. The chain through one output element runs `degree` ndu "
-    "stages then up to `n_deriv` a-table stages. "
+    "stages then `min(n_deriv, degree)` a-table stages -- capped at the degree and not "
+    "at n_deriv, because for k > degree the factorial factor is exactly zero, so no "
+    "chain reaching a non-zero output passes through more of them and charging them "
+    "would inflate the budget on the rows that are not zero. "
     "**The amplification is NOT the finished row**, and Rule 10 is explicit about why: "
     "A2.3 differences, so it is not convex, its partial sums can exceed what survives "
     "to the output, and no telescoping argument recovers them -- the finished row was "
@@ -562,9 +566,12 @@ def _companion(magnitudes: _FloatArray, stages: int, dtype: Any) -> _FloatArray:
 
     The additive floor is the format's smallest normal, so an entry that came out
     exactly zero still carries a tolerance the format can express. That is a floor
-    rather than a derivation and is deliberately larger than the smallest subnormal,
-    matching the harness's own :func:`~tests._parity_harness.underflow_floor`, which
-    takes the unhalved subnormal for the same reason.
+    rather than a derivation. It is **not** the same magnitude as the harness's own
+    :func:`~tests._parity_harness.underflow_floor`, which is the smallest *subnormal*
+    and so many orders smaller; what the two share is the reasoning, that a relative
+    model needs an absolute companion and the companion should err on the side of
+    existing. The two are added together by
+    :func:`~tests._parity_harness.absolute_tolerance`, so the larger governs.
 
     Args:
         magnitudes (_FloatArray): The computed magnitudes, elementwise.
@@ -629,8 +636,10 @@ def _deriv_claim(  # noqa: PLR0913
     """The parity claim for a derivative tabulation, conditional on the build.
 
     The chain is longer than the value kernel's: A2.3 builds the ``ndu`` triangle in
-    ``degree`` stages and then runs the ``a``-table recursion for up to ``n_deriv``
-    more, so the stage count is their sum.
+    ``degree`` stages and then runs the ``a``-table recursion. The a-table stages are
+    counted as ``min(n_deriv, degree)`` and not ``n_deriv``, because for ``k > degree``
+    the factorial factor is exactly zero and the row is identically zero, so charging
+    those stages only inflates the tolerance on the rows that are not zero.
 
     The amplification is :func:`_a23_majorant` and **not** the finished row. That
     distinction is the whole of the derivation and it is not a refinement: on a fusing
@@ -655,13 +664,14 @@ def _deriv_claim(  # noqa: PLR0913
     if not contraction_may_fuse():
         return bitwise_parity(why=_EXACT_BY_BUILD)
     majorant = _a23_majorant(knots, degree, n_deriv, points, first_basis, unit_spans=unit_spans)
+    # One expression for the chain length, so the rounding budget and the hull that
+    # widens the amplification cannot come to describe different chains.
+    stages = max(degree + min(n_deriv, degree), 1)
     return bounded_parity(
-        roundings=Roundings(
-            stages=max(degree + n_deriv, 1), accumulator_per_stage=3, storage_per_stage=0
-        ),
+        roundings=Roundings(stages=stages, accumulator_per_stage=3, storage_per_stage=0),
         accumulator=dtype,
         storage=dtype,
-        amplification=_companion(majorant, degree + n_deriv, dtype),
+        amplification=_companion(majorant, stages, dtype),
         why=_BOUNDED_BY_FMA_DERIVS,
     )
 
@@ -979,6 +989,185 @@ def _falling_factorial(degree: int, n_deriv: int) -> int:
     return largest
 
 
+_VACUOUS_CASE = "wrapping-p22"
+"""The one case whose derivative bound is too loose to assert anything, everywhere.
+
+Named so that :func:`test_no_bound_exceeds_the_value_it_compares` can exclude it and
+:func:`test_the_vacuous_region_is_named_and_still_vacuous` can require it to still be
+excluded. ``design/backend_parity.md`` Rule 8's obligation: a test that quietly stops
+where its bound runs out reads as full coverage of the module.
+"""
+
+
+def _vacuity_census(
+    case: str, n_deriv: int, dtype: Any
+) -> tuple[npt.NDArray[np.bool_], _FloatArray, _FloatArray]:
+    """Where a derivative parity bound is defined, and how it compares to the values.
+
+    Args:
+        case (str): Key into either general-knot table.
+        n_deriv (int): The highest derivative order.
+        dtype (Any): The storage dtype.
+
+    Returns:
+        tuple[npt.NDArray[np.bool_], _FloatArray, _FloatArray]: A mask selecting the
+        entries where a *relative* bound is meaningful at all -- the normal ones, per
+        Rule 5 -- and the elementwise tolerance and reference magnitude.
+    """
+    knots, degree = (_GENERAL_KNOTS | _HIGH_DEGREE_KNOTS)[case]
+    points = _evaluation_points(knots, degree, dtype)
+    reference = _tabulate(Backend.PYTHON, knots, degree, points, dtype, n_deriv)
+    claim = _deriv_claim(
+        knots, degree, n_deriv, points, reference.first_basis, dtype, unit_spans=False
+    )
+    tolerance = np.broadcast_to(absolute_tolerance(claim), reference.block.shape)
+    magnitude = np.abs(np.asarray(reference.block, dtype=np.float64))
+    return magnitude >= np.finfo(dtype).smallest_normal, tolerance, magnitude
+
+
+def test_the_vacuous_region_is_named_and_still_vacuous(cpp_backend: None) -> None:
+    """Enumerate where the derivative bound asserts nothing, and fail if that changes.
+
+    ``design/backend_parity.md`` Rule 8: when a bound stops being able to say anything,
+    the resolution is a smaller domain rather than a tighter bound -- and the domain
+    that was cut has to be **named**, in a test whose only job is to name it, which
+    fails if the gap is ever empty. An empty gap would mean either the bound collapsed
+    or the cases moved, and both are findings rather than good news.
+
+    **What is excluded and why.** At degree 22 the A2.3 majorant exceeds the finished
+    derivative row by about five orders of magnitude at a handful of entries. That is
+    not slack in the derivation: the recursion is not convex, so its partial sums can be
+    far larger than what survives the cancellation to the output, and Rule 10 records
+    that no telescoping argument recovers them. The majorant is still a majorant; it is
+    simply too loose to compare against those particular values, so the claim there
+    admits any answer including zero.
+
+    **The region is `float32` only, and that is the sharp statement.** The majorant's
+    excess over the finished row is the same at both widths, being a property of the
+    recursion rather than of the format; what differs is ``u``, so at ``float64`` the
+    tolerance stays far below the values and every entry is guarded. Only the narrow
+    format's budget is large enough for that excess to swallow a value. The excluded
+    region is therefore *degree 22 at float32*, not degree 22.
+
+    **What is still claimed there.** The parity tests at that degree pass and are not
+    excluded -- the bound holds. What this test records is that a handful of entries are
+    unguarded, which the harness's own guard cannot report because it compares the
+    arrays' maxima rather than element by element.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+    """
+    del cpp_backend
+    # This test reaches degree 22 at both widths, where the oracle's falling-factorial
+    # accumulator wraps when compiled and grows when interpreted.
+    demand_a_compiled_seed()
+    if not contraction_may_fuse():
+        pytest.skip(
+            "on a build whose target ISA cannot fuse, the derivative claim is bitwise "
+            "and its tolerance is exactly zero, so no entry can be vacuous and there is "
+            "no region to enumerate. Build with -march=native to exercise this"
+        )
+
+    guarded = 0
+    for n_deriv in _DERIVATIVE_ORDERS:
+        normal, tolerance, magnitude = _vacuity_census(_VACUOUS_CASE, n_deriv, np.float64)
+        guarded += int(np.count_nonzero(tolerance[normal] >= magnitude[normal]))
+    assert guarded == 0, (
+        f"{guarded} entries of {_VACUOUS_CASE} are unguarded at float64. The exclusion "
+        f"is float32-only by construction -- the majorant's excess over the finished row "
+        f"is a property of the recursion and the same at both widths, so only the narrow "
+        f"format's budget can swallow a value. If float64 has become vacuous too, the "
+        f"derivation moved and this whole region needs re-deriving"
+    )
+
+    worst = 0.0
+    vacuous = 0
+    for n_deriv in _DERIVATIVE_ORDERS:
+        normal, tolerance, magnitude = _vacuity_census(_VACUOUS_CASE, n_deriv, np.float32)
+        bad = tolerance[normal] >= magnitude[normal]
+        vacuous += int(np.count_nonzero(bad))
+        if bad.any():
+            worst = max(worst, float(np.max(tolerance[normal] / magnitude[normal])))
+
+    assert vacuous > 0, (
+        f"{_VACUOUS_CASE} no longer carries a vacuous entry. That is a finding rather "
+        f"than good news: either the majorant became tight enough to guard the whole "
+        f"row -- in which case this exclusion and "
+        f"test_no_bound_exceeds_the_value_it_compares's should both be revisited -- or "
+        f"the case stopped reaching the degrees where A2.3's cancellation bites"
+    )
+    assert worst > 1.0, "a vacuous entry by definition has tolerance at least its own value"
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("n_deriv", _DERIVATIVE_ORDERS)
+@pytest.mark.parametrize(
+    "case", sorted((_GENERAL_KNOTS | _HIGH_DEGREE_KNOTS).keys() - {_VACUOUS_CASE})
+)
+def test_no_bound_exceeds_the_value_it_compares(
+    cpp_backend: None, case: str, n_deriv: int, dtype: Any
+) -> None:
+    """No non-zero reference value carries a tolerance as large as its own magnitude.
+
+    Rule 3 of ``design/backend_parity.md`` refuses a bound at least as large as the
+    values it compares, and :func:`~tests._parity_harness.assert_parity` enforces it --
+    but only by **comparing the two arrays' maxima**, deliberately, so that a genuine
+    absolute floor on an entry that is truly zero is not rejected. Rule 10 records what
+    that misses: on the sibling derivative kernel, 45 of 280 non-zero ``float32``
+    values carried a tolerance at least as large as their own magnitude and the guard
+    did not fire, because a flat amplification is sized for exactly the largest
+    element. Rule 6 names the shape -- a scalar summary of two arrays is not a
+    comparison of two arrays.
+
+    So this is the elementwise half, which nothing in the harness can do for us.
+
+    **The excluded set is the subnormal range, not just exact zero**, and that boundary
+    is Rule 5's rather than a convenience. Higham's relative model
+    ``fl(x op y) = (x op y)(1 + delta) + eta`` silently assumes normal operands, and
+    Rule 5 records the counterexample: at ``2^-1074`` a single multiplication commits a
+    20% relative error that no ``|delta| <= u`` can express. A reference value a few
+    units above the smallest subnormal is in exactly that range, so **no relative bound
+    on it is meaningful** and the absolute companion -- the underflow floor the harness
+    adds and the smallest-normal floor :func:`_companion` adds -- is all that is
+    available. Measured when this test was written: every one of the roughly 100
+    vacuous entries across the whole matrix was subnormal, none was normal, and the
+    largest was 2 units of the smallest subnormal against a tolerance of 18.
+
+    Excluding only exact zero would therefore fail on correct code, for a reason
+    nobody could act on. Excluding everything below the smallest normal asserts the
+    thing that is actually claimable: that wherever the relative model applies at all,
+    the bound is not vacuous.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        case (str): Key into either general-knot table.
+        n_deriv (int): The highest derivative order.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    # The amplification is built from `_wrapped_falling_factorials`, which always
+    # wraps, while an interpreted oracle's accumulator grows without bound. Above
+    # degree 21 the two would describe different quantities.
+    demand_a_compiled_seed()
+    if case == _VACUOUS_CASE and np.dtype(dtype) == np.float32:
+        pytest.skip(
+            f"{_VACUOUS_CASE} at float32 is the region "
+            f"test_the_vacuous_region_is_named_and_still_vacuous enumerates; see there "
+            f"for why the bound cannot be tightened into it"
+        )
+    normal, tolerance, magnitude = _vacuity_census(case, n_deriv, dtype)
+    assert normal.any(), "the case must reach at least one normal value to say anything"
+    vacuous = int(np.count_nonzero(tolerance[normal] >= magnitude[normal]))
+    assert vacuous == 0, (
+        f"{vacuous} of {int(normal.sum())} normal values carry a tolerance at least as "
+        f"large as themselves, worst "
+        f"{float(np.max(tolerance[normal] / magnitude[normal])):.3g} times; a bound that "
+        f"large admits any answer including zero, and the harness's own guard cannot see "
+        f"it because it compares the arrays' maxima"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Independent accuracy oracles
 # ---------------------------------------------------------------------------
@@ -1005,7 +1194,7 @@ def _a22_chain_roundings(degree: int) -> int:
 
 
 def _a23_chain_roundings(degree: int, n_deriv: int) -> int:
-    """Roundings on the dependency chain through one A2.3 output element.
+    """Roundings on the dependency chain through one **non-zero** A2.3 output element.
 
     :func:`_a22_chain_roundings` for the ``ndu`` triangle, which A2.3 builds by the
     same steps, plus **four** per stage of the ``a``-table recursion, counted against
@@ -1013,6 +1202,9 @@ def _a23_chain_roundings(degree: int, n_deriv: int) -> int:
     ``ndu``, the multiplication ``a[s2,j] * ndu[...]`` and the accumulation into ``d``.
     Plus **one** for the factorial scaling, which happens once per element and not per
     stage.
+
+    The a-table stages are capped at ``degree`` rather than ``n_deriv``, which is what
+    makes the bound non-vacuous elementwise; see the comment on the return.
 
     An earlier version charged three per stage and no factorial, which under-counted --
     the dangerous direction, since a bound tighter than derivable can be exceeded by
@@ -1025,7 +1217,12 @@ def _a23_chain_roundings(degree: int, n_deriv: int) -> int:
     Returns:
         int: The rounding count, for use as ``m`` in ``gamma_m``.
     """
-    return _a22_chain_roundings(degree) + 4 * n_deriv + 1
+    # `min(n_deriv, degree)` and not `n_deriv`: for `k > degree` the factorial factor is
+    # exactly zero, so those rows are identically zero whatever the recursion did before
+    # them, and no chain reaching a non-zero output passes through more than `degree`
+    # a-table stages. Charging `n_deriv` would inflate the budget on the rows that are
+    # not zero, by a factor of the derivative order, for no derivable reason.
+    return _a22_chain_roundings(degree) + 4 * min(n_deriv, degree) + 1
 
 
 def _dot_product_roundings(degree: int) -> int:

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -902,6 +902,100 @@ def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: Any) 
     assert np.array_equal(indices, expected_first)
 
 
+@pytest.mark.parametrize("n_deriv", [None, 2])
+@pytest.mark.parametrize(("knot_dtype", "point_dtype"), [(np.float32, np.float64)])
+def test_a_mixed_dtype_call_falls_back_and_says_so(
+    cpp_backend: None,
+    knot_dtype: Any,
+    point_dtype: Any,
+    n_deriv: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A space and points of different dtypes run the Numba kernel under both backends.
+
+    The library supports a ``float32`` space evaluated at ``float64`` points and
+    returns the points' dtype; ``tests/test_mpi_thb_qi.py`` and
+    ``tests/test_thb_spline_space.py`` assert that by name. The C++ kernels are
+    templated on one scalar type and cannot express it, so
+    :func:`~pantr.bspline._basis_backend._the_cpp_kernels_cannot_serve` routes it to
+    the oracle -- which is what it did before the C++ path existed, so nothing
+    regresses and the values are the oracle's by construction rather than by bound.
+
+    **This test exists to stop the fallback widening unnoticed.** A capability
+    fallback is exactly what ``pantr._backend``'s never-fall-back rule guards against,
+    because an A/B measurement over such an input silently measures Numba twice. So it
+    is pinned in both directions: the two backends must agree *bitwise*, and the C++
+    binding must be provably **not** called. If a later change makes the C++ kernels
+    able to serve this shape, the second assertion fails and this test has to be
+    rewritten deliberately.
+
+    Only the ``float32``-knots/``float64``-points direction is parametrized, because
+    that is the one the library's own tests exercise; the opposite direction takes the
+    same branch on the same predicate.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        knot_dtype (Any): The space's storage dtype.
+        point_dtype (Any): The evaluation points' dtype.
+        n_deriv (int | None): Derivative order, or ``None`` for the value tabulation.
+        monkeypatch (pytest.MonkeyPatch): Used to count binding calls.
+    """
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (only this test needs the module)
+
+    knots, degree = _GENERAL_KNOTS["clamped-uniform-p2"]
+    points = np.array([0.1, 0.5, 0.9], dtype=point_dtype)
+    knot_array = np.array(knots, dtype=knot_dtype)
+
+    calls = 0
+
+    def counted(*args: Any, **kwargs: Any) -> None:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("the C++ binding was reached for a mixed-dtype call")
+
+    binding = (
+        "tabulate_bspline_basis_1d" if n_deriv is None else "tabulate_bspline_basis_derivatives_1d"
+    )
+    monkeypatch.setattr(_pantr_cpp, binding, counted, raising=True)
+
+    results = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = BsplineSpace1D(knot_array, degree)
+            if n_deriv is None:
+                block, first = space.tabulate_basis(points)
+            else:
+                block, first = space.tabulate_basis_derivatives(points, n_deriv)
+        results[backend] = (block, first)
+
+    assert calls == 0, (
+        "the C++ binding was called for a call its kernels cannot express; if that is "
+        "now intended, the fallback in pantr.bspline._basis_backend and this test both "
+        "need rewriting rather than relaxing"
+    )
+
+    py_block, py_first = results[Backend.PYTHON]
+    cpp_block, cpp_first = results[Backend.CPP]
+    assert py_block.dtype == np.dtype(point_dtype), (
+        "the result must carry the points' dtype, which is the behaviour "
+        "test_result_is_float64_for_float32_space pins"
+    )
+    assert_parity(
+        cpp_block,
+        py_block,
+        bitwise_parity(
+            why="both backends ran the same Numba kernel, because the C++ one cannot "
+            "express a mixed-dtype call and the adapter routes it to the oracle. This is "
+            "identity rather than agreement, and it is asserted so that the fallback "
+            "cannot silently stop happening.",
+        ),
+        context=f"mixed dtype {np.dtype(knot_dtype).name} knots / "
+        f"{np.dtype(point_dtype).name} points, n_deriv={n_deriv}",
+    )
+    assert np.array_equal(cpp_first, py_first)
+
+
 def test_the_seam_returns_kernels_for_every_available_backend() -> None:
     """Every backend the installation offers answers all three catalogue functions.
 

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -545,29 +545,51 @@ def _wrapped_falling_factorials(degree: int, n_deriv: int) -> list[int]:
     return factors
 
 
-def _companion(magnitudes: _FloatArray, dtype: Any) -> _FloatArray:
+def _companion(magnitudes: _FloatArray, stages: int, dtype: Any) -> _FloatArray:
     """Widen a computed magnitude into a hull that covers the true value too.
 
     A bound built from the *computed* coefficient collapses where that coefficient
     rounds to exactly zero while the true one does not, which
     ``design/backend_parity.md`` records as a correction the infrastructure PR had to
-    make: without it the bound could be violated by a factor of ``1/u``. Widening each
-    entry by its own first-order propagated error covers both.
+    make: without it the bound could be violated by a factor of ``1/u``.
 
-    The widening is ``(1 + gamma)`` with ``gamma`` the whole relative budget of the
-    recurrence, plus one unit of roundoff as an absolute floor so that an entry which
-    is exactly zero still carries the smallest tolerance the format can express.
+    The widening is ``(1 + gamma_m)`` with ``m = 3 * stages``, the reference backend's
+    own relative forward error over the same chain the parity budget charges: the
+    computed magnitude is within that of the true one, so scaling by it covers both. An
+    earlier version multiplied by ``1 + 4u`` while this docstring claimed the
+    recurrence's whole budget, which is the defect the file's history records twice --
+    a derivation stated in prose that the code does not implement.
+
+    The additive floor is the format's smallest normal, so an entry that came out
+    exactly zero still carries a tolerance the format can express. That is a floor
+    rather than a derivation and is deliberately larger than the smallest subnormal,
+    matching the harness's own :func:`~tests._parity_harness.underflow_floor`, which
+    takes the unhalved subnormal for the same reason.
 
     Args:
         magnitudes (_FloatArray): The computed magnitudes, elementwise.
+        stages (int): The dependency-chain length the parity budget charges, so that
+            the hull and the budget describe the same chain.
         dtype (Any): The storage dtype, which fixes ``u``.
 
     Returns:
         _FloatArray: The widened magnitudes, in ``float64``.
+
+    Raises:
+        ValueError: If the chain is long enough that ``gamma_m`` runs away, which
+            would make the hull meaningless rather than merely loose.
     """
     u = unit_roundoff(dtype)
+    m = 3 * max(stages, 1)
+    if m * u >= 0.5:
+        raise ValueError(
+            f"a chain of {stages} stages at {np.dtype(dtype).name} accumulates a "
+            f"relative budget of {m * u:.3g}, so the hull factor is not first order "
+            f"and the amplification it produces would not bound anything"
+        )
+    gamma = m * u / (1.0 - m * u)
     values = np.abs(np.asarray(magnitudes, dtype=np.float64))
-    widened = values * (1.0 + 4.0 * u) + np.finfo(dtype).smallest_normal
+    widened = values * (1.0 + gamma) + np.finfo(dtype).smallest_normal
     return np.asarray(widened, dtype=np.float64)
 
 
@@ -589,7 +611,7 @@ def _value_claim(reference: _FloatArray, degree: int, dtype: Any) -> ParityClaim
         roundings=Roundings(stages=max(degree, 1), accumulator_per_stage=3, storage_per_stage=0),
         accumulator=dtype,
         storage=dtype,
-        amplification=_companion(reference, dtype),
+        amplification=_companion(reference, degree, dtype),
         why=_BOUNDED_BY_FMA_VALUES,
     )
 
@@ -639,7 +661,7 @@ def _deriv_claim(  # noqa: PLR0913
         ),
         accumulator=dtype,
         storage=dtype,
-        amplification=_companion(majorant, dtype),
+        amplification=_companion(majorant, degree + n_deriv, dtype),
         why=_BOUNDED_BY_FMA_DERIVS,
     )
 

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -984,6 +984,91 @@ def _falling_factorial(degree: int, n_deriv: int) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _a22_chain_roundings(degree: int) -> int:
+    """Roundings on the dependency chain through one A2.2 output element.
+
+    Counted against ``_basis_funcs_point``, six per stage of the ``j`` loop:
+    ``left[j]``, ``right[j]``, ``denom``, the division ``N[r] / denom``, the
+    multiplication ``right[r+1] * temp`` and the addition ``saved + ...``. The
+    recurrence is a convex combination -- the two weights are ``right[r+1]/denom`` and
+    ``left[j-r]/denom``, non-negative for a non-decreasing knot vector and summing to
+    one -- so an inherited relative error is carried rather than amplified and the six
+    are additive per stage. There are ``degree`` stages.
+
+    Args:
+        degree (int): The polynomial degree.
+
+    Returns:
+        int: The rounding count, for use as ``m`` in ``gamma_m``.
+    """
+    return 6 * degree
+
+
+def _a23_chain_roundings(degree: int, n_deriv: int) -> int:
+    """Roundings on the dependency chain through one A2.3 output element.
+
+    :func:`_a22_chain_roundings` for the ``ndu`` triangle, which A2.3 builds by the
+    same steps, plus **four** per stage of the ``a``-table recursion, counted against
+    ``_basis_derivs_point``: the subtraction ``a[s1,j] - a[s1,j-1]``, the division by
+    ``ndu``, the multiplication ``a[s2,j] * ndu[...]`` and the accumulation into ``d``.
+    Plus **one** for the factorial scaling, which happens once per element and not per
+    stage.
+
+    An earlier version charged three per stage and no factorial, which under-counted --
+    the dangerous direction, since a bound tighter than derivable can be exceeded by
+    correct code. The margin had been absorbing it.
+
+    Args:
+        degree (int): The polynomial degree.
+        n_deriv (int): The highest derivative order.
+
+    Returns:
+        int: The rounding count, for use as ``m`` in ``gamma_m``.
+    """
+    return _a22_chain_roundings(degree) + 4 * n_deriv + 1
+
+
+def _dot_product_roundings(degree: int) -> int:
+    """Roundings in a dot product of the ``degree + 1`` values against exact weights.
+
+    ``degree + 1`` multiplications and ``degree`` additions, plus one for casting each
+    exact rational weight to ``double``. The cast is charged once because it is one
+    rounding per term and the terms are summed, so it enters the bound the same way a
+    per-term relative error does.
+
+    Args:
+        degree (int): The polynomial degree.
+
+    Returns:
+        int: The rounding count, for use as ``m`` in ``gamma_m``.
+    """
+    return (degree + 1) + degree + 1
+
+
+def _gamma(m: int, dtype: Any) -> float:
+    """Higham's ``gamma_m = m u / (1 - m u)``, refusing a budget that runs away.
+
+    Args:
+        m (int): The rounding count.
+        dtype (Any): The storage dtype, which fixes ``u = eps / 2``.
+
+    Returns:
+        float: ``gamma_m``, or at least one ``u`` so that a zero-stage case still
+        carries the smallest bound the format can express.
+
+    Raises:
+        ValueError: If ``m u >= 1/2``, where ``gamma_m`` no longer bounds a first-order
+            accumulation and a claim built on it would assert nothing.
+    """
+    u = unit_roundoff(dtype)
+    if m * u >= 0.5:
+        raise ValueError(
+            f"a budget of {m} roundings at {np.dtype(dtype).name} accumulates to "
+            f"{m * u:.3g}, at which gamma_m stops being a first-order bound"
+        )
+    return max(m * u / (1.0 - m * u), u)
+
+
 def _marsden_weights(
     knots: list[float], degree: int, first_basis: int, y: Fraction
 ) -> list[Fraction]:
@@ -1039,39 +1124,29 @@ def _outside_y(knots: list[float]) -> tuple[Fraction, Fraction]:
     return low - width, high + width
 
 
-def _partition_bound(values: _FloatArray, degree: int, dtype: Any) -> _FloatArray:
+def _partition_bound(degree: int, dtype: Any) -> float:
     """An absolute bound on ``|sum_i N_i - 1|``, derived rather than measured.
 
     Two contributions, both first order in ``u = eps/2``:
 
-    - **The values' own forward error.** A2.2 is a convex recurrence: at each of the
-      ``degree`` stages the new value is ``w1 * a + w2 * b`` with ``w1, w2 >= 0`` and
-      ``w1 + w2 = 1``, so a relative perturbation of the inputs is *carried*, never
-      amplified. Six operations lie on the dependency chain through one output element
-      per stage -- ``left[j]``, ``right[j]``, ``denom``, the division, the
-      multiplication and the addition -- so the relative error of each value is at most
-      ``gamma_{6p}``, and since the values are non-negative and sum to one, the sum of
-      their absolute errors is at most ``gamma_{6p}`` too.
-    - **The summation.** ``degree`` additions of quantities summing to one, so at most
-      ``gamma_p``.
+    - **The values' own forward error**, :func:`_a22_chain_roundings`. Since the values
+      are non-negative and sum to one, the sum of their *absolute* errors is bounded by
+      the same ``gamma`` that bounds each one's relative error.
+    - **The summation**, ``degree`` additions of quantities summing to one, so
+      ``gamma_degree``.
 
-    Written as ``gamma_m = m u / (1 - m u)`` with ``m = 7 * degree``, which is the two
-    counts added and not a safety factor. The floor of one ``u`` covers ``degree = 0``,
-    where the single value is exactly one and no operation runs.
+    The two counts are added rather than combined with a safety factor, and
+    :func:`_gamma` supplies the one-``u`` floor that covers ``degree = 0``, where the
+    single value is exactly one and no operation runs.
 
     Args:
-        values (_FloatArray): The computed basis values, shape ``(n_pts, degree + 1)``.
         degree (int): The polynomial degree.
         dtype (Any): The storage dtype, which fixes ``u``.
 
     Returns:
-        _FloatArray: One bound per point.
+        float: The bound, the same for every point.
     """
-    del values
-    u = unit_roundoff(dtype)
-    m = 7 * degree
-    gamma = m * u / (1.0 - m * u) if m * u < 0.5 else np.inf
-    return np.full(1, max(gamma, u), dtype=np.float64)
+    return _gamma(_a22_chain_roundings(degree) + degree, dtype)
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])
@@ -1104,11 +1179,12 @@ def test_partition_of_unity(cpp_backend: None, case: str, backend: Backend, dtyp
         sums,
         np.ones_like(sums),
         derived_accuracy(
-            bound=np.broadcast_to(_partition_bound(got.block, degree, dtype), sums.shape),
+            bound=np.full(sums.shape, _partition_bound(degree, dtype)),
             why="the partition of unity is exact in the reals, so the whole discrepancy "
-            "is the computation's own forward error: gamma_{6p} carried by the convex "
-            "recurrence plus gamma_p from summing degree+1 terms that add to one, "
-            "written as gamma_{7p}. See _partition_bound for the operation count.",
+            "is the computation's own forward error: six roundings per stage carried by "
+            "the convex recurrence over degree stages, plus the degree additions of the "
+            "sum. Both counts are counted against _basis_funcs_point rather than "
+            "estimated; see _a22_chain_roundings and _partition_bound.",
         ),
         context=f"partition of unity, {case}, {backend.name}, {np.dtype(dtype).name}",
     )
@@ -1137,7 +1213,6 @@ def test_marsden_identity_pins_the_values(
     points = _evaluation_points(knots, degree, dtype)
     got = _tabulate(backend, knots, degree, points, dtype, None)
     values = np.asarray(got.block, dtype=np.float64)
-    u = unit_roundoff(dtype)
 
     for y in _outside_y(knots):
         computed = np.empty(points.size, dtype=np.float64)
@@ -1152,12 +1227,11 @@ def test_marsden_identity_pins_the_values(
             # Every weight has the same sign and the values are non-negative, so this
             # sum does not cancel and its magnitude is |exact| up to the budget below.
             magnitude = float(np.dot(np.abs(floats), np.abs(values[p])))
-            # gamma_{7p} for the values (see _partition_bound), one u for casting each
-            # exact weight to double, and gamma_{2p} for the degree+1 products and the
-            # degree additions of the dot product.
-            m = 7 * degree + 1 + 2 * degree
-            gamma = m * u / (1.0 - m * u) if m * u < 0.5 else np.inf
-            bound[p] = max(gamma, u) * magnitude
+            # The values' own chain, plus the dot product against the exact weights.
+            # There is no partition-of-unity summation term here: Marsden's sum IS the
+            # dot product, and charging both would double-count it.
+            budget = _a22_chain_roundings(degree) + _dot_product_roundings(degree)
+            bound[p] = _gamma(budget, dtype) * magnitude
 
         assert np.all(bound < np.abs(exact) + np.finfo(np.float64).tiny), (
             f"the Marsden bound is not smaller than the value it compares for {case} "
@@ -1173,8 +1247,9 @@ def test_marsden_identity_pins_the_values(
                 "side is computed in exact rational arithmetic from dyadic knots, so the "
                 "reference carries no error. y sits a full knot range outside, which makes "
                 "every weight the same sign and the sum cancellation-free. The bound is the "
-                "values' own gamma_{7p}, one u per weight cast, and gamma_{2p} for the dot "
-                "product, times the sum of |weight| * |value|.",
+                "values' own chain (_a22_chain_roundings) plus the dot product's "
+                "(_dot_product_roundings), times the sum of |weight| * |value|. It carries "
+                "no separate summation term, Marsden's sum being the dot product itself.",
             ),
             context=f"Marsden at y={y}, {case}, {backend.name}, {np.dtype(dtype).name}",
         )
@@ -1205,7 +1280,6 @@ def test_derivative_sums_vanish(cpp_backend: None, case: str, backend: Backend, 
     points = _evaluation_points(knots, degree, dtype)
     got = _tabulate(backend, knots, degree, points, dtype, n_deriv)
     block = np.asarray(got.block, dtype=np.float64)
-    u = unit_roundoff(dtype)
 
     for k in range(1, n_deriv + 1):
         rows = block[:, k, :]
@@ -1213,9 +1287,8 @@ def test_derivative_sums_vanish(cpp_backend: None, case: str, backend: Backend, 
         # The row's own scale. `sum_i |N_i^(k)|` rather than the max, because the
         # summation error is driven by the partial sums and those reach the total.
         magnitude = np.abs(rows).sum(axis=-1)
-        m = 7 * degree + 3 * n_deriv + degree
-        gamma = m * u / (1.0 - m * u) if m * u < 0.5 else np.inf
-        bound = np.maximum(max(gamma, u) * magnitude, np.finfo(dtype).smallest_normal)
+        budget = _a23_chain_roundings(degree, n_deriv) + degree
+        bound = np.maximum(_gamma(budget, dtype) * magnitude, np.finfo(dtype).smallest_normal)
         assert_accuracy(
             sums,
             np.zeros_like(sums),
@@ -1223,10 +1296,11 @@ def test_derivative_sums_vanish(cpp_backend: None, case: str, backend: Backend, 
                 bound=bound,
                 why="sum_i N_i^(k) = 0 for k >= 1 follows from differentiating the "
                 "partition of unity, so the whole discrepancy is forward error. The bound "
-                "is gamma_{7p} for the ndu triangle, three roundings per a-table stage over "
-                "n_deriv stages, and gamma_p for the sum, times sum_i |N_i^(k)| -- an "
-                "absolute bound scaled by the row's own magnitude, since the quantity "
-                "vanishes and no relative bound on it is finite.",
+                "is _a23_chain_roundings -- six per ndu stage, four per a-table stage and "
+                "one for the factorial scaling, each counted against _basis_derivs_point -- "
+                "plus the degree additions of the sum, times sum_i |N_i^(k)|. Absolute and "
+                "scaled by the row's own magnitude, since the quantity vanishes and no "
+                "relative bound on it is finite.",
             ),
             context=f"derivative sum k={k}, {case}, {backend.name}, {np.dtype(dtype).name}",
         )
@@ -1265,7 +1339,6 @@ def test_differentiated_marsden_pins_the_derivative_scale(
     points = _evaluation_points(knots, degree, dtype)
     got = _tabulate(backend, knots, degree, points, dtype, n_deriv)
     block = np.asarray(got.block, dtype=np.float64)
-    u = unit_roundoff(dtype)
     y = _outside_y(knots)[0]
 
     falling = 1
@@ -1282,9 +1355,8 @@ def test_differentiated_marsden_pins_the_derivative_scale(
             computed[p] = float(np.dot(floats, row))
             exact[p] = float(falling * (Fraction(float(point)) - y) ** (degree - k))
             magnitude = float(np.dot(np.abs(floats), np.abs(row)))
-            m = 7 * degree + 3 * n_deriv + 1 + 2 * degree
-            gamma = m * u / (1.0 - m * u) if m * u < 0.5 else np.inf
-            bound[p] = max(gamma, u) * magnitude
+            budget = _a23_chain_roundings(degree, n_deriv) + _dot_product_roundings(degree)
+            bound[p] = _gamma(budget, dtype) * magnitude
 
         if not np.all(bound < np.abs(exact)):
             pytest.skip(
@@ -1418,7 +1490,7 @@ def test_the_partition_bound_is_still_approached(cpp_backend: None, dtype: Any) 
         points = _evaluation_points(knots, degree, dtype)
         got = _tabulate(Backend.CPP, knots, degree, points, dtype, None)
         sums = np.asarray(got.block.sum(axis=-1), dtype=np.float64)
-        bound = float(_partition_bound(got.block, degree, dtype)[0])
+        bound = _partition_bound(degree, dtype)
         worst = max(worst, float(np.max(np.abs(sums - 1.0))) / bound)
 
     # The threshold follows from the bound's own structure rather than from a

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -311,6 +311,21 @@ def _demand_the_two_spaces_agree(knots: list[float], degree: int, dtype: Any) ->
 # The rounding budget, for the branch where contraction is live
 # ---------------------------------------------------------------------------
 
+_BEZIER_VALUES_EXACT = (
+    "The Bezier-like value path does not reach tabulate.hpp: the change of variable "
+    "onto [0, 1] is the same numpy expression above the seam on both sides, and the "
+    "work is tabulate_bernstein_1d's ratio recurrence. That recurrence contains **no "
+    "a * b + c site at all** -- its inner step is (prev * const) * ratio, three "
+    "multiplications and no addition -- so the claim is bitwise unconditionally rather "
+    "than conditional on the build, exactly as tests/parity/test_basis_tabulations.py "
+    "already claims for the same kernel. cpp/include/pantr/basis/bernstein.hpp states "
+    "the argument; it was also checked here, by running this file against a "
+    "-march=native build, where zero of the values moved while 31 derivative cases "
+    "did. What the claim does rest on rather than derive is that numba's np.power "
+    "agrees with the platform libm, which is why demand_a_compiled_seed gates it."
+)
+
+
 _EXACT_BY_BUILD = (
     "A2.2 and A2.3 are built from +, -, *, / and an exact-zero comparison, with no "
     "transcendental and no library call, so IEEE 754 pins every result and the only "
@@ -327,23 +342,207 @@ _EXACT_BY_BUILD = (
     "instead."
 )
 
-_BOUNDED_BY_FMA = (
+_BOUNDED_BY_FMA_VALUES = (
     "This build's target ISA carries a fused multiply-add and PantrCompileOptions "
-    "adds -ffp-contract=on, so `saved + right[r+1] * temp` in A2.2 and "
-    "`d + a[s2,j] * ndu[...]` in A2.3 may each compile to one FMA while the numba "
-    "oracle never fuses (LLVM does not contract without fastmath, which no pantr "
-    "kernel sets). design/backend_parity.md Rule 10: at a fused site the two differ "
-    "by |b*c| u (1+u) + |a+b*c| 2u, three accumulator roundings, and the accumulator "
-    "is the storage format here so there is no narrowing store to charge. The "
-    "dependency chain through one output element passes exactly one fusable site per "
-    "stage of the outer recurrence, and there are `degree` stages. The amplification "
-    "is the absolute-value companion of the recurrence itself, which Rule 10 licenses "
-    "for a convex recurrence and refuses for a signed one: A2.2's weights are "
-    "non-negative and sum to one, so the companion is exactly the magnitude reachable "
-    "at each output element; A2.3 differences and so gets the majorant of its own "
-    "recursion, every coefficient replaced by its modulus, which bounds every "
-    "intermediate by induction and whose partial sums are then monotone."
+    "adds -ffp-contract=on, so `saved + right[r+1] * temp` in A2.2 may compile to one "
+    "FMA while the numba oracle never fuses (LLVM does not contract without fastmath, "
+    "which no pantr kernel sets). design/backend_parity.md Rule 10: at a fused site "
+    "the two differ by |b*c| u (1+u) + |a+b*c| 2u, three accumulator roundings, and "
+    "the accumulator is the storage format here so there is no narrowing store to "
+    "charge. The dependency chain through one output element passes one fusable site "
+    "per stage of the outer recurrence and there are `degree` stages. "
+    "The amplification is the absolute-value companion of the recurrence, which Rule "
+    "10 licenses for a convex recurrence: A2.2's two weights are right[r+1]/denom and "
+    "left[j-r]/denom, both non-negative for a non-decreasing knot vector and summing "
+    "to one, so replacing every coefficient by its modulus changes nothing and the "
+    "companion IS the computed row. It is hull-widened so an entry that rounded to "
+    "zero while the true value did not still carries a tolerance."
 )
+
+_BOUNDED_BY_FMA_DERIVS = (
+    "The fused sites are `saved + right[r+1] * temp` in the ndu triangle and "
+    "`d + a[s2,j] * ndu[...]` in the a-table recursion, and the per-site budget is "
+    "Rule 10's: three accumulator roundings, no narrowing store, the accumulator "
+    "being the storage format. The chain through one output element runs `degree` ndu "
+    "stages then up to `n_deriv` a-table stages. "
+    "**The amplification is NOT the finished row**, and Rule 10 is explicit about why: "
+    "A2.3 differences, so it is not convex, its partial sums can exceed what survives "
+    "to the output, and no telescoping argument recovers them -- the finished row was "
+    "measured to be exceeded by a structural factor on the sibling Bezier kernel. It "
+    "is instead the majorant of the recursion itself: the same algorithm with every "
+    "coefficient replaced by its modulus, which is the two sign changes in the a-table "
+    "that turn its differences into sums. For a linear recursion with signed "
+    "coefficients that bounds every intermediate by induction, and with the signs gone "
+    "the partial sums are monotone, so the final value majorises all of them. The "
+    "factorial scaling is applied with the same wrapped integers the kernel uses, since "
+    "the amplification must bound what the kernel computed and not what it should have."
+)
+
+
+def _a23_majorant(  # noqa: PLR0913
+    knots: list[float],
+    degree: int,
+    n_deriv: int,
+    points: _FloatArray,
+    first_basis: npt.NDArray[np.int_],
+    *,
+    unit_spans: bool,
+) -> _FloatArray:
+    """The majorant of the A2.3 recursion: the same algorithm on moduli.
+
+    Rule 10's licensed amplification for a **non-convex** recursion. Two lines differ
+    from the oracle, both in the ``a`` table: its two differences become sums. Every
+    quantity is then non-negative, so each intermediate bounds the corresponding signed
+    one by induction, and the monotone partial sums make the final value majorise all
+    of them.
+
+    Run in ``float64`` throughout. The amplification is a magnitude rather than a
+    computed value, so its own rounding is second order against the ``u`` it multiplies.
+
+    Args:
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        n_deriv (int): The highest derivative order.
+        points (_FloatArray): The evaluation points.
+        first_basis (npt.NDArray[np.int_]): The first-basis index per point, used only
+            to recover each point's span.
+        unit_spans (bool): ``True`` for the Bezier-like path, whose kernel is A2.3 with
+            every knot difference equal to one and whose ``ndu`` upper triangle is
+            therefore built from ``s`` and ``1 - s`` on the reference interval. The two
+            kernels are different algorithms, so one majorant cannot serve both.
+
+    Returns:
+        _FloatArray: Shape ``(points.size, n_deriv + 1, degree + 1)``, non-negative.
+    """
+    order = degree + 1
+    rows = n_deriv + 1
+    out = np.zeros((points.size, rows, order), dtype=np.float64)
+
+    if unit_spans:
+        begin, end = knots[degree], knots[len(knots) - degree - 1]
+        reference = (np.asarray(points, dtype=np.float64) - begin) / (end - begin)
+        inverse_span = 1.0 / (end - begin)
+    else:
+        reference = np.asarray(points, dtype=np.float64)
+        inverse_span = 1.0
+
+    exact_knots = np.asarray(knots, dtype=np.float64)
+    factorial = _wrapped_falling_factorials(degree, n_deriv)
+
+    for index in range(points.size):
+        span = degree if unit_spans else int(first_basis[index]) + degree
+        ndu = _ndu_majorant(
+            exact_knots,
+            degree,
+            span,
+            float(points[index]),
+            float(reference[index]),
+            unit_spans=unit_spans,
+        )
+        out[index, 0, :] = ndu[:, degree]
+        a = np.zeros((2, rows), dtype=np.float64)
+
+        for r in range(order):
+            s1, s2 = 0, 1
+            a[0, 0] = 1.0
+            for k in range(1, rows):
+                d = 0.0
+                rk, pk = r - k, degree - k
+                if r >= k:
+                    a[s2, 0] = a[s1, 0] / ndu[pk + 1, rk] if ndu[pk + 1, rk] else 0.0
+                    d = a[s2, 0] * ndu[rk, pk]
+                j1 = 1 if rk >= -1 else -rk
+                j2 = k - 1 if (r - 1) <= pk else degree - r
+                for j in range(j1, j2 + 1):
+                    # The first of the two sign changes: a difference becomes a sum.
+                    numerator = a[s1, j] + a[s1, j - 1]
+                    a[s2, j] = numerator / ndu[pk + 1, rk + j] if ndu[pk + 1, rk + j] else 0.0
+                    d += a[s2, j] * ndu[rk + j, pk]
+                if r <= pk:
+                    # The second: a negation becomes a modulus.
+                    a[s2, k] = a[s1, k - 1] / ndu[pk + 1, r] if ndu[pk + 1, r] else 0.0
+                    d += a[s2, k] * ndu[r, pk]
+                out[index, k, r] = d
+                s1, s2 = s2, s1
+
+    for k in range(1, rows):
+        out[:, k, :] *= abs(float(factorial[k])) * inverse_span**k
+    return out
+
+
+def _ndu_majorant(  # noqa: PLR0913
+    knots: _FloatArray,
+    degree: int,
+    span: int,
+    point: float,
+    reference_point: float,
+    *,
+    unit_spans: bool,
+) -> _FloatArray:
+    """The ``ndu`` table of A2.3 built on moduli, for either kernel variant.
+
+    For an in-domain point the knot differences are already non-negative, so taking
+    moduli changes nothing here and the table equals the kernel's. It is written on
+    moduli anyway, because the majorant's soundness must not depend on the caller
+    having clipped its points.
+
+    Args:
+        knots (_FloatArray): The knot vector, in ``float64``.
+        degree (int): The polynomial degree.
+        span (int): The point's knot span.
+        point (float): The evaluation point, in the knot vector's coordinate.
+        reference_point (float): The same point mapped onto ``[0, 1]``; used only by
+            the unit-span variant.
+        unit_spans (bool): ``True`` for the Bezier-like kernel, whose knot differences
+            are all one and whose triangle is built from ``s`` and ``1 - s``.
+
+    Returns:
+        _FloatArray: Shape ``(degree + 1, degree + 1)``, non-negative.
+    """
+    order = degree + 1
+    ndu = np.zeros((order, order), dtype=np.float64)
+    ndu[0, 0] = 1.0
+
+    for j in range(1, order):
+        saved = 0.0
+        for r in range(j):
+            if unit_spans:
+                ndu[j, r] = 1.0
+                left, right = abs(reference_point), abs(1.0 - reference_point)
+            else:
+                left = abs(point - knots[span + 1 - (j - r)])
+                right = abs(knots[span + r + 1] - point)
+                ndu[j, r] = right + left
+            denom = ndu[j, r]
+            temp = 0.0 if denom == 0.0 else ndu[r, j - 1] / denom
+            ndu[r, j] = saved + right * temp
+            saved = left * temp
+        ndu[j, j] = saved
+    return ndu
+
+
+def _wrapped_falling_factorials(degree: int, n_deriv: int) -> list[int]:
+    """``degree!/(degree-k)!`` as the kernel accumulates it, wrapping at signed int64.
+
+    The amplification has to bound what the kernel *computed*, so the wrapped factor is
+    the right one above degree 21 and the exact one would be wrong there.
+
+    Args:
+        degree (int): The polynomial degree.
+        n_deriv (int): The highest derivative order.
+
+    Returns:
+        list[int]: ``n_deriv + 1`` factors; entry 0 is unused and is 0.
+    """
+    mask = (1 << 64) - 1
+    factors = [0]
+    fac = degree
+    for k in range(1, n_deriv + 1):
+        factors.append(fac)
+        fac = (fac * (degree - k)) & mask
+        if fac >= 1 << 63:
+            fac -= 1 << 64
+    return factors
 
 
 def _companion(magnitudes: _FloatArray, dtype: Any) -> _FloatArray:
@@ -391,36 +590,57 @@ def _value_claim(reference: _FloatArray, degree: int, dtype: Any) -> ParityClaim
         accumulator=dtype,
         storage=dtype,
         amplification=_companion(reference, dtype),
-        why=_BOUNDED_BY_FMA,
+        why=_BOUNDED_BY_FMA_VALUES,
     )
 
 
-def _deriv_claim(reference: _FloatArray, degree: int, n_deriv: int, dtype: Any) -> ParityClaim:
+def _deriv_claim(  # noqa: PLR0913
+    knots: list[float],
+    degree: int,
+    n_deriv: int,
+    points: _FloatArray,
+    first_basis: npt.NDArray[np.int_],
+    dtype: Any,
+    *,
+    unit_spans: bool,
+) -> ParityClaim:
     """The parity claim for a derivative tabulation, conditional on the build.
 
-    The chain is longer than the value kernel's: A2.3 builds the same ``ndu`` triangle
-    in ``degree`` stages and then runs the ``a``-table recursion for up to ``n_deriv``
+    The chain is longer than the value kernel's: A2.3 builds the ``ndu`` triangle in
+    ``degree`` stages and then runs the ``a``-table recursion for up to ``n_deriv``
     more, so the stage count is their sum.
 
+    The amplification is :func:`_a23_majorant` and **not** the finished row. That
+    distinction is the whole of the derivation and it is not a refinement: on a fusing
+    build the finished row exceeded the observed difference on 31 of 418 cases, at both
+    widths, which is the signature Rule 10 names -- a structural shortfall rather than
+    rounding. The recursion is not convex, so its partial sums can exceed what survives
+    to the output.
+
     Args:
-        reference (_FloatArray): The Python backend's block.
+        knots (list[float]): The knot vector, needed to rebuild the majorant.
         degree (int): The polynomial degree.
         n_deriv (int): The highest derivative order.
+        points (_FloatArray): The evaluation points.
+        first_basis (npt.NDArray[np.int_]): The first-basis index per point.
         dtype (Any): The storage dtype.
+        unit_spans (bool): Whether the Bezier-like kernel ran; see
+            :func:`_a23_majorant`.
 
     Returns:
         ParityClaim: A bitwise claim where nothing can fuse, a bounded one otherwise.
     """
     if not contraction_may_fuse():
         return bitwise_parity(why=_EXACT_BY_BUILD)
+    majorant = _a23_majorant(knots, degree, n_deriv, points, first_basis, unit_spans=unit_spans)
     return bounded_parity(
         roundings=Roundings(
             stages=max(degree + n_deriv, 1), accumulator_per_stage=3, storage_per_stage=0
         ),
         accumulator=dtype,
         storage=dtype,
-        amplification=_companion(reference, dtype),
-        why=_BOUNDED_BY_FMA,
+        amplification=_companion(majorant, dtype),
+        why=_BOUNDED_BY_FMA_DERIVS,
     )
 
 
@@ -503,7 +723,15 @@ def test_general_knot_derivatives_match(
     assert_parity(
         actual.block,
         reference.block,
-        _deriv_claim(reference.block, degree, n_deriv, dtype),
+        _deriv_claim(
+            knots,
+            degree,
+            n_deriv,
+            points,
+            reference.first_basis,
+            dtype,
+            unit_spans=False,
+        ),
         context=f"tabulate_basis_derivatives {case} n_deriv={n_deriv} {np.dtype(dtype).name}",
     )
     assert np.array_equal(actual.first_basis, reference.first_basis)
@@ -519,6 +747,10 @@ def test_bezier_like_values_match(cpp_backend: None, case: str, dtype: Any) -> N
     change of variable is the *same numpy expression* on both sides, above the seam, so
     it is common mode and contributes nothing -- which is Rule 1's consequence applied
     here rather than restated.
+
+    **The claim is bitwise unconditionally**, unlike every other one in this file: that
+    recurrence has no fusable site, so contraction cannot reach it. See
+    :data:`_BEZIER_VALUES_EXACT`.
 
     Args:
         cpp_backend (None): Requires the extension.
@@ -539,7 +771,7 @@ def test_bezier_like_values_match(cpp_backend: None, case: str, dtype: Any) -> N
     assert_parity(
         actual.block,
         reference.block,
-        _value_claim(reference.block, degree, dtype),
+        bitwise_parity(why=_BEZIER_VALUES_EXACT),
         context=f"tabulate_basis bezier {case} {np.dtype(dtype).name}",
     )
     assert np.array_equal(actual.first_basis, reference.first_basis)
@@ -577,7 +809,15 @@ def test_bezier_like_derivatives_match(
     assert_parity(
         actual.block,
         reference.block,
-        _deriv_claim(reference.block, degree, n_deriv, dtype),
+        _deriv_claim(
+            knots,
+            degree,
+            n_deriv,
+            points,
+            reference.first_basis,
+            dtype,
+            unit_spans=True,
+        ),
         context=f"tabulate_basis_derivatives bezier {case} n_deriv={n_deriv} "
         f"{np.dtype(dtype).name}",
     )
@@ -603,12 +843,15 @@ def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: Any) 
     knots, degree = _GENERAL_KNOTS["clamped-uniform-p2"]
     points = np.array([0.1, 0.4, 0.9], dtype=dtype)
 
-    with use_backend(Backend.PYTHON):
-        space = BsplineSpace1D(np.array(knots, dtype=dtype), degree)
-        expected, _ = space.tabulate_basis(points)
-
     with use_backend(Backend.CPP):
         space = BsplineSpace1D(np.array(knots, dtype=dtype), degree)
+        # The reference is the SAME backend with a contiguous out, not the oracle. The
+        # question here is whether the adapter's buffer round-trip loses the answer,
+        # and comparing across backends would fold in the parity claim -- which on a
+        # fusing build is bounded rather than bitwise, so a bit-equality assertion
+        # would fail there for a reason that has nothing to do with the strides.
+        expected, expected_first = space.tabulate_basis(points)
+
         # Every other column of a wider array, so `out` is strided in its last axis.
         canvas = np.full((points.size, 2 * (degree + 1)), np.nan, dtype=dtype)
         strided = canvas[:, ::2]
@@ -618,9 +861,13 @@ def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: Any) 
 
     assert got is strided, "the caller's array must be returned, not a copy of it"
     assert not np.any(np.isnan(strided)), "the strided out was never written"
-    assert np.array_equal(strided, expected)
+    assert np.array_equal(strided, expected), (
+        "the same kernel on the same input through a strided out gave a different "
+        "answer, so the adapter's buffer round-trip is not transparent"
+    )
     assert got_first is indices
     assert np.all(indices >= 0), "the strided index array was never written"
+    assert np.array_equal(indices, expected_first)
 
 
 def test_the_seam_returns_kernels_for_every_available_backend() -> None:

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -400,6 +400,26 @@ def _a23_majorant(  # noqa: PLR0913
     one by induction, and the monotone partial sums make the final value majorise all
     of them.
 
+    **The claim is sound under a hypothesis, not unconditionally, and the hypothesis is
+    that no divisor the a-table uses is zero.** Step 1 of A2.3 guards its own division
+    (``denom == 0 ? 0 : ...``); step 2's three divisions by ``ndu[...]`` carry no guard
+    in either backend. Where one of them is zero the oracle raises
+    ``ZeroDivisionError`` and the C++ kernel returns ``nan``, while this majorant --
+    which *does* guard each division, returning ``0.0`` -- yields a finite all-zero
+    row. A finite zero bounds nothing, so the induction above does not reach that
+    input; it is not that the bound is loose there, it is that there is no bound.
+
+    That input is reachable: a space whose right end is clamped to multiplicity
+    ``degree + 2`` is accepted by the constructor, and the right domain endpoint on it
+    is such a point. **No case in this file constructs one** -- every clamped table
+    entry uses multiplicity exactly ``degree + 1`` -- so the hypothesis holds
+    throughout the suite, but it holds by the case list rather than by construction.
+
+    So the honest label for this bound is **sound under an unstated-until-now
+    hypothesis, and not shown tight**: there is no attainment check for it here, unlike
+    the sibling Bezier kernel's, which ``design/backend_parity.md`` Rule 10 records as
+    attained with a largest ratio of exactly 1.000000 over 75 563 entries.
+
     Run in ``float64`` throughout. The amplification is a magnitude rather than a
     computed value, so its own rounding is second order against the ``u`` it multiplies.
 
@@ -557,7 +577,8 @@ def _companion(magnitudes: _FloatArray, stages: int, dtype: Any) -> _FloatArray:
     ``design/backend_parity.md`` records as a correction the infrastructure PR had to
     make: without it the bound could be violated by a factor of ``1/u``.
 
-    The widening is ``(1 + gamma_m)`` with ``m = 3 * stages``, the reference backend's
+    The widening is ``(1 + gamma_m)`` with ``m = _FUSED_ROUNDINGS_PER_STAGE * stages``,
+    the reference backend's
     own relative forward error over the same chain the parity budget charges: the
     computed magnitude is within that of the true one, so scaling by it covers both. An
     earlier version multiplied by ``1 + 4u`` while this docstring claimed the
@@ -587,7 +608,7 @@ def _companion(magnitudes: _FloatArray, stages: int, dtype: Any) -> _FloatArray:
             would make the hull meaningless rather than merely loose.
     """
     u = unit_roundoff(dtype)
-    m = 3 * max(stages, 1)
+    m = _FUSED_ROUNDINGS_PER_STAGE * max(stages, 1)
     if m * u >= 0.5:
         raise ValueError(
             f"a chain of {stages} stages at {np.dtype(dtype).name} accumulates a "
@@ -642,11 +663,14 @@ def _deriv_claim(  # noqa: PLR0913
     those stages only inflates the tolerance on the rows that are not zero.
 
     The amplification is :func:`_a23_majorant` and **not** the finished row. That
-    distinction is the whole of the derivation and it is not a refinement: on a fusing
-    build the finished row exceeded the observed difference on 31 of 418 cases, at both
-    widths, which is the signature Rule 10 names -- a structural shortfall rather than
-    rounding. The recursion is not convex, so its partial sums can exceed what survives
-    to the output.
+    distinction is the whole of the derivation rather than a refinement of it: the
+    recursion is not convex, so its partial sums can exceed what survives to the
+    output, and the gap is orders of magnitude rather than a constant.
+    :func:`test_the_majorant_exceeds_the_finished_row_by_orders_of_magnitude` asserts
+    that gap, which is a property of the recursion and needs no fusing build to check.
+    Using the finished row instead was measured to fail on a fusing build, at both
+    widths identically -- the signature Rule 10 names for a structural shortfall rather
+    than for rounding.
 
     Args:
         knots (list[float]): The knot vector, needed to rebuild the majorant.
@@ -996,6 +1020,146 @@ def test_a_mixed_dtype_call_falls_back_and_says_so(
     assert np.array_equal(cpp_first, py_first)
 
 
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_the_majorant_exceeds_the_finished_row_by_orders_of_magnitude(
+    cpp_backend: None, dtype: Any
+) -> None:
+    """The finished derivative row cannot serve as the amplification, and by how much.
+
+    :func:`_deriv_claim` uses :func:`_a23_majorant` rather than the computed row, and
+    the reason is that A2.3 is **not convex**: its ``a``-table differences mean the
+    partial sums can be far larger than what survives the cancellation to the output,
+    and Rule 10 records that no telescoping argument recovers them. That is the
+    derivation; this is the measurement that says it matters in practice rather than
+    only in principle.
+
+    **The ratio is a property of the recursion, not of the build**, so this needs no
+    fusing build to check -- which is what makes it assertable at all, and which is
+    itself the evidence: measured independently, the excess agrees to within a few per
+    cent between ``float64`` and ``float32``, where anything build- or
+    rounding-dependent would not.
+
+    Bounded loosely on purpose. The claim that has to hold is "orders of magnitude, so
+    the finished row cannot serve", not a pinned figure; a pinned figure here would rot
+    the way a measured comment does.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_compiled_seed()
+    knots, degree = _HIGH_DEGREE_KNOTS[_VACUOUS_CASE]
+    n_deriv = degree
+    points = _evaluation_points(knots, degree, dtype)
+    reference = _tabulate(Backend.PYTHON, knots, degree, points, dtype, n_deriv)
+    majorant = _a23_majorant(
+        knots, degree, n_deriv, points, reference.first_basis, unit_spans=False
+    )
+    finished = np.abs(np.asarray(reference.block, dtype=np.float64))
+
+    normal = finished >= np.finfo(dtype).smallest_normal
+    assert normal.any()
+    excess = float(np.max(majorant[normal] / finished[normal]))
+    assert excess > 1.0e3, (
+        f"the majorant exceeds the finished row by only {excess:.3g} at degree {degree}. "
+        f"If that is now genuinely small, A2.3's cancellation has changed character and "
+        f"the choice of amplification should be re-derived -- the finished row would "
+        f"become defensible, and _deriv_claim's derivation text would no longer be true. "
+        f"It is not a threshold to relax: nothing about the recursion should move it"
+    )
+    # Compared against the **hulled** majorant, not the raw one, and the distinction is
+    # the hull's whole reason for existing. `_a23_majorant` bounds the *exact* value;
+    # `finished` is a *rounded* one, and where the row happens not to cancel -- an
+    # endpoint with a single active function -- the two are mathematically equal, so the
+    # rounded value can land an ulp above the exact bound. Measured: at float32 that
+    # happens on 1440 entries here and on none at float64, which is the signature of a
+    # width artifact rather than of a broken bound. `_companion` widens by the
+    # reference's own forward error for exactly this case.
+    hulled = _companion(majorant, degree + min(n_deriv, degree), dtype)
+    assert np.all(hulled[normal] >= finished[normal]), (
+        f"the hulled majorant is below the computed row on "
+        f"{int(np.count_nonzero(hulled[normal] < finished[normal]))} entries, so it is "
+        f"not a majorant at all and every bounded derivative claim built on it is void"
+    )
+
+
+_PERIODIC_KNOTS: tuple[list[float], int] = ([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2)
+"""A periodic space, which nothing else in this file or the C++ tests reaches.
+
+``find_span_and_first_basis`` has a genuinely different branch for a periodic space --
+it keeps the unclamped first-basis index, which the evaluation loop wraps modulo the
+control points -- and all four batch kernels reach it. Nothing in the dispatch refuses
+periodic, so it is a live path rather than dead code: this vector gives ``num_basis``
+3 and a domain of ``(2.0, 5.0)``, and both tabulations run on it.
+
+The existing periodic test in ``tests/test_bspline_basis_derivatives_1D.py`` is not
+coverage of this seam. It calls the Numba kernel directly, and its knot vector is
+refused by ``BsplineSpace1D``'s own validation, so it never reaches a backend at all.
+"""
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("n_deriv", [None, 0, 1, 3])
+def test_a_periodic_space_matches(cpp_backend: None, n_deriv: int | None, dtype: Any) -> None:
+    """The two backends agree on a periodic space, whose first-basis branch differs.
+
+    The only test anywhere that reaches the periodic arm of
+    ``find_span_and_first_basis``. Its ``first_basis`` is deliberately *un*clamped, so
+    a port that applied the non-periodic clamp regardless would pass every other case
+    in this file and fail here.
+
+    Args:
+        cpp_backend (None): Requires the extension.
+        n_deriv (int | None): Derivative order, or ``None`` for the value tabulation.
+        dtype (Any): The storage dtype.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    if n_deriv is not None:
+        demand_a_compiled_seed()
+    knots, degree = _PERIODIC_KNOTS
+
+    built = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = BsplineSpace1D(np.array(knots, dtype=dtype), degree, periodic=True)
+            begin, end = space.domain
+            points = np.linspace(float(begin), float(end), 11, dtype=dtype)
+            if n_deriv is None:
+                block, first = space.tabulate_basis(points)
+            else:
+                block, first = space.tabulate_basis_derivatives(points, n_deriv)
+        built[backend] = _Tabulation(block=block, first_basis=first)
+
+    reference, actual = built[Backend.PYTHON], built[Backend.CPP]
+    claim = (
+        _value_claim(reference.block, degree, dtype)
+        if n_deriv is None
+        else _deriv_claim(
+            knots, degree, n_deriv, points, reference.first_basis, dtype, unit_spans=False
+        )
+    )
+    assert_parity(
+        actual.block,
+        reference.block,
+        claim,
+        context=f"periodic space, n_deriv={n_deriv}, {np.dtype(dtype).name}",
+    )
+    assert np.array_equal(actual.first_basis, reference.first_basis)
+    # The invariant the periodic branch exists to keep: the index is NOT clamped to
+    # `num_basis - order`, so it can exceed it and the caller wraps it modulo
+    # `num_basis`. A port applying the non-periodic clamp would cap it here.
+    with use_backend(Backend.PYTHON):
+        space = BsplineSpace1D(np.array(knots, dtype=dtype), degree, periodic=True)
+    assert int(np.max(actual.first_basis)) > space.num_basis - degree - 1, (
+        "the periodic first-basis index never exceeded the non-periodic clamp, so this "
+        "case does not actually distinguish the two branches and the claim above is "
+        "not exercising the periodic arm"
+    )
+
+
 def test_the_seam_returns_kernels_for_every_available_backend() -> None:
     """Every backend the installation offers answers all three catalogue functions.
 
@@ -1082,6 +1246,20 @@ def _falling_factorial(degree: int, n_deriv: int) -> int:
         largest = max(largest, value)
     return largest
 
+
+_FUSED_ROUNDINGS_PER_STAGE = 3
+"""Accumulator roundings charged per fused site, from ``design/backend_parity.md`` Rule 10.
+
+At a fused site the oracle computes ``fl(a + fl(b*c))`` and the C++ backend
+``fl(a + b*c)``; expanding both with ``|delta| <= u`` bounds their difference by
+``|b*c| u (1 + u) + |a + b*c| 2u``, which is three accumulator roundings. Inherited from
+that rule rather than re-derived here.
+
+Named once because it is used twice -- as ``Roundings.accumulator_per_stage`` in the
+claim, and as the hull's widening budget in :func:`_companion` -- and the two must
+describe the same chain. Three rounding counts in this file were revised once already,
+so a second literal is not a hypothetical drift risk.
+"""
 
 _VACUOUS_CASE = "wrapping-p22"
 """The one case whose derivative bound is too loose to assert anything, everywhere.


### PR DESCRIPTION
**14 commits, 19 files, +5775/−30.** Both numbers read off `git log proto/cpp..HEAD` and
`git diff --stat` rather than recalled — the commit count is fourteen, not the thirteen my own
notes had, and the insertion count grew from 5417 with the correction rounds.

## What this unblocks

The 1D B-spline basis tabulation, ported as a free-function header over `const BsplineSpace1D&`,
which is what `cpp/include/pantr/bspline/space_1d.hpp:6-20` declared the shape of when it said
the space type owns no operations. It is the piece three fronts were waiting on: cut 2 of #397,
**all** of #400, and four methods of #398 — `evaluate`, `evaluate_derivatives`, `to_beziers`, and
`locate` by an indirect dependency through `spline.evaluate`.

## Reuse is the argument, and it was checked rather than asserted

`basis/bernstein.hpp` already ported the Bernstein value kernels, and the Bézier-like fast path
of both oracle entry points is Bernstein evaluation plus a chain-rule scaling. A review verified
line for line that **no second Bernstein or binomial recurrence hides in `tabulate.hpp`**, and
that the two headers from earlier cuts changed additively: 2 documentation lines removed from
`bernstein.hpp`, **zero** from `binomial.hpp`, no existing function touched.

Both additions have a layering reason rather than a convenience one:

- **`bernstein.hpp` gains `tabulate_bernstein_deriv_1d`**, because the oracle's Bézier-like
  *derivative* path calls `_tabulate_Bernstein_basis_deriv_1D_core` and nothing had ported it —
  that header covered only the three value kernels. It cannot live under `bspline/`: it ports
  `src/pantr/basis/_basis_core.py`, and putting it there would make `pantr.basis`'s own kernel
  reachable only through `pantr.bspline`. It is **not** the ratio recurrence with a derivative
  bolted on; it is A2.3 specialised to unit knot spans, a different algorithm whose row 0 differs
  from `tabulate_bernstein_1d`'s by a rounding, which is why the oracle keeps both.
- **`binomial.hpp` gains `wrapping_mul`**, because both new kernels reproduce numba's int64
  falling-factorial wrap and signed overflow in C++ is undefined rather than wrapping. Two
  headers in two packages need it, so it cannot live in either, and that file's own opening
  argument is exactly this. Its comment now records that it carries **both** answers to the int64
  question and why: `bincoeff` *guards* the envelope because its callers can refuse
  out-of-envelope input in Layer 2, where the refusal is shared by both backends; the tabulation
  *reproduces* the wrap because nothing in Layer 2 refuses that call.

## The independent check, and the claim that had to be rebuilt

Parity says the two backends agree, not that either is right, so the accuracy check is separate
and uses closed forms: partition of unity, the vanishing derivative sums, and Marsden's identity
taking **every** power `r ∈ [0, p]` rather than just Greville's `r = 1`, which is what makes
`p + 1` independent functionals fix each band.

**One claim in the harness was false and this cut is where it was found.** `_deriv_claim` passed
the *finished* derivative row as `bounded_parity`'s amplification, while its `why` text — quoted
verbatim in every failure message — said it was the A2.3 majorant with every coefficient replaced
by its modulus. It did not compute that. The shipped build takes the bitwise arm, so nothing
caught it; built at `-march=native`, cases failed.

Why the finished row cannot serve, and this half is proved rather than observed: A2.2's recurrence
is **convex** — the two weights are `right[r+1]/denom` and `left[j-r]/denom`, and `denom` is
exactly their sum, a difference of two knots whose index gap is `j ≥ 1`, so both are non-negative
for any non-decreasing knot vector — and the modulus companion therefore *is* the computed row.
**A2.3 differences**: its `a`-table forms `a[s1,j] - a[s1,j-1]` and `-a[s1,k-1]`. A non-convex
linear recursion's partial sums are not bounded by what survives to the output, and the gap is
not academic: the majorant exceeds the finished row by about `6.4e5` at degree 22, measured
independently at both widths (6.385e5 float64, 6.194e5 float32, within 3%).

`_a23_majorant` replaces it, and its label is **honest about what it is**: sound under a stated
hypothesis — no a-table divisor may be zero — and *not shown tight*, since attainment was not
re-established for this kernel. Three further quantities are labelled observed-not-proved in the
file: that the bound is non-vacuous, that it is exceeded nowhere in the matrix, and that the
per-site budget of three accumulator roundings is Rule 10's, inherited rather than re-derived.

**Three rounding counts were under-counts, found by auditing rather than by a test** — the
dangerous direction, since a bound tighter than derivable can be exceeded by correct code and only
the margin was absorbing it. The A2.3 chain was charged 3 roundings per `a`-table stage where the
kernel commits 4 plus one for the factorial scaling, and both Marsden bounds had inherited a
summation term Marsden does not have. Each count now lives in a named function that states what it
counted and against which kernel, and a verifier recounted all three operation by operation.

One region is deliberately unguarded **and named**, per Rule 8: at degree 22 in float32 the
majorant's excess swallows a handful of values, and
`test_the_vacuous_region_is_named_and_still_vacuous` enumerates it and fails if it ever becomes
empty. Float32 only — the excess is a property of the recursion, identical at both widths, so only
the narrow format's budget reaches it.

## Where the two backends can disagree, and why it was not patched

On `knots = [0,0,0,0,0.5,1,1,1,1,1]`, `degree = 3`, at the right domain endpoint, Python raises
`ZeroDivisionError` while C++ returns with 9 of 16 entries non-finite. **Reproduced
independently** against this branch's own build, switching backends with `use_backend`:
Python raises, C++ returns shape `(1, 4, 4)` — 16 entries, 9 non-finite, sum `nan`. `PANTR_BACKEND` converts an
exception into a silent nan, on an input the constructor accepts.

**Aborted after one attempt, with both rejected guards recorded in the header:**

- Guarding step 2's divisions the way step 1 guards its own is provably behaviour-preserving — it
  can only fire where the oracle divides by zero, and there the oracle returns nothing at all —
  but it turns the nan into a finite zero, which is a quieter wrong answer rather than a fix.
- Detecting the case structurally ("the point's knot window contains a zero-width interval") was
  **measured over-broad**: the suite's own `empty-span-p3` has four zero-width intervals in every
  window tested and both backends serve it correctly, so the test would route working C++ cases to
  numba and widen the fallback.

The upstream cause is separate and pre-existing: that same space also makes `tabulate_basis`
return a row summing to **0** instead of 1. Closing the constructor defect retires this divergence
with it, because the input stops being constructible. No test here trips it — every knot vector in
the suite has clamped-end multiplicity exactly `degree + 1`, checked by enumeration.

## Reviewed twice, and the second pass earned its place

A reviewer covered the code and a verifier the claims; then a second reviewer covered **only the
correction commit**, because two of three correction rounds in this project have themselves been
defective. It found one: a named constant introduced to stop two literals drifting had been
applied to one site and its docstring asserted it was used at the others. Now applied at all four,
defined before first use, with the docstring recording that the constant was itself shipped
half-applied — the drift it guards against being the one that actually happened.

That makes **four** instances in this cut of one defect class — a claim in prose that the code
beside it contradicts — and not one of them could fail a test.

## The accuracy battery is not redundant, and that was mutation-tested rather than assumed

Four mutations, each showing which check is load-bearing and which would have shrugged:

| mutation | what still passed | what caught it |
|---|---|---|
| carry a wide accumulator | — | 10 of 15 float32 value cases |
| narrow the factorial | — | 4 cases |
| reverse a row | **all 52** partition-of-unity cases | 18 Marsden cases |
| drop the factorial | **all 52** row-sum *and* all 52 zero-row cases | 16 differentiated-Marsden cases |

The last two are the point: partition of unity and the vanishing derivative sums both pass a
reversed or unscaled row, so Marsden taking every power `r ∈ [0, p]` is what actually pins the
band rather than decorating it.

## Three calls that are yours, not mine

- **The mixed-dtype contract.** `float32` knots evaluated at `float64` points is supported and
  tested by name; the C++ kernels are templated on one scalar type and cannot express it, so the
  adapter routes that call to the oracle. The three options are written out at the predicate and
  the one taken decides nothing permanent. What is needed is a ruling on whether a mixed-width
  answer is wanted at all.
- **Binding the space-level free functions.** `tabulate_basis_1d` and
  `tabulate_basis_derivatives_1d` are reachable only from C++ today, so the dispatch the
  Numba-free end state will use is exercised by `ctest` and not by parity.
- **Splitting `_bspline_basis_core.py`** the way the extraction port is split. Two deferred
  imports stand in. The split is the better shape but moves roughly 700 lines of private symbols,
  and the downstream consumer's largest exposure is `bspline`.

## Two aborted detours and two unsettled suspicions, all disclosed

**`B1` aborted.** `tabulate_basis` and `tabulate_basis_derivatives` never call
`wait_for_jit_warmup()` although they dispatch to `parallel=True` kernels warmed on the background
thread. The abort could not be reproduced in 6 warm and 3 cold runs, and this is a repo-wide
inconsistency across many modules rather than one line, so it was left alone and is unchanged by
this cut. (#446 closes the same gap for the extraction path, where the funnel is a single pair of
functions.)

**`B2` aborted** — the divergence above, with both rejected guards recorded.

**`U`** — a NaN out of `_basis_derivs_point` at degree 18 in float32 on a pathological knot
vector, unreachable from any case in the suite. **`U`** — a Fortran-ordered `out` with
multi-dimensional `pts` may not be written through by `reshape`; pre-existing and present in both
backends.

## Checks

As the author reports them, from the worktree's own `.venv`: `ruff check` clean, `ruff format --check` 347 files, `mypy` 322
files, `lint-imports` 2 kept / 0 broken. `ctest --preset gcc` 52/52 and `--preset gcc-debug`
(ASan + UBSan, preconditions live) 58/58. The parity file: 550 passed shipped, **551 at
`-march=native`** where the bounded arm of every conditional claim is live, and 246 passed / 309
skipped under `NUMBA_DISABLE_JIT=1`. `scripts/ci_local.sh` **52 PASS / 2 FAIL / 0 SKIP** — the branch
baseline exactly — the two failures being the pre-existing `floor: g++-10` pair, with the Python
half confirmed to have actually executed rather than skipped (its five PASS lines named).

**Re-run independently, and it confirms.** The script writes its summary to stdout rather than
into its log directory, so the author's tally could not be read back from disk — so the whole gate
was run again on this tree with nothing else in flight, which is the "last and alone" condition
actually satisfied rather than approximated:

```
52 PASS   2 FAIL   0 SKIP
FAIL    floor: g++-10 build (-Werror)
FAIL    floor: g++-10 ctest
PASS    editable install · parity: C++ vs numba · change_basis on python · change_basis on cpp
        · full suite on python · full suite on cpp
```

Zero SKIP is the load-bearing part: the Python half needs a worktree-local `.venv` and records a
SKIP for the entire section without one, so a nonzero SKIP count is how a green-looking run hides
having never executed. The two failures are the pre-existing `floor: g++-10` pair, unchanged.

Nothing was installed into the shared conda environment; the editable install lives in this
worktree's own `.venv`.

## No merge

Opened for review only. The merge authority granted on 4 September expired with the previous
stretch. This branch shares no file with #443, #444, #445 or #446 — 37 paths across the five,
zero duplicated — so they can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
