### PR TITLE
feat(bspline): port the structural knot-vector operations to C++

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -125,7 +125,8 @@ if(PANTR_NANOBIND_SPLIT)
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
                       bspline_extraction.cpp bspline_extraction_operators.cpp
                       bspline_basis.cpp
-                      bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp)
+                      bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp
+                      bspline_structural.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
@@ -135,7 +136,8 @@ else()
                       quad_types.cpp bezier_type.cpp bspline_types.cpp
                       bspline_extraction.cpp bspline_extraction_operators.cpp
                       bspline_basis.cpp
-                      bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp)
+                      bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp
+                      bspline_structural.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bspline_structural.cpp
+++ b/cpp/bindings/bspline_structural.cpp
@@ -1,0 +1,171 @@
+/// \file
+/// nanobind bindings for the structural operations on a `pantr::bspline::Bspline`.
+///
+/// Four entry points -- `open_bspline`, `split_bspline`, `slice_bspline` and
+/// `slice_bspline_point` -- each registered twice, once per storage format, exactly as
+/// `bspline_refinement.cpp` and `bezier.cpp` register theirs. Overload resolution
+/// separates the two instantiations on the field handle's own class, so none needs a
+/// dtype argument and none can be reached with a mismatched one.
+///
+/// ## What crosses, and what does not
+///
+/// **The field itself crosses, not its arrays**, for the reason
+/// `bspline_refinement.cpp` states in full: these are operations on a domain type C++
+/// owns since the 2026-08-27 amendment to `design/cross_backend_types.md`, and
+/// unpacking a field into a knot vector and a control net on one side and reassembling
+/// it on the other is the shape that amendment forbids. The arguments that cross are
+/// plain scalars -- an axis, a side, a parameter -- with no invariant to lose.
+///
+/// `split_bspline` returns a **pair**, which `nanobind/stl/pair.h` converts to a
+/// 2-tuple; `split_bezier` already crosses that way and this is the same shape.
+///
+/// ## Why `slice_bspline_point` fills a buffer while the others return a value
+///
+/// Because its result is a plain array of known length rather than a field, which is
+/// the same line `bezier.cpp` draws between `slice_bezier` and `slice_bezier_point`.
+/// The length is the net's component count, which the caller already knows, so letting
+/// Python own the allocation keeps the dtype and the read-only policy where the rest of
+/// `pantr`'s `out=` convention keeps them, and this file allocates nothing.
+///
+/// **The weight column is still on.** `pantr::bspline::slice_point` returns homogeneous
+/// components and `pantr.bspline._structural_backend` divides, because the oracle's
+/// division is a numpy expression and reproducing it here would be a second spelling of
+/// it. `pantr/bspline/structural.hpp` records the same for its own reason.
+///
+/// ## `boundary` is deliberately not bound
+///
+/// `pantr::bspline::boundary` exists for a C++ caller, and
+/// `pantr.bspline.Bspline.boundary` is defined as a `slice` at a domain endpoint -- so
+/// it reaches C++ through `slice_bspline` and a binding of its own would be public
+/// surface with no caller. `pantr._pantr_cpp.bezier_boundary` is exactly that today,
+/// bound and stubbed and reached by nothing in `src/` or `tests/`; one such precedent
+/// is enough.
+///
+/// ## What this file validates: nothing
+///
+/// `pantr/bspline/structural.hpp` validates its own arguments and throws
+/// `std::invalid_argument`, which nanobind maps to `ValueError` preserving `what()`.
+/// The messages are the oracle's character for character;
+/// `tests/parity/test_bspline_structural.py` compares the two texts rather than just
+/// the exception type.
+///
+/// Two refusals cannot be reached from Python and stay documented rather than tested
+/// against the oracle: `slice_bspline`'s "dimension at least two", which
+/// `pantr.bspline.Bspline.slice` routes past by calling `slice_bspline_point` instead,
+/// and `slice_bspline`'s out-of-domain message at `float32`, whose oracle interpolates
+/// a numpy scalar rather than a Python float. The header's file comment carries that
+/// second one in full.
+///
+/// ## The GIL is held through the computation
+///
+/// For `bspline_refinement.cpp`'s reason, unchanged: the space handles reachable from
+/// the field were created by `nanobind/stl/shared_ptr.h`, so their deleter is
+/// `py_deleter`, which touches a Python refcount. Dropping the last reference to one
+/// with the GIL released would be a crash rather than a slowdown.
+///
+/// `slice_bspline_point` is the one entry point whose whole body could run without it
+/// -- it reads `T` and writes `T` -- but it is also the cheapest of the four, so
+/// releasing the GIL around it would buy a handful of nanoseconds and add a rule a
+/// reader has to check. If a slice sweep ever shows up in a profile, the release
+/// belongs around `corner_cut_along_axis` alone.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/shared_ptr.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/structural.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+/// A writeable, contiguous 1-D array as nanobind sees it.
+template <class T>
+using out_vec = nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// The field re-expressed over clamped, non-periodic knot vectors.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field The field to convert.
+/// \return The open field.
+template <class T>
+pantr::bspline::Bspline<T> bind_to_open(const pantr::bspline::Bspline<T>& field) {
+    return pantr::bspline::to_open<T>(field);
+}
+
+/// The field cut in two at a parameter of one direction.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field The field to split.
+/// \param direction The direction to split.
+/// \param value The parameter to split at.
+/// \return The left and right halves, as a 2-tuple on the Python side.
+template <class T>
+std::pair<pantr::bspline::Bspline<T>, pantr::bspline::Bspline<T>>
+bind_split(const pantr::bspline::Bspline<T>& field, std::int64_t direction, double value) {
+    return pantr::bspline::split<T>(field, direction, value);
+}
+
+/// The field with one direction fixed at a value, so one dimension fewer.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field The field to slice, of dimension at least two.
+/// \param axis The direction to fix.
+/// \param value The parameter to fix it at.
+/// \return The sliced field.
+template <class T>
+pantr::bspline::Bspline<T> bind_slice(const pantr::bspline::Bspline<T>& field,
+                                      std::int64_t axis, double value) {
+    return pantr::bspline::slice<T>(field, axis, value);
+}
+
+/// The point a one-dimensional field takes at a parameter, in homogeneous components.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field A one-dimensional field.
+/// \param value The parameter.
+/// \param out The destination, of length `field.net().num_components()`.
+/// \throws nanobind::value_error If `out` is not that long.
+template <class T>
+void bind_slice_point(const pantr::bspline::Bspline<T>& field, double value, out_vec<T> out) {
+    const std::vector<T> point = pantr::bspline::slice_point<T>(field, value);
+    if (out.shape(0) != point.size()) {
+        throw nb::value_error(("out has length " + std::to_string(out.shape(0))
+                               + ", but this call needs " + std::to_string(point.size()))
+                                  .c_str());
+    }
+    for (std::size_t i = 0; i < point.size(); ++i) {
+        out(i) = point[i];
+    }
+}
+
+}  // namespace
+
+void register_bspline_structural(nb::module_& m) {
+    m.def("open_bspline", &bind_to_open<double>, nb::arg("bspline"));
+    m.def("open_bspline", &bind_to_open<float>, nb::arg("bspline"));
+
+    m.def("split_bspline", &bind_split<double>, nb::arg("bspline"), nb::arg("direction"),
+          nb::arg("value"));
+    m.def("split_bspline", &bind_split<float>, nb::arg("bspline"), nb::arg("direction"),
+          nb::arg("value"));
+
+    m.def("slice_bspline", &bind_slice<double>, nb::arg("bspline"), nb::arg("axis"),
+          nb::arg("value"));
+    m.def("slice_bspline", &bind_slice<float>, nb::arg("bspline"), nb::arg("axis"),
+          nb::arg("value"));
+
+    m.def("slice_bspline_point", &bind_slice_point<double>, nb::arg("bspline"),
+          nb::arg("value"), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("slice_bspline_point", &bind_slice_point<float>, nb::arg("bspline"), nb::arg("value"),
+          nb::kw_only(), nb::arg("out").noconvert());
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -90,6 +90,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_bspline_thb_space(m);
     register_bspline_type(m);
     register_bspline_refinement(m);
+    register_bspline_structural(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -139,6 +139,17 @@ void register_bspline_type(nanobind::module_& m);
 /// periodic direction is refused -- argue from somewhere else entirely.
 void register_bspline_refinement(nanobind::module_& m);
 
+/// Register the structural operations on a `pantr.bspline.Bspline`.
+///
+/// Its own entry point rather than four more functions inside
+/// `register_bspline_refinement`, for the reason that one is separate from
+/// `register_bspline_type`: refining a field and cutting one down are separate ports
+/// with separate parity claims, and this one's decisions -- why a one-dimensional
+/// slice is a second function, why its point crosses as an `out=` buffer, why the
+/// boundary is not bound at all -- argue from somewhere else entirely. Unlike
+/// refinement, none of these refuses a periodic direction.
+void register_bspline_structural(nanobind::module_& m);
+
 /// Register `pantr.bspline`'s Bézier extraction operator builder and its mask.
 ///
 /// Separate from `register_bspline_extraction` because the two are separate ports

--- a/cpp/include/pantr/bspline/structural.hpp
+++ b/cpp/include/pantr/bspline/structural.hpp
@@ -1,0 +1,1057 @@
+#pragma once
+
+/// \file
+/// Structural operations on a B-spline field: the open conversion, splitting,
+/// slicing and the boundary.
+///
+/// Ports `pantr.bspline.Bspline.to_open_bspline`, `.split`, `.slice` and
+/// `.boundary`, whose substance is `_bspline_knot_insertion.py`'s
+/// `_to_open_bspline_1d_impl` and `_to_open_bspline_impl`, `_bspline_split.py` and
+/// `_bspline_slice.py`. The Python side stays as the parity oracle.
+///
+/// ## What this file adds, and what it only calls
+///
+/// The open conversion and the split are **knot insertion with a different
+/// bookkeeping around it**, so neither carries any new numerics:
+///
+///  - `to_open` raises each end's multiplicity to `degree + 1` and drops the knots
+///    that fall outside the domain,
+///  - `split` raises the split value's multiplicity to `degree + 1` and cuts the
+///    knot vector and the net in two.
+///
+/// Both reach `pantr/bspline/knot_insertion.hpp`'s `inserted_knot_vector` and
+/// `oslo_bands_1d` and `pantr/bspline/refinement.hpp`'s `refine_along_axis` for the
+/// whole of that. **There is no second Oslo recurrence here, no second merge and no
+/// second two-scale sweep**; a reader looking for the recurrence should read the
+/// first of those files, and a reader looking for what a *field* does with it the
+/// second.
+///
+/// **The one new numerical kernel is `corner_cut_along_axis`**, the de Boor corner
+/// cut the slice is built on (Piegl and Tiller, *The NURBS Book*, A5.1
+/// `CurvePntByCornerCut`). It is genuinely new work rather than a rearrangement of
+/// something present: nothing in this tree evaluates a B-spline yet, because basis
+/// tabulation is its own port. The corner cut needs none of it -- it reads control
+/// points and knots and never touches a basis function -- which is why the slice is
+/// portable ahead of `Bspline::evaluate`.
+///
+/// The two remaining pieces of bookkeeping are `select_rows_along_axis`, which is one
+/// primitive standing in for three row selections the oracle spells three ways (a
+/// periodic net's modulo wrap, the trim of an open conversion, and the two halves of
+/// a split), and the wrapper-level argument checks.
+///
+/// ## Free functions, not methods
+///
+/// `pantr/bspline/bspline.hpp` lists "the boundary and periodic conversions, ...
+/// splitting, slicing" among the computations *over* a field rather than properties
+/// *of* one, and states that each is "a separate port over free functions taking a
+/// `const Bspline&`". `pantr/bspline/space_1d.hpp:6-20` and
+/// `pantr/bspline/space_nd.hpp` draw the same line for a space, and
+/// `pantr/bspline/refinement.hpp` already follows it. So every entry point below
+/// takes a `const Bspline<T>&` and returns a new field; the type has no mutator and
+/// this file adds none.
+///
+/// The names and the shapes are `pantr/bezier/shape.hpp`'s, deliberately: that file
+/// already ported the same four operations for a Bézier, and `split` returning a
+/// `std::pair`, `slice` refusing a one-dimensional field, `slice_point` serving that
+/// case instead and `boundary` being defined as a `slice` are its four decisions
+/// rather than four fresh ones. A caller who has learned one package's spelling has
+/// learned the other's.
+///
+/// ## Why a one-dimensional slice is a second function
+///
+/// The oracle returns a `Bspline` for `dim >= 2` and a numpy array for `dim == 1`,
+/// and C++ cannot return one type or the other. `slice` therefore refuses a
+/// one-dimensional field and `slice_point` serves it, which is exactly what
+/// `pantr/bezier/shape.hpp` does and for the same reason. **The projection of a
+/// rational result is the caller's**, as it is there: `slice_point` hands back the
+/// homogeneous components with the weight column still on, and the oracle's
+/// `result[:-1] / result[-1]` stays in the wrapper, where it is one numpy division
+/// on both backends instead of two spellings of one.
+///
+/// ## The floating-point discipline, quantity by quantity
+///
+/// `design/backend_parity.md` Rule 9 is that an oracle's arithmetic width is a
+/// per-kernel fact rather than a module convention, and this file is where that has
+/// the most teeth in the port so far: the oracle mixes Python scalars and numpy
+/// arrays inside single expressions, and the two round differently at `float32`.
+/// Each site below was settled by **executing** the oracle rather than by reading
+/// it.
+///
+/// **The corner cut computes its weights in `double` and applies them in `T`.**
+/// `_slice_bspline_1d` forms `left_knot`, `right_knot`, `denom` and `alpha` through
+/// `float(...)`, so all four are Python floats and the arithmetic is `double`
+/// whatever the knots are stored in. It then writes
+/// `R[i] = alpha * R[i + 1] + (1.0 - alpha) * R[i]`, where `R` is a `T` array and
+/// `alpha` a Python float -- and under NEP 50 a Python float is *weak*, so both
+/// weights are rounded to `T` and the whole update runs in `T`. Measured at
+/// `float32` on a case where the two differ: the `T` update gives `1.2469137` and a
+/// `double` update rounded once at the end gives `1.2469136`. Computing the weights
+/// in `T`, or the update in `double`, would each be a divergence, in opposite
+/// directions.
+///
+/// **The span search and the multiplicity count are `double`.** `_find_span` and
+/// `_count_multiplicity` reach every knot through `float(knots[i])`, so both
+/// comparisons widen first. `np.searchsorted` also compares in `double` against a
+/// `double` needle -- measured, and not what NEP 50 would suggest, because
+/// `searchsorted` promotes rather than weakening its needle. So the span search is
+/// `std::upper_bound`/`std::lower_bound` over the knots read as `double`.
+///
+/// **The end multiplicities of the open conversion, and the split's multiplicity
+/// count, are `T`.** These are the sites that go the other way.
+/// `np.sum(np.abs(knots[: p + 1] - a) <= tol)` is a numpy array expression, so the
+/// Python float `a` is weakened to `T`, the difference is formed in `T`, **and the
+/// `double` `tol` is weakened to `T` before the comparison** -- measured: at
+/// `float32`, `x <= tol` and `x <= float32(tol)` genuinely disagree for a `tol` that
+/// is not representable, and `numpy` gives the second. `split`'s
+/// `np.sum(np.abs(knots - value) <= tol)` is the same shape. So `same_knot_in_storage`
+/// below rounds the tolerance rather than widening the difference.
+///
+/// That is the opposite convention from `inserted_knot_vector`'s domain check in
+/// `pantr/bspline/knot_insertion.hpp`, which widens the difference to `double`. The
+/// two are not inconsistent about the same predicate: **they transcribe two
+/// different oracle expressions.** Whether that file's own is faithful is a question
+/// about `_is_in_domain_impl` and not about this one, and it is raised rather than
+/// answered here -- no path through this file depends on the answer, because every
+/// value this file hands that function is a knot of the vector it is inserting into
+/// or a value the wrapper has already put strictly inside the domain, and in both
+/// cases the tolerance leg of its predicate is never consulted.
+///
+/// **The refined knot vectors and the two-scale sweep are unchanged.**
+/// `inserted_knot_vector` and `refine_along_axis` carry their own derivations, and
+/// nothing here re-rounds their output.
+///
+/// **The strided sweep replaces the oracle's transpose, and cannot change a bit.**
+/// The oracle calls `_flatten_along_axis`, which is `np.moveaxis` plus
+/// `np.ascontiguousarray`: a permutation of values, not an arithmetic step. Every
+/// primitive below takes the axis's `outer` and `inner` extents instead, which is
+/// `refine_along_axis`'s own shape. The claim that this is free is worth stating
+/// precisely rather than by analogy: in `corner_cut_along_axis`, output coefficient
+/// `(o, k)` is a function of `values(o, ., k)` alone, and the sequence of operations
+/// on those operands is fixed by `j` and `i`; so the loops over `o` and over `k` are
+/// loops over independent destinations, and permuting them changes no operation and
+/// no operand. `select_rows_along_axis` performs no arithmetic at all.
+///
+/// Under this build -- `-ffp-contract=on`, no `-march`, so baseline x86-64 with no
+/// FMA to fuse into, `cpp/README.md` -- the two backends therefore execute the same
+/// IEEE-754 operations in the same order and every coefficient is bit-identical.
+/// That is a property of the *host* rather than of the code, which is Rule 7: a
+/// target with an FMA fuses the corner cut's `wa * R[i + 1] + wb * R[i]` and the
+/// claim becomes Rule 10's budget. `pantr._pantr_cpp.__fp_contract__` is the gate
+/// that tells them apart.
+///
+/// ## What is not ported, and it is a declared boundary
+///
+/// **`to_periodic` is not here, and neither is `remove_knots`.** Both decide
+/// *whether an operation is admissible* by a tolerance on a **geometric** quantity
+/// rather than by locating a knot: `_to_periodic_bspline_1d_impl` refuses a field
+/// whose endpoints differ by more than `max(tol, 100 * eps * max(|ctrl|, 1))` and
+/// again whose least-squares residual exceeds the same bound, and it reaches
+/// `numpy.linalg.qr` to get that residual at all. A verdict of that kind is not the
+/// same kind of work as the four operations here, whose every tolerance only ever
+/// answers "is this the same knot"; and a QR whose factorization is LAPACK's on one
+/// side and Eigen's on the other cannot be claimed bit-identical, so its parity
+/// statement is a derivation this file does not have. It gets its own port, with
+/// `remove_knots`.
+///
+/// Nothing here needs it: `split` converts a periodic direction to the open form and
+/// returns two non-periodic halves, `slice` expands a periodic net by its own modulo
+/// wrap, and `to_open` is the conversion. **So, unlike
+/// `pantr/bspline/refinement.hpp`, no entry point below refuses a periodic
+/// direction.**
+///
+/// ## Validating rather than asserting
+///
+/// This is the C++ counterpart of Layer 2, so it validates and throws in a release
+/// build as much as in a debug one, with the oracle's messages character for
+/// character. `pantr/core/error.hpp` sets the split: value and range checks here,
+/// type-kind checks in the Python wrapper.
+///
+/// Several of the refusals below are the oracle's **Layer 1** checks -- the
+/// direction and axis ranges, the strictly-inside-the-domain test, the in-domain
+/// test and the side. They are near-vacuous on the Python path, where
+/// `pantr.bspline.Bspline` has already made them, and load-bearing for a C++ caller
+/// with no wrapper in front of it. That is the same reason
+/// `pantr/bspline/refinement.hpp` restates three of `insert_knots`' Layer 1 checks
+/// and `pantr/bspline/bspline.hpp` re-checks the coefficient count its own wrapper
+/// checked.
+///
+/// **One of those texts cannot be reproduced at `float32`, and no Python caller can
+/// reach it.** `Bspline.slice`'s out-of-domain message interpolates
+/// `space.domain[0]`, which is a *numpy scalar* of the storage format rather than a
+/// Python float, so `numpy` renders it at `float32` precision -- `0.1` where
+/// `pantr::detail::format_scalar` gives `0.10000000149011612`, because that function
+/// widens to `double` first and every other message in the port needs it to. The
+/// wrapper refuses an out-of-domain value before dispatching, so the divergence is
+/// unreachable from Python and `tests/parity/test_bspline_structural.py` pins the
+/// wrapper's text on both backends instead. Changing `format_scalar` to render at
+/// the storage width would fix this message and break every message
+/// `pantr/bspline/knot_insertion.hpp` already matches, whose oracle *does* go
+/// through `float(...)`.
+///
+/// ## Thread safety
+///
+/// Every entry point reads its argument and allocates its result, and every type
+/// they touch is immutable. They are safe to call concurrently on the same field
+/// with no external locking, which is the contract
+/// `design/bspline_derived_caches.md` states for this package.
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/bezier/control_net.hpp"
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/knot_insertion.hpp"
+#include "pantr/bspline/knots.hpp"
+#include "pantr/bspline/refinement.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/space_nd.hpp"
+#include "pantr/core/format.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+/// Whether two knots are the same knot, in the storage format.
+///
+/// `|a - b| <= T(tol)`, with the difference formed in `T` and the tolerance
+/// **rounded to `T`** rather than the difference widened to `double`. That is the
+/// predicate `numpy` evaluates for `np.abs(knots - x) <= tol`, whose Python float
+/// `tol` NEP 50 weakens to the array's format; the file comment records the
+/// measurement, and the two spellings genuinely disagree at `float32` for a
+/// tolerance that format cannot represent.
+///
+/// It is *not* the predicate `pantr/bspline/knot_insertion.hpp`'s domain check uses,
+/// which transcribes a different oracle expression; see the file comment.
+///
+/// \param a One knot.
+/// \param b The other.
+/// \param tol The absolute parametric tolerance, from `BsplineSpace1D::tolerance()`.
+/// \return `true` when the two are within `tol` of one another.
+template <Real T>
+[[nodiscard]] bool same_knot_in_storage(const T& a, const T& b, double tol) {
+    using std::abs;
+    return abs(a - b) <= static_cast<T>(tol);
+}
+
+/// Re-index one axis of a row-major array by an explicit list of rows.
+///
+/// The array is read as `(outer, num_cols, inner)` and written as
+/// `(outer, rows.size(), inner)`, with
+/// `out(o, i, k) = values(o, rows[i], k)`. For a control net of shape
+/// `(e_0, ..., e_{d-1}, num_components)` re-indexed along direction `d`, `outer` is
+/// the product of the extents before `d` and `inner` the product of those after it,
+/// the component axis included -- `refine_along_axis`'s own convention.
+///
+/// One primitive rather than three: a periodic net's modulo wrap
+/// (`rows[i] = i % num_cols`), the trim of an open conversion (a contiguous run) and
+/// the two halves of a split (two contiguous runs) are the same operation with
+/// different row lists, and the oracle spells them as three different numpy
+/// indexings.
+///
+/// No arithmetic is performed, so nothing here can round.
+///
+/// \param values The coefficients, row-major under `(outer, num_cols, inner)`.
+/// \param num_cols The axis's extent in `values`.
+/// \param rows The rows to take, in output order. May repeat a row.
+/// \param outer The product of the extents ahead of the axis; 1 when it is the first.
+/// \param inner The product of the extents behind it, component axis included.
+/// \return `outer * rows.size() * inner` coefficients, row-major.
+/// \throws std::invalid_argument If any extent is negative, if `values.size()` is not
+///         `outer * num_cols * inner`, or if a row is outside `[0, num_cols)`.
+template <Real T>
+[[nodiscard]] std::vector<T> select_rows_along_axis(std::span<const T> values,
+                                                    std::int64_t num_cols,
+                                                    std::span<const std::int64_t> rows,
+                                                    std::int64_t outer, std::int64_t inner) {
+    if (num_cols < 0 || outer < 0 || inner < 0) {
+        throw std::invalid_argument("select_rows_along_axis: the extents are counts, so none "
+                                    "of them can be negative.");
+    }
+    const std::int64_t expected = outer * num_cols * inner;
+    if (static_cast<std::int64_t>(values.size()) != expected) {
+        throw std::invalid_argument(
+            "select_rows_along_axis: the buffer holds " + std::to_string(values.size())
+            + " coefficients and the shape (" + std::to_string(outer) + ", "
+            + std::to_string(num_cols) + ", " + std::to_string(inner) + ") needs "
+            + std::to_string(expected) + ".");
+    }
+    for (const std::int64_t row : rows) {
+        if (row < 0 || row >= num_cols) {
+            throw std::invalid_argument("select_rows_along_axis: row " + std::to_string(row)
+                                        + " is outside [0, " + std::to_string(num_cols) + ").");
+        }
+    }
+
+    const auto num_rows = static_cast<std::int64_t>(rows.size());
+    std::vector<T> out(static_cast<std::size_t>(outer * num_rows * inner));
+    for (std::int64_t o = 0; o < outer; ++o) {
+        const T* const in_block = values.data() + o * num_cols * inner;
+        T* const out_block = out.data() + o * num_rows * inner;
+        for (std::int64_t i = 0; i < num_rows; ++i) {
+            const T* const source = in_block + rows[static_cast<std::size_t>(i)] * inner;
+            std::copy_n(source, inner, out_block + i * inner);
+        }
+    }
+    return out;
+}
+
+/// Evaluate one axis of a row-major array at a parameter, by de Boor corner cutting.
+///
+/// The array is read as `(outer, num_basis, inner)` with
+/// `num_basis = knots.size() - degree - 1`, and written as `(outer, inner)`: the axis
+/// is gone. This is `CurvePntByCornerCut` (Piegl and Tiller, *The NURBS Book*, A5.1),
+/// which reaches the value from the `degree - s + 1` control points local to the span
+/// in `degree - s` triangular passes, where `s` is the multiplicity of the parameter
+/// as a knot. At a knot of multiplicity `degree` or more only one basis function is
+/// non-zero, so the answer is one control point and no pass runs at all.
+///
+/// The weights are computed in `double` and applied in `T`, which is the oracle's own
+/// mixture and not a choice; the file comment carries the measurement that
+/// distinguishes it from the two nearby alternatives.
+///
+/// \param knots The axis's knot vector, non-decreasing, at least `2 * degree + 2`
+///        entries.
+/// \param degree The polynomial degree, non-negative.
+/// \param tol The absolute parametric tolerance, from `BsplineSpace1D::tolerance()`.
+/// \param values The coefficients, row-major under `(outer, num_basis, inner)`.
+/// \param value The parameter, inside the axis's domain to within `tol`. A value
+///        within `tol` of an end is snapped onto it, as the oracle's `_find_span`
+///        snaps it.
+/// \param outer The product of the extents ahead of the axis; 1 when it is the first.
+/// \param inner The product of the extents behind it, component axis included.
+/// \return `outer * inner` coefficients, row-major.
+/// \throws std::invalid_argument If the degree is negative, the knot vector is too
+///         short, any extent is negative, or `values.size()` is not
+///         `outer * num_basis * inner`.
+///
+/// \note No check that `value` is in the domain is performed, and it does **not**
+///       extrapolate: `_find_span`'s two guards snap a parameter below the domain
+///       onto its start and one above it onto its end, so this returns the nearest
+///       endpoint's value rather than a polynomial continued outside its span. The
+///       domain is enforced by `slice`, `slice_point` and the Python wrapper, whose
+///       messages a caller should see instead of a silently clamped answer.
+template <Real T>
+[[nodiscard]] std::vector<T> corner_cut_along_axis(std::span<const T> knots, std::int64_t degree,
+                                                   double tol, std::span<const T> values,
+                                                   double value, std::int64_t outer,
+                                                   std::int64_t inner) {
+    if (degree < 0) {
+        throw std::invalid_argument("corner_cut_along_axis: degree must be non-negative; got "
+                                    + std::to_string(degree) + ".");
+    }
+    const auto knot_count = static_cast<std::int64_t>(knots.size());
+    if (knot_count < 2 * degree + 2) {
+        throw std::invalid_argument(
+            "corner_cut_along_axis: a knot vector of degree " + std::to_string(degree)
+            + " needs at least " + std::to_string(2 * degree + 2) + " entries; got "
+            + std::to_string(knot_count) + ".");
+    }
+    if (outer < 0 || inner < 0) {
+        throw std::invalid_argument("corner_cut_along_axis: the extents are counts, so neither "
+                                    "of them can be negative.");
+    }
+    const std::int64_t num_basis = knot_count - degree - 1;
+    const std::int64_t expected = outer * num_basis * inner;
+    if (static_cast<std::int64_t>(values.size()) != expected) {
+        throw std::invalid_argument(
+            "corner_cut_along_axis: the buffer holds " + std::to_string(values.size())
+            + " coefficients and the shape (" + std::to_string(outer) + ", "
+            + std::to_string(num_basis) + ", " + std::to_string(inner) + ") needs "
+            + std::to_string(expected) + ".");
+    }
+
+    using std::abs;
+    const std::int64_t p = degree;
+    // `_find_span`, in `double` throughout: the oracle reaches every knot through
+    // `float(...)`, and `np.searchsorted` promotes its needle rather than weakening
+    // it. See the file comment.
+    double u = value;
+    const double u_left = detail::as_double(knots[static_cast<std::size_t>(p)]);
+    const double u_right = detail::as_double(knots[static_cast<std::size_t>(num_basis)]);
+    std::int64_t k = 0;
+    if (u <= u_left + tol) {
+        k = p;
+        u = u_left;
+    } else if (u >= u_right - tol) {
+        k = num_basis - 1;
+        u = u_right;
+    } else {
+        // `np.searchsorted(knots, u, side="right") - 1`. The predicate is on the
+        // widened knot, so the comparator widens rather than narrowing `u`.
+        const auto upper = std::upper_bound(
+            knots.begin(), knots.end(), u,
+            [](double needle, const T& knot) { return needle < detail::as_double(knot); });
+        k = static_cast<std::int64_t>(upper - knots.begin()) - 1;
+    }
+
+    // `_count_multiplicity`: knots `k`, `k - 1`, ... while they match `u`, stopping
+    // after at most `degree + 1` of them. The oracle's `range(k, max(k - p - 1, -1),
+    // -1)` has inclusive lower bound `max(k - p, 0)`.
+    std::int64_t s = 0;
+    for (std::int64_t i = k; i >= std::max(k - p, std::int64_t{0}); --i) {
+        if (abs(detail::as_double(knots[static_cast<std::size_t>(i)]) - u) <= tol) {
+            ++s;
+        } else {
+            break;
+        }
+    }
+
+    // At a knot of multiplicity `degree` or more the answer is one control point, so
+    // the whole cut is a row selection. Sharing `select_rows_along_axis` for it is
+    // what keeps this branch from being a second copy of the strided copy loop.
+    if (s >= p) {
+        const std::array<std::int64_t, 1> row{k - p};
+        return select_rows_along_axis<T>(values, num_basis, std::span<const std::int64_t>(row),
+                                         outer, inner);
+    }
+
+    const std::int64_t r = p - s;
+    // The oracle's `_zero_denom_tol`, transcribed. It stands in for an exact-zero test
+    // on a knot-span width rather than deriving a magnitude from anything, so it is
+    // reproduced rather than re-derived, and it is deliberately not one of this
+    // project's tolerances: it denotes no bound that `BsplineSpace1D::tolerance()`
+    // denotes.
+    constexpr double kZeroDenominator = 1e-300;
+
+    // One working triangle of `r + 1` rows, refilled per outer block. The oracle
+    // allocates `R` once because its `outer` is always 1 -- it moves the axis to the
+    // front -- and reusing one buffer here is the same arithmetic on each block.
+    std::vector<T> work(static_cast<std::size_t>((r + 1) * inner));
+    std::vector<T> out(static_cast<std::size_t>(outer * inner));
+
+    for (std::int64_t o = 0; o < outer; ++o) {
+        const T* const in_block = values.data() + o * num_basis * inner;
+        std::copy_n(in_block + (k - p) * inner, (r + 1) * inner, work.data());
+
+        for (std::int64_t j = 1; j <= r; ++j) {
+            // Ascending `i`, in place: at `i` the row `i + 1` still holds the previous
+            // pass's value, because this pass writes rows `0 .. r - j` in order. That
+            // is the oracle's loop and the standard corner cut; descending would read
+            // a row this pass had already overwritten.
+            for (std::int64_t i = 0; i <= r - j; ++i) {
+                const double left =
+                    detail::as_double(knots[static_cast<std::size_t>(k - p + j + i)]);
+                const double right =
+                    detail::as_double(knots[static_cast<std::size_t>(i + k + 1)]);
+                const double denom = right - left;
+                const double alpha =
+                    abs(denom) < kZeroDenominator ? 0.0 : (u - left) / denom;
+                // Rounded to `T` here and only here: the weights are `double`
+                // expressions and the update is a `T` one. See the file comment.
+                const T wa = static_cast<T>(alpha);
+                const T wb = static_cast<T>(1.0 - alpha);
+                T* const row = work.data() + i * inner;
+                const T* const next = work.data() + (i + 1) * inner;
+                for (std::int64_t c = 0; c < inner; ++c) {
+                    // `alpha * R[i + 1] + (1.0 - alpha) * R[i]`, operand for operand
+                    // and in that order: the two products and the sum are three
+                    // roundings, and swapping the addends is a different number.
+                    row[c] = wa * next[c] + wb * row[c];
+                }
+            }
+        }
+        std::copy_n(work.data(), inner, out.data() + o * inner);
+    }
+    return out;
+}
+
+/// One direction's open (clamped) form: its knot vector and the re-expressed net.
+///
+/// \tparam T The scalar type the knots and the coefficients share.
+template <Real T>
+struct OpenAlongAxis {
+    /// The clamped knot vector, of multiplicity `degree + 1` at both ends.
+    std::vector<T> knots;
+
+    /// The coefficients, row-major under `(outer, knots.size() - degree - 1, inner)`.
+    std::vector<T> values;
+};
+
+/// Re-express one axis of a row-major array over a clamped knot vector.
+///
+/// Raises each end of the knot vector to multiplicity `degree + 1` by inserting the
+/// boundary knot as many times as it is short, then drops the knots that fall outside
+/// the domain and the coefficients they carried. For a periodic axis the
+/// `knots.size() - degree - 1` coefficients of the full non-periodic net are
+/// reconstructed first by wrapping the stored ones, `full[i] = stored[i % n_stored]`,
+/// which is the representation the ghost knots describe.
+///
+/// The geometry does not move: the insertion goes through `inserted_knot_vector` and
+/// `refine_along_axis`, so the coefficients are the two-scale image of the originals.
+///
+/// \param knots The axis's knot vector, ghost knots included when `periodic`.
+/// \param degree The polynomial degree, non-negative.
+/// \param periodic Whether the axis is periodic, which is what makes the stored net
+///        shorter than the knot vector implies.
+/// \param tol The absolute parametric tolerance, from `BsplineSpace1D::tolerance()`.
+/// \param values The coefficients, row-major under `(outer, n_stored, inner)` where
+///        `n_stored` is the axis's basis count.
+/// \param n_stored The axis's extent in `values`.
+/// \param outer The product of the extents ahead of the axis; 1 when it is the first.
+/// \param inner The product of the extents behind it, component axis included.
+/// \return The clamped knot vector and the coefficients over it.
+/// \throws std::invalid_argument If the axis is already clamped at both ends and not
+///         periodic -- with the oracle's message, since there is nothing to do and
+///         the oracle refuses rather than returning a copy -- or if any argument is
+///         one the primitives above refuse.
+template <Real T>
+[[nodiscard]] OpenAlongAxis<T> open_along_axis(std::span<const T> knots, std::int64_t degree,
+                                               bool periodic, double tol,
+                                               std::span<const T> values, std::int64_t n_stored,
+                                               std::int64_t outer, std::int64_t inner) {
+    if (degree < 0) {
+        throw std::invalid_argument("open_along_axis: degree must be non-negative; got "
+                                    + std::to_string(degree) + ".");
+    }
+    const auto knot_count = static_cast<std::int64_t>(knots.size());
+    if (knot_count < 2 * degree + 2) {
+        throw std::invalid_argument(
+            "open_along_axis: a knot vector of degree " + std::to_string(degree)
+            + " needs at least " + std::to_string(2 * degree + 2) + " entries; got "
+            + std::to_string(knot_count) + ".");
+    }
+
+    const std::int64_t p = degree;
+    const T a = knots[static_cast<std::size_t>(p)];
+    const T b = knots[static_cast<std::size_t>(knot_count - p - 1)];
+
+    // The end multiplicities, in `T` and against a `T`-rounded tolerance: these two
+    // are numpy array expressions in the oracle. See `same_knot_in_storage`.
+    std::int64_t m_left = 0;
+    for (std::int64_t i = 0; i <= p; ++i) {
+        if (same_knot_in_storage<T>(knots[static_cast<std::size_t>(i)], a, tol)) {
+            ++m_left;
+        }
+    }
+    std::int64_t m_right = 0;
+    for (std::int64_t i = knot_count - p - 1; i < knot_count; ++i) {
+        if (same_knot_in_storage<T>(knots[static_cast<std::size_t>(i)], b, tol)) {
+            ++m_right;
+        }
+    }
+
+    if (m_left == p + 1 && m_right == p + 1 && !periodic) {
+        throw std::invalid_argument(
+            "B-spline is already open (both boundary knots have multiplicity degree + 1).");
+    }
+
+    // The full non-periodic net the knot vector describes. A non-periodic axis already
+    // stores it; a periodic one stores one period of it.
+    const std::int64_t n_full = knot_count - p - 1;
+    std::vector<T> full;
+    if (periodic) {
+        std::vector<std::int64_t> wrapped(static_cast<std::size_t>(n_full));
+        for (std::int64_t i = 0; i < n_full; ++i) {
+            wrapped[static_cast<std::size_t>(i)] = i % n_stored;
+        }
+        full = select_rows_along_axis<T>(values, n_stored,
+                                         std::span<const std::int64_t>(wrapped), outer, inner);
+    } else {
+        if (n_stored != n_full) {
+            throw std::invalid_argument(
+                "open_along_axis: a non-periodic axis stores one coefficient per basis "
+                "function, so the extent must be "
+                + std::to_string(n_full) + "; got " + std::to_string(n_stored) + ".");
+        }
+        full.assign(values.begin(), values.end());
+    }
+
+    const std::int64_t n_trim_left = p + 1 - m_left;
+    const std::int64_t n_trim_right = p + 1 - m_right;
+
+    std::vector<T> to_insert;
+    to_insert.reserve(static_cast<std::size_t>(n_trim_left + n_trim_right));
+    to_insert.insert(to_insert.end(), static_cast<std::size_t>(n_trim_left), a);
+    to_insert.insert(to_insert.end(), static_cast<std::size_t>(n_trim_right), b);
+
+    std::vector<T> merged;
+    std::int64_t num_rows = 0;
+    if (to_insert.empty()) {
+        merged.assign(knots.begin(), knots.end());
+        num_rows = n_full;
+    } else {
+        merged = inserted_knot_vector<T>(knots, p, std::span<const T>(to_insert), tol);
+        const OsloBands<T> bands = oslo_bands_1d<T>(p, knots, std::span<const T>(merged));
+        full = refine_along_axis<T>(bands, n_full, std::span<const T>(full), outer, inner);
+        num_rows = bands.num_rows;
+    }
+
+    // The trim. Each side drops `p + 1 - m` entries, counted with *its own* boundary
+    // multiplicity: the two may differ, and an earlier reading of the oracle that used
+    // one count for both would be wrong on a vector clamped at one end only.
+    OpenAlongAxis<T> out;
+    out.knots.assign(merged.begin() + n_trim_left, merged.end() - n_trim_right);
+    const auto n_open = static_cast<std::int64_t>(out.knots.size()) - p - 1;
+    std::vector<std::int64_t> kept(static_cast<std::size_t>(n_open));
+    for (std::int64_t i = 0; i < n_open; ++i) {
+        kept[static_cast<std::size_t>(i)] = n_trim_left + i;
+    }
+    out.values = select_rows_along_axis<T>(std::span<const T>(full), num_rows,
+                                           std::span<const std::int64_t>(kept), outer, inner);
+    return out;
+}
+
+namespace detail {
+
+/// The product of a net's extents ahead of one axis.
+///
+/// \param shape The net's shape, component axis included.
+/// \param axis The axis.
+/// \return 1 when `axis` is the first, the product of the earlier extents otherwise.
+[[nodiscard]] inline std::int64_t extents_before(std::span<const std::size_t> shape,
+                                                 std::int64_t axis) {
+    std::int64_t product = 1;
+    for (std::int64_t d = 0; d < axis; ++d) {
+        product *= static_cast<std::int64_t>(shape[static_cast<std::size_t>(d)]);
+    }
+    return product;
+}
+
+/// The product of a net's extents behind one axis, component axis included.
+///
+/// \param shape The net's shape, component axis included.
+/// \param axis The axis.
+/// \return The product of the later extents, which is at least the component count.
+[[nodiscard]] inline std::int64_t extents_after(std::span<const std::size_t> shape,
+                                                std::int64_t axis) {
+    std::int64_t product = 1;
+    for (std::size_t d = static_cast<std::size_t>(axis) + 1; d < shape.size(); ++d) {
+        product *= static_cast<std::int64_t>(shape[d]);
+    }
+    return product;
+}
+
+/// Refuse an axis index the field does not have, with the oracle's message.
+///
+/// \param name The oracle's own name for the parameter, `"axis"` or `"direction"`.
+/// \param axis The index to check.
+/// \param dim The field's number of parametric directions.
+/// \throws std::invalid_argument If `axis` is outside `[0, dim)`.
+inline void require_axis(const char* name, std::int64_t axis, std::int64_t dim) {
+    if (axis < 0 || axis >= dim) {
+        throw std::invalid_argument(std::string(name) + " must be in [0, " + std::to_string(dim)
+                                    + "), got " + std::to_string(axis) + ".");
+    }
+}
+
+/// Assemble a field from per-direction spaces, a net shape and its coefficients.
+///
+/// \tparam T The scalar type the field stores.
+/// \param directions One space handle per direction, in axis order.
+/// \param values The coefficients, row-major under `shape`.
+/// \param shape The net's shape, component axis last.
+/// \param is_rational Whether the last component of each coefficient is a weight.
+/// \return The field.
+/// \throws std::invalid_argument If `Bspline`'s or `BsplineSpace`'s constructor
+///         refuses the pieces.
+template <Real T>
+[[nodiscard]] Bspline<T>
+assemble(std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions,
+         const std::vector<T>& values, const std::vector<std::size_t>& shape, bool is_rational) {
+    return Bspline<T>(std::make_shared<const BsplineSpace<T>>(std::move(directions)),
+                      typename Bspline<T>::net_type(std::span<const T>(values),
+                                                    std::span<const std::size_t>(shape)),
+                      is_rational);
+}
+
+}  // namespace detail
+
+/// The field re-expressed over clamped, non-periodic knot vectors in every direction.
+///
+/// Each direction that is periodic or unclamped is converted by `open_along_axis`;
+/// one that is already open is left exactly alone, its space handle carried into the
+/// result rather than rebuilt, so `opened.space.spaces[d] is field.space.spaces[d]`
+/// holds for it on the Python side. The geometry is unchanged up to the rounding the
+/// file comment bounds.
+///
+/// \param field The field to convert.
+/// \return An open, non-periodic field over the same geometry.
+/// \throws std::invalid_argument If every direction is already open and non-periodic,
+///         with the oracle's message, since there would be nothing to do.
+template <Real T>
+[[nodiscard]] Bspline<T> to_open(const Bspline<T>& field) {
+    const BsplineSpace<T>& space = field.space_ref();
+    const std::int64_t dim = space.dim();
+
+    // Checked before any conversion runs, which is the oracle's order.
+    bool anything_to_do = false;
+    for (std::int64_t d = 0; d < dim; ++d) {
+        const BsplineSpace1D<T>& direction = space.space_ref(d);
+        anything_to_do =
+            anything_to_do || direction.periodic() || !direction.has_open_knots();
+    }
+    if (!anything_to_do) {
+        throw std::invalid_argument("B-spline is already open in every direction.");
+    }
+
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions(space.spaces().begin(),
+                                                                     space.spaces().end());
+    std::vector<std::size_t> shape(field.net().shape().begin(), field.net().shape().end());
+    std::vector<T> values(field.net().values().begin(), field.net().values().end());
+
+    for (std::int64_t d = 0; d < dim; ++d) {
+        const BsplineSpace1D<T>& direction = *directions[static_cast<std::size_t>(d)];
+        if (direction.has_open_knots() && !direction.periodic()) {
+            continue;
+        }
+        const std::int64_t degree = direction.degree();
+        const OpenAlongAxis<T> opened = open_along_axis<T>(
+            direction.knots(), degree, direction.periodic(), direction.tolerance(),
+            std::span<const T>(values),
+            static_cast<std::int64_t>(shape[static_cast<std::size_t>(d)]),
+            detail::extents_before(std::span<const std::size_t>(shape), d),
+            detail::extents_after(std::span<const std::size_t>(shape), d));
+
+        values = opened.values;
+        shape[static_cast<std::size_t>(d)] =
+            static_cast<std::size_t>(opened.knots.size()) - static_cast<std::size_t>(degree) - 1;
+        // Snapping on, which is the oracle's `BsplineSpace1D(open_knots, degree,
+        // periodic=False)` taking its default -- and *not* the split's, which passes
+        // `snap_knots=False`. The two are different calls in the oracle and stay
+        // different here.
+        directions[static_cast<std::size_t>(d)] = std::make_shared<const BsplineSpace1D<T>>(
+            std::span<const T>(opened.knots), degree, false,
+            KnotSnapping::merge_near_duplicates);
+    }
+
+    return detail::assemble<T>(std::move(directions), values, shape, field.is_rational());
+}
+
+/// The field cut in two at a parameter of one direction.
+///
+/// The split value's multiplicity is raised to `degree + 1`, which makes the knot
+/// vector separable there, and the vector and the net are then partitioned. The left
+/// half spans `[domain_start, value]` and the right `[value, domain_end]`; every
+/// other direction is untouched and its space handle is shared by both halves and by
+/// `field`. A periodic split direction is converted to its open form first, so both
+/// halves are non-periodic in it whatever `field` was.
+///
+/// \param field The field to split.
+/// \param direction The direction to split, in `[0, field.dim())`.
+/// \param value The parameter to split at, strictly inside that direction's domain by
+///        more than its tolerance.
+/// \return The left and right halves.
+/// \throws std::invalid_argument If `direction` is out of range or `value` is not
+///         strictly inside the domain, both with the oracle's Layer 1 messages.
+template <Real T>
+[[nodiscard]] std::pair<Bspline<T>, Bspline<T>> split(const Bspline<T>& field,
+                                                      std::int64_t direction, double value) {
+    const BsplineSpace<T>& space = field.space_ref();
+    const std::int64_t dim = space.dim();
+    detail::require_axis("direction", direction, dim);
+
+    const BsplineSpace1D<T>& along = space.space_ref(direction);
+    const std::array<T, 2> domain = along.domain();
+    const double lo = pantr::bspline::detail::as_double(domain[0]);
+    const double hi = pantr::bspline::detail::as_double(domain[1]);
+    const double tol = along.tolerance();
+    if (value <= lo + tol || value >= hi - tol) {
+        throw std::invalid_argument("value must be strictly inside the domain ("
+                                    + pantr::detail::format_repr(lo) + ", "
+                                    + pantr::detail::format_repr(hi) + "), got "
+                                    + pantr::detail::format_repr(value) + ".");
+    }
+
+    const std::int64_t p = along.degree();
+    std::vector<std::size_t> shape(field.net().shape().begin(), field.net().shape().end());
+    const std::int64_t outer = detail::extents_before(std::span<const std::size_t>(shape),
+                                                      direction);
+    const std::int64_t inner = detail::extents_after(std::span<const std::size_t>(shape),
+                                                     direction);
+
+    std::vector<T> knots;
+    std::vector<T> values;
+    if (along.periodic()) {
+        OpenAlongAxis<T> opened = open_along_axis<T>(
+            along.knots(), p, true, tol, field.net().values(),
+            static_cast<std::int64_t>(shape[static_cast<std::size_t>(direction)]), outer, inner);
+        knots = std::move(opened.knots);
+        values = std::move(opened.values);
+    } else {
+        knots.assign(along.knots().begin(), along.knots().end());
+        values.assign(field.net().values().begin(), field.net().values().end());
+    }
+
+    // The split value's current multiplicity, in `T` against a `T`-rounded tolerance:
+    // the oracle's `np.sum(np.abs(knots - value) <= tol)` is a numpy array expression.
+    const T value_in_T = static_cast<T>(value);
+    std::int64_t multiplicity = 0;
+    for (const T& knot : knots) {
+        if (same_knot_in_storage<T>(knot, value_in_T, tol)) {
+            ++multiplicity;
+        }
+    }
+
+    const std::int64_t deficit = p + 1 - multiplicity;
+    if (deficit > 0) {
+        const std::int64_t num_cols = static_cast<std::int64_t>(knots.size()) - p - 1;
+        const std::vector<T> to_insert(static_cast<std::size_t>(deficit), value_in_T);
+        std::vector<T> merged = inserted_knot_vector<T>(
+            std::span<const T>(knots), p, std::span<const T>(to_insert), tol);
+        const OsloBands<T> bands =
+            oslo_bands_1d<T>(p, std::span<const T>(knots), std::span<const T>(merged));
+        values = refine_along_axis<T>(bands, num_cols, std::span<const T>(values), outer, inner);
+        knots = std::move(merged);
+    }
+
+    // `np.searchsorted(knots, value - tol)`, whose default side is `"left"` and whose
+    // comparison is in `double`; the needle is a `double` expression on both sides.
+    const double needle = value - tol;
+    const auto lower = std::lower_bound(
+        knots.begin(), knots.end(), needle,
+        [](const T& knot, double target) {
+            return pantr::bspline::detail::as_double(knot) < target;
+        });
+    const auto i_split = static_cast<std::int64_t>(lower - knots.begin());
+
+    const auto knot_count = static_cast<std::int64_t>(knots.size());
+    const std::int64_t num_cols = knot_count - p - 1;
+
+    std::vector<std::int64_t> left_rows(static_cast<std::size_t>(i_split));
+    for (std::int64_t i = 0; i < i_split; ++i) {
+        left_rows[static_cast<std::size_t>(i)] = i;
+    }
+    std::vector<std::int64_t> right_rows(static_cast<std::size_t>(num_cols - i_split));
+    for (std::int64_t i = i_split; i < num_cols; ++i) {
+        right_rows[static_cast<std::size_t>(i - i_split)] = i;
+    }
+
+    const std::vector<T> left_values = select_rows_along_axis<T>(
+        std::span<const T>(values), num_cols, std::span<const std::int64_t>(left_rows), outer,
+        inner);
+    const std::vector<T> right_values = select_rows_along_axis<T>(
+        std::span<const T>(values), num_cols, std::span<const std::int64_t>(right_rows), outer,
+        inner);
+
+    const std::vector<T> left_knots(knots.begin(), knots.begin() + i_split + p + 1);
+    const std::vector<T> right_knots(knots.begin() + i_split, knots.end());
+
+    // Snapping **off**, which is the oracle's `snap_knots=False` at both halves and
+    // not the default `to_open` takes: a half's knot vector is a subrange of one that
+    // was already snapped, so snapping it again could only merge a pair the parent
+    // kept apart.
+    auto direction_space = [p](const std::vector<T>& vector) {
+        return std::make_shared<const BsplineSpace1D<T>>(std::span<const T>(vector), p, false,
+                                                         KnotSnapping::as_given);
+    };
+
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> left_directions(
+        space.spaces().begin(), space.spaces().end());
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> right_directions(
+        space.spaces().begin(), space.spaces().end());
+    left_directions[static_cast<std::size_t>(direction)] = direction_space(left_knots);
+    right_directions[static_cast<std::size_t>(direction)] = direction_space(right_knots);
+
+    std::vector<std::size_t> left_shape = shape;
+    std::vector<std::size_t> right_shape = shape;
+    left_shape[static_cast<std::size_t>(direction)] = static_cast<std::size_t>(i_split);
+    right_shape[static_cast<std::size_t>(direction)] =
+        static_cast<std::size_t>(num_cols - i_split);
+
+    return {detail::assemble<T>(std::move(left_directions), left_values, left_shape,
+                                field.is_rational()),
+            detail::assemble<T>(std::move(right_directions), right_values, right_shape,
+                                field.is_rational())};
+}
+
+namespace detail {
+
+/// Refuse a parameter outside one direction's domain, with the oracle's message.
+///
+/// \tparam T The scalar type the space stores.
+/// \param space The direction whose domain is the bound.
+/// \param axis The direction's index, which the message names.
+/// \param value The parameter.
+/// \throws std::invalid_argument If `value` leaves the domain by more than the
+///         direction's tolerance.
+///
+/// \note The two rendered bounds are `format_scalar` of the knots, which is Python's
+///       `repr` of the *widened* value. The oracle interpolates a numpy scalar of the
+///       storage format instead, so at `float32` the two texts can differ; the file
+///       comment records why that is unreachable from Python and why the fix belongs
+///       elsewhere.
+template <Real T>
+void require_in_domain(const BsplineSpace1D<T>& space, std::int64_t axis, double value) {
+    const std::array<T, 2> domain = space.domain();
+    const double tol = space.tolerance();
+    if (value < as_double(domain[0]) - tol || value > as_double(domain[1]) + tol) {
+        throw std::invalid_argument("value " + pantr::detail::format_repr(value)
+                                    + " is outside the domain ["
+                                    + pantr::detail::format_scalar(domain[0]) + ", "
+                                    + pantr::detail::format_scalar(domain[1])
+                                    + "] of direction " + std::to_string(axis) + ".");
+    }
+}
+
+/// One direction's net, expanded to the full non-periodic form when it is periodic.
+///
+/// The oracle's `np.take(ctrl, np.arange(n_full) % n_periodic, axis=axis)`, which is
+/// what makes the corner cut's span indices address a coefficient: a periodic axis
+/// stores one period and the knot vector describes the whole ghost-extended net.
+///
+/// \tparam T The scalar type the field stores.
+/// \param space The direction.
+/// \param values The coefficients, row-major under `(outer, n_stored, inner)`.
+/// \param n_stored The direction's extent in `values`.
+/// \param outer The product of the extents ahead of the axis.
+/// \param inner The product of the extents behind it, component axis included.
+/// \return The coefficients over `knots.size() - degree - 1` rows; a copy of `values`
+///         when the direction is not periodic.
+template <Real T>
+[[nodiscard]] std::vector<T> unwrapped_net(const BsplineSpace1D<T>& space,
+                                           std::span<const T> values, std::int64_t n_stored,
+                                           std::int64_t outer, std::int64_t inner) {
+    if (!space.periodic()) {
+        return std::vector<T>(values.begin(), values.end());
+    }
+    const std::int64_t n_full =
+        static_cast<std::int64_t>(space.knots().size()) - space.degree() - 1;
+    std::vector<std::int64_t> wrapped(static_cast<std::size_t>(n_full));
+    for (std::int64_t i = 0; i < n_full; ++i) {
+        wrapped[static_cast<std::size_t>(i)] = i % n_stored;
+    }
+    return select_rows_along_axis<T>(values, n_stored, std::span<const std::int64_t>(wrapped),
+                                     outer, inner);
+}
+
+}  // namespace detail
+
+/// The field with one parametric direction fixed at a value, so one dimension fewer.
+///
+/// A volume becomes a surface and a surface a curve. The surviving directions are
+/// untouched and their space handles are shared with `field`, so
+/// `sliced.space.spaces[j]` is the wrapper `field.space.spaces[i]` already had for
+/// the direction `i` that `j` came from. A periodic sliced direction is expanded to
+/// its full non-periodic net first; the *surviving* directions keep whatever they
+/// were, periodic included.
+///
+/// \param field The field to slice, of dimension at least two.
+/// \param axis The direction to fix, in `[0, field.dim())`.
+/// \param value The parameter, inside that direction's domain to within its
+///        tolerance.
+/// \return The sliced field, of dimension `field.dim() - 1`.
+/// \throws std::invalid_argument If the field is one-dimensional -- use `slice_point`
+///         -- if `axis` is out of range, or if `value` leaves the domain. The last two
+///         carry the oracle's Layer 1 messages.
+template <Real T>
+[[nodiscard]] Bspline<T> slice(const Bspline<T>& field, std::int64_t axis, double value) {
+    const BsplineSpace<T>& space = field.space_ref();
+    const std::int64_t dim = space.dim();
+    if (dim < 2) {
+        throw std::invalid_argument(
+            "slice needs a B-spline of dimension at least two; a one-dimensional one slices "
+            "to a point, which slice_point returns.");
+    }
+    detail::require_axis("axis", axis, dim);
+    const BsplineSpace1D<T>& along = space.space_ref(axis);
+    detail::require_in_domain<T>(along, axis, value);
+
+    const std::span<const std::size_t> shape = field.net().shape();
+    const std::int64_t outer = detail::extents_before(shape, axis);
+    const std::int64_t inner = detail::extents_after(shape, axis);
+    const auto n_stored = static_cast<std::int64_t>(shape[static_cast<std::size_t>(axis)]);
+
+    const std::vector<T> full =
+        detail::unwrapped_net<T>(along, field.net().values(), n_stored, outer, inner);
+    const std::vector<T> values =
+        corner_cut_along_axis<T>(along.knots(), along.degree(), along.tolerance(),
+                                 std::span<const T>(full), value, outer, inner);
+
+    // The axis is dropped and the others keep their order, which is what the oracle's
+    // `moveaxis`-plus-reshape produces and what the strided sweep already wrote.
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions;
+    directions.reserve(static_cast<std::size_t>(dim) - 1);
+    std::vector<std::size_t> reduced;
+    reduced.reserve(shape.size() - 1);
+    for (std::int64_t d = 0; d < dim; ++d) {
+        if (d != axis) {
+            directions.push_back(space.space(d));
+            reduced.push_back(shape[static_cast<std::size_t>(d)]);
+        }
+    }
+    reduced.push_back(shape.back());
+
+    return detail::assemble<T>(std::move(directions), values, reduced, field.is_rational());
+}
+
+/// The point a one-dimensional field takes at a parameter, in homogeneous components.
+///
+/// The `dim == 1` case of the oracle's `slice`, a separate function because its result
+/// is a point rather than a field and C++ cannot return one type or the other. It is
+/// the de Boor corner cut and nothing else, so it is also the single-point evaluation
+/// of a B-spline curve -- reachable ahead of the basis-tabulation port because the
+/// corner cut needs no basis function.
+///
+/// **The projection of a rational result is the caller's**, exactly as
+/// `pantr/bezier/shape.hpp`'s is: the weight column is still on, and the oracle's
+/// `point[:-1] / point[-1]` is one numpy division in the wrapper rather than a second
+/// spelling here.
+///
+/// \param field A one-dimensional field.
+/// \param value The parameter, inside the domain to within the space's tolerance.
+/// \return The `field.net().num_components()` components at that parameter, weight
+///         column included.
+/// \throws std::invalid_argument If the field is not one-dimensional, or if `value`
+///         leaves the domain -- the latter with the oracle's Layer 1 message.
+template <Real T>
+[[nodiscard]] std::vector<T> slice_point(const Bspline<T>& field, double value) {
+    const BsplineSpace<T>& space = field.space_ref();
+    if (space.dim() != 1) {
+        throw std::invalid_argument("slice_point needs a one-dimensional B-spline, got "
+                                    "dimension "
+                                    + std::to_string(space.dim()) + ".");
+    }
+    const BsplineSpace1D<T>& along = space.space_ref(0);
+    detail::require_in_domain<T>(along, 0, value);
+
+    const std::span<const std::size_t> shape = field.net().shape();
+    const auto components = static_cast<std::int64_t>(field.net().num_components());
+    const auto n_stored = static_cast<std::int64_t>(shape[0]);
+
+    const std::vector<T> full =
+        detail::unwrapped_net<T>(along, field.net().values(), n_stored, 1, components);
+    return corner_cut_along_axis<T>(along.knots(), along.degree(), along.tolerance(),
+                                    std::span<const T>(full), value, 1, components);
+}
+
+/// One face of the parametric domain.
+///
+/// `boundary(f, axis, side)` is `slice(f, axis, domain[side])`, which is the oracle's
+/// own definition rather than a reimplementation of it: `Bspline.boundary` computes
+/// the endpoint and calls `Bspline.slice`.
+///
+/// It is deliberately **not bound**. The Python `Bspline.boundary` reaches C++ through
+/// its own `slice`, so a binding would be public surface with no caller --
+/// `pantr._pantr_cpp.bezier_boundary` is exactly that today, bound and stubbed and
+/// used by nothing, and one such precedent is enough. This exists for the consumer
+/// with no interpreter, which is what the port is for.
+///
+/// \param field The field, of dimension at least two.
+/// \param axis The direction whose face is wanted, in `[0, field.dim())`.
+/// \param side 0 for the face at the domain's start, 1 for the one at its end.
+/// \return The face, of dimension `field.dim() - 1`.
+/// \throws std::invalid_argument If `side` is neither 0 nor 1 -- with the oracle's
+///         message -- or as `slice` throws.
+template <Real T>
+[[nodiscard]] Bspline<T> boundary(const Bspline<T>& field, std::int64_t axis, int side) {
+    // The oracle checks the side before the axis, so a call that is wrong in both ways
+    // reports the side. Only the order decides which message a caller reads.
+    if (side != 0 && side != 1) {
+        throw std::invalid_argument("side must be 0 or 1, got " + std::to_string(side) + ".");
+    }
+    const BsplineSpace<T>& space = field.space_ref();
+    detail::require_axis("axis", axis, space.dim());
+    const std::array<T, 2> domain = space.space_ref(axis).domain();
+    const double value = pantr::bspline::detail::as_double(domain[static_cast<std::size_t>(side)]);
+    return slice<T>(field, axis, value);
+}
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/structural.hpp
+++ b/cpp/include/pantr/bspline/structural.hpp
@@ -85,14 +85,16 @@
 /// whatever the knots are stored in. It then writes
 /// `R[i] = alpha * R[i + 1] + (1.0 - alpha) * R[i]`, where `R` is a `T` array and
 /// `alpha` a Python float -- and under NEP 50 a Python float is *weak*, so both
-/// weights are rounded to `T` and the whole update runs in `T`. Measured at
-/// `float32` on a case where the two differ: the `T` update gives `1.2469137` and a
-/// `double` update rounded once at the end gives `1.2469136`. Computing the weights
+/// weights are rounded to `T` and the whole update runs in `T`. Computing the weights
 /// in `T`, or the update in `double`, would each be a divergence, in opposite
-/// directions -- and this is not left resting on that one measurement.
-/// `tests/parity/test_bspline_structural.py` fails 10 of its `float32` slice cases
-/// against a `double` update and none of its `float64` ones, so the claim has a test
-/// that would report its violation rather than a comment that would not.
+/// directions, and both are visible at `float32` in the last bit while neither is at
+/// `float64`.
+///
+/// The claim is **pinned by a test rather than by this comment**: replacing the update
+/// with a `double` one fails `tests/parity/test_bspline_structural.py`'s `float32`
+/// slice cases and none of its `float64` ones. No count is quoted here, because a
+/// count is pinned to the fixture list it was taken over and nothing would re-take
+/// it.
 ///
 /// **The span search and the multiplicity count are `double`.** `_find_span` and
 /// `_count_multiplicity` reach every knot through `float(knots[i])`, so both
@@ -150,6 +152,22 @@
 /// target with an FMA fuses the corner cut's `wa * R[i + 1] + wb * R[i]` and the
 /// claim becomes Rule 10's budget. `pantr._pantr_cpp.__fp_contract__` is the gate
 /// that tells them apart.
+///
+/// ## Why the parameter is a `double` and not an `accumulator_t<T>`
+///
+/// `pantr/bezier/shape.hpp` types the analogous parameter of its `split`, `slice` and
+/// `slice_point` as `accumulator_t<T>`, so that a differentiable scalar keeps its own
+/// type through the operation. Every entry point here takes a plain `double` instead,
+/// and the reason is `pantr/core/scalar.hpp`'s own rule 4: **a parameter that changes
+/// discrete structure is value-only.** A Bézier's parameter changes nothing discrete --
+/// de Casteljau runs the same number of passes at every value. A B-spline's decides
+/// which knot span it falls in, what multiplicity it has there, and how many knots an
+/// insertion adds, so it selects the computation and not merely its operands. That is
+/// the same standing this rule gives the degree.
+///
+/// It costs nothing today, since `accumulator_t<float>` and `accumulator_t<double>` are
+/// both `double`, and it is stated here because the deviation from the sibling header is
+/// otherwise invisible.
 ///
 /// ## What is not ported, and it is a declared boundary
 ///
@@ -1039,6 +1057,15 @@ template <Real T>
 /// `boundary(f, axis, side)` is `slice(f, axis, domain[side])`, which is the oracle's
 /// own definition rather than a reimplementation of it: `Bspline.boundary` computes
 /// the endpoint and calls `Bspline.slice`.
+///
+/// **It is that composition over a narrower domain than the oracle's, and this is the
+/// one place the two differ.** `Bspline.boundary` works at `dim == 1` too, where its
+/// `slice` returns a point; this forwards to the `slice` below, which refuses a
+/// one-dimensional field, and there is no `boundary_point` beside it. That is
+/// `pantr/bezier/shape.hpp`'s `boundary` unchanged, and it is reachable by no caller:
+/// this function is not bound, so the Python `boundary` at `dim == 1` composes its own
+/// `slice` into `slice_point` and never arrives here. A C++ caller wanting the point
+/// spells it `slice_point(f, f.space_ref().space_ref(0).domain()[side])`.
 ///
 /// It is deliberately **not bound**. The Python `Bspline.boundary` reaches C++ through
 /// its own `slice`, so a binding would be public surface with no caller --

--- a/cpp/include/pantr/bspline/structural.hpp
+++ b/cpp/include/pantr/bspline/structural.hpp
@@ -29,10 +29,12 @@
 /// **The one new numerical kernel is `corner_cut_along_axis`**, the de Boor corner
 /// cut the slice is built on (Piegl and Tiller, *The NURBS Book*, A5.1
 /// `CurvePntByCornerCut`). It is genuinely new work rather than a rearrangement of
-/// something present: nothing in this tree evaluates a B-spline yet, because basis
-/// tabulation is its own port. The corner cut needs none of it -- it reads control
-/// points and knots and never touches a basis function -- which is why the slice is
-/// portable ahead of `Bspline::evaluate`.
+/// something present: **no header under `pantr/bspline/` evaluates a basis function**,
+/// because basis tabulation is its own port. (`pantr/basis/cardinal_bspline.hpp` does
+/// tabulate a B-spline basis, but only the *cardinal* one, over uniform integer knots
+/// and not over a `BsplineSpace1D` -- so it is no help here.) The corner cut needs
+/// none of it: it reads control points and knots and never touches a basis function,
+/// which is why the slice is portable ahead of `Bspline::evaluate`.
 ///
 /// The two remaining pieces of bookkeeping are `select_rows_along_axis`, which is one
 /// primitive standing in for three row selections the oracle spells three ways (a
@@ -87,7 +89,10 @@
 /// `float32` on a case where the two differ: the `T` update gives `1.2469137` and a
 /// `double` update rounded once at the end gives `1.2469136`. Computing the weights
 /// in `T`, or the update in `double`, would each be a divergence, in opposite
-/// directions.
+/// directions -- and this is not left resting on that one measurement.
+/// `tests/parity/test_bspline_structural.py` fails 10 of its `float32` slice cases
+/// against a `double` update and none of its `float64` ones, so the claim has a test
+/// that would report its violation rather than a comment that would not.
 ///
 /// **The span search and the multiplicity count are `double`.** `_find_span` and
 /// `_count_multiplicity` reach every knot through `float(knots[i])`, so both
@@ -107,14 +112,21 @@
 /// below rounds the tolerance rather than widening the difference.
 ///
 /// That is the opposite convention from `inserted_knot_vector`'s domain check in
-/// `pantr/bspline/knot_insertion.hpp`, which widens the difference to `double`. The
-/// two are not inconsistent about the same predicate: **they transcribe two
-/// different oracle expressions.** Whether that file's own is faithful is a question
-/// about `_is_in_domain_impl` and not about this one, and it is raised rather than
-/// answered here -- no path through this file depends on the answer, because every
-/// value this file hands that function is a knot of the vector it is inserting into
-/// or a value the wrapper has already put strictly inside the domain, and in both
-/// cases the tolerance leg of its predicate is never consulted.
+/// `pantr/bspline/knot_insertion.hpp`, which widens the difference to `double`, **and
+/// both are right**, which is worth stating because the pair looks like a
+/// contradiction and is not. The predicate is written the same way in both oracles;
+/// what differs is that one of them is *compiled*. `_is_in_domain_impl` is
+/// `@nb_jit(nopython=True)`, and numba unifies a `float32` array against a `float64`
+/// scalar by widening the array -- so its comparison is in `double`. The three
+/// expressions this file transcribes sit in plain Layer 2 Python, where NEP 50
+/// *weakens* the Python float to the array's format instead. Measured on one
+/// constructed input at `float32`: the same distance and the same tolerance give
+/// `False` from the jitted oracle, `True` from the numpy spelling.
+///
+/// So `design/backend_parity.md` Rule 9's "per-kernel fact" is sharper than per-kernel
+/// here -- the width follows the **compilation** of the expression, not the module it
+/// lives in -- and a transcription that reads the predicate without checking which
+/// side of that line it is on will be wrong half the time.
 ///
 /// **The refined knot vectors and the two-scale sweep are unchanged.**
 /// `inserted_knot_vector` and `refine_along_axis` carry their own derivations, and

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(PANTR_TEST_SOURCES
     test_bspline_extraction.cpp
     test_bspline_knot_insertion.cpp
     test_bspline_refinement.cpp
+    test_bspline_structural.cpp
     test_thb_space.cpp
     test_bspline_type.cpp)
 

--- a/cpp/tests/test_bspline_structural.cpp
+++ b/cpp/tests/test_bspline_structural.cpp
@@ -189,19 +189,27 @@ Bspline<T> field_of(std::vector<std::shared_ptr<const BsplineSpace1D<T>>> direct
 
 /// The Greville abscissae of a knot vector.
 ///
-/// `g_i = (t_{i+1} + ... + t_{i+p}) / p` for degree `p >= 1`; the knots themselves for
-/// degree 0, where the average is over an empty range and the identity map is not
-/// representable.
+/// `g_i = (t_{i+1} + ... + t_{i+p}) / p`, which at `p = 0` is an average over an empty
+/// range: the knot `t_i` is returned instead. **That branch is written rather than
+/// merely documented**, because `vectors()` now carries a degree-0 entry and every
+/// caller but `check_corner_cut_is_linearly_precise` reaches this unguarded --
+/// `sum / T(0)` is a NaN that would propagate into a geometry comparison and read
+/// there as a moved curve. Linear precision itself does not hold at degree 0, which is
+/// why that one check skips it: a piecewise constant cannot reproduce the identity map.
 ///
 /// \tparam T The storage format.
 /// \param knots The knot vector.
-/// \param degree The degree, at least 1.
+/// \param degree The degree, non-negative.
 /// \return One abscissa per basis function.
 template <class T>
 std::vector<T> greville(const std::vector<T>& knots, std::int64_t degree) {
     const auto count = static_cast<std::int64_t>(knots.size()) - degree - 1;
     std::vector<T> out(static_cast<std::size_t>(count));
     for (std::int64_t i = 0; i < count; ++i) {
+        if (degree == 0) {
+            out[static_cast<std::size_t>(i)] = knots[static_cast<std::size_t>(i)];
+            continue;
+        }
         T sum = T(0);
         for (std::int64_t j = 1; j <= degree; ++j) {
             sum = sum + knots[static_cast<std::size_t>(i + j)];
@@ -250,21 +258,32 @@ struct Vector1D {
 
 /// The knot vectors every templated check below runs over.
 ///
-/// Clamped at both ends, clamped at one, clamped at neither, and periodic; degrees 1
-/// through 4; interior multiplicities both 1 and above.
+/// Clamped at both ends, clamped at one, clamped at neither, and periodic; degrees 0
+/// through 4; interior multiplicities both 1 and above; one vector with **no** interior
+/// knot, where the corner cut's span is the whole domain; and one periodic vector at
+/// each end of the `[1, degree]` boundary-multiplicity range a periodic knot vector
+/// admits, since the two trim a different number of ghost entries.
+///
+/// The vector clamped at one end only is named for the end it is **not** clamped at,
+/// which is the reading `to_open` and `has_open_knots()` use: "open" here means
+/// clamped.
 ///
 /// \return The vectors.
 std::vector<Vector1D> vectors() {
     return {
+        {"p0-open", 0, false, {0.0, 0.4, 1.0}},
         {"p1-open", 1, false, {0.0, 0.0, 0.3, 0.7, 1.0, 1.0}},
         {"p2-open", 2, false, {0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0}},
+        {"p2-single-span", 2, false, {0.0, 0.0, 0.0, 1.0, 1.0, 1.0}},
         {"p3-open", 3, false, {0.0, 0.0, 0.0, 0.0, 0.4, 1.0, 1.0, 1.0, 1.0}},
         {"p4-open", 4, false, {0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0}},
         {"p2-double-interior", 2, false, {0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0}},
         {"p3-c0-interior", 3, false, {0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0}},
         {"p2-unclamped", 2, false, {-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.1, 1.2}},
-        {"p2-left-open-only", 2, false, {-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0}},
-        {"p2-periodic", 2, true, {-0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5}},
+        {"p2-unclamped-left-only", 2, false,
+         {-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0}},
+        {"p2-periodic-m1", 2, true, {-0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5}},
+        {"p2-periodic-m2", 2, true, {-0.5, 0.0, 0.0, 0.5, 1.0, 1.0, 1.5}},
         {"p2-shifted", 2, false, {2.0, 2.0, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0, 4.0}},
     };
 }
@@ -413,6 +432,16 @@ std::vector<T> sample(const Bspline<T>& field, double u) {
 template <class T>
 void check_to_open_keeps_the_map(const char* format) {
     for (const Vector1D& vector : vectors()) {
+        if (vector.degree == 0) {
+            // A degree-0 spline is a piecewise constant, so it is discontinuous at
+            // every breakpoint -- and `sample_parameters` is mostly breakpoints. "The
+            // two representations describe the same map" is then undefined exactly
+            // where this would test it, since the two knot vectors disagree about
+            // which side of the jump a breakpoint belongs to. Degree 0 is covered by
+            // partition of unity above and, cross-backend, by
+            // `tests/parity/test_bspline_structural.py`'s `p0` cases.
+            continue;
+        }
         const std::vector<T> knots = at_format<T>(vector.raw);
         auto space = direction<T>(knots, vector.degree, vector.periodic);
         if (space->has_open_knots() && !space->periodic()) {
@@ -504,6 +533,9 @@ void check_to_open_shares_an_untouched_direction() {
 template <class T>
 void check_split_keeps_the_map(const char* format) {
     for (const Vector1D& vector : vectors()) {
+        if (vector.degree == 0) {
+            continue;  // Discontinuous at a breakpoint; see `check_to_open_keeps_the_map`.
+        }
         const std::vector<T> knots = at_format<T>(vector.raw);
         auto space = direction<T>(knots, vector.degree, vector.periodic);
         const std::vector<T> net = greville<T>(knots, vector.degree);
@@ -667,6 +699,17 @@ void check_boundary_is_a_slice_at_an_end() {
     }
     PANTR_CHECK_MSG(message == "side must be 0 or 1, got 2.",
                     "boundary's side refusal reads \"" + message + "\"");
+
+    // Bad in both ways. The oracle checks the side first, so that is the message a
+    // caller reads; the claim is in `boundary`'s own comment and had no test until now.
+    std::string both;
+    try {
+        static_cast<void>(boundary<double>(surface, 7, 2));
+    } catch (const std::invalid_argument& error) {
+        both = error.what();
+    }
+    PANTR_CHECK_MSG(both == "side must be 0 or 1, got 2.",
+                    "a bad side together with a bad axis reports \"" + both + "\"");
 }
 
 /// `slice_point` hands back the weight column of a rational field unprojected.
@@ -690,54 +733,92 @@ void check_slice_point_leaves_a_rational_unprojected() {
 // The primitives' own refusals
 // ---------------------------------------------------------------------------
 
+/// The rationality flag and the weight column survive all three operations.
+///
+/// The C++-only gap the parity suite covers cross-backend but this file did not: a
+/// defect in how `detail::assemble` carries `is_rational`, or in a sweep that dropped
+/// the last component, would show here and nowhere else in this file.
+void check_the_weight_column_survives() {
+    const std::vector<double> knots{-0.2, -0.1, 0.0, 0.5, 1.0, 1.1, 1.2};
+    const std::vector<double> other{0.0, 0.0, 0.4, 1.0, 1.0};
+    auto first = direction<double>(knots, 2, false);
+    auto second = direction<double>(other, 1, false);
+    // Coefficients of (x, y, w), every weight 2 so an accidental projection or a
+    // dropped column shows in the value as well as in the component count.
+    std::vector<double> values(4 * 3 * 3);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = (i % 3 == 2) ? 2.0 : 1.0 + static_cast<double>(i);
+    }
+    const Bspline<double> field = field_of<double>({first, second}, values, 3, true);
+    PANTR_CHECK(field.rank() == 2);
+
+    const Bspline<double> opened = to_open<double>(field);
+    const std::pair<Bspline<double>, Bspline<double>> halves = split<double>(field, 0, 0.25);
+    const Bspline<double> sliced = slice<double>(field, 1, 0.4);
+    for (const Bspline<double>* result : {&opened, &halves.first, &halves.second, &sliced}) {
+        PANTR_CHECK_MSG(result->is_rational(), "an operation dropped the rationality flag");
+        PANTR_CHECK_MSG(result->rank() == 2, "an operation changed the rank");
+        PANTR_CHECK_MSG(result->net().num_components() == 3,
+                        "an operation dropped the weight column");
+        // Every input weight is 2 and every operation recombines weights with
+        // coefficients summing to one, so each output weight is 2 to within its own
+        // rounding. A projection would give 1; a dropped column changes the count
+        // above.
+        const std::span<const double> got = result->net().values();
+        for (std::size_t i = 2; i < got.size(); i += 3) {
+            PANTR_CHECK_MSG(std::abs(got[i] - 2.0) <= bound_for<double>(30, 2.0),
+                            "an operation moved a weight to " + std::to_string(got[i]));
+        }
+    }
+}
+
 /// The two strided primitives refuse a shape they cannot address.
 void check_the_primitives_refuse_a_bad_shape() {
     const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
     const std::vector<double> values(4, 1.0);
     const std::vector<std::int64_t> rows{0, 1};
+    const std::vector<std::int64_t> bad_row{4};
+    const std::vector<double> too_short{0.0, 1.0};
 
-    int refused = 0;
-    const auto attempt = [&refused](const auto& call) {
+    // One assertion per refusal rather than one counter for six: a counter reading
+    // "accepted 1 shape(s)" does not say which of the six stopped firing.
+    const auto attempt = [](const char* what, const auto& call) {
+        bool refused = false;
         try {
             call();
         } catch (const std::invalid_argument&) {
-            ++refused;
+            refused = true;
         }
+        PANTR_CHECK_MSG(refused, std::string("accepted ") + what);
     };
-    attempt([&] {
-        static_cast<void>(select_rows_along_axis<double>(std::span<const double>(values), 4,
-                                                         std::span<const std::int64_t>(rows), 2,
-                                                         1));
+
+    attempt("a select_rows buffer that is not outer * num_cols * inner", [&] {
+        static_cast<void>(select_rows_along_axis<double>(
+            std::span<const double>(values), 4, std::span<const std::int64_t>(rows), 2, 1));
     });
-    attempt([&] {
-        static_cast<void>(select_rows_along_axis<double>(std::span<const double>(values), 4,
-                                                         std::span<const std::int64_t>(rows), -1,
-                                                         1));
+    attempt("a negative extent in select_rows", [&] {
+        static_cast<void>(select_rows_along_axis<double>(
+            std::span<const double>(values), 4, std::span<const std::int64_t>(rows), -1, 1));
     });
-    const std::vector<std::int64_t> bad_row{4};
-    attempt([&] {
+    attempt("a select_rows row outside [0, num_cols)", [&] {
         static_cast<void>(select_rows_along_axis<double>(
             std::span<const double>(values), 4, std::span<const std::int64_t>(bad_row), 1, 1));
     });
-    attempt([&] {
+    attempt("a corner-cut buffer that is not outer * num_basis * inner", [&] {
         static_cast<void>(corner_cut_along_axis<double>(std::span<const double>(knots), 2, 1e-15,
                                                         std::span<const double>(values), 0.5, 1,
                                                         2));
     });
-    attempt([&] {
+    attempt("a negative degree in the corner cut", [&] {
         static_cast<void>(corner_cut_along_axis<double>(std::span<const double>(knots), -1,
                                                         1e-15, std::span<const double>(values),
                                                         0.5, 1, 1));
     });
-    const std::vector<double> too_short{0.0, 1.0};
-    attempt([&] {
+    attempt("a knot vector too short for its degree in the corner cut", [&] {
         static_cast<void>(corner_cut_along_axis<double>(std::span<const double>(too_short), 2,
                                                         1e-15, std::span<const double>(values),
                                                         0.5, 1, 1));
     });
-    PANTR_CHECK_MSG(refused == 6,
-                    "the strided primitives accepted " + std::to_string(6 - refused)
-                        + " shape(s) they cannot address");
 }
 
 /// `split`'s two Layer 1 refusals carry the oracle's texts.
@@ -836,6 +917,7 @@ int main() {
     check_the_slice_pair_refuses_each_other_s_case();
     check_boundary_is_a_slice_at_an_end();
     check_slice_point_leaves_a_rational_unprojected();
+    check_the_weight_column_survives();
 
     check_the_primitives_refuse_a_bad_shape();
     check_split_refusals();

--- a/cpp/tests/test_bspline_structural.cpp
+++ b/cpp/tests/test_bspline_structural.cpp
@@ -1,0 +1,846 @@
+/// \file
+/// Tests for `pantr/bspline/structural.hpp`: the open conversion, the split, the
+/// slice and the boundary.
+///
+/// ## What is checked against what
+///
+/// The three operations divide cleanly into one that needs an **independent oracle**
+/// and two that need a **consistency** check, and the file is arranged that way.
+///
+/// **`corner_cut_along_axis` is the one new kernel, so it is checked against closed
+/// forms rather than against another implementation of itself.** Two identities pin
+/// it, both exact in exact arithmetic for *any* knot vector and any degree:
+///
+///  - **Partition of unity.** A field whose every coefficient is 1 is the constant 1,
+///    because the B-spline basis sums to one on the domain. So the corner cut must
+///    return 1 at every parameter.
+///  - **Linear precision.** A field whose coefficient `i` is the Greville abscissa
+///    `g_i = (t_{i+1} + ... + t_{i+p}) / p` is the identity map `S(u) = u`. This is
+///    the degree-one case of Marsden's identity, and it is a *stronger* test than
+///    partition of unity: it fails if the span search picks the wrong span, if the
+///    multiplicity count is off by one, or if a knot index in the recurrence is
+///    shifted -- none of which partition of unity can see, since every coefficient
+///    there is the same number.
+///
+/// Neither identity is a second computation of the corner cut, which is what makes
+/// them oracles rather than mirrors. `test_bspline_refinement.cpp` uses Marsden's
+/// identity in coefficient space for the same reason.
+///
+/// **`to_open` and `split` add no numerics** -- they are `inserted_knot_vector`,
+/// `oslo_bands_1d` and `refine_along_axis`, which have their own tests and their own
+/// derivations, wrapped in bookkeeping. So what is checked here is that the
+/// bookkeeping is right: **the geometry does not move.** Both are sampled with the
+/// corner cut, at parameters the identities above have just certified it on, and
+/// compared against the original field sampled the same way. A wrong trim, a wrong
+/// partition index, a wrong end multiplicity or a wrong wrap all displace the map,
+/// and none of them is visible in the knot vector alone.
+///
+/// The structural facts each also guarantees -- the end multiplicities `to_open`
+/// reaches, the domains the two halves span, the axis the slice drops, the handles it
+/// shares -- are checked exactly, since they are integers and identities.
+///
+/// ## The accuracy bound, derived
+///
+/// `gamma_K = K u / (1 - K u)` with `u` the unit roundoff of the storage format, times
+/// the magnitude of the quantity, plus `K` denormal floors. The floor is the absolute
+/// half of Higham's model and it is load-bearing rather than decoration: linear
+/// precision at `u = 0` has an exact-zero closed form, and a purely relative bound
+/// there would assert bit-identity that nothing here has grounds for.
+///
+/// `K` for one corner cut at degree `p`:
+///
+///  - **`p` for the Greville abscissa itself** -- `p - 1` additions and one division.
+///    Charged only where the coefficients are Greville abscissae; partition of unity
+///    stores an exact 1.
+///  - **`5p` for the cut**, being at most `p` passes at 5 roundings each: the two
+///    products and the sum are 3 roundings of the coefficients, and the weight pair
+///    `(fl_T(alpha), fl_T(1 - alpha))` departs from summing to one by at most 2 more.
+///    The weights are in `[0, 1]` for a parameter inside its span, so no pass
+///    amplifies the magnitude and the passes compose additively.
+///
+/// So `K = 6p` for linear precision and `K = 5p` for partition of unity. The
+/// geometry-preservation checks compare two corner cuts of the *same* field over
+/// different knot vectors, so they charge two cuts plus the insertion the refined side
+/// went through, whose own count `test_bspline_refinement.cpp` derives as
+/// `2p + 3 + (7p + 2)` per refined direction; `insertion_roundings` below assembles
+/// the sum rather than restating it.
+///
+/// The magnitude is `max(|lo|, |hi|)` for linear precision -- a Greville abscissa is a
+/// convex combination of knots, so it cannot leave the knot vector's own range -- and
+/// 1 for partition of unity.
+///
+/// ## Both storage formats
+///
+/// Every templated check runs at `double` and at `float`, because the file comment of
+/// `pantr/bspline/structural.hpp` records three sites where the oracle's arithmetic
+/// width differs between them and a `double`-only suite would exercise none of the
+/// three. The refusal checks are `double`-only: a message's text does not depend on
+/// the format except in the one case that file records as unreachable.
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/space_nd.hpp"
+#include "pantr/bspline/structural.hpp"
+
+using pantr::bspline::Bspline;
+using pantr::bspline::BsplineSpace;
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::boundary;
+using pantr::bspline::corner_cut_along_axis;
+using pantr::bspline::KnotSnapping;
+using pantr::bspline::open_along_axis;
+using pantr::bspline::select_rows_along_axis;
+using pantr::bspline::slice;
+using pantr::bspline::slice_point;
+using pantr::bspline::split;
+using pantr::bspline::to_open;
+
+namespace {
+
+/// `gamma_m = m u / (1 - m u)`, the standard accumulation constant.
+///
+/// Defined here rather than shared, which is the convention the three test files that
+/// already need it follow; collecting them is a cleanup this file does not take.
+///
+/// \tparam T The format the roundings are charged in.
+/// \param m The number of roundings.
+/// \return The constant, in units of the value being bounded.
+template <class T>
+double gamma_of(std::int64_t m) {
+    const double u = 0.5 * static_cast<double>(std::numeric_limits<T>::epsilon());
+    const double mu = static_cast<double>(m) * u;
+    return mu / (1.0 - mu);
+}
+
+/// The absolute bound on a quantity of the given magnitude after `K` roundings.
+///
+/// \tparam T The storage format.
+/// \param roundings `K`.
+/// \param magnitude The magnitude of the quantity being bounded.
+/// \return The bound, strictly positive even at magnitude zero.
+template <class T>
+double bound_for(std::int64_t roundings, double magnitude) {
+    return gamma_of<T>(roundings) * magnitude
+           + static_cast<double>(roundings) * static_cast<double>(std::numeric_limits<T>::min());
+}
+
+/// The roundings one knot insertion of a `p`-degree direction is charged.
+///
+/// `test_bspline_refinement.cpp` derives `2p + 3 + D(7p + 2)` for `D` refined
+/// directions; here `D` is always 1, because every insertion below touches one
+/// direction.
+///
+/// \param degree The direction's degree.
+/// \return The count.
+std::int64_t insertion_roundings(std::int64_t degree) {
+    return 2 * degree + 3 + (7 * degree + 2);
+}
+
+/// A space over a knot vector, shared.
+///
+/// \tparam T The storage format.
+/// \param knots The knot vector.
+/// \param degree The degree.
+/// \param periodic Whether the space is periodic.
+/// \return The space, in a handle a field can take.
+template <class T>
+std::shared_ptr<const BsplineSpace1D<T>> direction(const std::vector<T>& knots,
+                                                   std::int64_t degree, bool periodic) {
+    return std::make_shared<const BsplineSpace1D<T>>(
+        std::span<const T>(knots), degree, periodic, KnotSnapping::merge_near_duplicates);
+}
+
+/// A field over the given directions, with the given coefficients.
+///
+/// \tparam T The storage format.
+/// \param directions One space handle per direction.
+/// \param values The coefficients, row-major under `(*num_basis, num_components)`.
+/// \param num_components How many components each coefficient has.
+/// \param is_rational Whether the last component is a homogeneous weight.
+/// \return The field.
+template <class T>
+Bspline<T> field_of(std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions,
+                    const std::vector<T>& values, std::size_t num_components,
+                    bool is_rational) {
+    auto space = std::make_shared<const BsplineSpace<T>>(std::move(directions));
+    std::vector<std::size_t> shape;
+    for (const std::int64_t count : space->num_basis()) {
+        shape.push_back(static_cast<std::size_t>(count));
+    }
+    shape.push_back(num_components);
+    return Bspline<T>(space,
+                      typename Bspline<T>::net_type(std::span<const T>(values),
+                                                    std::span<const std::size_t>(shape)),
+                      is_rational);
+}
+
+/// The Greville abscissae of a knot vector.
+///
+/// `g_i = (t_{i+1} + ... + t_{i+p}) / p` for degree `p >= 1`; the knots themselves for
+/// degree 0, where the average is over an empty range and the identity map is not
+/// representable.
+///
+/// \tparam T The storage format.
+/// \param knots The knot vector.
+/// \param degree The degree, at least 1.
+/// \return One abscissa per basis function.
+template <class T>
+std::vector<T> greville(const std::vector<T>& knots, std::int64_t degree) {
+    const auto count = static_cast<std::int64_t>(knots.size()) - degree - 1;
+    std::vector<T> out(static_cast<std::size_t>(count));
+    for (std::int64_t i = 0; i < count; ++i) {
+        T sum = T(0);
+        for (std::int64_t j = 1; j <= degree; ++j) {
+            sum = sum + knots[static_cast<std::size_t>(i + j)];
+        }
+        out[static_cast<std::size_t>(i)] = sum / static_cast<T>(degree);
+    }
+    return out;
+}
+
+/// The parameters a check samples across one direction's domain.
+///
+/// The two endpoints, every distinct interior knot, and a handful of points that are
+/// neither -- the endpoints and the knots because they are where the span search and
+/// the multiplicity count branch, and the rest because a wrong branch there would be
+/// invisible.
+///
+/// \tparam T The storage format.
+/// \param space The direction.
+/// \return The parameters, as `double`.
+template <class T>
+std::vector<double> sample_parameters(const BsplineSpace1D<T>& space) {
+    const std::array<T, 2> domain = space.domain();
+    const double lo = static_cast<double>(domain[0]);
+    const double hi = static_cast<double>(domain[1]);
+    std::vector<double> out{lo, hi};
+    for (const T& knot : space.unique_knots_in_domain()) {
+        out.push_back(static_cast<double>(knot));
+    }
+    for (int step = 1; step < 8; ++step) {
+        out.push_back(lo + (hi - lo) * static_cast<double>(step) / 8.0);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// The corner cut, against two closed forms
+// ---------------------------------------------------------------------------
+
+/// One knot vector's label, degree and entries.
+struct Vector1D {
+    const char* label;        ///< What to name it in a failure.
+    std::int64_t degree;      ///< The degree.
+    bool periodic;            ///< Whether the entries describe a periodic space.
+    std::vector<double> raw;  ///< The entries, in `double`.
+};
+
+/// The knot vectors every templated check below runs over.
+///
+/// Clamped at both ends, clamped at one, clamped at neither, and periodic; degrees 1
+/// through 4; interior multiplicities both 1 and above.
+///
+/// \return The vectors.
+std::vector<Vector1D> vectors() {
+    return {
+        {"p1-open", 1, false, {0.0, 0.0, 0.3, 0.7, 1.0, 1.0}},
+        {"p2-open", 2, false, {0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0}},
+        {"p3-open", 3, false, {0.0, 0.0, 0.0, 0.0, 0.4, 1.0, 1.0, 1.0, 1.0}},
+        {"p4-open", 4, false, {0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0}},
+        {"p2-double-interior", 2, false, {0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0}},
+        {"p3-c0-interior", 3, false, {0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0}},
+        {"p2-unclamped", 2, false, {-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.1, 1.2}},
+        {"p2-left-open-only", 2, false, {-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0}},
+        {"p2-periodic", 2, true, {-0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5}},
+        {"p2-shifted", 2, false, {2.0, 2.0, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0, 4.0}},
+    };
+}
+
+/// The vector's entries at the storage format.
+///
+/// \tparam T The storage format.
+/// \param raw The entries in `double`.
+/// \return The entries in `T`.
+template <class T>
+std::vector<T> at_format(const std::vector<double>& raw) {
+    std::vector<T> out(raw.size());
+    for (std::size_t i = 0; i < raw.size(); ++i) {
+        out[i] = static_cast<T>(raw[i]);
+    }
+    return out;
+}
+
+/// The corner cut returns 1 wherever every coefficient is 1.
+///
+/// \tparam T The storage format.
+/// \param format The format's name, for a failure note.
+template <class T>
+void check_corner_cut_sums_to_one(const char* format) {
+    for (const Vector1D& vector : vectors()) {
+        const std::vector<T> knots = at_format<T>(vector.raw);
+        const auto n_full = static_cast<std::int64_t>(knots.size()) - vector.degree - 1;
+        const std::vector<T> ones(static_cast<std::size_t>(n_full), T(1));
+        const BsplineSpace1D<T> space(std::span<const T>(knots), vector.degree, vector.periodic,
+                                      KnotSnapping::merge_near_duplicates);
+        const double bound = bound_for<T>(5 * vector.degree, 1.0);
+        for (const double u : sample_parameters<T>(space)) {
+            const std::vector<T> got =
+                corner_cut_along_axis<T>(std::span<const T>(knots), vector.degree,
+                                         space.tolerance(), std::span<const T>(ones), u, 1, 1);
+            const double deviation = std::abs(static_cast<double>(got[0]) - 1.0);
+            PANTR_CHECK_MSG(got.size() == 1 && deviation <= bound,
+                            std::string("partition of unity, ") + format + " "
+                                + vector.label + " at u=" + std::to_string(u) + ": off by "
+                                + std::to_string(deviation) + ", bound "
+                                + std::to_string(bound));
+        }
+    }
+}
+
+/// The corner cut over the Greville abscissae is the identity map.
+///
+/// \tparam T The storage format.
+/// \param format The format's name, for a failure note.
+template <class T>
+void check_corner_cut_is_linearly_precise(const char* format) {
+    for (const Vector1D& vector : vectors()) {
+        if (vector.degree < 1) {
+            continue;
+        }
+        const std::vector<T> knots = at_format<T>(vector.raw);
+        const std::vector<T> net = greville<T>(knots, vector.degree);
+        const BsplineSpace1D<T> space(std::span<const T>(knots), vector.degree, vector.periodic,
+                                      KnotSnapping::merge_near_duplicates);
+        const std::array<T, 2> domain = space.domain();
+        const double magnitude = std::max(std::abs(static_cast<double>(domain[0])),
+                                          std::abs(static_cast<double>(domain[1])));
+        const double bound = bound_for<T>(6 * vector.degree, magnitude);
+        for (const double u : sample_parameters<T>(space)) {
+            const std::vector<T> got =
+                corner_cut_along_axis<T>(std::span<const T>(knots), vector.degree,
+                                         space.tolerance(), std::span<const T>(net), u, 1, 1);
+            const double deviation = std::abs(static_cast<double>(got[0]) - u);
+            PANTR_CHECK_MSG(deviation <= bound,
+                            std::string("linear precision, ") + format + " " + vector.label
+                                + " at u=" + std::to_string(u) + ": off by "
+                                + std::to_string(deviation) + ", bound "
+                                + std::to_string(bound));
+        }
+    }
+}
+
+/// The corner cut of an interior block equals the corner cut of that block alone.
+///
+/// The strided sweep's own claim: output `(o, k)` depends on `values(o, ., k)` and
+/// nothing else, so running a three-dimensional net through one call must agree
+/// **bitwise** with running each `(o, k)` line through its own call. That is the
+/// argument `pantr/bspline/structural.hpp` makes for replacing the oracle's transpose,
+/// and it is the one claim in this file that is exact rather than bounded, because
+/// both sides execute the same operations on the same operands.
+///
+/// \tparam T The storage format.
+/// \param format The format's name, for a failure note.
+template <class T>
+void check_the_strided_sweep_is_line_by_line(const char* format) {
+    const std::vector<T> knots =
+        at_format<T>({0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0});
+    const std::int64_t degree = 2;
+    const std::int64_t num_basis = 6;
+    const std::int64_t outer = 3;
+    const std::int64_t inner = 4;
+    std::vector<T> values(static_cast<std::size_t>(outer * num_basis * inner));
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<T>(0.5) + static_cast<T>(i) * static_cast<T>(0.125);
+    }
+    const BsplineSpace1D<T> space(std::span<const T>(knots), degree, false,
+                                  KnotSnapping::merge_near_duplicates);
+    const double u = 0.4;
+    const std::vector<T> together =
+        corner_cut_along_axis<T>(std::span<const T>(knots), degree, space.tolerance(),
+                                 std::span<const T>(values), u, outer, inner);
+    PANTR_CHECK(together.size() == static_cast<std::size_t>(outer * inner));
+
+    for (std::int64_t o = 0; o < outer; ++o) {
+        for (std::int64_t k = 0; k < inner; ++k) {
+            std::vector<T> line(static_cast<std::size_t>(num_basis));
+            for (std::int64_t i = 0; i < num_basis; ++i) {
+                line[static_cast<std::size_t>(i)] =
+                    values[static_cast<std::size_t>(o * num_basis * inner + i * inner + k)];
+            }
+            const std::vector<T> alone =
+                corner_cut_along_axis<T>(std::span<const T>(knots), degree, space.tolerance(),
+                                         std::span<const T>(line), u, 1, 1);
+            PANTR_CHECK_MSG(alone[0] == together[static_cast<std::size_t>(o * inner + k)],
+                            std::string("the strided sweep is not line by line at ")
+                                + format + " (" + std::to_string(o) + ", "
+                                + std::to_string(k) + ")");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The open conversion
+// ---------------------------------------------------------------------------
+
+/// The `k`-th coefficient line of a one-dimensional field, sampled at `u`.
+///
+/// \tparam T The storage format.
+/// \param field A one-dimensional field.
+/// \param u The parameter.
+/// \return The homogeneous components at `u`.
+template <class T>
+std::vector<T> sample(const Bspline<T>& field, double u) {
+    return slice_point<T>(field, u);
+}
+
+/// `to_open` reaches full end multiplicity, drops periodicity, and keeps the map.
+///
+/// \tparam T The storage format.
+/// \param format The format's name, for a failure note.
+template <class T>
+void check_to_open_keeps_the_map(const char* format) {
+    for (const Vector1D& vector : vectors()) {
+        const std::vector<T> knots = at_format<T>(vector.raw);
+        auto space = direction<T>(knots, vector.degree, vector.periodic);
+        if (space->has_open_knots() && !space->periodic()) {
+            continue;  // Nothing to convert; the refusal is checked separately.
+        }
+        const std::vector<T> net = greville<T>(knots, vector.degree);
+        // A periodic space stores one period, so the field's net is the leading
+        // `num_basis` Greville abscissae of the ghost-extended vector. The map that
+        // net describes is *not* the identity -- the wrap makes it periodic -- which
+        // is fine: what is compared is the two representations of one map, not a
+        // closed form.
+        const auto stored = static_cast<std::size_t>(space->num_basis());
+        const std::vector<T> values(net.begin(), net.begin() + static_cast<std::ptrdiff_t>(stored));
+        const Bspline<T> original = field_of<T>({space}, values, 1, false);
+        const Bspline<T> opened = to_open<T>(original);
+
+        const BsplineSpace1D<T>& got = opened.space_ref().space_ref(0);
+        PANTR_CHECK_MSG(!got.periodic(), std::string("to_open left ") + vector.label
+                                             + " periodic at " + format);
+        PANTR_CHECK_MSG(got.has_open_knots(), std::string("to_open left ") + vector.label
+                                                  + " unclamped at " + format);
+        PANTR_CHECK_MSG(got.multiplicity_in_domain().front() == vector.degree + 1
+                            && got.multiplicity_in_domain().back() == vector.degree + 1,
+                        std::string("to_open did not reach multiplicity degree + 1 on ")
+                            + vector.label + " at " + format);
+
+        const std::int64_t roundings =
+            insertion_roundings(vector.degree) + 10 * vector.degree;
+        const double magnitude = std::max(std::abs(static_cast<double>(net.front())),
+                                          std::abs(static_cast<double>(net.back())));
+        const double bound = bound_for<T>(roundings, magnitude);
+        for (const double u : sample_parameters<T>(*space)) {
+            const std::vector<T> before = sample<T>(original, u);
+            const std::vector<T> after = sample<T>(opened, u);
+            const double deviation = std::abs(static_cast<double>(before[0])
+                                              - static_cast<double>(after[0]));
+            PANTR_CHECK_MSG(deviation <= bound,
+                            std::string("to_open moved the map, ") + format + " "
+                                + vector.label + " at u=" + std::to_string(u) + ": by "
+                                + std::to_string(deviation) + ", bound "
+                                + std::to_string(bound));
+        }
+    }
+}
+
+/// `to_open` refuses a field that is already open in every direction.
+void check_to_open_refuses_an_open_field() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const std::vector<double> values{0.0, 0.25, 0.75, 1.0};
+    const Bspline<double> field = field_of<double>({direction<double>(knots, 2, false)},
+                                                   values, 1, false);
+    std::string message;
+    try {
+        static_cast<void>(to_open<double>(field));
+    } catch (const std::invalid_argument& error) {
+        message = error.what();
+    }
+    PANTR_CHECK_MSG(message == "B-spline is already open in every direction.",
+                    "to_open's refusal text is \"" + message + "\"");
+}
+
+/// `to_open` leaves an already-open direction's handle alone.
+///
+/// The property the Python wrapper's `opened.space.spaces[d] is field.space.spaces[d]`
+/// rests on, and the reason `to_open` carries the handle rather than rebuilding an
+/// equal-valued space.
+void check_to_open_shares_an_untouched_direction() {
+    const std::vector<double> open{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const std::vector<double> unclamped{-0.2, -0.1, 0.0, 0.5, 1.0, 1.1, 1.2};
+    auto first = direction<double>(open, 2, false);
+    auto second = direction<double>(unclamped, 2, false);
+    const std::vector<double> values(16, 1.0);
+    const Bspline<double> field = field_of<double>({first, second}, values, 1, false);
+    const Bspline<double> opened = to_open<double>(field);
+    PANTR_CHECK_MSG(opened.space_ref().space(0) == first,
+                    "to_open rebuilt a direction it did not have to touch");
+    PANTR_CHECK_MSG(opened.space_ref().space(1) != second,
+                    "to_open kept the direction it was supposed to convert");
+}
+
+// ---------------------------------------------------------------------------
+// The split
+// ---------------------------------------------------------------------------
+
+/// `split` cuts the domain in two and keeps the map on each half.
+///
+/// \tparam T The storage format.
+/// \param format The format's name, for a failure note.
+template <class T>
+void check_split_keeps_the_map(const char* format) {
+    for (const Vector1D& vector : vectors()) {
+        const std::vector<T> knots = at_format<T>(vector.raw);
+        auto space = direction<T>(knots, vector.degree, vector.periodic);
+        const std::vector<T> net = greville<T>(knots, vector.degree);
+        const auto stored = static_cast<std::size_t>(space->num_basis());
+        const std::vector<T> values(net.begin(), net.begin() + static_cast<std::ptrdiff_t>(stored));
+        const Bspline<T> original = field_of<T>({space}, values, 1, false);
+
+        const std::array<T, 2> domain = space->domain();
+        const double lo = static_cast<double>(domain[0]);
+        const double hi = static_cast<double>(domain[1]);
+        // Two cut points: one that is no knot at all, and one that is an interior knot
+        // already -- the second exercises the `deficit` path with a head start, and a
+        // knot of full multiplicity already would exercise `deficit == 0`.
+        for (const double at : {lo + 0.4 * (hi - lo), lo + 0.5 * (hi - lo)}) {
+            const std::pair<Bspline<T>, Bspline<T>> halves = split<T>(original, 0, at);
+            const BsplineSpace1D<T>& left = halves.first.space_ref().space_ref(0);
+            const BsplineSpace1D<T>& right = halves.second.space_ref().space_ref(0);
+
+            PANTR_CHECK_MSG(!left.periodic() && !right.periodic(),
+                            std::string("a half of ") + vector.label + " is periodic at "
+                                + format);
+            const double left_hi = static_cast<double>(left.domain()[1]);
+            const double right_lo = static_cast<double>(right.domain()[0]);
+            const double seam = bound_for<T>(2, std::max(std::abs(at), 1.0));
+            PANTR_CHECK_MSG(std::abs(left_hi - at) <= seam && std::abs(right_lo - at) <= seam,
+                            std::string("the halves of ") + vector.label
+                                + " do not meet at the cut at " + format);
+
+            const std::int64_t roundings =
+                insertion_roundings(vector.degree) + 10 * vector.degree;
+            const double magnitude = std::max(std::abs(lo), std::abs(hi));
+            const double bound = bound_for<T>(roundings, magnitude);
+            for (const double u : sample_parameters<T>(*space)) {
+                const Bspline<T>& half = u <= at ? halves.first : halves.second;
+                const double clamped = u <= at ? std::min(u, left_hi) : std::max(u, right_lo);
+                const std::vector<T> before = sample<T>(original, clamped);
+                const std::vector<T> after = sample<T>(half, clamped);
+                const double deviation = std::abs(static_cast<double>(before[0])
+                                                  - static_cast<double>(after[0]));
+                PANTR_CHECK_MSG(deviation <= bound,
+                                std::string("split moved the map, ") + format + " "
+                                    + vector.label + " cut at " + std::to_string(at)
+                                    + ", u=" + std::to_string(clamped) + ": by "
+                                    + std::to_string(deviation) + ", bound "
+                                    + std::to_string(bound));
+            }
+        }
+    }
+}
+
+/// `split` leaves every other direction's handle alone, in both halves.
+void check_split_shares_the_untouched_directions() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    auto first = direction<double>(knots, 2, false);
+    auto second = direction<double>(knots, 2, false);
+    const std::vector<double> values(16, 1.0);
+    const Bspline<double> field = field_of<double>({first, second}, values, 1, false);
+    const std::pair<Bspline<double>, Bspline<double>> halves = split<double>(field, 0, 0.25);
+    PANTR_CHECK_MSG(halves.first.space_ref().space(1) == second
+                        && halves.second.space_ref().space(1) == second,
+                    "split rebuilt a direction it did not cut");
+    PANTR_CHECK_MSG(halves.first.space_ref().space(0) != first
+                        && halves.second.space_ref().space(0) != first,
+                    "split kept the direction it was supposed to cut");
+    PANTR_CHECK_MSG(halves.first.dim() == 2 && halves.second.dim() == 2,
+                    "split changed the dimension");
+}
+
+// ---------------------------------------------------------------------------
+// The slice and the boundary
+// ---------------------------------------------------------------------------
+
+/// `slice` drops the axis, keeps the other directions' handles, and agrees with a
+/// direct corner cut of the same field.
+void check_slice_drops_the_axis() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const std::vector<double> other{0.0, 0.0, 0.4, 1.0, 1.0};
+    auto first = direction<double>(knots, 2, false);
+    auto second = direction<double>(other, 1, false);
+    auto third = direction<double>(knots, 2, false);
+    std::vector<double> values(4 * 3 * 4 * 2);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = 0.5 + static_cast<double>(i) * 0.125;
+    }
+    const Bspline<double> field = field_of<double>({first, second, third}, values, 2, false);
+
+    const Bspline<double> sliced = slice<double>(field, 1, 0.4);
+    PANTR_CHECK(sliced.dim() == 2);
+    PANTR_CHECK_MSG(sliced.space_ref().space(0) == first
+                        && sliced.space_ref().space(1) == third,
+                    "slice rebuilt a surviving direction or reordered them");
+    PANTR_CHECK(sliced.net().extent(0) == 4 && sliced.net().extent(1) == 4
+                && sliced.net().num_components() == 2);
+
+    // The same computation the other way round: the axis's own corner cut, strided.
+    const std::vector<double> direct = corner_cut_along_axis<double>(
+        std::span<const double>(other), 1, second->tolerance(), field.net().values(), 0.4, 4,
+        4 * 2);
+    PANTR_CHECK(direct.size() == sliced.net().size());
+    bool identical = true;
+    for (std::size_t i = 0; i < direct.size(); ++i) {
+        identical = identical && direct[i] == sliced.net().values()[i];
+    }
+    PANTR_CHECK_MSG(identical, "slice and a direct strided corner cut disagree");
+}
+
+/// `slice` refuses a one-dimensional field and `slice_point` refuses a wider one.
+void check_the_slice_pair_refuses_each_other_s_case() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    auto one = direction<double>(knots, 2, false);
+    const Bspline<double> curve =
+        field_of<double>({one}, {0.0, 0.25, 0.75, 1.0}, 1, false);
+    const std::vector<double> flat(16, 1.0);
+    const Bspline<double> surface = field_of<double>({one, one}, flat, 1, false);
+
+    std::string first;
+    try {
+        static_cast<void>(slice<double>(curve, 0, 0.5));
+    } catch (const std::invalid_argument& error) {
+        first = error.what();
+    }
+    PANTR_CHECK_MSG(first.find("dimension at least two") != std::string::npos,
+                    "slice's one-dimensional refusal reads \"" + first + "\"");
+
+    std::string second;
+    try {
+        static_cast<void>(slice_point<double>(surface, 0.5));
+    } catch (const std::invalid_argument& error) {
+        second = error.what();
+    }
+    PANTR_CHECK_MSG(second == "slice_point needs a one-dimensional B-spline, got dimension 2.",
+                    "slice_point's refusal reads \"" + second + "\"");
+}
+
+/// `boundary` is `slice` at a domain endpoint, and refuses a side that is neither.
+void check_boundary_is_a_slice_at_an_end() {
+    const std::vector<double> knots{2.0, 2.0, 2.0, 3.0, 4.0, 4.0, 4.0};
+    auto one = direction<double>(knots, 2, false);
+    std::vector<double> values(16);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        values[i] = 1.0 + static_cast<double>(i);
+    }
+    const Bspline<double> surface = field_of<double>({one, one}, values, 1, false);
+
+    for (const int side : {0, 1}) {
+        const Bspline<double> face = boundary<double>(surface, 0, side);
+        const Bspline<double> want = slice<double>(surface, 0, side == 0 ? 2.0 : 4.0);
+        bool identical = face.net().size() == want.net().size();
+        for (std::size_t i = 0; identical && i < want.net().size(); ++i) {
+            identical = face.net().values()[i] == want.net().values()[i];
+        }
+        PANTR_CHECK_MSG(identical, "boundary and the slice it is defined as disagree on side "
+                                       + std::to_string(side));
+    }
+
+    std::string message;
+    try {
+        static_cast<void>(boundary<double>(surface, 0, 2));
+    } catch (const std::invalid_argument& error) {
+        message = error.what();
+    }
+    PANTR_CHECK_MSG(message == "side must be 0 or 1, got 2.",
+                    "boundary's side refusal reads \"" + message + "\"");
+}
+
+/// `slice_point` hands back the weight column of a rational field unprojected.
+///
+/// The division is the caller's, which is what the header and the binding both say and
+/// what keeps the oracle's own numpy division in one place.
+void check_slice_point_leaves_a_rational_unprojected() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    // Four coefficients of (x, w) with every weight 2, so the projection is x / 2 and
+    // an accidental projection here would be visible.
+    const std::vector<double> values{0.0, 2.0, 1.0, 2.0, 3.0, 2.0, 4.0, 2.0};
+    const Bspline<double> curve =
+        field_of<double>({direction<double>(knots, 2, false)}, values, 2, true);
+    const std::vector<double> point = slice_point<double>(curve, 0.5);
+    PANTR_CHECK(point.size() == 2);
+    PANTR_CHECK_MSG(std::abs(point[1] - 2.0) <= bound_for<double>(10, 2.0),
+                    "slice_point projected a rational field, or lost its weight");
+}
+
+// ---------------------------------------------------------------------------
+// The primitives' own refusals
+// ---------------------------------------------------------------------------
+
+/// The two strided primitives refuse a shape they cannot address.
+void check_the_primitives_refuse_a_bad_shape() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const std::vector<double> values(4, 1.0);
+    const std::vector<std::int64_t> rows{0, 1};
+
+    int refused = 0;
+    const auto attempt = [&refused](const auto& call) {
+        try {
+            call();
+        } catch (const std::invalid_argument&) {
+            ++refused;
+        }
+    };
+    attempt([&] {
+        static_cast<void>(select_rows_along_axis<double>(std::span<const double>(values), 4,
+                                                         std::span<const std::int64_t>(rows), 2,
+                                                         1));
+    });
+    attempt([&] {
+        static_cast<void>(select_rows_along_axis<double>(std::span<const double>(values), 4,
+                                                         std::span<const std::int64_t>(rows), -1,
+                                                         1));
+    });
+    const std::vector<std::int64_t> bad_row{4};
+    attempt([&] {
+        static_cast<void>(select_rows_along_axis<double>(
+            std::span<const double>(values), 4, std::span<const std::int64_t>(bad_row), 1, 1));
+    });
+    attempt([&] {
+        static_cast<void>(corner_cut_along_axis<double>(std::span<const double>(knots), 2, 1e-15,
+                                                        std::span<const double>(values), 0.5, 1,
+                                                        2));
+    });
+    attempt([&] {
+        static_cast<void>(corner_cut_along_axis<double>(std::span<const double>(knots), -1,
+                                                        1e-15, std::span<const double>(values),
+                                                        0.5, 1, 1));
+    });
+    const std::vector<double> too_short{0.0, 1.0};
+    attempt([&] {
+        static_cast<void>(corner_cut_along_axis<double>(std::span<const double>(too_short), 2,
+                                                        1e-15, std::span<const double>(values),
+                                                        0.5, 1, 1));
+    });
+    PANTR_CHECK_MSG(refused == 6,
+                    "the strided primitives accepted " + std::to_string(6 - refused)
+                        + " shape(s) they cannot address");
+}
+
+/// `split`'s two Layer 1 refusals carry the oracle's texts.
+void check_split_refusals() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const Bspline<double> curve = field_of<double>({direction<double>(knots, 2, false)},
+                                                   {0.0, 0.25, 0.75, 1.0}, 1, false);
+    std::string direction_text;
+    try {
+        static_cast<void>(split<double>(curve, 1, 0.5));
+    } catch (const std::invalid_argument& error) {
+        direction_text = error.what();
+    }
+    PANTR_CHECK_MSG(direction_text == "direction must be in [0, 1), got 1.",
+                    "split's direction refusal reads \"" + direction_text + "\"");
+
+    for (const double at : {0.0, 1.0, -0.5}) {
+        std::string value_text;
+        try {
+            static_cast<void>(split<double>(curve, 0, at));
+        } catch (const std::invalid_argument& error) {
+            value_text = error.what();
+        }
+        PANTR_CHECK_MSG(value_text
+                            == "value must be strictly inside the domain (0.0, 1.0), got "
+                                   + std::string(at == 0.0 ? "0.0" : (at == 1.0 ? "1.0" : "-0.5"))
+                                   + ".",
+                        "split's value refusal reads \"" + value_text + "\"");
+    }
+}
+
+/// `slice`'s two Layer 1 refusals carry the oracle's texts.
+void check_slice_refusals() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    auto one = direction<double>(knots, 2, false);
+    const std::vector<double> flat(16, 1.0);
+    const Bspline<double> surface = field_of<double>({one, one}, flat, 1, false);
+
+    std::string axis_text;
+    try {
+        static_cast<void>(slice<double>(surface, 2, 0.5));
+    } catch (const std::invalid_argument& error) {
+        axis_text = error.what();
+    }
+    PANTR_CHECK_MSG(axis_text == "axis must be in [0, 2), got 2.",
+                    "slice's axis refusal reads \"" + axis_text + "\"");
+
+    std::string domain_text;
+    try {
+        static_cast<void>(slice<double>(surface, 1, 1.7));
+    } catch (const std::invalid_argument& error) {
+        domain_text = error.what();
+    }
+    PANTR_CHECK_MSG(domain_text == "value 1.7 is outside the domain [0.0, 1.0] of direction 1.",
+                    "slice's domain refusal reads \"" + domain_text + "\"");
+}
+
+/// `open_along_axis` refuses an axis that is already clamped and not periodic.
+void check_open_along_axis_refuses_a_clamped_axis() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0};
+    const std::vector<double> values{0.0, 0.25, 0.75, 1.0};
+    std::string message;
+    try {
+        static_cast<void>(open_along_axis<double>(std::span<const double>(knots), 2, false,
+                                                  1e-15, std::span<const double>(values), 4, 1,
+                                                  1));
+    } catch (const std::invalid_argument& error) {
+        message = error.what();
+    }
+    PANTR_CHECK_MSG(
+        message
+            == "B-spline is already open (both boundary knots have multiplicity degree + 1).",
+        "open_along_axis's refusal reads \"" + message + "\"");
+}
+
+}  // namespace
+
+int main() {
+    check_corner_cut_sums_to_one<double>("float64");
+    check_corner_cut_sums_to_one<float>("float32");
+    check_corner_cut_is_linearly_precise<double>("float64");
+    check_corner_cut_is_linearly_precise<float>("float32");
+    check_the_strided_sweep_is_line_by_line<double>("float64");
+    check_the_strided_sweep_is_line_by_line<float>("float32");
+
+    check_to_open_keeps_the_map<double>("float64");
+    check_to_open_keeps_the_map<float>("float32");
+    check_to_open_refuses_an_open_field();
+    check_to_open_shares_an_untouched_direction();
+
+    check_split_keeps_the_map<double>("float64");
+    check_split_keeps_the_map<float>("float32");
+    check_split_shares_the_untouched_directions();
+
+    check_slice_drops_the_axis();
+    check_the_slice_pair_refuses_each_other_s_case();
+    check_boundary_is_a_slice_at_an_end();
+    check_slice_point_leaves_a_rational_unprojected();
+
+    check_the_primitives_refuse_a_bad_shape();
+    check_split_refusals();
+    check_slice_refusals();
+    check_open_along_axis_refuses_a_clamped_axis();
+
+    return pantr::test::summary("test_bspline_structural");
+}

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -128,6 +128,10 @@ from ._bspline import (
 from ._bspline_field import Bspline32 as Bspline32
 from ._bspline_field import Bspline64 as Bspline64
 from ._bspline_field import insert_bspline_knots as insert_bspline_knots
+from ._bspline_field import open_bspline as open_bspline
+from ._bspline_field import slice_bspline as slice_bspline
+from ._bspline_field import slice_bspline_point as slice_bspline_point
+from ._bspline_field import split_bspline as split_bspline
 from ._bspline_field import subdivide_bspline as subdivide_bspline
 from ._geometry import AABB as AABB
 from ._grid import BVH as BVH

--- a/src/pantr/_pantr_cpp/_bspline_field.pyi
+++ b/src/pantr/_pantr_cpp/_bspline_field.pyi
@@ -1,10 +1,15 @@
 """Type stub for `pantr.bspline.Bspline`, bound in `cpp/bindings/bspline_type.cpp`.
 
-The two refinement entry points at the bottom come from
-``cpp/bindings/bspline_refinement.cpp`` instead, and they are here rather than in a
-third stub module because they are operations on the classes above: a stub split by
-binding file would put a function's argument type in one module and the function in
-another for no reader's benefit.
+The two refinement entry points come from ``cpp/bindings/bspline_refinement.cpp`` and
+the four structural ones from ``cpp/bindings/bspline_structural.cpp`` instead, and
+they are here rather than in further stub modules because they are operations on the
+classes above: a stub split by binding file would put a function's argument type in
+one module and the function in another for no reader's benefit.
+
+``bspline_structural.cpp`` binds no ``bspline_boundary``, so none is declared here.
+``pantr.bspline.Bspline.boundary`` is a ``slice`` at a domain endpoint and reaches C++
+through :func:`slice_bspline`; ``pantr._pantr_cpp.bezier_boundary`` is the bound-with-
+no-caller shape that decision avoids repeating.
 
 Its own stub module rather than a third pair of classes in ``_bspline.pyi``, for the
 reason ``__init__.pyi`` gives for splitting the stub at all: a ticket that ports a
@@ -126,4 +131,55 @@ def subdivide_bspline(
 
     A count of 1 skips its direction. ``regularity`` is ``None`` for ``degree - 1`` per
     direction, the maximal smoothness each degree admits.
+    """
+
+def open_bspline(bspline: Bspline32 | Bspline64) -> Bspline32 | Bspline64:
+    """Re-express a field over clamped, non-periodic knot vectors in every direction.
+
+    A direction that is already open is left alone and its space handle carried into
+    the result, which is what keeps ``opened.space.spaces[d] is field.space.spaces[d]``
+    true for it. Raises ``ValueError`` when every direction is already open, with the
+    oracle's own text: there would be nothing to do.
+    """
+
+def split_bspline(
+    bspline: Bspline32 | Bspline64,
+    direction: int,
+    value: float,
+) -> tuple[Bspline32, Bspline32] | tuple[Bspline64, Bspline64]:
+    """Cut a field in two at a parameter of one direction.
+
+    The left half spans ``[domain_start, value]`` and the right ``[value, domain_end]``;
+    every other direction is untouched and its space handle is shared by both halves.
+    A periodic split direction is converted to its open form first, so both halves are
+    non-periodic in it. ``value`` must be strictly inside the domain by more than the
+    direction's tolerance, which ``pantr.bspline.Bspline.split`` checks first.
+    """
+
+def slice_bspline(
+    bspline: Bspline32 | Bspline64,
+    axis: int,
+    value: float,
+) -> Bspline32 | Bspline64:
+    """Fix one parametric direction at a value, dropping it.
+
+    Needs a field of dimension at least two; a one-dimensional one slices to a point,
+    which :func:`slice_bspline_point` returns instead. The surviving directions keep
+    their order and their space handles.
+    """
+
+def slice_bspline_point(
+    bspline: Bspline32 | Bspline64,
+    value: float,
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """The point a one-dimensional field takes at a parameter, into ``out``.
+
+    ``out`` must be 1-D, contiguous, of the field's storage format and as long as the
+    control net has components -- the **weight column included**, because the
+    projection of a rational field is the caller's.
+    ``pantr.bspline._structural_backend`` allocates it and divides, which is where the
+    oracle's own numpy division lives. Overloaded on the field's class in C++, so no
+    cast is performed on ``out``.
     """

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -1240,6 +1240,9 @@ class Bspline:
 
         Raises:
             ValueError: If the B-spline is already open in every direction.
+            TypeError: If this field was built under the other backend. New with the
+                C++ dispatch: the operation crosses the boundary as a *field*, and
+                ``_cpp_handle`` refuses a foreign one rather than converting it.
         """
         return to_open_field(self)
 
@@ -1311,6 +1314,9 @@ class Bspline:
         Raises:
             ValueError: If ``direction`` is out of range ``[0, dim)``.
             ValueError: If ``value`` is not strictly inside the domain.
+            TypeError: If this field was built under the other backend. New with the
+                C++ dispatch: the operation crosses the boundary as a *field*, and
+                ``_cpp_handle`` refuses a foreign one rather than converting it.
 
         Example:
             >>> import numpy as np
@@ -1891,6 +1897,9 @@ class Bspline:
             ValueError: If ``axis`` is out of range ``[0, dim)``.
             ValueError: If ``value`` is outside the domain of the specified
                 direction.
+            TypeError: If this field was built under the other backend. New with the
+                C++ dispatch: the operation crosses the boundary as a *field*, and
+                ``_cpp_handle`` refuses a foreign one rather than converting it.
 
         Example:
             >>> import numpy as np
@@ -1939,6 +1948,9 @@ class Bspline:
         Raises:
             ValueError: If ``axis`` is out of range ``[0, dim)``.
             ValueError: If ``side`` is not 0 or 1.
+            TypeError: If this field was built under the other backend. New with the
+                C++ dispatch: the operation crosses the boundary as a *field*, and
+                ``_cpp_handle`` refuses a foreign one rather than converting it.
 
         Example:
             >>> import numpy as np

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -59,19 +59,15 @@ from .._transform_control_points import _apply_affine_to_control_points
 from ._bspline_degree import _degree_elevate_bspline, _degree_reduce_bspline
 from ._bspline_derivative import _derivative_bspline
 from ._bspline_eval import _evaluate_Bspline, _evaluate_Bspline_deriv
-from ._bspline_knot_insertion import (
-    _to_open_bspline_impl,
-    _to_periodic_bspline_impl,
-)
+from ._bspline_knot_insertion import _to_periodic_bspline_impl
 from ._bspline_knot_removal import _remove_knots_bspline
 from ._bspline_locate import _locate_impl
 from ._bspline_restrict import _restrict_bspline_impl
-from ._bspline_slice import _slice_bspline
 from ._bspline_space_nd import BsplineSpace as _BsplineSpace
 from ._bspline_space_nd import _impl_class as _space_impl_class
-from ._bspline_split import _split_bspline_impl
 from ._bspline_to_beziers import _to_beziers_impl
 from ._refinement_backend import insert_knots_into_field, subdivide_field
+from ._structural_backend import slice_field, split_field, to_open_field
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -82,6 +78,7 @@ if TYPE_CHECKING:
     from ..quad import PointsLattice
     from ..transform import AffineTransform
     from ._bspline_locate import _LocateContext
+    from ._bspline_space_1d import BsplineSpace1D
     from ._bspline_space_nd import BsplineSpace
 
     _Impl: TypeAlias = "_BsplinePython | _CppBspline32 | _CppBspline64"
@@ -470,8 +467,8 @@ class Bspline:
         self._take(_new_impl(space, validated, is_rational), space)
 
     @classmethod
-    def _wrap_over(cls, impl: _Impl, prior: BsplineSpace) -> Bspline:
-        """Wrap an implementation an operation produced from ``prior``'s field.
+    def _wrap_over(cls, impl: _Impl, prior: Sequence[BsplineSpace1D]) -> Bspline:
+        """Wrap an implementation an operation produced from ``prior``'s directions.
 
         The path an operation takes when C++ built the result: refining a field under
         the C++ backend hands back a ``Bspline<T>`` handle, and this wrapper must hold
@@ -481,10 +478,18 @@ class Bspline:
         wrapper's space and the implementation's space as two computations of one
         answer.
 
-        ``prior`` is the space the operation started from, and it travels down to
-        :meth:`BsplineSpace._wrap_over`, which explains what it buys: a direction the
-        operation left alone keeps the wrapper it already had, so
-        ``result.space.spaces[d] is field.space.spaces[d]`` holds under both backends.
+        ``prior`` travels down to :meth:`BsplineSpace._wrap_over`, which explains what
+        it buys: a direction the operation left alone keeps the wrapper it already had,
+        so ``result.space.spaces[d] is field.space.spaces[d]`` holds under both
+        backends.
+
+        **It is one wrapper per direction of ``impl``, not of the field the operation
+        started from**, and the two differ for a dimension-reducing operation. A
+        caller that drops a direction has to drop it from ``prior`` too --
+        :func:`pantr.bspline._structural_backend._cpp_slice` passes
+        ``spaces`` with the sliced axis removed -- and one that permutes the directions
+        has to permute ``prior``. Handing the unreduced list instead is refused rather
+        than silently mismatched, by the length check one level down.
 
         The derived block starts cold, because :meth:`_take` is the only writer and it
         replaces the block wholesale; a refined field shares no memo with the field it
@@ -492,15 +497,18 @@ class Bspline:
 
         Args:
             impl (_Impl): The implementation to adopt, with no re-validation.
-            prior (~pantr.bspline.BsplineSpace): The space wrapper the operation
-                started from, whose direction wrappers are reused where ``impl`` still
-                holds their implementations.
+            prior (Sequence[BsplineSpace1D]): The univariate wrappers the operation
+                started from, in axis order, one per direction of ``impl``. Each is
+                reused where ``impl`` still holds its implementation.
 
         Returns:
             Bspline: A wrapper around ``impl``.
+
+        Raises:
+            ValueError: If ``prior`` does not have one entry per direction of ``impl``.
         """
         self = object.__new__(cls)
-        self._take(impl, _BsplineSpace._wrap_over(impl.space, prior.spaces))
+        self._take(impl, _BsplineSpace._wrap_over(impl.space, prior))
         return self
 
     def _take(self, impl: _Impl, space: BsplineSpace) -> None:
@@ -1233,7 +1241,7 @@ class Bspline:
         Raises:
             ValueError: If the B-spline is already open in every direction.
         """
-        return _to_open_bspline_impl(self)
+        return to_open_field(self)
 
     def restrict(
         self,
@@ -1325,7 +1333,7 @@ class Bspline:
         if value <= a + tol or value >= b - tol:
             raise ValueError(f"value must be strictly inside the domain ({a}, {b}), got {value}.")
 
-        return _split_bspline_impl(self, direction, value)
+        return split_field(self, direction, value)
 
     def to_periodic(self, continuity: int | tuple[int | None, ...] | None = None) -> Bspline:
         """Return a periodic B-spline equivalent to this one.
@@ -1909,7 +1917,7 @@ class Bspline:
                 f"of direction {axis}."
             )
 
-        return _slice_bspline(self, axis, value)
+        return slice_field(self, axis, value)
 
     def boundary(self, axis: int, side: int) -> Bspline | npt.NDArray[np.float32 | np.float64]:
         """Extract the boundary of the B-spline along one parametric direction.

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -433,13 +433,16 @@ class BsplineSpace:
         difference no value comparison would ever report.
         ``pantr.grid.HierarchicalGrid._wrap_over`` exists for the same reason.
 
-        **The reuse is positional, so this method is only correct for an operation that
-        preserves the directions and their order.** Refinement does; a boundary
-        extraction or a permutation would not, and reusing direction ``d``'s wrapper
-        there would hand back a wrapper for a different direction while every value
-        comparison agreed. So the dimensions must match, and that is checked rather
-        than documented: it is the one precondition of this method a caller could get
-        wrong silently.
+        **The reuse is positional against ``impl``'s directions**, so ``prior`` has to
+        be in the order and of the length ``impl`` has, not the ones the operation
+        started from. Refinement preserves both and passes its field's own list; a
+        *slice* drops one direction and must drop the matching entry, which
+        :func:`pantr.bspline._structural_backend._cpp_slice` does; a permutation would
+        have to permute. Reusing direction ``d``'s wrapper against a list that no
+        longer describes ``d`` would hand back a wrapper for a different direction
+        while every value comparison agreed. The length is therefore checked rather
+        than documented -- it catches the unreduced list, which is the mistake a caller
+        is most likely to make -- while the *order* is the caller's to get right.
 
         Args:
             impl (_Impl): The implementation object to adopt, with no re-validation.

--- a/src/pantr/bspline/_refinement_backend.py
+++ b/src/pantr/bspline/_refinement_backend.py
@@ -265,7 +265,9 @@ def _cpp_insert_knots(bspline: Bspline, new_knots_per_dim: Sequence[_Knots | Non
 
     handle = _cpp_handle(bspline)
     flat = _flat_insertions(new_knots_per_dim, bspline.dtype)
-    return BsplineCls._wrap_over(_pantr_cpp.insert_bspline_knots(handle, flat), bspline.space)
+    return BsplineCls._wrap_over(
+        _pantr_cpp.insert_bspline_knots(handle, flat), bspline.space.spaces
+    )
 
 
 def _cpp_subdivide(
@@ -298,7 +300,7 @@ def _cpp_subdivide(
         _pantr_cpp.subdivide_bspline(
             handle, [1 if count is None else int(count) for count in counts], regularity
         ),
-        bspline.space,
+        bspline.space.spaces,
     )
 
 

--- a/src/pantr/bspline/_refinement_backend.py
+++ b/src/pantr/bspline/_refinement_backend.py
@@ -95,9 +95,26 @@ Cross-backend fields
 converting it, which is what ``design/cross_backend_types.md`` forbids and what
 :meth:`pantr.bspline.Bspline._mutate` already refuses for the three ``in_place=``
 methods. The refusal is a property of *taking the C++ route*, so it fires under the C++
-backend and not under the Python one, where the oracle runs happily over a C++ field's
-read-only control points. That asymmetry is
+backend and not under the Python one. That asymmetry is
 :func:`pantr.bezier._bezier_backend._cpp_handle`'s, unchanged.
+
+**What the Python route does with a C++ field is narrower than this used to say**, and
+the correction is measured rather than reasoned. It said the oracle "runs happily over
+a C++ field's read-only control points", without qualification. It does so only when
+**every** direction is refined: :func:`_insert_knots_bspline` rebuilds a refined
+direction's space wrapper, which under the Python backend is a Python one, but *carries
+the caller's wrapper through* for a direction it skips -- and
+:class:`~pantr.bspline.BsplineSpace` cannot aggregate a direction from the other
+backend, so it raises ``ValueError: All B-spline spaces must come from the active
+backend``. Measured on a two-direction C++ field under the Python backend:
+``insert_knots`` with knots for both directions succeeds, with knots for one it raises,
+and ``subdivide`` behaves the same way at ``[2, 2]`` and ``[2, 1]``.
+
+So the cross-backend rule is enforced on both routes -- up front and by ``TypeError``
+here, late and by ``ValueError`` in the space constructor there.
+:func:`tests.parity.test_bspline_structural.test_a_cross_backend_field_is_refused_on_both_routes`
+pins both halves, for the three operations where the oracle route *always* carries a
+wrapper through and so always raises.
 """
 
 from __future__ import annotations

--- a/src/pantr/bspline/_structural_backend.py
+++ b/src/pantr/bspline/_structural_backend.py
@@ -1,0 +1,339 @@
+"""Which implementation performs a structural operation on a field: Numba or C++.
+
+:mod:`pantr._backend` owns the **policy**. This module owns the **catalogue** for the
+three structural operations, exactly as :mod:`pantr.bspline._refinement_backend` does
+for the two refinement ones, and for the same reason: a catalogue imports the
+implementations it hands out, so keeping each one beside its own is what stops the
+policy module from importing the library it must stay independent of.
+
+Three entry points rather than accessors
+----------------------------------------
+
+:func:`to_open_field`, :func:`split_field` and :func:`slice_field` are functions that
+*do* the work, not accessors that return a callable, for the reason
+:mod:`pantr.bspline._refinement_backend` gives in full: what crosses the seam is a
+:class:`~pantr.bspline.Bspline`, and there is exactly one consumer per entry point.
+
+:meth:`pantr.bspline.Bspline.boundary` has no entry point here because it needs none.
+It is defined as :meth:`~pantr.bspline.Bspline.slice` at a domain endpoint, so it
+reaches C++ through :func:`slice_field` and a fourth spelling would be a second
+definition of one operation. ``pantr._pantr_cpp`` binds no ``bspline_boundary``
+either, for the same reason.
+
+What crosses the boundary
+-------------------------
+
+**The field, not its arrays**, which is what
+``design/cross_backend_types.md``'s 2026-08-27 amendment requires of an operation on a
+domain type C++ owns: the adapter hands the binding the handle the wrapper already
+holds and wraps the handle that comes back. The *arguments* cross as plain scalars --
+an axis, a direction, a parameter -- with no invariant to lose.
+
+The one exception is a one-dimensional slice, whose result is a point rather than a
+field. It crosses as an ``out=`` buffer this module allocates in the field's own
+format, which is where the rest of ``pantr``'s ``out=`` convention puts the allocation,
+and which is how ``slice_bezier_point`` already crosses.
+
+Where the two backends differ, and there is one place
+-----------------------------------------------------
+
+**Nothing here refuses a periodic direction**, which is the one asymmetry with
+refinement worth stating rather than leaving to be noticed.
+:mod:`~pantr.bspline._refinement_backend` keeps a periodic direction on the oracle
+because refining one needs the open-to-periodic conversion, which is not ported. None
+of these three needs it: :func:`split_field` converts a periodic direction to its open
+form and returns two non-periodic halves, :func:`slice_field` expands a periodic net by
+its own modulo wrap, and :func:`to_open_field` *is* the conversion in the direction
+that is ported. So the C++ path takes every field either backend takes.
+
+**The one divergence that does exist is unreachable**, and it is recorded here so that
+a later reader does not have to rediscover it.
+:meth:`pantr.bspline.Bspline.slice`'s out-of-domain message interpolates
+``space.domain[0]``, a *numpy scalar* of the storage format, and the C++ half renders
+the widened value instead -- ``0.1`` against ``0.10000000149011612`` at ``float32``.
+The wrapper makes that check before dispatching, so no caller can reach the C++ text;
+``cpp/include/pantr/bspline/structural.hpp`` carries why the fix belongs to
+``pantr/core/format.hpp`` and not here. ``tests/parity/test_bspline_structural.py``
+pins the wrapper's own text under both backends.
+
+Which refusals each backend makes, and where
+--------------------------------------------
+
+Every Layer 1 check of :meth:`~pantr.bspline.Bspline.split`,
+:meth:`~pantr.bspline.Bspline.slice` and :meth:`~pantr.bspline.Bspline.boundary` runs
+in the wrapper, above the branch, so both backends refuse the same argument with the
+same message and neither path can differ in order. The C++ header restates those
+checks for a caller with no wrapper in front of it, which is
+``cpp/include/pantr/bspline/refinement.hpp``'s own reason for restating three of
+``insert_knots``'.
+
+:meth:`~pantr.bspline.Bspline.to_open_bspline` is the exception: it makes **no** Layer 1
+check, and "already open in every direction" is raised by whichever implementation
+runs. Both texts are the oracle's and both predicates are the oracle's, negated the
+same way.
+
+Cross-backend fields
+--------------------
+
+:func:`_cpp_handle` refuses a field built under the other backend rather than
+converting it, which is what ``design/cross_backend_types.md`` forbids. The refusal is
+a property of *taking the C++ route*, so it fires under the C++ backend and not under
+the Python one, where the oracle runs happily over a C++ field's read-only control
+points. That asymmetry is
+:func:`pantr.bspline._refinement_backend._cpp_handle`'s, unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias, cast
+
+import numpy as np
+
+from .._backend import Backend, active_backend, available_backends
+from ._bspline_knot_insertion import _to_open_bspline_impl
+from ._bspline_slice import _slice_bspline
+from ._bspline_split import _split_bspline_impl
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from .._pantr_cpp import Bspline32 as _CppBspline32
+    from .._pantr_cpp import Bspline64 as _CppBspline64
+    from ._bspline import Bspline
+
+    _CppHandle: TypeAlias = "_CppBspline32 | _CppBspline64"
+    """A field's C++ implementation, of either storage format."""
+
+_Point: TypeAlias = "npt.NDArray[np.float32 | np.float64]"
+"""The point a one-dimensional slice returns, in the field's storage format."""
+
+
+def _cpp_handle(bspline: Bspline) -> _CppHandle:
+    """The C++ implementation a field holds, refusing a Python one.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field whose handle is wanted.
+
+    Returns:
+        _CppHandle: The ``Bspline32`` or ``Bspline64`` handle.
+
+    Raises:
+        TypeError: If the field holds the Python implementation. That means the active
+            backend changed after it was built, and converting one implementation into
+            the other is what ``design/cross_backend_types.md`` forbids.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    impl = bspline._impl  # same package; the wrapper exposes no public handle
+    if not isinstance(impl, _pantr_cpp.Bspline32 | _pantr_cpp.Bspline64):
+        raise TypeError(
+            f"Bspline: cannot restructure a Bspline built under a different backend "
+            f"({type(impl).__name__} against the active C++ one); the backend is "
+            f"chosen per process, so this means the active one changed after this "
+            f"Bspline was built."
+        )
+    return impl
+
+
+def _the_cpp_backend_can_take_it() -> bool:
+    """Report whether the C++ path covers a structural call.
+
+    One condition, unlike refinement's three: the C++ backend has to be the active one.
+    There is no periodicity question here -- the module docstring says why -- and no
+    "at least one direction" question either, since none of the three takes a
+    per-direction argument that could be empty.
+
+    Returns:
+        bool: True when the ``_cpp_*`` functions below may run.
+
+    Raises:
+        RuntimeError: If the C++ backend is the active one and is not available. That
+            cannot happen through :func:`pantr._backend.active_backend`, which refuses
+            an unavailable backend at import; the check is here so that this module
+            states the never-fall-back rule rather than relying on where it was
+            enforced.
+    """
+    if active_backend() is Backend.PYTHON:
+        return False
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    return True
+
+
+def _cpp_to_open(bspline: Bspline) -> Bspline:
+    """Convert every direction to open form through the C++ binding.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field, holding a C++ handle.
+
+    Returns:
+        ~pantr.bspline.Bspline: The open field, wrapping a C++ handle.
+
+    Raises:
+        ValueError: If every direction is already open and non-periodic, with the
+            oracle's message.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bspline import Bspline as BsplineCls  # noqa: PLC0415  (cycle)
+
+    handle = _cpp_handle(bspline)
+    return BsplineCls._wrap_over(_pantr_cpp.open_bspline(handle), bspline.space.spaces)
+
+
+def _cpp_split(bspline: Bspline, direction: int, value: float) -> tuple[Bspline, Bspline]:
+    """Split a field through the C++ binding.
+
+    Both halves are wrapped over the *same* prior direction list, because both keep
+    every direction but the split one: an untouched direction's wrapper is therefore
+    shared by the two halves and by ``bspline``.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field, holding a C++ handle.
+        direction (int): The direction to split, already checked by the wrapper.
+        value (float): The parameter to split at, already checked by the wrapper.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, ~pantr.bspline.Bspline]: The left and right
+        halves, each wrapping a C++ handle.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bspline import Bspline as BsplineCls  # noqa: PLC0415  (cycle)
+
+    handle = _cpp_handle(bspline)
+    prior = bspline.space.spaces
+    left, right = _pantr_cpp.split_bspline(handle, direction, float(value))
+    return BsplineCls._wrap_over(left, prior), BsplineCls._wrap_over(right, prior)
+
+
+def _cpp_slice(bspline: Bspline, axis: int, value: float) -> Bspline:
+    """Slice a field of dimension at least two through the C++ binding.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field, holding a C++ handle, of dimension
+            at least two.
+        axis (int): The direction to fix, already checked by the wrapper.
+        value (float): The parameter, already checked by the wrapper.
+
+    Returns:
+        ~pantr.bspline.Bspline: The sliced field, of one dimension fewer, wrapping a
+        C++ handle.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bspline import Bspline as BsplineCls  # noqa: PLC0415  (cycle)
+
+    handle = _cpp_handle(bspline)
+    # The sliced axis is dropped from the prior list too: the reuse is positional
+    # against the *result's* directions. See :meth:`Bspline._wrap_over`.
+    prior = [space for index, space in enumerate(bspline.space.spaces) if index != axis]
+    return BsplineCls._wrap_over(_pantr_cpp.slice_bspline(handle, axis, float(value)), prior)
+
+
+def _cpp_slice_point(bspline: Bspline, value: float) -> _Point:
+    """Evaluate a one-dimensional field at a parameter through the C++ binding.
+
+    The binding hands back the homogeneous components with the weight column still on,
+    so the projection of a rational field happens here -- as one numpy division, which
+    is the oracle's own expression rather than a second spelling of it in C++.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): A one-dimensional field, holding a C++ handle.
+        value (float): The parameter, already checked by the wrapper.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The point, of length ``bspline.rank``.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    handle = _cpp_handle(bspline)
+    components = bspline.control_points.shape[-1]
+    point: _Point = np.empty(components, dtype=bspline.dtype)
+    _pantr_cpp.slice_bspline_point(handle, float(value), out=point)
+    if bspline.is_rational:
+        # `cast` rather than `np.asarray`: the division of a `T` array by a `T` scalar
+        # is already a `T` array, and the oracle's own
+        # :func:`~pantr.bspline._bspline_slice._slice_bspline` casts the identical
+        # expression for the identical reason -- the numpy stubs type `/` as `Any`.
+        return cast("_Point", point[:-1] / point[-1])
+    return point
+
+
+def to_open_field(bspline: Bspline) -> Bspline:
+    """Convert a field to open, non-periodic form, on whichever backend covers the call.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to convert.
+
+    Returns:
+        ~pantr.bspline.Bspline: An open, non-periodic field over the same geometry.
+
+    Raises:
+        TypeError: If the C++ backend is active and the field was built under the other
+            one.
+        ValueError: If every direction is already open and non-periodic. Both backends
+            raise it, with the same text; see the module docstring on why this is the
+            one refusal the wrapper does not make first.
+    """
+    if _the_cpp_backend_can_take_it():
+        return _cpp_to_open(bspline)
+    return _to_open_bspline_impl(bspline)
+
+
+def split_field(bspline: Bspline, direction: int, value: float) -> tuple[Bspline, Bspline]:
+    """Split a field in two, on whichever backend covers the call.
+
+    The direction and the parameter have already been validated by
+    :meth:`pantr.bspline.Bspline.split`, so neither branch re-derives which arguments
+    are legal.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to split.
+        direction (int): The direction to split, in ``[0, dim)``.
+        value (float): The parameter to split at, strictly inside that direction's
+            domain.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, ~pantr.bspline.Bspline]: The left and right
+        halves, non-periodic in the split direction whatever ``bspline`` was.
+
+    Raises:
+        TypeError: If the C++ backend is active and the field was built under the other
+            one.
+    """
+    if _the_cpp_backend_can_take_it():
+        return _cpp_split(bspline, direction, value)
+    return _split_bspline_impl(bspline, direction, value)
+
+
+def slice_field(bspline: Bspline, axis: int, value: float) -> Bspline | _Point:
+    """Fix one direction of a field at a value, on whichever backend covers the call.
+
+    The axis and the parameter have already been validated by
+    :meth:`pantr.bspline.Bspline.slice`, so neither branch re-derives which arguments
+    are legal.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to slice.
+        axis (int): The direction to fix, in ``[0, dim)``.
+        value (float): The parameter, inside that direction's domain.
+
+    Returns:
+        ~pantr.bspline.Bspline | npt.NDArray[np.float32 | np.float64]: A field of one
+        dimension fewer when ``bspline.dim >= 2``, or the point itself when it is 1 --
+        projected to physical coordinates for a rational field, as the oracle projects
+        it.
+
+    Raises:
+        TypeError: If the C++ backend is active and the field was built under the other
+            one.
+    """
+    if _the_cpp_backend_can_take_it():
+        # Two bindings rather than one, because C++ cannot return a field or an array;
+        # `cpp/include/pantr/bspline/structural.hpp` argues the split in full and the
+        # branch is the oracle's own `bspline.dim == 1`.
+        if bspline.dim == 1:
+            return _cpp_slice_point(bspline, value)
+        return _cpp_slice(bspline, axis, value)
+    return _slice_bspline(bspline, axis, value)

--- a/tests/parity/test_bspline_structural.py
+++ b/tests/parity/test_bspline_structural.py
@@ -1,0 +1,967 @@
+"""Parity of the four structural field operations on a `Bspline`.
+
+`to_open_bspline`, `split`, `slice` and `boundary`.
+
+Like ``tests/parity/test_bspline_refinement.py`` this compares a **computation** rather
+than a value the two backends only copy, so the criterion is argued per quantity rather
+than assumed once. Unlike that file, two of the three computations carry no new
+arithmetic at all, and the third is the first *evaluator* in the port.
+
+## The criterion, quantity by quantity
+
+**Bitwise, for every coefficient and every knot**, and the reason splits three ways.
+
+*The open conversion and the split* reach `inserted_knot_vector`, `oslo_bands_1d` and
+`refine_along_axis`, whose bitwise claim ``test_bspline_refinement.py`` already derives
+and ``cpp/include/pantr/bspline/refinement.hpp`` carries beside the code. Nothing in
+``cpp/include/pantr/bspline/structural.hpp`` re-rounds their output: the trim and the
+partition are row selections, and a row selection performs no arithmetic.
+
+*The slice* is the de Boor corner cut, whose statement is
+``alpha * R[i + 1] + (1.0 - alpha) * R[i]``. Three arithmetic-width facts decide whether
+the two sides can match at all, and each was settled by executing the oracle:
+
+ - ``alpha`` and its knot differences are Python floats, so the weights are computed in
+   ``double`` whatever the knots are stored in;
+ - the update is a numpy array expression with a *weak* Python float scalar, so under
+   NEP 50 both weights are rounded to the storage format and the update runs there. At
+   ``float32`` this differs in the last bit from computing the update in ``double``;
+ - the span search and the multiplicity count read every knot through ``float(...)``,
+   and ``np.searchsorted`` promotes its needle rather than weakening it, so both are
+   ``double``.
+
+*The end multiplicities and the split's multiplicity count* go the other way: they are
+numpy array expressions, so the ``double`` tolerance is **weakened to the storage
+format** before the comparison. That one is a discrete verdict rather than a
+displacement -- it decides how many knots are inserted -- so
+``design/backend_parity.md`` Rule 11 applies and there is no bound that could absorb a
+disagreement. It is not directly asserted here, because a divergence would surface as a
+different knot count, which the knot-vector comparison reports as a shape mismatch
+rather than as a tolerance failure. **The band where the two spellings disagree is
+ulp-wide and no case below constructs one**, which is recorded as a limit of this file
+rather than left to be assumed away.
+
+Bitwise is a claim about **this build**, per ``design/backend_parity.md`` Rule 7: the
+corner cut's two products and their sum would contract on a target with a fused
+multiply-add, and the baseline x86-64 this project compiles for has none.
+:func:`~tests._parity_harness.contraction_may_fuse` is the gate, and a fusing build
+skips the claim rather than weakening it.
+
+**Exact, for the counts, the degrees, the flags and the dimensions.** A slice's
+dimension and a half's basis count are integers; Rule 11 is why they are not folded in
+with the coefficients, which compare elementwise and cannot see two results of different
+length.
+
+## What this file can check that the refinement file could not
+
+``test_bspline_refinement.py`` records that the natural invariant for knot insertion --
+that it must not move the curve -- was unavailable to it, because evaluating a field
+needs ``BsplineSpace1D.tabulate_basis`` and that is a separate port.
+**`slice_point` is an evaluator that needs no basis function**, so the invariant is
+available now, and :func:`test_the_open_conversion_does_not_move_the_curve` and
+:func:`test_the_split_does_not_move_the_curve` state it. They are not parity checks: they
+compare one backend against *itself* across a representation change, so they would catch
+a shared error that every comparison above is blind to, which is the gap
+``design/backend_parity.md`` opens by naming.
+
+The closed-form checks that pin the evaluator itself -- partition of unity and linear
+precision over the Greville abscissae -- live in ``cpp/tests/test_bspline_structural.cpp``
+rather than here, because they are properties of the C++ kernel and need no interpreter.
+
+## The divergence this file pins rather than removes
+
+:meth:`pantr.bspline.Bspline.slice`'s out-of-domain message interpolates a numpy scalar
+of the storage format, and the C++ half renders the widened value. The wrapper makes
+that check before dispatching, so **the divergence is unreachable** and what is asserted
+here is that the *wrapper's* text is identical under both backends --
+:func:`test_the_wrapper_refusals_are_identical`. ``pantr.bspline._structural_backend``
+and ``cpp/include/pantr/bspline/structural.hpp`` both carry why the repair belongs to
+``pantr/core/format.hpp``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, TypeAlias
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline._structural_backend import slice_field, split_field, to_open_field
+from tests._parity_harness import (
+    Field,
+    assert_object_parity,
+    assert_parity,
+    bitwise_parity,
+    contraction_may_fuse,
+    exact_parity,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    _Act: TypeAlias = "Callable[[Bspline], Any]"
+    """What a test does to a field it has just built under one backend."""
+
+pytestmark = pytest.mark.usefixtures("cpp_backend")
+
+DTYPES: Final = (np.float64, np.float32)
+"""The two storage formats, both of which the three width facts above depend on."""
+
+_FUSING: Final = (
+    "a build whose contraction may fuse: the corner cut's `wa * next + wb * row` is "
+    "exactly the site an FMA would contract, so the bitwise claim is a property of "
+    "this build and `design/backend_parity.md` Rule 7 says to skip rather than weaken "
+    "it"
+)
+
+
+class _Vector(NamedTuple):
+    """One direction's knot vector, degree and periodicity.
+
+    Attributes:
+        label (str): What to call it in a test id.
+        degree (int): The polynomial degree.
+        knots (tuple[float, ...]): The knot vector, in ``double``.
+        periodic (bool): Whether the entries describe a periodic space.
+    """
+
+    label: str
+    degree: int
+    knots: tuple[float, ...]
+    periodic: bool = False
+
+
+P1: Final = _Vector("p1", 1, (0.0, 0.0, 0.3, 0.7, 1.0, 1.0))
+P2: Final = _Vector("p2", 2, (0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0))
+P3: Final = _Vector("p3", 3, (0.0, 0.0, 0.0, 0.0, 0.4, 1.0, 1.0, 1.0, 1.0))
+P2_C0: Final = _Vector("p2c0", 2, (0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0))
+P0: Final = _Vector("p0", 0, (0.0, 0.4, 1.0))
+UNCLAMPED: Final = _Vector("uncl", 2, (-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.1, 1.2))
+LEFT_ONLY: Final = _Vector("left", 2, (-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0))
+PERIODIC: Final = _Vector("per", 2, (-0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5), True)
+SHIFTED: Final = _Vector("shift", 2, (2.0, 2.0, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0, 4.0))
+"""A vector based away from the origin, where an absolute tolerance and a relative one
+part company; ``design/backend_parity.md`` Rule 2 is why one of these is always in a
+case list."""
+
+
+class _Case(NamedTuple):
+    """A field to build, and what to do to it.
+
+    Attributes:
+        label (str): The test id.
+        vectors (tuple[_Vector, ...]): One per parametric direction.
+        rank (int): How many value components the field carries, weight column
+            excluded.
+        rational (bool): Whether the last stored component is a homogeneous weight.
+    """
+
+    label: str
+    vectors: tuple[_Vector, ...]
+    rank: int
+    rational: bool = False
+
+
+def _build(case: _Case, dtype: npt.DTypeLike) -> Bspline:
+    """Build ``case``'s field under the active backend.
+
+    The coefficients are an affine ramp over the flat index rather than random: it is
+    reproducible without a seed, it makes every coefficient distinct so a transposed or
+    mis-strided sweep cannot pass, and it is exactly representable at both formats so
+    the field itself introduces no rounding.
+
+    Args:
+        case (_Case): The field to build.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        ~pantr.bspline.Bspline: The field.
+    """
+    spaces = [
+        BsplineSpace1D(
+            np.asarray(vector.knots, dtype=dtype), vector.degree, periodic=vector.periodic
+        )
+        for vector in case.vectors
+    ]
+    space = BsplineSpace(spaces)
+    counts = [one_d.num_basis for one_d in spaces]
+    components = case.rank + (1 if case.rational else 0)
+    total = int(np.prod(counts)) * components
+    values = (np.arange(total, dtype=dtype) + np.asarray(1.0, dtype=dtype)) * np.asarray(
+        0.25, dtype=dtype
+    )
+    return Bspline(space, values.reshape(*counts, components), is_rational=case.rational)
+
+
+def _both(case: _Case, dtype: npt.DTypeLike, act: _Act) -> tuple[Any, Any]:
+    """Build and act on ``case``'s field once under each backend.
+
+    Everything happens inside the ``use_backend`` block, the operation included: the
+    branch :mod:`pantr.bspline._structural_backend` takes is decided by the *active*
+    backend, so acting outside the block would measure the wrong path.
+
+    Args:
+        case (_Case): The field to build.
+        dtype (npt.DTypeLike): The storage format.
+        act (_Act): What to do to the field; takes it and returns anything.
+
+    Returns:
+        tuple[Any, Any]: ``(py, cpp)``, in the order
+        :func:`~tests._parity_harness.assert_object_parity` names its arguments.
+    """
+    with use_backend(Backend.PYTHON):
+        py = act(_build(case, dtype))
+    with use_backend(Backend.CPP):
+        cpp = act(_build(case, dtype))
+    return py, cpp
+
+
+def _as_curve(field: Bspline, keep: int) -> tuple[Bspline, int]:
+    """Reduce a field to a curve by fixing every direction but ``keep``.
+
+    Each removed direction is fixed at its own domain midpoint. Removing them from the
+    last one backwards keeps the surviving index computable: a direction after ``keep``
+    does not move it and one before it shifts it down by one.
+
+    This composes the operation under test with itself, which is fine for an
+    *invariant* check and would not be for a parity one: what
+    :func:`test_the_open_conversion_does_not_move_the_curve` compares is two
+    representations of one map, both reduced the same way, so a slice that is wrong in
+    the same way on both sides cancels and a wrong *trim* or *partition* does not. The
+    closed-form checks that pin the slice itself are in
+    ``cpp/tests/test_bspline_structural.cpp``.
+
+    Args:
+        field (~pantr.bspline.Bspline): The field to reduce.
+        keep (int): The direction to keep.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, int]: The curve, and ``keep``'s index in it --
+        which is always 0, returned so that a caller does not have to re-derive it.
+    """
+    surviving = keep
+    for axis in reversed(range(field.dim)):
+        if axis == keep:
+            continue
+        lo, hi = (float(edge) for edge in field.space.spaces[axis].domain)
+        reduced = field.slice(axis, 0.5 * (lo + hi))
+        assert isinstance(reduced, Bspline), "a field of dimension >= 2 slices to a field"
+        field = reduced
+        if axis < surviving:
+            surviving -= 1
+    return field, surviving
+
+
+def _invariance_bound(field: Bspline, degree: int, dtype: npt.DTypeLike) -> float:
+    """The absolute bound on how far a representation change may move the map.
+
+    `gamma_K` times the coefficients' magnitude, with `K` assembled rather than fitted:
+
+     - `2p + 3 + (7p + 2)` for the one knot insertion the changed representation went
+       through, which is ``tests/parity/test_bspline_refinement.py``'s derivation at one
+       refined direction and `p` the changed direction's degree;
+     - `5 * p_d` per corner cut, being 3 roundings for the two products and the sum and
+       2 for the weight pair's departure from summing to one. Reducing to a curve and
+       sampling it is one cut per direction, on each of the two sides, so `10 * sum p_d`.
+
+    The weights are in `[0, 1]` for a parameter inside its span, so no cut amplifies the
+    magnitude and the counts compose additively.
+
+    Args:
+        field (~pantr.bspline.Bspline): The field whose coefficients set the magnitude.
+        degree (int): The degree of the direction the operation changed.
+        dtype (npt.DTypeLike): The storage format the roundings are charged in.
+
+    Returns:
+        float: The bound, in the units of the coefficients.
+    """
+    roundings = (2 * degree + 3 + 7 * degree + 2) + 10 * sum(field.degree)
+    unit = 0.5 * float(np.finfo(np.dtype(dtype)).eps)
+    magnitude = float(np.max(np.abs(np.asarray(field.control_points, dtype=np.float64))))
+    return roundings * unit / (1.0 - roundings * unit) * magnitude
+
+
+_COEFFICIENTS_WHY: Final = (
+    "the coefficients. On the open-conversion and split paths every arithmetic "
+    "operation is `refine_along_axis`'s, whose bitwise claim "
+    "`tests/parity/test_bspline_refinement.py` derives: the sweep accumulates in the "
+    "storage format, in ascending band order, from an exact zero. The trim and the "
+    "partition around it are row selections and perform no arithmetic. On the slice "
+    "path every operation is the corner cut's `wa * next + wb * row`, whose two "
+    "weights are `double` expressions rounded once to the storage format -- measured, "
+    "not inferred -- and whose update then runs in that format, which is what numpy's "
+    "weak-scalar promotion makes the oracle do. Same operations, same order, same "
+    "operands."
+)
+
+_KNOTS_WHY: Final = (
+    "a resulting knot vector. Both operations build theirs by selection and "
+    "concatenation of values that already exist: `inserted_knot_vector` stable-sorts "
+    "the old vector against the boundary or split value it was handed, and the trim "
+    "and the partition take subranges of that. No arithmetic touches a knot, so a "
+    "difference could only be a lost entry, a reordering, a narrowing cast, or a "
+    "multiplicity count that decided to insert a different number of knots -- which "
+    "would show here as a length mismatch rather than as a displaced value."
+)
+
+_TOLERANCE_WHY: Final = (
+    "the resulting space derives its own tolerance from its own knot vector, so it is "
+    "a *new* quantity of the result and not one carried over, and it is what every "
+    "later comparison on that space will use. The knots agree bit for bit and "
+    "`knot_tolerance` is the same reduction over them on both sides. A difference "
+    "would mean the two backends disagree about which knots are the same knot, which "
+    "no comparison of the knots themselves would reveal."
+)
+
+
+def _fields(dim: int) -> tuple[Field, ...]:
+    """Every piece of a resulting field's state, one field each with its own reason.
+
+    Args:
+        dim (int): The result's number of parametric directions.
+
+    Returns:
+        tuple[Field, ...]: The field list for
+        :func:`~tests._parity_harness.assert_object_parity`.
+    """
+    per_direction: list[Field] = []
+    for direction in range(dim):
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].knots",
+                bitwise_parity(why=_KNOTS_WHY),
+                read=lambda field, d=direction: field.space.spaces[d].knots,  # type: ignore[misc]
+            )
+        )
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].tolerance",
+                bitwise_parity(why=_TOLERANCE_WHY),
+                read=lambda field, d=direction: field.space.spaces[d].tolerance,  # type: ignore[misc]
+            )
+        )
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].periodic",
+                exact_parity(
+                    why=(
+                        "periodicity is a flag, and both operations decide it "
+                        "structurally rather than numerically: the open conversion "
+                        "clears it and the split clears it in the cut direction, "
+                        "whatever the input was. A slice carries a surviving "
+                        "direction's flag through untouched. A difference would be a "
+                        "different *kind* of space, which no tolerance covers."
+                    )
+                ),
+                read=lambda field, d=direction: field.space.spaces[d].periodic,  # type: ignore[misc]
+            )
+        )
+    return (
+        Field("control_points", bitwise_parity(why=_COEFFICIENTS_WHY)),
+        Field(
+            "dim",
+            exact_parity(
+                why=(
+                    "the parametric dimension is a count. It is the field that would "
+                    "catch a slice that failed to drop its axis, and it must be "
+                    "asserted separately from the coefficients, which compare "
+                    "elementwise and cannot see two results of different shape."
+                )
+            ),
+        ),
+        Field(
+            "space.num_basis",
+            exact_parity(
+                why=(
+                    "the basis counts are integers derived from the resulting knot "
+                    "vectors and degrees, so they are exact whenever those are. They "
+                    "are what a wrong trim or a wrong partition index moves first, and "
+                    "`design/backend_parity.md` Rule 11 is why a count is asserted on "
+                    "its own rather than folded into a bounded comparison."
+                )
+            ),
+        ),
+        Field(
+            "degree",
+            exact_parity(why="the degree of each direction is carried, never recomputed."),
+        ),
+        Field(
+            "rank",
+            exact_parity(
+                why=(
+                    "the rank is the component count less the weight column. None of "
+                    "these operations touches the component axis, so a difference "
+                    "would mean one backend dropped or projected a component."
+                )
+            ),
+        ),
+        Field(
+            "is_rational",
+            exact_parity(
+                why=(
+                    "the rationality flag is the invariant an unpack-and-reassemble "
+                    "across the seam would lose, which is why the field crosses rather "
+                    "than its arrays. `design/cross_backend_types.md` names it."
+                )
+            ),
+        ),
+        *per_direction,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The open conversion
+# ---------------------------------------------------------------------------
+
+OPEN_CASES: Final = (
+    _Case("uncl-1d", (UNCLAMPED,), 3),
+    _Case("left-only-1d", (LEFT_ONLY,), 2),
+    _Case("per-1d", (PERIODIC,), 3),
+    _Case("per-1d-rational", (PERIODIC,), 2, rational=True),
+    _Case("per-uncl-2d", (PERIODIC, UNCLAMPED), 2),
+    _Case("open-uncl-2d", (P2, UNCLAMPED), 2),
+    _Case("uncl-open-2d", (UNCLAMPED, P1), 3),
+    _Case("per-open-uncl-3d", (PERIODIC, P1, UNCLAMPED), 1),
+    _Case("shifted-uncl-2d", (SHIFTED, UNCLAMPED), 2),
+)
+"""Fields with something to convert. Every combination of "already open", "unclamped"
+and "periodic" appears in at least one direction of at least one case, and the mixed
+cases are what catch a conversion that reads the wrong axis's extents."""
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", OPEN_CASES, ids=lambda case: case.label)
+def test_the_open_conversion_agrees_field_by_field(case: _Case, dtype: npt.DTypeLike) -> None:
+    """Every piece of the open field's state agrees, under its own claim.
+
+    Args:
+        case (_Case): The field to build.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    if contraction_may_fuse():
+        pytest.skip(_FUSING)
+    py, cpp = _both(case, dtype, lambda field: field.to_open_bspline())
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=_fields(len(case.vectors)),
+        context=f"to_open_bspline on {case.label} at {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", OPEN_CASES, ids=lambda case: case.label)
+def test_the_open_conversion_does_not_move_the_curve(case: _Case, dtype: npt.DTypeLike) -> None:
+    """The open form evaluates to the same map as the field it came from.
+
+    Not a parity check: it compares the C++ backend against *itself* across a
+    representation change, so unlike everything above it would catch an error the two
+    backends share. The evaluator is `slice_point`, which needs no basis function and so
+    is available in this cut -- ``tests/parity/test_bspline_refinement.py`` records that
+    it was not available to the refinement port.
+
+    A multi-dimensional field is reduced to a curve first, by :func:`_as_curve`, so
+    every case is sampled rather than only the univariate ones -- the strided sweep is
+    exactly what a multi-dimensional case exercises and a univariate one cannot.
+
+    Args:
+        case (_Case): The field to build.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    with use_backend(Backend.CPP):
+        field = _build(case, dtype)
+        opened = field.to_open_bspline()
+        bound = _invariance_bound(field, max(vector.degree for vector in case.vectors), dtype)
+        for direction in range(field.dim):
+            before, keep = _as_curve(field, direction)
+            after, _ = _as_curve(opened, direction)
+            lo, hi = (float(edge) for edge in before.space.spaces[keep].domain)
+            for step in range(9):
+                at = lo + (hi - lo) * step / 8.0
+                was = np.atleast_1d(np.asarray(before.slice(keep, at), dtype=np.float64))
+                now = np.atleast_1d(np.asarray(after.slice(keep, at), dtype=np.float64))
+                assert np.all(np.abs(was - now) <= bound), (
+                    f"to_open_bspline moved the curve of {case.label} at "
+                    f"{np.dtype(dtype).name}, direction {direction}, u={at}: "
+                    f"{was} against {now}, bound {bound}"
+                )
+
+
+def test_the_open_conversion_refuses_an_open_field_the_same_way() -> None:
+    """A field that is already open in every direction is refused with one text.
+
+    The only refusal of the four operations that no wrapper check makes first, so it is
+    the only one raised by whichever implementation runs and the only one whose text
+    could differ between the backends without anything else noticing.
+    """
+    case = _Case("already-open", (P2, P1), 2)
+    messages: list[str] = []
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field = _build(case, np.float64)
+            with pytest.raises(ValueError) as raised:
+                field.to_open_bspline()
+            messages.append(str(raised.value))
+    assert messages[0] == "B-spline is already open in every direction.", messages[0]
+    assert messages[0] == messages[1], messages
+
+
+def test_the_open_conversion_shares_an_untouched_direction() -> None:
+    """An already-open direction keeps the wrapper it had, under both backends.
+
+    The identity contract ``design/bspline_ownership_lifetime.md`` states and the reason
+    the C++ half carries a space handle rather than rebuilding an equal-valued space. No
+    value comparison could report a difference here.
+    """
+    case = _Case("open-uncl-2d", (P2, UNCLAMPED), 2)
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field = _build(case, np.float64)
+            opened = field.to_open_bspline()
+            assert opened.space.spaces[0] is field.space.spaces[0], backend
+            assert opened.space.spaces[1] is not field.space.spaces[1], backend
+
+
+# ---------------------------------------------------------------------------
+# The split
+# ---------------------------------------------------------------------------
+
+
+class _SplitCase(NamedTuple):
+    """A field to split, the direction and the parameter.
+
+    Attributes:
+        label (str): The test id.
+        case (_Case): The field.
+        direction (int): The direction to cut.
+        value (float): Where to cut it.
+    """
+
+    label: str
+    case: _Case
+    direction: int
+    value: float
+
+
+SPLIT_CASES: Final = (
+    _SplitCase("p1-mid", _Case("p1", (P1,), 2), 0, 0.5),
+    _SplitCase("p2-off-knot", _Case("p2", (P2,), 3), 0, 0.4),
+    _SplitCase("p2-on-knot", _Case("p2", (P2,), 3), 0, 0.5),
+    _SplitCase("p3-off-knot", _Case("p3", (P3,), 1), 0, 0.6),
+    _SplitCase("p2-at-c0-knot", _Case("p2c0", (P2_C0,), 2), 0, 0.5),
+    _SplitCase("p0", _Case("p0", (P0,), 2), 0, 0.5),
+    _SplitCase("2d-first", _Case("2d", (P2, P1), 3), 0, 0.3),
+    _SplitCase("2d-second", _Case("2d", (P2, P1), 3), 1, 0.55),
+    _SplitCase("3d-middle", _Case("3d", (P2, P1, P3), 2), 1, 0.42),
+    _SplitCase("rational", _Case("rat", (P2, P1), 3, rational=True), 0, 0.6),
+    _SplitCase("unclamped", _Case("uncl", (UNCLAMPED,), 2), 0, 0.5),
+    _SplitCase("periodic", _Case("per", (PERIODIC,), 3), 0, 0.4),
+    _SplitCase("periodic-2d", _Case("per2d", (PERIODIC, P1), 2), 0, 0.6),
+    _SplitCase("shifted", _Case("shift", (SHIFTED,), 2), 0, 2.75),
+)
+"""Cuts off a knot, on a knot of multiplicity 1, on a knot already at C0, at degree 0,
+on each axis of a two- and a three-direction field, on a rational field, and on
+unclamped and periodic directions -- the two that take a different path into the cut."""
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("split", SPLIT_CASES, ids=lambda split: split.label)
+def test_the_split_agrees_half_by_half(split: _SplitCase, dtype: npt.DTypeLike) -> None:
+    """Every piece of both halves' state agrees, under its own claim.
+
+    Args:
+        split (_SplitCase): The field, the direction and the parameter.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    if contraction_may_fuse():
+        pytest.skip(_FUSING)
+    py, cpp = _both(split.case, dtype, lambda field: field.split(split.direction, split.value))
+    fields = _fields(len(split.case.vectors))
+    for index, side in enumerate(("left", "right")):
+        assert_object_parity(
+            py=py[index],
+            cpp=cpp[index],
+            fields=fields,
+            context=(
+                f"split({split.direction}, {split.value}) {side} half on "
+                f"{split.label} at {np.dtype(dtype).name}"
+            ),
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("split", SPLIT_CASES, ids=lambda split: split.label)
+def test_the_split_does_not_move_the_curve(split: _SplitCase, dtype: npt.DTypeLike) -> None:
+    """Each half evaluates to the same map as the field it came from, on its own domain.
+
+    The other check that compares a backend against itself rather than against the other
+    one; see :func:`test_the_open_conversion_does_not_move_the_curve`. It is what a wrong
+    partition index moves, and a wrong index that shifts both the knot vector and the
+    coefficients consistently would pass every comparison above.
+
+    A multi-dimensional field is reduced to a curve along the cut direction first, by
+    :func:`_as_curve`, so every case is sampled and the strided partition is covered.
+
+    Args:
+        split (_SplitCase): The field, the direction and the parameter.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    with use_backend(Backend.CPP):
+        field = _build(split.case, dtype)
+        halves = field.split(split.direction, split.value)
+        degree = split.case.vectors[split.direction].degree
+        bound = _invariance_bound(field, degree, dtype)
+        whole, keep = _as_curve(field, split.direction)
+        for side, half in zip(("left", "right"), halves, strict=True):
+            reduced, _ = _as_curve(half, split.direction)
+            lo, hi = (float(edge) for edge in reduced.space.spaces[keep].domain)
+            for step in range(5):
+                at = lo + (hi - lo) * step / 4.0
+                was = np.atleast_1d(np.asarray(whole.slice(keep, at), dtype=np.float64))
+                now = np.atleast_1d(np.asarray(reduced.slice(keep, at), dtype=np.float64))
+                assert np.all(np.abs(was - now) <= bound), (
+                    f"split moved the {side} half of {split.label} at "
+                    f"{np.dtype(dtype).name}, u={at}: {was} against {now}, bound {bound}"
+                )
+
+
+def test_the_split_halves_share_the_untouched_directions() -> None:
+    """Every direction but the cut one keeps its wrapper, in both halves and both backends.
+
+    The two halves are wrapped over the *same* prior direction list, so an untouched
+    direction's wrapper is one object shared three ways.
+    """
+    case = _Case("3d", (P2, P1, P3), 2)
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field = _build(case, np.float64)
+            left, right = field.split(1, 0.5)
+            for half in (left, right):
+                assert half.space.spaces[0] is field.space.spaces[0], backend
+                assert half.space.spaces[2] is field.space.spaces[2], backend
+                assert half.space.spaces[1] is not field.space.spaces[1], backend
+
+
+# ---------------------------------------------------------------------------
+# The slice and the boundary
+# ---------------------------------------------------------------------------
+
+
+class _SliceCase(NamedTuple):
+    """A field to slice, the axis and the parameter.
+
+    Attributes:
+        label (str): The test id.
+        case (_Case): The field.
+        axis (int): The direction to fix.
+        value (float): Where to fix it.
+    """
+
+    label: str
+    case: _Case
+    axis: int
+    value: float
+
+
+SLICE_CASES: Final = (
+    _SliceCase("1d-off-knot", _Case("p2", (P2,), 3), 0, 0.4),
+    _SliceCase("1d-on-knot", _Case("p2", (P2,), 3), 0, 0.5),
+    _SliceCase("1d-at-start", _Case("p2", (P2,), 3), 0, 0.0),
+    _SliceCase("1d-at-end", _Case("p2", (P2,), 3), 0, 1.0),
+    _SliceCase("1d-at-c0-knot", _Case("p2c0", (P2_C0,), 2), 0, 0.5),
+    _SliceCase("1d-degree-0", _Case("p0", (P0,), 2), 0, 0.6),
+    _SliceCase("1d-p1", _Case("p1", (P1,), 2), 0, 0.45),
+    _SliceCase("1d-p3", _Case("p3", (P3,), 1), 0, 0.15),
+    _SliceCase("1d-rational", _Case("rat", (P2,), 3, rational=True), 0, 0.4),
+    _SliceCase("1d-periodic", _Case("per", (PERIODIC,), 3), 0, 0.4),
+    _SliceCase("1d-unclamped", _Case("uncl", (UNCLAMPED,), 2), 0, 0.4),
+    _SliceCase("1d-shifted", _Case("shift", (SHIFTED,), 2), 0, 2.75),
+    _SliceCase("2d-first", _Case("2d", (P2, P1), 3), 0, 0.3),
+    _SliceCase("2d-second", _Case("2d", (P2, P1), 3), 1, 0.55),
+    _SliceCase("2d-rational", _Case("rat2d", (P2, P1), 3, rational=True), 1, 0.55),
+    _SliceCase("2d-periodic-first", _Case("per2d", (PERIODIC, P1), 2), 0, 0.6),
+    _SliceCase("2d-periodic-second", _Case("2dper", (P1, PERIODIC), 2), 1, 0.6),
+    _SliceCase("3d-middle", _Case("3d", (P2, P1, P3), 2), 1, 0.42),
+    _SliceCase("3d-last", _Case("3d", (P2, P1, P3), 2), 2, 0.42),
+    _SliceCase("3d-first", _Case("3d", (P2, P1, P3), 2), 0, 0.42),
+)
+"""Both endpoints and an interior knot -- the three places the span search branches --
+plus each axis of a two- and a three-direction field, which is what catches a sweep that
+strides the wrong axis, and the periodic and rational paths."""
+
+_POINT_WHY: Final = (
+    "the point a one-dimensional slice returns. Every operation is the corner cut's, "
+    "operand for operand: the weights are `double` expressions rounded once to the "
+    "storage format and the update runs in that format. For a rational field the "
+    "division by the weight is one numpy expression on both paths, because the C++ "
+    "binding hands back the homogeneous components and "
+    "`pantr.bspline._structural_backend` divides."
+)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", SLICE_CASES, ids=lambda case: case.label)
+def test_the_slice_agrees(case: _SliceCase, dtype: npt.DTypeLike) -> None:
+    """The slice agrees, field by field for a surface and pointwise for a curve.
+
+    Args:
+        case (_SliceCase): The field, the axis and the parameter.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    if contraction_may_fuse():
+        pytest.skip(_FUSING)
+    py, cpp = _both(case.case, dtype, lambda field: field.slice(case.axis, case.value))
+    context = f"slice({case.axis}, {case.value}) on {case.label} at {np.dtype(dtype).name}"
+    if len(case.case.vectors) == 1:
+        assert isinstance(py, np.ndarray) and isinstance(cpp, np.ndarray), context
+        assert py.shape == (case.case.rank,), f"{context}: oracle shape {py.shape}"
+        assert_parity(cpp, py, claim=bitwise_parity(why=_POINT_WHY), context=context)
+        return
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=_fields(len(case.case.vectors) - 1),
+        context=context,
+    )
+
+
+def test_the_slice_drops_the_axis_and_shares_the_survivors() -> None:
+    """A slice keeps the surviving directions' wrappers, in order, under both backends.
+
+    The property that forced :meth:`pantr.bspline.Bspline._wrap_over` to take a
+    per-direction list rather than the whole prior space: the reuse is positional
+    against the *result's* directions, so the sliced axis has to be dropped from the
+    prior list too. Reusing the unreduced list would hand back a wrapper for a different
+    direction while every value comparison agreed, which is exactly what this asserts
+    did not happen.
+    """
+    case = _Case("3d", (P2, P1, P3), 2)
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field = _build(case, np.float64)
+            sliced = field.slice(1, 0.5)
+            assert isinstance(sliced, Bspline), backend
+            assert sliced.dim == 2, backend
+            assert sliced.space.spaces[0] is field.space.spaces[0], backend
+            assert sliced.space.spaces[1] is field.space.spaces[2], backend
+
+
+def test_a_sliced_field_holds_the_space_its_implementation_holds() -> None:
+    """The wrapper's space is the one its implementation holds, not an equal rebuild.
+
+    ``design/bspline_derived_caches.md``'s reason for ``_wrap_over`` at all: two
+    computations of one answer is a second truth about a value. Only meaningful under
+    the C++ backend, where the two objects could differ.
+    """
+    with use_backend(Backend.CPP):
+        field = _build(_Case("2d", (P2, P1), 3), np.float64)
+        sliced = field.slice(0, 0.3)
+        assert isinstance(sliced, Bspline)
+        assert sliced.space._impl is sliced._impl.space
+        left, right = field.split(0, 0.3)
+        assert left.space._impl is left._impl.space
+        assert right.space._impl is right._impl.space
+        opened = _build(_Case("uncl", (UNCLAMPED,), 2), np.float64).to_open_bspline()
+        assert opened.space._impl is opened._impl.space
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("side", (0, 1))
+def test_the_boundary_agrees(side: int, dtype: npt.DTypeLike) -> None:
+    """The boundary agrees, and is the slice at the endpoint it is defined as.
+
+    ``boundary`` has no entry point in :mod:`pantr.bspline._structural_backend` and no
+    binding of its own, so what this checks is that routing it through
+    :meth:`~pantr.bspline.Bspline.slice` really does reach C++ and really does agree.
+
+    Args:
+        side (int): Which end of the domain.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    if contraction_may_fuse():
+        pytest.skip(_FUSING)
+    case = _Case("2d", (SHIFTED, P1), 3)
+    py, cpp = _both(case, dtype, lambda field: field.boundary(0, side))
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=_fields(1),
+        context=f"boundary(0, {side}) at {np.dtype(dtype).name}",
+    )
+    with use_backend(Backend.CPP):
+        field = _build(case, dtype)
+        face = field.boundary(0, side)
+        edge = float(field.space.spaces[0].domain[side])
+        assert isinstance(face, Bspline)
+        direct = field.slice(0, edge)
+        assert isinstance(direct, Bspline)
+        assert np.array_equal(face.control_points, direct.control_points), side
+
+
+# ---------------------------------------------------------------------------
+# The refusals, and the seam
+# ---------------------------------------------------------------------------
+
+
+def _refusal(backend: Backend, act: _Act) -> str:
+    """The text of the ``ValueError`` ``act`` raises under ``backend``.
+
+    Args:
+        backend (Backend): The backend to run under.
+        act (_Act): Takes a field and does something that must refuse.
+
+    Returns:
+        str: The message.
+    """
+    with use_backend(backend):
+        field = _build(_Case("2d", (P2, P1), 3), np.float64)
+        with pytest.raises(ValueError) as raised:
+            act(field)
+        return str(raised.value)
+
+
+@pytest.mark.parametrize(
+    ("label", "act", "expected"),
+    [
+        (
+            "split-direction",
+            lambda field: field.split(2, 0.5),
+            "direction must be in [0, 2), got 2.",
+        ),
+        (
+            "split-at-start",
+            lambda field: field.split(0, 0.0),
+            "value must be strictly inside the domain (0.0, 1.0), got 0.0.",
+        ),
+        (
+            "split-outside",
+            lambda field: field.split(0, 1.7),
+            "value must be strictly inside the domain (0.0, 1.0), got 1.7.",
+        ),
+        ("slice-axis", lambda field: field.slice(2, 0.5), "axis must be in [0, 2), got 2."),
+        (
+            "slice-outside",
+            lambda field: field.slice(1, 1.7),
+            "value 1.7 is outside the domain [0.0, 1.0] of direction 1.",
+        ),
+        ("boundary-side", lambda field: field.boundary(0, 2), "side must be 0 or 1, got 2."),
+        ("boundary-axis", lambda field: field.boundary(2, 0), "axis must be in [0, 2), got 2."),
+    ],
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_the_wrapper_refusals_are_identical(label: str, act: _Act, expected: str) -> None:
+    """Every Layer 1 refusal reads the same under both backends, and is the oracle's.
+
+    All seven are made by the wrapper above the branch, which is what makes them
+    common mode. Asserting the literal as well as the equality is what would catch both
+    backends drifting together -- the failure a parity comparison cannot see.
+
+    The out-of-domain slice is the one whose C++ text differs at ``float32``, and this
+    is the test that pins the divergence as unreachable: the wrapper refuses first, so
+    what a caller reads is this text on both backends. See the module docstring.
+
+    Args:
+        label (str): The case's name.
+        act (_Act): What to do to the field.
+        expected (str): The oracle's message.
+    """
+    texts = [_refusal(backend, act) for backend in (Backend.PYTHON, Backend.CPP)]
+    assert texts[0] == expected, f"{label}: the oracle's text is {texts[0]!r}"
+    assert texts[0] == texts[1], f"{label}: {texts}"
+
+
+def test_a_cross_backend_field_is_refused_on_both_routes() -> None:
+    """Neither route converts a field the other backend built, and the two differ in how.
+
+    ``design/cross_backend_types.md`` forbids the conversion. **Both directions are
+    refused, by different mechanisms and with different messages**, and the asymmetry is
+    measured rather than assumed:
+
+     - the C++ route refuses it up front, in :func:`_cpp_handle`, with a ``TypeError``
+       naming the backend;
+     - the *oracle* route refuses it late and incidentally, in
+       :class:`~pantr.bspline.BsplineSpace`'s own constructor, with a ``ValueError``:
+       both operations carry at least one untouched direction's wrapper into the result,
+       and a space cannot aggregate a direction from the other backend.
+
+    That second half is why the claim in
+    :mod:`pantr.bspline._refinement_backend`'s docstring -- that the oracle runs happily
+    over a C++ field -- needed the qualification it now carries: it holds only where
+    *every* direction is rebuilt, which for these operations is never.
+    """
+    with use_backend(Backend.PYTHON):
+        python_field = _build(_Case("2d", (P2, P1), 3), np.float64)
+    with use_backend(Backend.CPP):
+        native = _build(_Case("2d", (P2, P1), 3), np.float64)
+        for act in (
+            lambda: to_open_field(python_field),
+            lambda: split_field(python_field, 0, 0.5),
+            lambda: slice_field(python_field, 0, 0.5),
+        ):
+            with pytest.raises(TypeError, match="different backend"):
+                act()
+    with use_backend(Backend.PYTHON):
+        for act in (
+            lambda: split_field(native, 0, 0.5),
+            lambda: slice_field(native, 0, 0.5),
+        ):
+            with pytest.raises(ValueError, match="must come from the active backend"):
+                act()
+
+
+def test_the_cpp_route_is_the_one_that_ran() -> None:
+    """Under the C++ backend the results hold C++ implementations, not Python ones.
+
+    The vacuity guard for every parity test above: a dispatcher that silently fell back
+    to the oracle would make all of them pass while measuring nothing, and no comparison
+    of values could tell.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    cpp_types = (_pantr_cpp.Bspline32, _pantr_cpp.Bspline64)
+    with use_backend(Backend.CPP):
+        field = _build(_Case("2d", (P2, UNCLAMPED), 3), np.float64)
+        assert isinstance(field.to_open_bspline()._impl, cpp_types)
+        left, right = field.split(0, 0.3)
+        assert isinstance(left._impl, cpp_types)
+        assert isinstance(right._impl, cpp_types)
+        sliced = field.slice(0, 0.3)
+        assert isinstance(sliced, Bspline)
+        assert isinstance(sliced._impl, cpp_types)
+
+
+def test_wrap_over_refuses_the_unreduced_prior_list() -> None:
+    """A dimension-reducing result cannot be wrapped over the field's own direction list.
+
+    The precondition :meth:`pantr.bspline.Bspline._wrap_over` documents and the length
+    check one level down enforces. It is what stops a slice from reusing direction 1's
+    wrapper for what is now direction 1 of a smaller space, which would be a wrapper for
+    a different direction with every value still agreeing.
+    """
+    with use_backend(Backend.CPP):
+        field = _build(_Case("3d", (P2, P1, P3), 2), np.float64)
+        sliced = field.slice(1, 0.5)
+        assert isinstance(sliced, Bspline)
+        assert len(field.space.spaces) == 3, "the guard needs a prior list that is too long"
+        with pytest.raises(ValueError, match="one prior wrapper per direction"):
+            Bspline._wrap_over(sliced._impl, field.space.spaces)
+
+
+def test_the_results_are_still_immutable() -> None:
+    """A structural result is as frozen as any other field wrapper.
+
+    ``__slots__``-only and no ``__dict__``: the three slots refuse assignment, so an
+    operation that handed back a half-built wrapper would be caught here rather than by
+    whatever read it next.
+    """
+    with use_backend(Backend.CPP):
+        field = _build(_Case("2d", (P2, UNCLAMPED), 3), np.float64)
+        results: Sequence[Bspline] = (field.to_open_bspline(), *field.split(0, 0.3))
+        for result in results:
+            with pytest.raises(AttributeError):
+                result._impl = field._impl
+            with pytest.raises(AttributeError):
+                del result._space

--- a/tests/parity/test_bspline_structural.py
+++ b/tests/parity/test_bspline_structural.py
@@ -140,7 +140,10 @@ P3: Final = _Vector("p3", 3, (0.0, 0.0, 0.0, 0.0, 0.4, 1.0, 1.0, 1.0, 1.0))
 P2_C0: Final = _Vector("p2c0", 2, (0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0))
 P0: Final = _Vector("p0", 0, (0.0, 0.4, 1.0))
 UNCLAMPED: Final = _Vector("uncl", 2, (-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.1, 1.2))
-LEFT_ONLY: Final = _Vector("left", 2, (-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0))
+UNCLAMPED_LEFT: Final = _Vector("unclleft", 2, (-0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0))
+"""Unclamped on the left and clamped on the right, and named for the end it is *not*
+clamped at -- which is the reading ``to_open`` and ``has_open_knots()`` use, where
+"open" means clamped."""
 PERIODIC: Final = _Vector("per", 2, (-0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5), True)
 SHIFTED: Final = _Vector("shift", 2, (2.0, 2.0, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0, 4.0))
 """A vector based away from the origin, where an absolute tolerance and a relative one
@@ -255,14 +258,35 @@ def _as_curve(field: Bspline, keep: int) -> tuple[Bspline, int]:
     return field, surviving
 
 
-def _invariance_bound(field: Bspline, degree: int, dtype: npt.DTypeLike) -> float:
+def _insertions_to_open(field: Bspline) -> int:
+    """How many knot insertions :meth:`~pantr.bspline.Bspline.to_open_bspline` performs.
+
+    One per direction it actually converts, which is one per direction that is periodic
+    or not clamped at both ends -- the predicate
+    :func:`~pantr.bspline._bspline_knot_insertion._to_open_bspline_impl` skips on.
+
+    Args:
+        field (~pantr.bspline.Bspline): The field about to be converted.
+
+    Returns:
+        int: The count, at least 1 for any field the conversion does not refuse.
+    """
+    return sum(1 for one_d in field.space.spaces if one_d.periodic or not one_d.has_open_knots())
+
+
+def _invariance_bound(field: Bspline, degree: int, dtype: npt.DTypeLike, insertions: int) -> float:
     """The absolute bound on how far a representation change may move the map.
 
     `gamma_K` times the coefficients' magnitude, with `K` assembled rather than fitted:
 
-     - `2p + 3 + (7p + 2)` for the one knot insertion the changed representation went
-       through, which is ``tests/parity/test_bspline_refinement.py``'s derivation at one
-       refined direction and `p` the changed direction's degree;
+     - `insertions * (2p + 3 + (7p + 2))` for the knot insertions the changed
+       representation went through, which is
+       ``tests/parity/test_bspline_refinement.py``'s derivation at one refined direction,
+       charged once per insertion because sequential transforms add their counts. **The
+       factor is not 1**: `to_open_bspline` inserts once per converted direction, and a
+       *periodic* split inserts twice -- once converting to the open form and again
+       raising the split value's multiplicity
+       (``pantr/bspline/_bspline_split.py``'s two steps).
      - `5 * p_d` per corner cut, being 3 roundings for the two products and the sum and
        2 for the weight pair's departure from summing to one. Reducing to a curve and
        sampling it is one cut per direction, on each of the two sides, so `10 * sum p_d`.
@@ -272,13 +296,16 @@ def _invariance_bound(field: Bspline, degree: int, dtype: npt.DTypeLike) -> floa
 
     Args:
         field (~pantr.bspline.Bspline): The field whose coefficients set the magnitude.
-        degree (int): The degree of the direction the operation changed.
+        degree (int): The degree of the direction the operation changed; the largest of
+            them where it changed more than one.
         dtype (npt.DTypeLike): The storage format the roundings are charged in.
+        insertions (int): How many knot insertions the changed representation went
+            through.
 
     Returns:
         float: The bound, in the units of the coefficients.
     """
-    roundings = (2 * degree + 3 + 7 * degree + 2) + 10 * sum(field.degree)
+    roundings = insertions * (2 * degree + 3 + 7 * degree + 2) + 10 * sum(field.degree)
     unit = 0.5 * float(np.finfo(np.dtype(dtype)).eps)
     magnitude = float(np.max(np.abs(np.asarray(field.control_points, dtype=np.float64))))
     return roundings * unit / (1.0 - roundings * unit) * magnitude
@@ -418,7 +445,7 @@ def _fields(dim: int) -> tuple[Field, ...]:
 
 OPEN_CASES: Final = (
     _Case("uncl-1d", (UNCLAMPED,), 3),
-    _Case("left-only-1d", (LEFT_ONLY,), 2),
+    _Case("unclamped-left-1d", (UNCLAMPED_LEFT,), 2),
     _Case("per-1d", (PERIODIC,), 3),
     _Case("per-1d-rational", (PERIODIC,), 2, rational=True),
     _Case("per-uncl-2d", (PERIODIC, UNCLAMPED), 2),
@@ -474,7 +501,12 @@ def test_the_open_conversion_does_not_move_the_curve(case: _Case, dtype: npt.DTy
     with use_backend(Backend.CPP):
         field = _build(case, dtype)
         opened = field.to_open_bspline()
-        bound = _invariance_bound(field, max(vector.degree for vector in case.vectors), dtype)
+        bound = _invariance_bound(
+            field,
+            max(vector.degree for vector in case.vectors),
+            dtype,
+            _insertions_to_open(field),
+        )
         for direction in range(field.dim):
             before, keep = _as_curve(field, direction)
             after, _ = _as_curve(opened, direction)
@@ -613,7 +645,10 @@ def test_the_split_does_not_move_the_curve(split: _SplitCase, dtype: npt.DTypeLi
         field = _build(split.case, dtype)
         halves = field.split(split.direction, split.value)
         degree = split.case.vectors[split.direction].degree
-        bound = _invariance_bound(field, degree, dtype)
+        # A periodic direction is converted to the open form first and *then* has the
+        # split value's multiplicity raised: two insertions, not one.
+        insertions = 2 if split.case.vectors[split.direction].periodic else 1
+        bound = _invariance_bound(field, degree, dtype, insertions)
         whole, keep = _as_curve(field, split.direction)
         for side, half in zip(("left", "right"), halves, strict=True):
             reduced, _ = _as_curve(half, split.direction)
@@ -849,6 +884,13 @@ def _refusal(backend: Backend, act: _Act) -> str:
         ),
         ("boundary-side", lambda field: field.boundary(0, 2), "side must be 0 or 1, got 2."),
         ("boundary-axis", lambda field: field.boundary(2, 0), "axis must be in [0, 2), got 2."),
+        # Bad in both ways. The wrapper checks the side first, so that is the message,
+        # and the C++ `boundary` restates the same order; the claim had no test before.
+        (
+            "boundary-side-and-axis",
+            lambda field: field.boundary(7, 2),
+            "side must be 0 or 1, got 2.",
+        ),
     ],
     ids=lambda value: value if isinstance(value, str) else "",
 )


### PR DESCRIPTION
Cut 3 of #398: the structural knot-vector operations. **14 files, +3697/−37, four commits.**

## Four of five, and the fifth is a correction to my own scoping

I scoped this cut as five methods, on the criterion that they "use a tolerance only to *locate* a
knot", excluding `remove_knots` because it carries a geometric scale. **That criterion is false
for `to_periodic`, and the engineer refused the method rather than build on it.** Verified against
the source before accepting:

- `_bspline_knot_insertion.py:526-529` computes `scale = max(max|ctrl|, 1.0)` and
  `c0_tol = max(tol, 100 * eps * scale)`, then **raises** when the endpoint deviation exceeds it.
  That is a tolerance on a *geometric* quantity deciding admissibility — the same class as
  `remove_knots`.
- `:583-596` reaches `np.linalg.qr` and `np.linalg.solve`, then compares a **residual** against
  `residual_tol` and raises. So the verdict rests on a QR solve, and Eigen's Householder QR is not
  LAPACK's blocked `geqrf`: the control points cannot be claimed bit-identical and **the verdict
  can flip near threshold**. `design/backend_parity.md` has no rule covering a two-sided verdict —
  Rule 8 bounds a *displacement*.

So `to_periodic` belongs with `remove_knots` in a cut of their own, which would also let cut 2's
periodic-refinement refusal be lifted. Nothing here needs it.

## What is ported

`to_open_bspline`, `split`, `slice`, `boundary` — as free functions over `const Bspline<T>&` in
`cpp/include/pantr/bspline/structural.hpp`, per `space_1d.hpp`'s declared layering.

**Reuse is the argument.** `inserted_knot_vector`, `oslo_bands_1d` and `refine_along_axis` from
cut 2 do *all* of `to_open`'s and `split`'s arithmetic — no second Oslo recurrence, no second
merge, no second sweep. The `split`/`slice`/`slice_point`/`boundary` decomposition was derived
independently and then found to already exist in `cpp/include/pantr/bezier/shape.hpp`, so it was
adopted verbatim rather than spelled a second way.

**Genuinely new**: `corner_cut_along_axis` (de Boor, Piegl–Tiller A5.1) — the first evaluator in
the port, and portable ahead of the tabulation because it touches no basis function.

**`slice` is two functions** because C++ can return neither a field nor an array: `slice_point`
serves dimension 1 and returns *homogeneous* components, with the rational division staying in
Python as one numpy expression. Bézier's precedent.

## Three arithmetic widths, each settled by executing the oracle

The corner cut computes weights in `double` and applies them in `T`; the span search and
multiplicity count are `double`; the end and split multiplicity counts are `T` against a
`T`-rounded tolerance. That is **sharper than Rule 9**: the width follows whether the expression
is Numba-compiled (which widens) or plain Python (where NEP 50 weakens), not which module it
lives in. Pinned by a test rather than by a comment — replacing the corner-cut update with a
`double` one fails the `float32` slice cases and none of the `float64` ones.

## Two files from earlier cuts, and why

Both asked for explicitly, as the previous cut was asked about `bernstein.hpp` and `binomial.hpp`.

**`_refinement_backend.py`** — one signature generalization and one docstring correction, no
folded-in bug. `BsplineSpace._wrap_over` already took a `Sequence[BsplineSpace1D]` and refuses a
length mismatch; a slice's result has one direction fewer, so the prior list must be the reduced
one, and `Bspline._wrap_over` sat between them taking the whole `BsplineSpace`, from which no
reduced list is derivable. The alternatives were a second `_wrap_over` variant — two spellings of
one thing — or hand-rolling the space and losing the identity
`sliced.space.spaces[j] is field.space.spaces[i]`. The docstring correction has **its own commit**:
it claimed unqualified that the oracle "runs happily over a C++ field", which is measured false —
only when *every* direction is refined.

**`_bspline_space_nd.py`** — docstring only. Its `_wrap_over` said the method is "only correct for
an operation that preserves the directions and their order… a boundary extraction would not",
which would read as forbidding exactly what the slice legitimately does.

## Verification

`scripts/ci_local.sh` **52 PASS / 2 FAIL / 0 SKIP** — the two failures being the documented
pre-existing `floor: g++-10` pair (libstdc++ 10 has no floating-point `std::to_chars`, #376), and
the zero SKIP count confirming the Python half executed rather than skipping. `ruff check` clean,
`ruff format --check` 346 files, `mypy` 321 files, `ctest` 52/52, full `pytest`
**10029 passed, 57 skipped, 7 xfailed**.

**A 34-case raw-binding parity probe** — periodic, unclamped, rational, degree 0, 1D/2D/3D, at-knot
and at-endpoint — bit-exact at both widths, 0 failures. **Seven header mutations**, each caught by
the C++ suite. Worst observed invariance deviation is 2–4% of the bound, so Rule 3's vacuity guard
does not fire.

## Its own review round found the bound was passing on slack

Two reviewers, then fixes in `28ad34f`. The one worth naming: **the parity invariance bound
charged one insertion**, while `to_open` inserts once per converted direction and a periodic split
inserts twice. It was passing on slack — which is the failure mode, not the reassurance — and the
bound now takes the count. Also an `I` where a test helper's `greville()` documented a degree-0
branch it did not have (`sum / T(0)` is NaN, two of three callers reach it unguarded), and an `I`
adding the cross-backend `TypeError` to all four methods' `Raises:`.

Adding degree 0 surfaced a real mathematical limit rather than a defect: a piecewise constant is
discontinuous at every breakpoint and the sample list *is* the breakpoints, so "the same map" is
undefined there. Two checks skip degree 0 and say why.

## One suspicion, pre-existing and not fixed

`BsplineSpace1D` never validates a periodic space's boundary multiplicity against the
`[1, degree]` range enforced elsewhere. Constructed with `m_bdy = degree + 1`, the **Python oracle
silently no-ops** `_to_open_bspline_1d_impl` and returns the ghost-laden vector unchanged; the C++
reproduces it exactly, so this is correct parity over a shared defect in already-merged code.
Adjacent to, but distinct from, the right-end-multiplicity defect. Not fixed: a numerical
wrong-answer bug in another file defaults to aborting.

**The downstream-consumer question is settled**: `Bspline._wrap_over`'s signature changed, and the
consumer does not use it — it touches no pantr private symbol at all, checked directly in that
repository just now.

## No merge

Opened for review only. The merge authority granted on 4 September expired with the previous
stretch. This will conflict trivially with #447 on the three binding-registration files —
additive lists, three lines for whoever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
