### PR TITLE
fix(bspline): refuse a knot vector whose end knot repeats too often

### DIFF
--- a/cpp/include/pantr/bspline/knots.hpp
+++ b/cpp/include/pantr/bspline/knots.hpp
@@ -86,6 +86,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "pantr/core/format.hpp"
@@ -501,6 +502,59 @@ void check_space_has_an_interval(std::span<const T> knots, std::int64_t degree,
           "evaluated, tabulated or located on it. The domain needs two consecutive knots more "
           "than "
         + tol_text + " apart.");
+}
+
+/// Refuse a knot vector whose first or last knot repeats more than it may.
+///
+/// Runs after `check_space_has_an_interval`, deliberately: that one names a mesh
+/// with no interval at all, which is the more useful diagnosis. This owns what is
+/// left, a vector whose interval structure is sound while an end knot repeats past
+/// `degree + 1`. An excess at the right end makes the basis sum to zero instead of
+/// one at the right endpoint and makes the derivatives divide by zero; an excess in
+/// the *interior* computes correctly and is the ordinary way to lower continuity,
+/// so it stays legal. A periodic space fails the partition of unity identically,
+/// which is why it is refused too and why the message says "end knot".
+///
+/// The floor of two keeps degree 0 alive: there `degree + 1` is 1, and the ordinary
+/// clamped vector `[0, 0, 1, 1]` repeats twice at each end.
+///
+/// The two end runs are counted here rather than read off `unique_knots_and_multiplicity`
+/// so that construction does not force the lazy memo that holds them. The grouping
+/// rule is that function's, knot for knot: a step of more than `tol` starts a new class.
+///
+/// \param knots The knot vector, non-decreasing and already snapped if snapping was
+///        requested, so this and `snap_knots` cannot disagree about which knots are
+///        the same knot.
+/// \param degree The polynomial degree.
+/// \param tol The absolute parametric tolerance, from `knot_tolerance`.
+/// \throws std::invalid_argument If either end run holds more than
+///         `max(degree + 1, 2)` knots.
+template <Real T>
+void check_end_multiplicity(std::span<const T> knots, std::int64_t degree, double tol) {
+    const std::int64_t max_end_multiplicity = std::max(degree + 1, std::int64_t{2});
+
+    const auto run_length = [&](auto next) {
+        std::int64_t length = 1;
+        for (std::size_t i = 1; i < knots.size(); ++i) {
+            const auto [lo, hi] = next(i);
+            if (detail::as_double(knots[hi] - knots[lo]) > tol) {
+                break;
+            }
+            ++length;
+        }
+        return length;
+    };
+    const std::int64_t at_front =
+        run_length([&](std::size_t i) { return std::pair{i - 1, i}; });
+    const std::int64_t at_back = run_length([&](std::size_t i) {
+        const std::size_t last = knots.size() - 1;
+        return std::pair{last - i, last - i + 1};
+    });
+
+    if (std::max(at_front, at_back) > max_end_multiplicity) {
+        throw std::invalid_argument("an end knot may repeat at most "
+                                    + std::to_string(max_end_multiplicity) + " times");
+    }
 }
 
 }  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/knots.hpp
+++ b/cpp/include/pantr/bspline/knots.hpp
@@ -504,22 +504,23 @@ void check_space_has_an_interval(std::span<const T> knots, std::int64_t degree,
         + tol_text + " apart.");
 }
 
-/// Refuse a knot vector whose first or last knot repeats more than it may.
+/// Refuse a knot vector whose last knot repeats more than it may.
 ///
 /// Runs after `check_space_has_an_interval`, deliberately: that one names a mesh
 /// with no interval at all, which is the more useful diagnosis. This owns what is
-/// left, a vector whose interval structure is sound while an end knot repeats past
-/// `degree + 1`. An excess at the right end makes the basis sum to zero instead of
-/// one at the right endpoint and makes the derivatives divide by zero; an excess in
-/// the *interior* computes correctly and is the ordinary way to lower continuity,
-/// so it stays legal. A periodic space fails the partition of unity identically,
-/// which is why it is refused too and why the message says "end knot".
+/// left, a vector whose interval structure is sound while its last knot repeats
+/// past `degree + 1`. At `degree + 2` copies the basis sums to zero instead of one
+/// at the right endpoint and the derivatives there divide by zero; a periodic space
+/// fails identically and is not exempt.
 ///
-/// The floor of two keeps degree 0 alive: there `degree + 1` is 1, and the ordinary
-/// clamped vector `[0, 0, 1, 1]` repeats twice at each end.
+/// The rule is exactly as wide as that. An excess at the *first* knot leaves the
+/// partition of unity intact and only adds an identically zero basis function, an
+/// excess in the interior is the ordinary way to lower continuity, and degree 0 has
+/// no denominator to divide by zero at any multiplicity: none of the three is
+/// refused. The oracle's `_BsplineSpace1DPython.__init__` carries the measurements.
 ///
-/// The two end runs are counted here rather than read off `unique_knots_and_multiplicity`
-/// so that construction does not force the lazy memo that holds them. The grouping
+/// The end run is counted here rather than read off `unique_knots_and_multiplicity`
+/// so that construction does not force the lazy memo that holds it. The grouping
 /// rule is that function's, knot for knot: a step of more than `tol` starts a new class.
 ///
 /// \param knots The knot vector, non-decreasing and already snapped if snapping was
@@ -527,33 +528,26 @@ void check_space_has_an_interval(std::span<const T> knots, std::int64_t degree,
 ///        the same knot.
 /// \param degree The polynomial degree.
 /// \param tol The absolute parametric tolerance, from `knot_tolerance`.
-/// \throws std::invalid_argument If either end run holds more than
-///         `max(degree + 1, 2)` knots.
+/// \throws std::invalid_argument If the last knot's class holds more than
+///         `degree + 1` knots, at positive degree.
 template <Real T>
-void check_end_multiplicity(std::span<const T> knots, std::int64_t degree, double tol) {
-    const std::int64_t max_end_multiplicity = std::max(degree + 1, std::int64_t{2});
+void check_last_multiplicity(std::span<const T> knots, std::int64_t degree, double tol) {
+    if (degree == 0) {
+        return;
+    }
 
-    const auto run_length = [&](auto next) {
-        std::int64_t length = 1;
-        for (std::size_t i = 1; i < knots.size(); ++i) {
-            const auto [lo, hi] = next(i);
-            if (detail::as_double(knots[hi] - knots[lo]) > tol) {
-                break;
-            }
-            ++length;
+    const std::size_t last = knots.size() - 1;
+    std::int64_t multiplicity = 1;
+    for (std::size_t i = 1; i < knots.size(); ++i) {
+        if (detail::as_double(knots[last - i + 1] - knots[last - i]) > tol) {
+            break;
         }
-        return length;
-    };
-    const std::int64_t at_front =
-        run_length([&](std::size_t i) { return std::pair{i - 1, i}; });
-    const std::int64_t at_back = run_length([&](std::size_t i) {
-        const std::size_t last = knots.size() - 1;
-        return std::pair{last - i, last - i + 1};
-    });
+        ++multiplicity;
+    }
 
-    if (std::max(at_front, at_back) > max_end_multiplicity) {
-        throw std::invalid_argument("an end knot may repeat at most "
-                                    + std::to_string(max_end_multiplicity) + " times");
+    if (multiplicity > degree + 1) {
+        throw std::invalid_argument("the last knot may repeat at most "
+                                    + std::to_string(degree + 1) + " times");
     }
 }
 

--- a/cpp/include/pantr/bspline/space_1d.hpp
+++ b/cpp/include/pantr/bspline/space_1d.hpp
@@ -129,7 +129,8 @@ class BsplineSpace1D {
     /// \throws std::invalid_argument If the degree is negative, the vector is too
     ///         short or not non-decreasing, the vector cannot support the degree,
     ///         snapping collapsed a vector that had more than one distinct knot,
-    ///         or the resulting space spans no interval.
+    ///         the resulting space spans no interval, or an end knot repeats
+    ///         more than `max(degree + 1, 2)` times.
     BsplineSpace1D(std::span<const T> knots, std::int64_t degree, bool periodic,
                    KnotSnapping snapping)
         : degree_(degree), periodic_(periodic) {
@@ -153,6 +154,9 @@ class BsplineSpace1D {
         const KnotClassRange range = classify_knots<T>(knots_, degree_, tol_);
         num_intervals_ = range.num_intervals();
         check_space_has_an_interval<T>(knots_, degree_, num_intervals_, tol_);
+        // Last, and deliberately: the checks above name a mesh with no interval at
+        // all, which is the more useful diagnosis. This owns what is left.
+        check_end_multiplicity<T>(std::span<const T>(knots_), degree_, tol_);
         num_basis_ = pantr::bspline::num_basis<T>(knots_, degree_, periodic_, tol_);
     }
 

--- a/cpp/include/pantr/bspline/space_1d.hpp
+++ b/cpp/include/pantr/bspline/space_1d.hpp
@@ -129,8 +129,8 @@ class BsplineSpace1D {
     /// \throws std::invalid_argument If the degree is negative, the vector is too
     ///         short or not non-decreasing, the vector cannot support the degree,
     ///         snapping collapsed a vector that had more than one distinct knot,
-    ///         the resulting space spans no interval, or an end knot repeats
-    ///         more than `max(degree + 1, 2)` times.
+    ///         the resulting space spans no interval, or the last knot repeats
+    ///         more than `degree + 1` times at positive degree.
     BsplineSpace1D(std::span<const T> knots, std::int64_t degree, bool periodic,
                    KnotSnapping snapping)
         : degree_(degree), periodic_(periodic) {
@@ -156,7 +156,7 @@ class BsplineSpace1D {
         check_space_has_an_interval<T>(knots_, degree_, num_intervals_, tol_);
         // Last, and deliberately: the checks above name a mesh with no interval at
         // all, which is the more useful diagnosis. This owns what is left.
-        check_end_multiplicity<T>(std::span<const T>(knots_), degree_, tol_);
+        check_last_multiplicity<T>(std::span<const T>(knots_), degree_, tol_);
         num_basis_ = pantr::bspline::num_basis<T>(knots_, degree_, periodic_, tol_);
     }
 

--- a/cpp/tests/test_bspline_space_1d.cpp
+++ b/cpp/tests/test_bspline_space_1d.cpp
@@ -470,34 +470,36 @@ void check_concurrent_first_touch() {
     }
 }
 
-/// The end-multiplicity refusal, at both ends and on both kinds of space.
+/// The last-knot refusal, and the three neighbours it deliberately does not cover.
 ///
 /// It runs last of the knot rules, so a vector that is *also* flat must still be
 /// told it has no interval: that is the more useful diagnosis and the one the
-/// oracle gives. The interior case is here to keep the rule from widening -- an
-/// interior knot of high multiplicity is the ordinary way to lower continuity and
-/// must stay legal -- and degree 0 is here because `degree + 1` is 1 there while
-/// the perfectly ordinary `[0, 0, 1, 1]` repeats twice at each end.
-void check_end_multiplicity_refusal() {
-    const std::vector<double> right{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0, 3.0};
-    same(message_of([&] { (void)space(right, 2); }), "an end knot may repeat at most 3 times",
-         "an excess at the right end");
+/// oracle gives. The three legal cases are the rule's width: an excess at the
+/// FIRST knot keeps the partition of unity, an interior knot of high multiplicity
+/// is the ordinary way to lower continuity, and degree 0 has no denominator to
+/// divide by zero at any multiplicity.
+void check_last_multiplicity_refusal() {
+    const std::vector<double> excess{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0, 3.0};
+    same(message_of([&] { (void)space(excess, 2); }), "the last knot may repeat at most 3 times",
+         "an excess at the last knot");
 
-    const std::vector<double> left{0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
-    same(message_of([&] { (void)space(left, 2); }), "an end knot may repeat at most 3 times",
-         "an excess at the left end");
+    // Not an exemption: a periodic space's basis fails to sum to one at the right
+    // endpoint exactly as a clamped one's does.
+    same(message_of([&] { (void)space(excess, 2, true); }),
+         "the last knot may repeat at most 3 times", "an excess on a periodic space");
 
-    // A periodic space fails the partition of unity at the right endpoint exactly as
-    // the clamped one does, which is why the rule does not exempt it and why the
-    // message says "end knot" rather than "clamped end".
-    same(message_of([&] { (void)space(right, 2, true); }),
-         "an end knot may repeat at most 3 times", "an excess on a periodic space");
+    // Legal: the first knot. Measured on the oracle, the partition of unity holds
+    // and the derivatives are clean; all it adds is an identically zero basis
+    // function, which degree 0's ordinary `[0, 0, 1, 1]` also has.
+    const std::vector<double> first{0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    PANTR_CHECK(space(first, 2).num_basis() == 6);
 
-    // Legal, and the reason the rule reads the two end classes rather than all of them.
+    // Legal: the interior, which is how continuity is lowered.
     const std::vector<double> interior{0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0};
     PANTR_CHECK(space(interior, 2).num_basis() == 7);
 
-    // Legal at degree 0, where `degree + 1` is 1 and the floor of two is what keeps it so.
+    // Legal: degree 0 at any multiplicity.
+    PANTR_CHECK(space(std::vector<double>{0.0, 1.0, 1.0, 1.0}, 0).num_basis() == 3);
     PANTR_CHECK(space(std::vector<double>{0.0, 0.0, 1.0, 1.0}, 0).num_basis() == 3);
 
     // Flat *and* over-repeated: the interval rule owns it, because it runs first.
@@ -524,7 +526,7 @@ int main() {
     check_float_storage();
     check_argument_refusals();
     check_knot_refusals();
-    check_end_multiplicity_refusal();
+    check_last_multiplicity_refusal();
     check_the_non_finite_message();
     check_concurrent_first_touch();
     return pantr::test::summary("test_bspline_space_1d");

--- a/cpp/tests/test_bspline_space_1d.cpp
+++ b/cpp/tests/test_bspline_space_1d.cpp
@@ -470,6 +470,43 @@ void check_concurrent_first_touch() {
     }
 }
 
+/// The end-multiplicity refusal, at both ends and on both kinds of space.
+///
+/// It runs last of the knot rules, so a vector that is *also* flat must still be
+/// told it has no interval: that is the more useful diagnosis and the one the
+/// oracle gives. The interior case is here to keep the rule from widening -- an
+/// interior knot of high multiplicity is the ordinary way to lower continuity and
+/// must stay legal -- and degree 0 is here because `degree + 1` is 1 there while
+/// the perfectly ordinary `[0, 0, 1, 1]` repeats twice at each end.
+void check_end_multiplicity_refusal() {
+    const std::vector<double> right{0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0, 3.0};
+    same(message_of([&] { (void)space(right, 2); }), "an end knot may repeat at most 3 times",
+         "an excess at the right end");
+
+    const std::vector<double> left{0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    same(message_of([&] { (void)space(left, 2); }), "an end knot may repeat at most 3 times",
+         "an excess at the left end");
+
+    // A periodic space fails the partition of unity at the right endpoint exactly as
+    // the clamped one does, which is why the rule does not exempt it and why the
+    // message says "end knot" rather than "clamped end".
+    same(message_of([&] { (void)space(right, 2, true); }),
+         "an end knot may repeat at most 3 times", "an excess on a periodic space");
+
+    // Legal, and the reason the rule reads the two end classes rather than all of them.
+    const std::vector<double> interior{0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0};
+    PANTR_CHECK(space(interior, 2).num_basis() == 7);
+
+    // Legal at degree 0, where `degree + 1` is 1 and the floor of two is what keeps it so.
+    PANTR_CHECK(space(std::vector<double>{0.0, 0.0, 1.0, 1.0}, 0).num_basis() == 3);
+
+    // Flat *and* over-repeated: the interval rule owns it, because it runs first.
+    const std::vector<double> both{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    PANTR_CHECK_MSG(
+        message_of([&] { (void)space(both, 2); }).rfind("knot vector spans no interval:", 0) == 0,
+        "a vector that fails both rules is told about the interval first");
+}
+
 }  // namespace
 
 int main() {
@@ -487,6 +524,7 @@ int main() {
     check_float_storage();
     check_argument_refusals();
     check_knot_refusals();
+    check_end_multiplicity_refusal();
     check_the_non_finite_message();
     check_concurrent_first_touch();
     return pantr::test::summary("test_bspline_space_1d");

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -137,7 +137,9 @@ class _BsplineSpace1DPython:
                 point, which means the requested spacing is finer than the dtype
                 resolves at that coordinate magnitude. ``snap_knots=False`` bypasses
                 the merging and the snapping diagnosis, but not the interval
-                requirement.
+                requirement. Also if the first or last knot repeats more than
+                ``max(degree + 1, 2)`` times, which leaves a space whose basis does
+                not sum to one at that end.
         """
         _BsplineSpace1DPython._validate_input(knots, degree, periodic)
 
@@ -164,6 +166,31 @@ class _BsplineSpace1DPython:
             _check_snapping_kept_an_interval(knots_arr, self._knots, self._tol)
 
         _check_space_has_an_interval(self._knots, self._degree, self.num_intervals, self._tol)
+
+        # Last, and deliberately: the two checks above name a mesh that has no
+        # interval at all, which is the more useful diagnosis and the one a caller can
+        # act on. This one owns what is left -- a vector whose interval structure is
+        # sound but whose first or last knot repeats more than it may.
+        #
+        # An excess at the right end makes `tabulate_basis` sum to 0 instead of 1 at
+        # the right endpoint, and leaves the backends disagreeing about the
+        # derivatives there: the oracle raises `ZeroDivisionError`, the port returns
+        # NaN. Refusing at construction closes that without a parity rule. An excess
+        # in the interior computes correctly and is the ordinary way to lower
+        # continuity, so it stays legal. Periodic spaces fail the partition of unity
+        # identically, so they are refused too -- hence "end knot", not "clamped end".
+        #
+        # The floor of two keeps degree 0 alive: there `degree + 1` is 1, and the
+        # perfectly ordinary clamped vector `[0, 0, 1, 1]` repeats twice at each end.
+        #
+        # Multiplicities are read after snapping, so this and `_snap_knots` cannot
+        # disagree about which knots are the same knot.
+        max_end_multiplicity = max(self._degree + 1, 2)
+        end_multiplicities = _get_unique_knots_and_multiplicity_impl(
+            self._knots, self._degree, self._tol, False
+        )[1][[0, -1]]
+        if int(end_multiplicities.max()) > max_end_multiplicity:
+            raise ValueError(f"an end knot may repeat at most {max_end_multiplicity} times")
 
         self._knots.flags.writeable = False
 

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -137,9 +137,9 @@ class _BsplineSpace1DPython:
                 point, which means the requested spacing is finer than the dtype
                 resolves at that coordinate magnitude. ``snap_knots=False`` bypasses
                 the merging and the snapping diagnosis, but not the interval
-                requirement. Also if the first or last knot repeats more than
-                ``max(degree + 1, 2)`` times, which leaves a space whose basis does
-                not sum to one at that end.
+                requirement. Also, at positive degree, if the last knot repeats
+                more than ``degree + 1`` times, which leaves a space whose basis does
+                not sum to one at the right endpoint.
         """
         _BsplineSpace1DPython._validate_input(knots, degree, periodic)
 
@@ -170,27 +170,36 @@ class _BsplineSpace1DPython:
         # Last, and deliberately: the two checks above name a mesh that has no
         # interval at all, which is the more useful diagnosis and the one a caller can
         # act on. This one owns what is left -- a vector whose interval structure is
-        # sound but whose first or last knot repeats more than it may.
+        # sound while its LAST knot repeats more than it may.
         #
-        # An excess at the right end makes `tabulate_basis` sum to 0 instead of 1 at
-        # the right endpoint, and leaves the backends disagreeing about the
-        # derivatives there: the oracle raises `ZeroDivisionError`, the port returns
-        # NaN. Refusing at construction closes that without a parity rule. An excess
-        # in the interior computes correctly and is the ordinary way to lower
-        # continuity, so it stays legal. Periodic spaces fail the partition of unity
-        # identically, so they are refused too -- hence "end knot", not "clamped end".
+        # The rule is exactly as wide as what was measured. At `degree + 2` copies of
+        # the last knot, `tabulate_basis` sums to 0 instead of 1 at the right endpoint
+        # and the two backends disagree about the derivatives there: the oracle raises
+        # `ZeroDivisionError`, the port returns NaN. Refusing at construction closes
+        # that divergence without needing a parity rule. A periodic space fails
+        # identically, so it is not exempt.
         #
-        # The floor of two keeps degree 0 alive: there `degree + 1` is 1, and the
-        # perfectly ordinary clamped vector `[0, 0, 1, 1]` repeats twice at each end.
+        # Three neighbouring cases were measured and are deliberately NOT refused,
+        # because none of them shows that failure. An excess at the FIRST knot: the
+        # partition of unity holds and the derivatives are clean, and all it adds is an
+        # identically zero basis function -- which `[0, 0, 1, 1]` at degree 0 also has
+        # and this library accepts. An excess in the interior: the ordinary way to
+        # lower continuity. Degree 0 at any multiplicity: that recurrence has no
+        # denominator, so there is nothing to divide by zero.
         #
-        # Multiplicities are read after snapping, so this and `_snap_knots` cannot
-        # disagree about which knots are the same knot.
-        max_end_multiplicity = max(self._degree + 1, 2)
-        end_multiplicities = _get_unique_knots_and_multiplicity_impl(
-            self._knots, self._degree, self._tol, False
-        )[1][[0, -1]]
-        if int(end_multiplicities.max()) > max_end_multiplicity:
-            raise ValueError(f"an end knot may repeat at most {max_end_multiplicity} times")
+        # The multiplicity is read after snapping, so this and `_snap_knots` cannot
+        # disagree about which knots are the same knot. It recomputes rather than
+        # reusing what `_snap_knots` saw, to leave the `_unique_all` memo unpopulated;
+        # the C++ counterpart avoids forcing its own memo for the same reason.
+        if self._degree > 0:
+            max_last_multiplicity = self._degree + 1
+            last_multiplicity = int(
+                _get_unique_knots_and_multiplicity_impl(
+                    self._knots, self._degree, self._tol, False
+                )[1][-1]
+            )
+            if last_multiplicity > max_last_multiplicity:
+                raise ValueError(f"the last knot may repeat at most {max_last_multiplicity} times")
 
         self._knots.flags.writeable = False
 

--- a/tests/parity/test_bspline_space_1d.py
+++ b/tests/parity/test_bspline_space_1d.py
@@ -620,15 +620,20 @@ def _tolerance_drift_sweep(trials: int, seed: int) -> tuple[int, int, float, flo
             dtype
         )
 
-        # Chain the tail: several knots each within a tolerance of the previous, so
-        # the final class spans more than one tolerance and the flat bound is wrong.
+        # Chain the last class: its `degree + 1` knots become distinct values, each
+        # within a tolerance of the previous, so the class spans more than one
+        # tolerance and the flat bound is wrong. The chain *replaces* the clamped
+        # copies rather than adding to them: a class of more than `degree + 1` knots
+        # is a space whose basis does not sum to one at that end, refused at
+        # construction, so a sweep that produced them would measure nothing.
         tol = 8.0 * eps * scale
-        tail = [knots[-1]]
-        for _ in range(int(rng.integers(1, 6))):
-            tail.append(dtype(tail[-1] + dtype(tol * rng.uniform(0.3, 0.95))))
+        chain = [knots[-degree - 1]]
+        for _ in range(degree):
+            chain.append(dtype(chain[-1] + dtype(tol * rng.uniform(0.3, 0.95))))
         knots = np.sort(
             np.ascontiguousarray(
-                np.concatenate([knots[:-1], np.array(tail, dtype=dtype)]), dtype=dtype
+                np.concatenate([knots[: -degree - 1], np.array(chain, dtype=dtype)]),
+                dtype=dtype,
             )
         )
 

--- a/tests/test_degenerate_end_multiplicity.py
+++ b/tests/test_degenerate_end_multiplicity.py
@@ -1,4 +1,4 @@
-"""A knot vector whose end knot repeats past ``degree + 1`` is refused.
+"""A knot vector whose last knot repeats past ``degree + 1`` is refused.
 
 ``BsplineSpace1D`` used to accept ``[0, 0, 0, 1, 2, 3, 3, 3, 3]`` at degree 2: the
 interval structure is sound, so neither the snapping rule nor the interval rule owns
@@ -17,10 +17,15 @@ The last two rows are the reason the rule lives in the constructor rather than i
 *differently*, and a space that cannot be built removes the divergence without anyone
 having to write a parity rule about which failure is the right one.
 
-The rule reads the two end classes only. An interior knot of high multiplicity is the
-ordinary way to lower continuity and stays legal, and the ceiling has a floor of two
-so that degree 0 keeps its ordinary clamped vector ``[0, 0, 1, 1]``, where
-``degree + 1`` is 1.
+**The rule is exactly as wide as that measurement**, which is most of what the tests
+below are for. Three neighbouring cases were measured and are legal, because none of
+them shows the failure:
+
+- an excess at the **first** knot, where the partition of unity holds and the
+  derivatives are clean. It adds an identically zero basis function, which the
+  ordinary degree-0 vector ``[0, 0, 1, 1]`` also has and this library accepts;
+- an excess in the **interior**, the ordinary way to lower continuity;
+- **degree 0** at any multiplicity, whose recurrence has no denominator.
 """
 
 from __future__ import annotations
@@ -37,11 +42,31 @@ from pantr.bspline import BsplineSpace1D
 wait_for_jit_warmup()
 
 
-_TOO_MANY = re.compile("end knot may repeat")
+_TOO_MANY = re.compile("last knot may repeat")
 """Match the refusal without pinning the whole message."""
 
 
-def test_an_excess_at_the_right_end_is_refused() -> None:
+def _peak_of_each_basis_function(space: BsplineSpace1D, samples: int = 401) -> Any:
+    """Sample the domain and return each basis function's largest absolute value.
+
+    Args:
+        space (BsplineSpace1D): The space to tabulate.
+        samples (int): How many points to sample. Defaults to 401.
+
+    Returns:
+        Any: One non-negative float per basis function.
+    """
+    lo, hi = space.domain
+    basis, first = space.tabulate_basis(np.linspace(lo, hi, samples))
+    basis = np.asarray(basis)
+    peak = np.zeros(space.num_basis)
+    for point, start in enumerate(np.asarray(first)):
+        for offset in range(basis.shape[-1]):
+            peak[start + offset] = max(peak[start + offset], abs(basis[point, offset]))
+    return peak
+
+
+def test_an_excess_at_the_last_knot_is_refused() -> None:
     with pytest.raises(ValueError, match=_TOO_MANY) as excinfo:
         BsplineSpace1D(np.array([0.0, 0, 0, 1, 2, 3, 3, 3, 3]), 2)
 
@@ -50,15 +75,9 @@ def test_an_excess_at_the_right_end_is_refused() -> None:
     assert "at most 3 times" in str(excinfo.value), str(excinfo.value)
 
 
-def test_an_excess_at_the_left_end_is_refused() -> None:
-    with pytest.raises(ValueError, match=_TOO_MANY):
-        BsplineSpace1D(np.array([0.0, 0, 0, 0, 1, 2, 3, 3, 3]), 2)
-
-
 def test_a_periodic_space_is_refused_on_the_same_evidence() -> None:
     # Not an exemption: the partition of unity fails at the right endpoint there
-    # exactly as it does on a clamped space, which is what the message's wording
-    # ("end knot", not "clamped end") records.
+    # exactly as it does on a clamped space.
     with pytest.raises(ValueError, match=_TOO_MANY):
         BsplineSpace1D(np.array([0.0, 0, 0, 1, 2, 3, 3, 3, 3]), 2, periodic=True)
 
@@ -79,23 +98,47 @@ def test_the_ceiling_is_degree_plus_one_at_every_degree_and_dtype(
         BsplineSpace1D(one_too_many, degree)
 
 
-def test_degree_zero_keeps_its_ordinary_clamped_vector() -> None:
-    # Where the floor of two earns its place: `degree + 1` is 1 here, so a rule
-    # without it would refuse the most ordinary degree-0 space there is.
-    assert BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 0).num_basis == 3
+@pytest.mark.parametrize("multiplicity", [1, 2, 3, 4])
+def test_degree_zero_is_not_subject_to_the_rule(multiplicity: int) -> None:
+    # Measured before the rule existed: at degree 0 the basis sums to one everywhere
+    # and the derivatives are clean at every multiplicity tried, on both backends.
+    # The recurrence has no denominator, so the failure the rule guards cannot occur
+    # and a ceiling here would refuse spaces that compute correctly.
+    knots = np.concatenate([np.zeros(1), np.full(multiplicity, 1.0)])
+    space = BsplineSpace1D(knots, 0)
+
+    assert space.num_basis == len(knots) - 1
+    basis, _ = space.tabulate_basis(np.array([0.0, 0.5, 1.0]))
+    # Exact, and legitimately so: a degree-0 basis function is an indicator, so the
+    # sum is a single stored 1.0 rather than the result of any arithmetic.
+    np.testing.assert_array_equal(np.asarray(basis).sum(axis=-1), 1.0)
+
+
+def test_an_excess_at_the_first_knot_stays_legal() -> None:
+    # Measured: the partition of unity holds and the derivatives are clean. What it
+    # does produce is one identically zero basis function -- a different degeneracy,
+    # which `[0, 0, 1, 1]` at degree 0 has as well and this library accepts, so
+    # refusing here would be wider than the evidence this rule rests on.
+    space = BsplineSpace1D(np.array([0.0, 0, 0, 0, 1, 2, 3, 3, 3]), 2)
+
+    assert space.num_basis == 6
+    peak = _peak_of_each_basis_function(space)
+    assert int((peak == 0.0).sum()) == 1, peak
+    basis, _ = space.tabulate_basis(np.array([0.0, 0.5, 1.5, 3.0]))
+    # The recurrence is convex, so each of the `degree + 1` non-zero values carries
+    # at most a few ulps and their sum at most one more rounding per addition: an
+    # absolute bound of `(degree + 2) * eps` covers both, with no fitted constant.
+    partition = (space.degree + 2) * float(np.finfo(np.float64).eps)
+    np.testing.assert_allclose(np.asarray(basis).sum(axis=-1), 1.0, rtol=0.0, atol=partition)
 
 
 def test_an_interior_knot_of_high_multiplicity_stays_legal() -> None:
     # The rule must not widen into the interior: this is how continuity is lowered,
     # and the space it builds is correct.
-    knots = np.array([0.0, 0, 0, 1, 1, 1, 2, 3, 3, 3])
-    space = BsplineSpace1D(knots, 2)
+    space = BsplineSpace1D(np.array([0.0, 0, 0, 1, 1, 1, 2, 3, 3, 3]), 2)
 
     assert space.num_basis == 7
     basis, _ = space.tabulate_basis(np.array([0.0, 0.5, 1.0, 2.5, 3.0]))
-    # The recurrence is convex, so each of the `degree + 1` non-zero values carries
-    # at most a few ulps and their sum at most one more rounding per addition: an
-    # absolute bound of `(degree + 2) * eps` covers both, with no fitted constant.
     partition = (space.degree + 2) * float(np.finfo(np.float64).eps)
     np.testing.assert_allclose(np.asarray(basis).sum(axis=-1), 1.0, rtol=0.0, atol=partition)
 

--- a/tests/test_degenerate_end_multiplicity.py
+++ b/tests/test_degenerate_end_multiplicity.py
@@ -1,0 +1,108 @@
+"""A knot vector whose end knot repeats past ``degree + 1`` is refused.
+
+``BsplineSpace1D`` used to accept ``[0, 0, 0, 1, 2, 3, 3, 3, 3]`` at degree 2: the
+interval structure is sound, so neither the snapping rule nor the interval rule owns
+it, and the space it built was not one. Measured on both backends:
+
+=============================================  ====================================
+call on that space                             behaviour before the refusal
+=============================================  ====================================
+``tabulate_basis`` at the right endpoint       the basis sums to ``0``, not ``1``
+``tabulate_basis_derivatives``, oracle         ``ZeroDivisionError``
+``tabulate_basis_derivatives``, port           returns ``NaN``
+=============================================  ====================================
+
+The last two rows are the reason the rule lives in the constructor rather than in
+``tabulate_basis_derivatives``: the two backends do not merely both fail, they fail
+*differently*, and a space that cannot be built removes the divergence without anyone
+having to write a parity rule about which failure is the right one.
+
+The rule reads the two end classes only. An interior knot of high multiplicity is the
+ordinary way to lower continuity and stays legal, and the ceiling has a floor of two
+so that degree 0 keeps its ordinary clamped vector ``[0, 0, 1, 1]``, where
+``degree + 1`` is 1.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import numpy as np
+import pytest
+
+from pantr._numba_compat import wait_for_jit_warmup
+from pantr.bspline import BsplineSpace1D
+
+wait_for_jit_warmup()
+
+
+_TOO_MANY = re.compile("end knot may repeat")
+"""Match the refusal without pinning the whole message."""
+
+
+def test_an_excess_at_the_right_end_is_refused() -> None:
+    with pytest.raises(ValueError, match=_TOO_MANY) as excinfo:
+        BsplineSpace1D(np.array([0.0, 0, 0, 1, 2, 3, 3, 3, 3]), 2)
+
+    # The caller has to be able to act without opening our source: the ceiling is
+    # the number they have to compare their own vector against.
+    assert "at most 3 times" in str(excinfo.value), str(excinfo.value)
+
+
+def test_an_excess_at_the_left_end_is_refused() -> None:
+    with pytest.raises(ValueError, match=_TOO_MANY):
+        BsplineSpace1D(np.array([0.0, 0, 0, 0, 1, 2, 3, 3, 3]), 2)
+
+
+def test_a_periodic_space_is_refused_on_the_same_evidence() -> None:
+    # Not an exemption: the partition of unity fails at the right endpoint there
+    # exactly as it does on a clamped space, which is what the message's wording
+    # ("end knot", not "clamped end") records.
+    with pytest.raises(ValueError, match=_TOO_MANY):
+        BsplineSpace1D(np.array([0.0, 0, 0, 1, 2, 3, 3, 3, 3]), 2, periodic=True)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("degree", [1, 2, 3])
+def test_the_ceiling_is_degree_plus_one_at_every_degree_and_dtype(
+    degree: int, dtype: type[Any]
+) -> None:
+    interior = np.arange(1.0, 5.0)
+    at_the_ceiling = np.concatenate(
+        [np.zeros(degree + 1), interior, np.full(degree + 1, 5.0)]
+    ).astype(dtype)
+    one_too_many = np.concatenate([at_the_ceiling, np.array([5.0], dtype=dtype)])
+
+    assert BsplineSpace1D(at_the_ceiling, degree).num_basis == len(at_the_ceiling) - degree - 1
+    with pytest.raises(ValueError, match=_TOO_MANY):
+        BsplineSpace1D(one_too_many, degree)
+
+
+def test_degree_zero_keeps_its_ordinary_clamped_vector() -> None:
+    # Where the floor of two earns its place: `degree + 1` is 1 here, so a rule
+    # without it would refuse the most ordinary degree-0 space there is.
+    assert BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 0).num_basis == 3
+
+
+def test_an_interior_knot_of_high_multiplicity_stays_legal() -> None:
+    # The rule must not widen into the interior: this is how continuity is lowered,
+    # and the space it builds is correct.
+    knots = np.array([0.0, 0, 0, 1, 1, 1, 2, 3, 3, 3])
+    space = BsplineSpace1D(knots, 2)
+
+    assert space.num_basis == 7
+    basis, _ = space.tabulate_basis(np.array([0.0, 0.5, 1.0, 2.5, 3.0]))
+    # The recurrence is convex, so each of the `degree + 1` non-zero values carries
+    # at most a few ulps and their sum at most one more rounding per addition: an
+    # absolute bound of `(degree + 2) * eps` covers both, with no fitted constant.
+    partition = (space.degree + 2) * float(np.finfo(np.float64).eps)
+    np.testing.assert_allclose(np.asarray(basis).sum(axis=-1), 1.0, rtol=0.0, atol=partition)
+
+
+def test_a_vector_that_fails_two_rules_is_told_about_the_interval_first() -> None:
+    # The order is the content of the decision: a mesh with no interval at all is
+    # the more useful diagnosis, so this check runs after that one and never
+    # shadows it.
+    with pytest.raises(ValueError, match="spans no interval"):
+        BsplineSpace1D(np.zeros(8), 2)

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -316,7 +316,10 @@ def test_lagrange_structural_identity_degree0_all_identity() -> None:
 def test_lagrange_structural_identity_smooth_space_never_identity() -> None:
     """Smooth spaces are never Lagrange-identity regardless of degree or variant."""
     for degree in (1, 2, 3):
-        knots = [0.0] * (degree + 1) + [1.0, 2.0, 3.0] + [3.0] * (degree + 1)
+        # The interior knots are 1 and 2; 3 belongs to the clamp, and listing it here
+        # as well gave the last class `degree + 2` knots, which is a space whose basis
+        # does not sum to one at that end and is now refused at construction.
+        knots = [0.0] * (degree + 1) + [1.0, 2.0] + [3.0] * (degree + 1)
         sp1 = BsplineSpace1D(knots, degree)
         for variant in LagrangeVariant:
             mask = _lagrange_structural_identity_mask(sp1, variant)


### PR DESCRIPTION
## Context

`BsplineSpace1D` accepted `[0, 0, 0, 1, 2, 3, 3, 3, 3]` at degree 2. The interval
structure is sound, so neither the snapping rule nor the interval rule owns it, and
what came back was not a B-spline space. Measured on both backends:

| call on that space | before |
|---|---|
| `tabulate_basis` at the right endpoint | the basis sums to `0`, not `1` |
| `tabulate_basis_derivatives`, oracle | `ZeroDivisionError` |
| `tabulate_basis_derivatives`, port | returns `NaN` |

The last two rows are why the rule belongs in the constructor. The backends do not
merely both fail, they fail **differently**, so the alternative to refusing the space
is a parity rule deciding which of `ZeroDivisionError` and `NaN` is correct. A space
that cannot be built needs no such rule.

## Specification

Both backends refuse, last among the knot rules, when the **last** knot's class holds
more than `degree + 1` knots at positive degree:

```
the last knot may repeat at most 3 times
```

**The rule is exactly as wide as that measurement, and no wider.** Three neighbouring
cases were measured, none of them shows the failure, and all three stay legal:

- **an excess at the first knot.** `[0, 0, 0, 0, 1, 2, 3, 3, 3]` at degree 2 keeps the
  partition of unity at every point and its derivatives are clean. What it does add is
  one identically zero basis function, which the ordinary degree-0 vector `[0, 0, 1, 1]`
  also has and this library accepts, so refusing it here would be a different rule
  resting on different evidence.
- **an excess in the interior**, which is the ordinary way to lower continuity.
- **degree 0 at any multiplicity.** `[0, 1, 1, 1]` and `[0, 1, 1, 1, 1]` sum to one
  everywhere and differentiate cleanly: that recurrence has no denominator, so the
  failure this rule guards cannot occur, and a ceiling there would refuse spaces that
  compute correctly.

A **periodic** space is not exempt: its basis fails to sum to one at the right endpoint
exactly as a clamped one's does, measured the same way.

The rule also runs *after* the interval checks, so a vector that fails both is told it
has no interval, which is the more useful diagnosis. A C++ case and a Python case pin
that order.

The C++ side counts the end run directly rather than reading
`unique_knots_and_multiplicity`, so construction does not force the lazy memo; the
grouping rule is that function's, knot for knot.

## Acceptance

- AC1: an excess at the last knot is refused on both backends, with the same message.
- AC2: a periodic space with that excess is refused too.
- AC3: an excess at the *first* knot still builds, its partition of unity holds, and
  exactly one basis function is identically zero.
- AC4: an interior knot of high multiplicity still builds and its basis still sums to one.
- AC5: degree 0 builds at multiplicity 1 through 4.
- AC6: a vector that fails two rules gets the interval message, not this one.

## Non-goals

An identically zero basis function is a separate degeneracy, present today at degree 0
and at a first-knot excess, and nothing here changes it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
