### PR TITLE
fix(basis): write the result back when a reshaped out is a copy

### DIFF
--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -27,6 +27,7 @@ from ._basis_utils import (
     _allocate_or_validate_out,
     _compute_final_output_shape_1D,
     _normalize_points_1D,
+    _reshaped_out,
 )
 
 if TYPE_CHECKING:
@@ -93,12 +94,15 @@ def _tabulate_basis_1D_impl_helper(
 
     out = _allocate_or_validate_out(out, expected_final_shape, t.dtype)
 
-    B_normalized = out.reshape(expected_normalized_shape)
+    B_normalized, copy_back = _reshaped_out(out, expected_normalized_shape)
 
     if core_func_serial is not None and num_pts < _PARALLEL_MIN_NUM_PTS:
         core_func_serial(np.int32(n), t, B_normalized)
     else:
         core_func(np.int32(n), t, B_normalized)
+
+    if copy_back:
+        out[...] = B_normalized.reshape(out.shape)
 
     return out
 

--- a/src/pantr/basis/_basis_utils.py
+++ b/src/pantr/basis/_basis_utils.py
@@ -212,3 +212,54 @@ def _allocate_or_validate_out(
         return np.empty(expected_shape, dtype=expected_dtype)
     _validate_out_array(out, expected_shape, expected_dtype)
     return out
+
+
+def _reshaped_out(
+    out: npt.NDArray[Any],
+    shape: tuple[int, ...],
+) -> tuple[npt.NDArray[Any], bool]:
+    """Reshape a caller's ``out`` for a kernel, and say whether to copy back.
+
+    Layer 2 normalises an ``out`` array's shape before handing it to a kernel that
+    writes into it. ``reshape`` returns a *view* whenever the strides allow one, and
+    a **copy** otherwise -- and a kernel writing into a copy leaves the caller's
+    array untouched, so the result is silently discarded and the caller reads back
+    whatever it allocated: a ``float64`` tabulation with an ``order="F"`` ``out`` and
+    multi-dimensional points used to return the caller's array untouched, because the
+    kernel had filled a copy of it.
+
+    **The test is whether the reshape shared memory, not whether the array was
+    C-contiguous**, and the difference is not academic: a strided slice such as
+    ``big[..., ::2]`` is *not* C-contiguous and *does* reshape to a view, because
+    merging the leading axes is expressible in strides. Refusing or copying it would
+    slow down a case that works correctly today.
+
+    The counterpart on the C++ side is
+    :func:`pantr.bspline._extraction_backend._contiguous_out`, which absorbs the same
+    situation for a different reason -- the bindings declare their writable arguments
+    ``c_contig`` -- and states the shared policy: a strided ``out`` is rare and legal,
+    so it is absorbed rather than refused.
+
+    Args:
+        out (npt.NDArray[Any]): The caller's output array, already validated.
+        shape (tuple[int, ...]): The shape the kernel expects to write into.
+
+    Returns:
+        tuple[npt.NDArray[Any], bool]: The array to hand the kernel, and whether the
+        caller's ``out`` still has to be written from it once the kernel returns.
+
+    Example:
+        >>> import numpy as np
+        >>> out = np.zeros((2, 2, 3), order="F")
+        >>> buf, copy_back = _reshaped_out(out, (4, 3))
+        >>> copy_back
+        True
+        >>> buf[:] = 1.0
+        >>> bool(out.any())
+        False
+        >>> out[...] = buf.reshape(out.shape)
+        >>> bool(out.all())
+        True
+    """
+    buffer = out.reshape(shape)
+    return buffer, not np.shares_memory(buffer, out)

--- a/src/pantr/basis/_basis_utils.py
+++ b/src/pantr/basis/_basis_utils.py
@@ -8,6 +8,8 @@ helpers) of PaNTr:
   dimensions and the number of basis functions.
 - Output array validation: check shape, dtype, and writability of pre-allocated
   ``out`` arrays before calling Layer 3 kernels.
+- Output array reshaping: hand a kernel the shape it expects, and say whether the
+  caller's array still has to be written from the result.
 """
 
 from typing import Any
@@ -247,6 +249,10 @@ def _reshaped_out(
     Returns:
         tuple[npt.NDArray[Any], bool]: The array to hand the kernel, and whether the
         caller's ``out`` still has to be written from it once the kernel returns.
+
+    Raises:
+        ValueError: If ``shape`` holds a different number of elements than ``out``.
+            Call sites validate the shape first, so this cannot be reached from them.
 
     Example:
         >>> import numpy as np

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -19,6 +19,7 @@ from ..basis._basis_utils import (
     _compute_final_output_shape_1D,
     _compute_final_output_shape_1D_deriv,
     _normalize_points_1D,
+    _reshaped_out,
     _validate_out_array,
 )
 from ._basis_backend import bspline_basis_core, bspline_basis_deriv_core
@@ -781,12 +782,12 @@ def _tabulate_Bspline_basis_1D_impl(
     if out_basis is None:
         out_basis = np.empty(expected_final_shape, dtype=expected_dtype)
     _validate_out_array(out_basis, expected_final_shape, expected_dtype)
-    basis_normalized = out_basis.reshape(num_pts, n_basis)
+    basis_normalized, copy_back_basis = _reshaped_out(out_basis, (num_pts, n_basis))
 
     if out_first_basis is None:
         out_first_basis = np.empty(expected_first_basis_shape, dtype=np.int_)
     _validate_out_array(out_first_basis, expected_first_basis_shape, np.int_)
-    first_indices_normalized = out_first_basis.reshape(num_pts)
+    first_indices_normalized, copy_back_first = _reshaped_out(out_first_basis, (num_pts,))
 
     if spline.has_Bezier_like_knots():
         _tabulate_Bspline_basis_Bernstein_like_1D(
@@ -808,6 +809,11 @@ def _tabulate_Bspline_basis_1D_impl(
             basis_normalized,
             first_indices_normalized,
         )
+
+    if copy_back_basis:
+        out_basis[...] = basis_normalized.reshape(out_basis.shape)
+    if copy_back_first:
+        out_first_basis[...] = first_indices_normalized.reshape(out_first_basis.shape)
 
     return out_basis, out_first_basis
 
@@ -888,12 +894,12 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
     if out_deriv is None:
         out_deriv = np.empty(expected_deriv_shape, dtype=expected_dtype)
     _validate_out_array(out_deriv, expected_deriv_shape, expected_dtype)
-    deriv_normalized = out_deriv.reshape(num_pts, n_deriv + 1, order)
+    deriv_normalized, copy_back_deriv = _reshaped_out(out_deriv, (num_pts, n_deriv + 1, order))
 
     if out_first_basis is None:
         out_first_basis = np.empty(expected_first_basis_shape, dtype=np.int_)
     _validate_out_array(out_first_basis, expected_first_basis_shape, np.int_)
-    first_indices_normalized = out_first_basis.reshape(num_pts)
+    first_indices_normalized, copy_back_first = _reshaped_out(out_first_basis, (num_pts,))
 
     if spline.has_Bezier_like_knots():
         _tabulate_Bspline_basis_Bernstein_like_deriv_1D(
@@ -916,6 +922,11 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
             deriv_normalized,
             first_indices_normalized,
         )
+
+    if copy_back_deriv:
+        out_deriv[...] = deriv_normalized.reshape(out_deriv.shape)
+    if copy_back_first:
+        out_first_basis[...] = first_indices_normalized.reshape(out_first_basis.shape)
 
     return out_deriv, out_first_basis
 

--- a/tests/test_out_writeback.py
+++ b/tests/test_out_writeback.py
@@ -4,8 +4,9 @@ Layer 2 normalises an ``out`` array's shape before handing it to a kernel. ``res
 returns a *view* when the strides allow one and a **copy** otherwise, and a kernel
 writing into a copy leaves the caller's array untouched. Measured before the fix, on a
 ``float64`` space with two-dimensional points and an ``order="F"`` ``out``: six public
-entry points returned an all-zero array and partition of unity read 0 instead of 1,
-with the function handing the caller back its own untouched array.
+entry points returned the caller's own array, untouched and therefore all zeros. On
+the five whose basis is a partition of unity -- Legendre's is not -- that reads as the
+rows summing to 0 instead of 1.
 
 **The strided case is here to stop the fix from being too wide, not too narrow.** A
 slice such as ``big[..., ::2]`` is not C-contiguous and yet reshapes to a view, because
@@ -58,19 +59,23 @@ def test_the_layouts_differ_in_the_way_that_matters() -> None:
     # Without this the parametrisation could silently degenerate to three C-contiguous
     # arrays and every case below would pass while checking one layout three times.
     shape = (2, 2, 3)
-    reshaped = {layout: _make(shape, layout).reshape(4, 3) for layout in _LAYOUTS}
+    arrays = {layout: _make(shape, layout) for layout in _LAYOUTS}
+    # Each array is reshaped against *itself*, not against a second allocation: two
+    # separate allocations never share memory, so that comparison would read as a
+    # check and decide nothing.
     shares = {
-        layout: np.shares_memory(reshaped[layout], _make(shape, layout)) for layout in _LAYOUTS
+        layout: np.shares_memory(array.reshape(4, 3), array) for layout, array in arrays.items()
     }
-    assert not _make(shape, "F").flags["C_CONTIGUOUS"]
-    assert not _make(shape, "strided").flags["C_CONTIGUOUS"]
+
+    assert arrays["C"].flags["C_CONTIGUOUS"]
+    assert not arrays["F"].flags["C_CONTIGUOUS"]
+    assert not arrays["strided"].flags["C_CONTIGUOUS"]
+
     # The strided one is the case a C_CONTIGUOUS-keyed fix would get wrong: not
-    # contiguous, yet its reshape is a view.
-    strided = _make(shape, "strided")
-    assert np.shares_memory(strided.reshape(4, 3), strided)
-    fortran = _make(shape, "F")
-    assert not np.shares_memory(fortran.reshape(4, 3), fortran)
-    assert shares is not None
+    # contiguous, yet its reshape is a view. The Fortran one is the case that needs
+    # the copy-back. Both flags being the same would mean the layouts do not differ
+    # in the way the fix keys on.
+    assert shares == {"C": True, "F": False, "strided": True}
 
 
 @pytest.mark.parametrize("layout", _LAYOUTS)

--- a/tests/test_out_writeback.py
+++ b/tests/test_out_writeback.py
@@ -1,0 +1,144 @@
+"""Guard that a caller's ``out`` receives the result whatever its strides.
+
+Layer 2 normalises an ``out`` array's shape before handing it to a kernel. ``reshape``
+returns a *view* when the strides allow one and a **copy** otherwise, and a kernel
+writing into a copy leaves the caller's array untouched. Measured before the fix, on a
+``float64`` space with two-dimensional points and an ``order="F"`` ``out``: six public
+entry points returned an all-zero array and partition of unity read 0 instead of 1,
+with the function handing the caller back its own untouched array.
+
+**The strided case is here to stop the fix from being too wide, not too narrow.** A
+slice such as ``big[..., ::2]`` is not C-contiguous and yet reshapes to a view, because
+merging the leading axes is expressible in strides. A fix that keyed on the
+``C_CONTIGUOUS`` flag rather than on whether the reshape shared memory would copy it
+needlessly, so every case below is parametrised over all three layouts.
+
+Both output parameters are covered. ``out_first_basis`` is the one worth saying out
+loud: it comes back as zeros too, and a caller trusting it indexes the wrong basis
+function with nothing to show that anything went wrong.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr import basis
+from pantr.basis import LagrangeVariant
+from pantr.bspline import BsplineSpace1D
+
+_PTS_2D = np.array([[0.1, 0.2], [0.6, 0.9]])
+"""Multi-dimensional points, which is what makes the reshape non-trivial."""
+
+_LAYOUTS = ("C", "F", "strided")
+
+
+def _make(shape: tuple[int, ...], layout: str, dtype: npt.DTypeLike = np.float64) -> Any:
+    """Build a zeroed ``out`` array of the requested memory layout.
+
+    Args:
+        shape (tuple[int, ...]): The shape the entry point requires.
+        layout (str): One of ``"C"``, ``"F"`` or ``"strided"``.
+        dtype (npt.DTypeLike): The array's dtype. Defaults to ``np.float64``.
+
+    Returns:
+        Any: A writeable array of that shape, zero-filled.
+    """
+    if layout == "C":
+        return np.zeros(shape, dtype=dtype)
+    if layout == "F":
+        return np.zeros(shape, dtype=dtype, order="F")
+    return np.zeros((*shape[:-1], shape[-1] * 2), dtype=dtype)[..., ::2]
+
+
+def test_the_layouts_differ_in_the_way_that_matters() -> None:
+    # Without this the parametrisation could silently degenerate to three C-contiguous
+    # arrays and every case below would pass while checking one layout three times.
+    shape = (2, 2, 3)
+    reshaped = {layout: _make(shape, layout).reshape(4, 3) for layout in _LAYOUTS}
+    shares = {
+        layout: np.shares_memory(reshaped[layout], _make(shape, layout)) for layout in _LAYOUTS
+    }
+    assert not _make(shape, "F").flags["C_CONTIGUOUS"]
+    assert not _make(shape, "strided").flags["C_CONTIGUOUS"]
+    # The strided one is the case a C_CONTIGUOUS-keyed fix would get wrong: not
+    # contiguous, yet its reshape is a view.
+    strided = _make(shape, "strided")
+    assert np.shares_memory(strided.reshape(4, 3), strided)
+    fortran = _make(shape, "F")
+    assert not np.shares_memory(fortran.reshape(4, 3), fortran)
+    assert shares is not None
+
+
+@pytest.mark.parametrize("layout", _LAYOUTS)
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda out: basis.tabulate_bernstein_1d(2, _PTS_2D, out=out), id="bernstein"),
+        pytest.param(
+            lambda out: basis.tabulate_cardinal_bspline_1d(2, _PTS_2D, out=out),
+            id="cardinal",
+        ),
+        pytest.param(
+            lambda out: basis.tabulate_lagrange_1d(2, LagrangeVariant.EQUISPACES, _PTS_2D, out=out),
+            id="lagrange",
+        ),
+        pytest.param(lambda out: basis.tabulate_legendre_1d(2, _PTS_2D, out=out), id="legendre"),
+    ],
+)
+def test_a_basis_tabulator_writes_through_to_out(call: Any, layout: str) -> None:
+    reference = np.asarray(call(None))
+    out = _make(reference.shape, layout)
+    returned = np.asarray(call(out))
+    np.testing.assert_allclose(returned, reference)
+    np.testing.assert_allclose(
+        out,
+        reference,
+        err_msg=f"the {layout} out array was not written through",
+    )
+
+
+@pytest.mark.parametrize("layout", _LAYOUTS)
+def test_tabulate_basis_writes_through_both_outputs(layout: str) -> None:
+    space = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]), 2)
+    ref_values, ref_first = space.tabulate_basis(_PTS_2D)
+    ref_values = np.asarray(ref_values)
+    ref_first = np.asarray(ref_first)
+
+    out_basis = _make(ref_values.shape, layout)
+    out_first = _make(ref_first.shape, layout, np.int_)
+    values, first = space.tabulate_basis(_PTS_2D, out_basis=out_basis, out_first_basis=out_first)
+
+    np.testing.assert_allclose(np.asarray(values), ref_values)
+    np.testing.assert_allclose(out_basis, ref_values)
+    np.testing.assert_array_equal(np.asarray(first), ref_first)
+    np.testing.assert_array_equal(
+        out_first, ref_first, err_msg="out_first_basis was not written through"
+    )
+    # The property a caller would actually notice: it fails on an unwritten array.
+    np.testing.assert_allclose(out_basis.sum(axis=-1), 1.0)
+
+
+@pytest.mark.parametrize("layout", _LAYOUTS)
+def test_tabulate_basis_derivatives_writes_through_both_outputs(layout: str) -> None:
+    space = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]), 2)
+    ref_deriv, ref_first = space.tabulate_basis_derivatives(_PTS_2D, n_deriv=1)
+    ref_deriv = np.asarray(ref_deriv)
+    ref_first = np.asarray(ref_first)
+
+    out_deriv = _make(ref_deriv.shape, layout)
+    out_first = _make(ref_first.shape, layout, np.int_)
+    deriv, first = space.tabulate_basis_derivatives(
+        _PTS_2D, n_deriv=1, out_deriv=out_deriv, out_first_basis=out_first
+    )
+
+    np.testing.assert_allclose(np.asarray(deriv), ref_deriv)
+    np.testing.assert_allclose(out_deriv, ref_deriv)
+    np.testing.assert_array_equal(np.asarray(first), ref_first)
+    np.testing.assert_array_equal(out_first, ref_first)
+    # Values sum to one and first derivatives sum to zero; both fail on zeros.
+    np.testing.assert_allclose(out_deriv[..., 0, :].sum(axis=-1), 1.0)
+    np.testing.assert_allclose(out_deriv[..., 1, :].sum(axis=-1), 0.0, atol=1e-12)


### PR DESCRIPTION
## Context

Layer 2 reshapes a caller's `out` array before handing it to a kernel. `reshape`
returns a **view** when the strides allow one and a **copy** otherwise, and a kernel
filling a copy leaves the caller's array untouched. No exception is raised and
nothing in the suite noticed: the function hands back the array the caller passed in,
exactly as they allocated it.

Measured on `proto/cpp` before this change, with a `float64` space, two-dimensional
points and an `order="F"` `out`: the basis table came back all zeros, so the partition
of unity read 0 instead of 1, and `out_first_basis` came back all zeros too, which is
the worse half: a caller trusting it indexes basis function 0 everywhere with nothing
to show that anything went wrong.

## Specification

`_reshaped_out(out, shape)` does the reshape and reports whether the result has to be
written back. Every site that reshaped an `out` now goes through it, and copies back
when it says so.

**The predicate is `np.shares_memory`, not the `C_CONTIGUOUS` flag.** A strided slice
such as `big[..., ::2]` is not C-contiguous and still reshapes to a view, because
merging the leading axes is expressible in strides. Keying on the flag would copy a
case that works correctly today, so the tests parametrise all three layouts and one
of them asserts that the three really do differ.

The six affected entry points are the four `pantr.basis` tabulators, which share one
helper, and `BsplineSpace1D.tabulate_basis` / `tabulate_basis_derivatives`, which have
two output parameters each.

## Acceptance

- AC1: an `order="F"` `out` receives the result, on every affected entry point.
- AC2: a strided `out` receives the result and is not copied needlessly.
- AC3: `out_first_basis` is covered alongside the basis table.
- AC4: the three layouts are proved distinct, so the parametrisation cannot degenerate.

## Non-goals

The C++ side already absorbs the same situation, for a different reason: its bindings
declare their writable arguments `c_contig`, and `_contiguous_out` copies back. This
change does not touch it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
