### PR TITLE
feat(bspline)!: compute a mixed-width call at the wider of its two dtypes

### DIFF
--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -21,6 +21,9 @@ widen a `float32`, which is the mechanism the three earlier width surprises rest
 2026-08-26 with Rule 12 (the interpreted oracle is a different object), which enumerates the
 three ways `NUMBA_DISABLE_JIT=1` changes what the oracle computes, and records that a
 width-dependent regression test can be inert in that configuration without saying so.
+Amended 2026-09-11 by the mixed-width contract change, which adds a section to Rule 9: the one
+width in the library that is a decision rather than a reading of the oracle, and the removal of
+the port's only documented fallback along with it.
 
 **Validated against:** `proto/cpp` at `765d9b9`, the `quad` port on `feat/cpp-quad`, and the
 root-finding port on `feat/cpp-bezier-roots`, whose fused branch was exercised against an
@@ -490,6 +493,40 @@ The `float32` asymmetry above survived the derivation and is now explained rathe
 seven of the eight kernels contract in a `float64` accumulator, so only a straddled narrowing
 store carries a difference to a `float32` output.
 
+
+### The one width that is a contract rather than a measurement, added 2026-09-11
+
+Everything above reads a width **off the oracle**, because the oracle is what parity is measured
+against. A call whose knots and points have *different* widths is the exception, and the reason is
+that no reading of the oracle could settle it.
+
+The oracle used to open its general-knot kernels with `dtype = knots.dtype` for their scratch while
+reading points at the points' own width, so a `float32` space evaluated at `float64` points
+truncated every intermediate to `float32` and returned an array that was `float64` in name only.
+That was not a decision anyone took; it is what the two lines happen to do. The C++ kernels are
+templated on one scalar type and cannot express the shape at all, which left three answers --
+refuse the call, promote both sides, or run Numba for it under both backends -- and only the third
+decides nothing, so `_the_cpp_kernels_cannot_serve` took it and said in its own docstring that the
+choice was a contract decision deferred.
+
+**The contract is now that such a call computes at the wider of the two widths, and returns it.**
+`_promote_for_mixed_width` applies that above the seam, which is Rule 1's shape: both backends are
+handed arrays of one dtype and the promotion cancels exactly. The fallback is gone with it, and
+with the fallback goes the port's only documented case of a selected backend not running.
+
+Two things this changes that a dtype assertion cannot see. The mixed call's **values** move, since
+the intermediates are no longer truncated; and the *other* direction -- `float64` knots at
+`float32` points -- now returns `float64` where it returned `float32`. Five tests exercised a mixed
+call before this and every one of them asserted the result's **dtype**, which the old behaviour
+satisfied too. The property that actually pins the contract is equality with the call whose two
+sides the caller widened himself, bit for bit, and that is what
+`tests/test_mixed_dtype_promotion.py` and the rewritten
+`tests/parity/test_bspline_basis_tabulation.py::test_a_mixed_dtype_call_is_promoted_and_reaches_cpp`
+assert.
+
+Widening the knots does **not** move the space's tolerance. That is an absolute parametric
+tolerance fixed at construction from the knot vector's own extent and storage format, and widening
+the array moves no knot.
 
 ## Rule 10: contraction removes one rounding per fused site, and only the amplification differs
 

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -524,9 +524,26 @@ sides the caller widened himself, bit for bit, and that is what
 `tests/parity/test_bspline_basis_tabulation.py::test_a_mixed_dtype_call_is_promoted_and_reaches_cpp`
 assert.
 
-Widening the knots does **not** move the space's tolerance. That is an absolute parametric
-tolerance fixed at construction from the knot vector's own extent and storage format, and widening
-the array moves no knot.
+Widening the knots does **not** move the space's tolerance, and the consequence is worth stating.
+That tolerance is fixed at construction from the knot vector's extent *and its storage format* -- a
+`float32` vector over `[0, 3]` carries 2.9e-6 against a `float64` one's 5.3e-15 -- and widening the
+array adds no resolution to knots that were already rounded. So a mixed call is **not** equivalent
+to a space built at the wide width in every respect: the domain-membership gate is the narrow
+space's, and is looser by that ratio. Measured: a point 1.4e-6 past the right endpoint is accepted
+by the `float32` space and refused by its widened twin. What the promotion makes equal is the
+*arithmetic* on the points that are accepted, which is what the tests assert.
+
+Two places had to be changed beyond the two 1D entry points, and a review found both. The
+Bernstein fast path maps its points with `(pts - k0) / (k1 - k0)`: the subtraction from the array
+widens on its own, but `k1 - k0` is scalar against scalar and was computed at the space's storage
+width, so a mixed call carried the narrow span's rounding into every point -- 8.4e-8 on a Bézier
+space whose bounds are not representable in `float32`. And the tensor-product entry point sized its
+output buffer from the space's own dtype, then combined the per-direction results into it with
+`np.multiply(..., out=...)`, whose default `casting="same_kind"` narrows without complaint: the
+multi-dimensional mixed call computed wide per direction and returned `float32`, 2.4e-8 from the
+widened answer. **Both were invisible to a first version of the tests**, the first because its
+fixture's bounds were exactly representable at either width, the second because no mixed-width case
+reached that module at all.
 
 ## Rule 10: contraction removes one rounding per fused site, and only the amplification differs
 

--- a/src/pantr/bspline/_basis_backend.py
+++ b/src/pantr/bspline/_basis_backend.py
@@ -165,9 +165,8 @@ def _cpp_basis(  # noqa: PLR0913
 
     - the numba kernels accept a non-contiguous ``out`` and fill it, while the binding
       requires C-contiguous memory and refuses anything else;
-    - ``tol`` is accepted and **not forwarded on the C++ path**, because the C++ kernel
-      has no such parameter (the fallback path below does forward it, to the kernel that
-      declares it). That is not a dropped argument: the oracle threads ``tol`` through to
+    - ``tol`` is accepted and **not forwarded**, because the C++ kernel has no such
+      parameter. That is not a dropped argument: the oracle threads ``tol`` through to
       :func:`pantr.bspline._bspline_knots._get_Bspline_num_basis_1D_impl` purely for
       interface consistency, and its own docstrings record that it goes unused --
       the non-periodic basis count is ``len(knots) - degree - 1`` and involves no

--- a/src/pantr/bspline/_basis_backend.py
+++ b/src/pantr/bspline/_basis_backend.py
@@ -27,9 +27,12 @@ numpy expressions* under both backends and cannot contribute a difference. That 
 ``design/backend_parity.md`` Rule 1's consequence applied here: keep a shared map on
 the common side and it cancels exactly.
 
-**One call shape falls back to Numba**, and it is the only one:
-:func:`_the_cpp_kernels_cannot_serve` names it and says at length why falling back is
-the least-bad of the three available answers. Everything else reaches C++.
+**Nothing here falls back.** A mixed-width call -- ``float32`` knots at ``float64``
+points, or the reverse -- used to, because the C++ kernels are templated on one scalar
+type and could not express it while the oracle could. The library's contract now says
+such a call computes at the wider of the two widths, and
+:func:`pantr.bspline._bspline_basis_core._promote_for_mixed_width` applies that *above*
+this seam, so both backends are handed arrays of one dtype and every call reaches C++.
 
 **The C++ side has one kernel at every batch size, and that is not an omission.**
 The oracle keeps a ``parallel=True`` kernel and a serial twin and picks between them
@@ -145,54 +148,6 @@ def _contiguous_int64(out: npt.NDArray[np.int_]) -> npt.NDArray[np.int64] | None
     return np.empty(out.shape, dtype=np.int64)
 
 
-def _the_cpp_kernels_cannot_serve(knots: _FloatArray, pts: _FloatArray) -> bool:
-    """Whether this call's dtypes are outside what the C++ kernels can express.
-
-    **The library deliberately supports a space whose knots are ``float32`` evaluated
-    at ``float64`` points**, and returns the points' dtype;
-    ``tests/test_mpi_thb_qi.py::test_result_is_float64_for_float32_space`` and
-    ``tests/test_thb_spline_space.py::TestCellMembershipTolerance
-    ::test_a_float32_root_space_is_still_graded_in_float64`` assert it by name. The
-    Numba kernels serve it by opening with ``dtype = knots.dtype`` for their scratch
-    while reading points at the points' own width, so the computation runs in a mixed
-    width that narrows at every array store.
-
-    The C++ kernels are templated on one scalar type and have no mixed overload, so
-    they cannot express that call at all. Three ways to reconcile that, and only one
-    of them keeps both halves of the contract:
-
-    - **Refuse it.** Tried, and wrong: it makes the selected backend change what the
-      library accepts, and it fails the five tests above.
-    - **Promote both sides and compute in ``float64``.** Keeps the output dtype but
-      changes the *values*, since the oracle truncates every intermediate to the knots'
-      width. A silent value divergence between backends is worse than a visible
-      fallback.
-    - **Run the Numba kernel for this call.** What this does. It is exactly the
-      behaviour the mixed case had before the C++ path existed, so nothing regresses,
-      and the values stay identical to the oracle's because they *are* the oracle's.
-
-    The cost is real and is why this is a narrow, named predicate rather than a
-    ``try``/``except``: an A/B measurement over mixed-dtype input measures Numba on
-    both sides, which is what ``pantr._backend``'s never-fall-back rule exists to
-    prevent. It is confined to a call the C++ side cannot express at all, and
-    ``tests/parity/test_bspline_basis_tabulation.py`` asserts both that the two
-    backends agree there and that the C++ binding is genuinely not reached, so the
-    fallback cannot widen unnoticed.
-
-    Which of the three is right in the long run is a contract decision rather than a
-    port decision: it turns on whether a mixed-width answer is wanted at all. This
-    takes the option that decides nothing.
-
-    Args:
-        knots (_FloatArray): The space's knot vector.
-        pts (_FloatArray): The evaluation points.
-
-    Returns:
-        bool: True when the dtypes differ, so the C++ kernels cannot be used.
-    """
-    return knots.dtype != pts.dtype
-
-
 def _cpp_basis(  # noqa: PLR0913
     knots: _FloatArray,
     degree: int,
@@ -234,16 +189,6 @@ def _cpp_basis(  # noqa: PLR0913
         Layer 2 caller in :mod:`pantr.bspline._bspline_basis_core`, whose checks run
         before either backend and so cannot diverge between them.
     """
-    if _the_cpp_kernels_cannot_serve(knots, pts):
-        from ._bspline_basis_core import (  # noqa: PLC0415  (see the module docstring)
-            _compute_basis_nurbs_book_impl,
-        )
-
-        _compute_basis_nurbs_book_impl(
-            knots, degree, periodic, tol, pts, out_basis, out_first_basis
-        )
-        return
-
     from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
 
     del tol
@@ -309,16 +254,6 @@ def _cpp_basis_derivatives(  # noqa: PLR0913
     Note:
         No input validation is performed; see :func:`_cpp_basis`.
     """
-    if _the_cpp_kernels_cannot_serve(knots, pts):
-        from ._bspline_basis_core import (  # noqa: PLC0415  (see the module docstring)
-            _compute_basis_deriv_nurbs_book_impl,
-        )
-
-        _compute_basis_deriv_nurbs_book_impl(
-            knots, degree, periodic, tol, n_deriv, pts, out_deriv, out_first_basis
-        )
-        return
-
     from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
 
     del tol

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -623,8 +623,14 @@ def _tabulate_Bspline_basis_Bernstein_like_1D(
     if not spline.has_Bezier_like_knots():
         raise ValueError("B-spline does not have Bézier-like knots.")
 
-    # map the points to the reference interval [0, 1]
-    k0, k1 = spline.domain
+    # map the points to the reference interval [0, 1].
+    #
+    # The two bounds are read at `pts`'s width, which Layer 2 has already promoted to
+    # the call's. `pts - k0` would widen on its own, but `k1 - k0` is scalar against
+    # scalar and would otherwise be computed at the space's storage width, so a
+    # mixed-width call would carry the narrow span's rounding into every point. On a
+    # same-width call the cast is the identity.
+    k0, k1 = (pts.dtype.type(bound) for bound in spline.domain)
     pts_normalized = (pts - k0) / (k1 - k0)
 
     num_pts = pts.size
@@ -674,7 +680,11 @@ def _tabulate_Bspline_basis_Bernstein_like_deriv_1D(
     if not spline.has_Bezier_like_knots():
         raise ValueError("B-spline does not have Bézier-like knots.")
 
-    k0, k1 = spline.domain
+    # At `pts`'s width, which Layer 2 has already promoted: see the note in
+    # `_tabulate_Bspline_basis_Bernstein_like_1D`. `k1 - k0` is scalar against scalar
+    # and would otherwise carry the space's storage width into the span and, through
+    # `inv_span` below, into every chain-rule factor.
+    k0, k1 = (pts.dtype.type(bound) for bound in spline.domain)
     pts_normalized = (pts - k0) / (k1 - k0)  # map to [0, 1]
 
     kernels = bernstein_deriv_core()
@@ -716,10 +726,19 @@ def _promote_for_mixed_width(
 
     A same-width call is untouched, and neither array is copied.
 
-    **The space's tolerance is deliberately not promoted with the knots.** It is an
-    absolute parametric tolerance fixed when the space was built, derived from that
-    knot vector's own extent and storage format; widening the array moves no knot, so
-    nothing the tolerance was derived from has changed.
+    **The space's tolerance is deliberately not promoted with the knots**, and that has
+    a consequence worth stating rather than discovering. It is an absolute parametric
+    tolerance fixed when the space was built, derived from that knot vector's extent
+    *and its storage format*: a ``float32`` vector over ``[0, 3]`` carries a tolerance
+    of 2.9e-6 against a ``float64`` one's 5.3e-15. Widening the array moves no knot, and
+    adds no resolution to knots that were already rounded, so the tolerance stays the
+    narrow one and the mesh keeps saying what it can actually distinguish.
+
+    So a mixed call is **not** equivalent to a space built at the wide width in every
+    respect: the domain-membership gate that ``validate=True`` applies is the narrow
+    space's, and is correspondingly looser. Measured: a point 1.4e-6 past the right
+    endpoint is accepted by the ``float32`` space and refused by its widened twin. What
+    the promotion makes equal is the **arithmetic** on the points that are accepted.
 
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): The space's knot vector.

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -693,6 +693,48 @@ def _tabulate_Bspline_basis_Bernstein_like_deriv_1D(
     out_first_basis.fill(0)
 
 
+def _promote_for_mixed_width(
+    knots: npt.NDArray[np.float32 | np.float64],
+    pts: npt.NDArray[np.float32 | np.float64],
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Bring a mixed-width call up to the wider of its two dtypes.
+
+    A call whose knots and points have different widths -- a ``float32`` space
+    evaluated at ``float64`` points, or the reverse -- computes at the **wider** of the
+    two, and returns it. That is the library's contract rather than an implementation
+    detail, so it is applied here, above the backend seam, where both backends see the
+    same arrays: ``design/backend_parity.md`` Rule 1, a shared map on the common side
+    cancels exactly. Applying it in one backend only would leave the two computing
+    different values for the same input, which is what the parity suite exists to
+    prevent.
+
+    It replaces an older answer, under which the oracle opened its kernels with
+    ``dtype = knots.dtype`` for their scratch while reading points at the points' own
+    width, so a mixed call truncated every intermediate to the *narrower* of the two.
+    The C++ kernels are templated on one scalar type and cannot express that at all,
+    and the seam fell back to Numba for exactly this call shape.
+
+    A same-width call is untouched, and neither array is copied.
+
+    **The space's tolerance is deliberately not promoted with the knots.** It is an
+    absolute parametric tolerance fixed when the space was built, derived from that
+    knot vector's own extent and storage format; widening the array moves no knot, so
+    nothing the tolerance was derived from has changed.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): The space's knot vector.
+        pts (npt.NDArray[np.float32 | np.float64]): The evaluation points, normalized.
+
+    Returns:
+        tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 |
+        np.float64]]: The knots and the points, both at the promoted dtype.
+    """
+    if knots.dtype == pts.dtype:
+        return knots, pts
+    work_dtype = np.promote_types(knots.dtype, pts.dtype)
+    return knots.astype(work_dtype, copy=False), pts.astype(work_dtype, copy=False)
+
+
 def _tabulate_Bspline_basis_1D_impl(
     spline: BsplineSpace1D,
     pts: npt.ArrayLike,
@@ -773,6 +815,8 @@ def _tabulate_Bspline_basis_1D_impl(
             f"One or more values in pts are outside the knot vector domain {spline.domain}"
         )
 
+    knots, pts = _promote_for_mixed_width(spline.knots, pts)
+
     num_pts = pts.shape[0]
     n_basis = spline.degree + 1
     expected_final_shape = _compute_final_output_shape_1D(input_shape, n_basis)
@@ -801,7 +845,7 @@ def _tabulate_Bspline_basis_1D_impl(
             else kernels.parallel
         )
         kernel(
-            spline.knots,
+            knots,
             spline.degree,
             spline.periodic,
             spline.tolerance,
@@ -885,6 +929,8 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
             f"One or more values in pts are outside the knot vector domain {spline.domain}"
         )
 
+    knots, pts = _promote_for_mixed_width(spline.knots, pts)
+
     num_pts = pts.shape[0]
     order = spline.degree + 1
     expected_dtype = pts.dtype
@@ -913,7 +959,7 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
             else deriv_kernels.parallel
         )
         deriv_kernel(
-            spline.knots,
+            knots,
             spline.degree,
             spline.periodic,
             spline.tolerance,

--- a/src/pantr/bspline/_bspline_basis_multidim.py
+++ b/src/pantr/bspline/_bspline_basis_multidim.py
@@ -144,7 +144,13 @@ def _tabulate_Bspline_basis_for_points_array_impl(
     order = tuple(int(degree + 1) for degree in spline.degrees)
     num_pts = pts.shape[0]
     expected_basis_shape = (num_pts, *order)
-    expected_dtype = np.dtype(spline.dtype)
+    # The same promotion the 1D calls below will apply, hoisted so the buffer they
+    # are combined into is wide enough to hold the result. Taking the space's own
+    # dtype here made a mixed-width call compute at the promoted width per direction
+    # and then narrow silently on the `np.multiply(..., out=...)` that combines them,
+    # whose default `casting="same_kind"` downcasts without complaint. The lattice
+    # entry point below already reads its dtype off the per-direction results.
+    expected_dtype = np.promote_types(spline.dtype, pts.dtype)
     expected_first_basis_shape = (num_pts, spline.dim)
 
     if out_basis is None:

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -1095,6 +1095,13 @@ class BsplineSpace1D:
                   for each evaluation point. The length is the same as the number
                   of evaluation points. If `out_first_basis` was provided, returns the same array.
 
+        Note:
+            The result's dtype is the wider of this space's and ``pts``'s. A
+            ``float32`` space evaluated at ``float64`` points computes **and returns**
+            ``float64``, and so does the reverse; widening narrow points recovers no
+            information they never carried, so the two directions agree on the rule
+            while differing in value.
+
         Raises:
             ValueError: If ``validate`` is True and any evaluation point is outside the
                 B-spline domain, or if `out_basis` or `out_first_basis` is provided and
@@ -1167,6 +1174,13 @@ class BsplineSpace1D:
                   local B-spline basis function at each point.
                 - first_basis_indices: Integer array of shape ``pts_shape`` giving the
                   global index of the first nonzero basis function for each point.
+
+        Note:
+            The result's dtype is the wider of this space's and ``pts``'s. A
+            ``float32`` space evaluated at ``float64`` points computes **and returns**
+            ``float64``, and so does the reverse; widening narrow points recovers no
+            information they never carried, so the two directions agree on the rule
+            while differing in value.
 
         Raises:
             ValueError: If ``n_deriv < 0``, if ``validate`` is True and any evaluation

--- a/tests/parity/test_bspline_basis_tabulation.py
+++ b/tests/parity/test_bspline_basis_tabulation.py
@@ -978,35 +978,38 @@ def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: Any) 
 
 
 @pytest.mark.parametrize("n_deriv", [None, 2])
-@pytest.mark.parametrize(("knot_dtype", "point_dtype"), [(np.float32, np.float64)])
-def test_a_mixed_dtype_call_falls_back_and_says_so(
+@pytest.mark.parametrize(
+    ("knot_dtype", "point_dtype"),
+    [(np.float32, np.float64), (np.float64, np.float32)],
+)
+def test_a_mixed_dtype_call_is_promoted_and_reaches_cpp(
     cpp_backend: None,
     knot_dtype: Any,
     point_dtype: Any,
     n_deriv: int | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A space and points of different dtypes run the Numba kernel under both backends.
+    """A space and points of different dtypes compute at the wider of the two.
 
-    The library supports a ``float32`` space evaluated at ``float64`` points and
-    returns the points' dtype; ``tests/test_mpi_thb_qi.py`` and
-    ``tests/test_thb_spline_space.py`` assert that by name. The C++ kernels are
-    templated on one scalar type and cannot express it, so
-    :func:`~pantr.bspline._basis_backend._the_cpp_kernels_cannot_serve` routes it to
-    the oracle -- which is what it did before the C++ path existed, so nothing
-    regresses and the values are the oracle's by construction rather than by bound.
+    This replaces a test that pinned the opposite, and did so deliberately: the C++
+    kernels are templated on one scalar type, so a mixed call used to be the one shape
+    they could not express, and the seam ran the Numba kernel for it under both
+    backends. That test said in as many words that if the C++ side ever became able to
+    serve the shape, it had to be rewritten rather than relaxed. Promoting above the
+    seam is what made it able.
 
-    **This test exists to stop the fallback widening unnoticed.** A capability
-    fallback is exactly what ``pantr._backend``'s never-fall-back rule guards against,
-    because an A/B measurement over such an input silently measures Numba twice. So it
-    is pinned in both directions: the two backends must agree *bitwise*, and the C++
-    binding must be provably **not** called. If a later change makes the C++ kernels
-    able to serve this shape, the second assertion fails and this test has to be
-    rewritten deliberately.
+    Three things are asserted, and the third is the contract rather than the mechanism:
 
-    Only the ``float32``-knots/``float64``-points direction is parametrized, because
-    that is the one the library's own tests exercise; the opposite direction takes the
-    same branch on the same predicate.
+    1. the C++ binding **is** reached, so no fallback survives anywhere;
+    2. the two backends agree bitwise, since they now run on identical arrays;
+    3. the mixed call equals the call with **both** sides widened, bit for bit. That
+       is what "computes at the wider of the two widths" means, and nothing else in
+       the suite says it: the five tests that exercise a mixed call assert the
+       result's *dtype*, which the old narrow-accumulation behaviour also satisfied.
+
+    Both directions are parametrized. They are not symmetric: widening ``float32``
+    points recovers no information the points never carried, so the two differ in
+    value while obeying the same rule.
 
     Args:
         cpp_backend (None): Requires the extension.
@@ -1021,54 +1024,64 @@ def test_a_mixed_dtype_call_falls_back_and_says_so(
     knots, degree = _GENERAL_KNOTS["clamped-uniform-p2"]
     points = np.array([0.1, 0.5, 0.9], dtype=point_dtype)
     knot_array = np.array(knots, dtype=knot_dtype)
+    promoted = np.promote_types(knot_dtype, point_dtype)
 
-    calls = 0
-
-    def counted(*args: Any, **kwargs: Any) -> None:
-        nonlocal calls
-        calls += 1
-        raise AssertionError("the C++ binding was reached for a mixed-dtype call")
-
-    binding = (
+    binding_name = (
         "tabulate_bspline_basis_1d" if n_deriv is None else "tabulate_bspline_basis_derivatives_1d"
     )
-    monkeypatch.setattr(_pantr_cpp, binding, counted, raising=True)
+    original = getattr(_pantr_cpp, binding_name)
+    calls = 0
+
+    def counted(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(_pantr_cpp, binding_name, counted, raising=True)
+
+    def tabulate(space: BsplineSpace1D, pts: Any) -> Any:
+        if n_deriv is None:
+            return space.tabulate_basis(pts)
+        return space.tabulate_basis_derivatives(pts, n_deriv)
 
     results = {}
     for backend in (Backend.PYTHON, Backend.CPP):
         with use_backend(backend):
             space = BsplineSpace1D(knot_array, degree)
-            if n_deriv is None:
-                block, first = space.tabulate_basis(points)
-            else:
-                block, first = space.tabulate_basis_derivatives(points, n_deriv)
-        results[backend] = (block, first)
+            results[backend] = tabulate(space, points)
 
-    assert calls == 0, (
-        "the C++ binding was called for a call its kernels cannot express; if that is "
-        "now intended, the fallback in pantr.bspline._basis_backend and this test both "
-        "need rewriting rather than relaxing"
+    assert calls > 0, (
+        "the C++ binding was not reached for a mixed-dtype call; the promotion above "
+        "the seam exists precisely so that no call shape falls back"
     )
 
     py_block, py_first = results[Backend.PYTHON]
     cpp_block, cpp_first = results[Backend.CPP]
-    assert py_block.dtype == np.dtype(point_dtype), (
-        "the result must carry the points' dtype, which is the behaviour "
-        "test_result_is_float64_for_float32_space pins"
+    assert py_block.dtype == promoted, (
+        f"a mixed call returns the promoted dtype, got {py_block.dtype}"
     )
     assert_parity(
         cpp_block,
         py_block,
         bitwise_parity(
-            why="both backends ran the same Numba kernel, because the C++ one cannot "
-            "express a mixed-dtype call and the adapter routes it to the oracle. This is "
-            "identity rather than agreement, and it is asserted so that the fallback "
-            "cannot silently stop happening.",
+            why="both backends are handed arrays the shared promotion already brought "
+            "to one dtype, so this is identity rather than agreement.",
         ),
         context=f"mixed dtype {np.dtype(knot_dtype).name} knots / "
         f"{np.dtype(point_dtype).name} points, n_deriv={n_deriv}",
     )
     assert np.array_equal(cpp_first, py_first)
+
+    # The contract itself: promoting first is the same computation as having been
+    # handed the wide arrays to begin with.
+    with use_backend(Backend.CPP):
+        widened = BsplineSpace1D(knot_array.astype(promoted), degree)
+        wide_block, wide_first = tabulate(widened, points.astype(promoted))
+    assert np.array_equal(cpp_block, wide_block), (
+        "the mixed call did not compute at the promoted width: it differs from the "
+        "same call with both sides widened by the caller"
+    )
+    assert np.array_equal(cpp_first, wide_first)
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])

--- a/tests/test_mixed_dtype_promotion.py
+++ b/tests/test_mixed_dtype_promotion.py
@@ -1,0 +1,124 @@
+"""A mixed-width call computes and returns at the wider of its two dtypes.
+
+A space stores its knots at one width and may be evaluated at points of another. The
+library used to answer that by running the kernels with scratch in the *knots'* dtype
+while reading the points at their own, so a ``float32`` space at ``float64`` points
+truncated every intermediate to ``float32`` and returned an array that was ``float64``
+in name only. The C++ kernels are templated on one scalar type and cannot express that
+shape at all, so the backend seam had to fall back to Numba for it -- the only
+documented fallback in the port.
+
+The contract now says such a call computes at the **wider** of the two widths and
+returns it. The promotion is applied above the backend seam, so it is the same
+computation under both, and the fallback is gone.
+
+**The property that pins it is value equality with the fully widened call**, not the
+result's dtype. Every one of these assertions would also have passed under the old
+behaviour if it only checked the dtype, which is exactly why the five pre-existing
+tests that exercise a mixed call did not notice the change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from pantr._numba_compat import wait_for_jit_warmup
+from pantr.bspline import BsplineSpace1D
+
+wait_for_jit_warmup()
+
+
+_GENERAL = ([0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0], 2)
+"""A clamped quadratic with interior knots: takes the general-knot kernels."""
+
+_BEZIER_LIKE = ([0.0, 0.0, 0.0, 3.0, 3.0, 3.0], 2)
+"""No interior knot, so the space takes the Bernstein fast path instead."""
+
+_POINTS = [0.0, 0.3, 1.7, 2.9, 3.0]
+"""Endpoints included, since those are where the recurrences special-case."""
+
+
+def _space_and_points(
+    knots: list[float], degree: int, knot_dtype: Any, point_dtype: Any
+) -> tuple[BsplineSpace1D, Any]:
+    """Build a space and a point array at the requested dtypes.
+
+    Args:
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        knot_dtype (Any): Storage dtype for the space.
+        point_dtype (Any): Dtype for the evaluation points.
+
+    Returns:
+        tuple[BsplineSpace1D, Any]: The space, and the points.
+    """
+    return (
+        BsplineSpace1D(np.array(knots, dtype=knot_dtype), degree),
+        np.array(_POINTS, dtype=point_dtype),
+    )
+
+
+@pytest.mark.parametrize(("knots", "degree"), [_GENERAL, _BEZIER_LIKE], ids=["general", "bezier"])
+@pytest.mark.parametrize(
+    ("knot_dtype", "point_dtype"),
+    [(np.float32, np.float64), (np.float64, np.float32)],
+    ids=["f32-knots", "f64-knots"],
+)
+@pytest.mark.parametrize("n_deriv", [None, 0, 2], ids=["values", "d0", "d2"])
+def test_a_mixed_call_equals_the_fully_widened_one(
+    knots: list[float], degree: int, knot_dtype: Any, point_dtype: Any, n_deriv: int | None
+) -> None:
+    promoted = np.promote_types(knot_dtype, point_dtype)
+    space, points = _space_and_points(knots, degree, knot_dtype, point_dtype)
+    wide_space, _ = _space_and_points(knots, degree, promoted, promoted)
+    # Widened *from the narrow array*, never parsed afresh at the wide width: the two
+    # calls have to be given the same values, or this compares two different inputs.
+    wide_points = points.astype(promoted)
+
+    call = (
+        (lambda s, p: s.tabulate_basis(p))
+        if n_deriv is None
+        else (lambda s, p: s.tabulate_basis_derivatives(p, n_deriv))
+    )
+    mixed, mixed_first = call(space, points)
+    wide, wide_first = call(wide_space, wide_points)
+
+    assert mixed.dtype == promoted
+    np.testing.assert_array_equal(mixed, wide)
+    np.testing.assert_array_equal(mixed_first, wide_first)
+
+
+@pytest.mark.parametrize(("knots", "degree"), [_GENERAL, _BEZIER_LIKE], ids=["general", "bezier"])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_a_same_width_call_is_untouched(knots: list[float], degree: int, dtype: Any) -> None:
+    # The promotion must fire on mixed widths only: a `float32` space at `float32`
+    # points still computes and returns `float32`, which is the whole of what the
+    # narrow storage is for.
+    space, points = _space_and_points(knots, degree, dtype, dtype)
+    values, _ = space.tabulate_basis(points)
+    derivs, _ = space.tabulate_basis_derivatives(points, 1)
+
+    assert values.dtype == np.dtype(dtype)
+    assert derivs.dtype == np.dtype(dtype)
+
+
+def test_the_mixed_result_differs_from_the_narrow_computation() -> None:
+    """Non-vacuity: the contract change moved values, not only the output dtype.
+
+    Without this the rest of the file could pass on a library that still truncated
+    every intermediate to the knots' width and merely cast the result on the way out.
+    """
+    space, points = _space_and_points(*_GENERAL, np.float32, np.float64)
+    narrow_space, narrow_points = _space_and_points(*_GENERAL, np.float32, np.float32)
+
+    wide, _ = space.tabulate_basis(points)
+    narrow, _ = narrow_space.tabulate_basis(narrow_points)
+
+    assert np.any(wide != narrow.astype(np.float64)), (
+        "the mixed call agrees bit for bit with the all-float32 one, so either the "
+        "points chosen cannot tell the two widths apart or the promotion is not "
+        "reaching the kernels"
+    )

--- a/tests/test_mixed_dtype_promotion.py
+++ b/tests/test_mixed_dtype_promotion.py
@@ -16,6 +16,11 @@ computation under both, and the fallback is gone.
 result's dtype. Every one of these assertions would also have passed under the old
 behaviour if it only checked the dtype, which is exactly why the five pre-existing
 tests that exercise a mixed call did not notice the change.
+
+That equality is about the *arithmetic*, on the points a call accepts. It is not
+equality of everything: the space keeps its own tolerance, which is derived from its
+storage width, so a narrow space's domain-membership gate stays looser than its widened
+twin's. Promoting the array adds no resolution to knots that were already rounded.
 """
 
 from __future__ import annotations
@@ -26,42 +31,58 @@ import numpy as np
 import pytest
 
 from pantr._numba_compat import wait_for_jit_warmup
-from pantr.bspline import BsplineSpace1D
+from pantr.bspline import BsplineSpace, BsplineSpace1D
 
 wait_for_jit_warmup()
 
 
-_GENERAL = ([0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0], 2)
-"""A clamped quadratic with interior knots: takes the general-knot kernels."""
+_GENERAL = ([0.0, 0.0, 0.0, 0.7, 1.3, 2.0, 2.0, 2.0], 2, [0.0, 0.3, 1.0, 1.9, 2.0])
+"""A clamped quadratic with interior knots: takes the general-knot kernels.
 
-_BEZIER_LIKE = ([0.0, 0.0, 0.0, 3.0, 3.0, 3.0], 2)
-"""No interior knot, so the space takes the Bernstein fast path instead."""
+Its **interior** knots are not representable in ``float32``, so the narrow and the
+widened space really do differ in the knots the kernel reads, while the domain bounds
+are exact at either width and the endpoints can therefore be evaluated.
+"""
 
-_POINTS = [0.0, 0.3, 1.7, 2.9, 3.0]
-"""Endpoints included, since those are where the recurrences special-case."""
+_BEZIER_LIKE = ([0.1, 0.1, 0.1, 2.2, 2.2, 2.2], 2, [0.15, 0.3, 1.0, 2.1])
+"""No interior knot, so the space takes the Bernstein fast path instead.
+
+**The bounds are deliberately not representable in ``float32``**, which is the only way
+to exercise this path at all: its knots *are* its bounds. It maps the points with
+``(pts - k0) / (k1 - k0)``, and ``k1 - k0`` is scalar against scalar, so read at the
+space's storage width it carries the narrow span's rounding into every point, while
+``pts - k0`` widens on its own and hides nothing. A first version of this file used
+``0.0`` and ``3.0``, exact at either width, and the subtraction then had no rounding to
+carry: the assertion passed however the code was written. Measured before the span was
+read at the promoted width: 8.4e-8 between the mixed call and the fully widened one,
+and 0 after.
+
+The points stay strictly inside, because ``float32(2.2)`` lies outside the widened
+space's domain and that space's tolerance is eight orders tighter.
+"""
 
 
 def _space_and_points(
-    knots: list[float], degree: int, knot_dtype: Any, point_dtype: Any
+    fixture: tuple[list[float], int, list[float]], knot_dtype: Any, point_dtype: Any
 ) -> tuple[BsplineSpace1D, Any]:
     """Build a space and a point array at the requested dtypes.
 
     Args:
-        knots (list[float]): The knot vector.
-        degree (int): The polynomial degree.
+        fixture (tuple[list[float], int, list[float]]): Knots, degree and points.
         knot_dtype (Any): Storage dtype for the space.
         point_dtype (Any): Dtype for the evaluation points.
 
     Returns:
         tuple[BsplineSpace1D, Any]: The space, and the points.
     """
+    knots, degree, points = fixture
     return (
         BsplineSpace1D(np.array(knots, dtype=knot_dtype), degree),
-        np.array(_POINTS, dtype=point_dtype),
+        np.array(points, dtype=point_dtype),
     )
 
 
-@pytest.mark.parametrize(("knots", "degree"), [_GENERAL, _BEZIER_LIKE], ids=["general", "bezier"])
+@pytest.mark.parametrize("fixture", [_GENERAL, _BEZIER_LIKE], ids=["general", "bezier"])
 @pytest.mark.parametrize(
     ("knot_dtype", "point_dtype"),
     [(np.float32, np.float64), (np.float64, np.float32)],
@@ -69,13 +90,19 @@ def _space_and_points(
 )
 @pytest.mark.parametrize("n_deriv", [None, 0, 2], ids=["values", "d0", "d2"])
 def test_a_mixed_call_equals_the_fully_widened_one(
-    knots: list[float], degree: int, knot_dtype: Any, point_dtype: Any, n_deriv: int | None
+    fixture: tuple[list[float], int, list[float]],
+    knot_dtype: Any,
+    point_dtype: Any,
+    n_deriv: int | None,
 ) -> None:
     promoted = np.promote_types(knot_dtype, point_dtype)
-    space, points = _space_and_points(knots, degree, knot_dtype, point_dtype)
-    wide_space, _ = _space_and_points(knots, degree, promoted, promoted)
-    # Widened *from the narrow array*, never parsed afresh at the wide width: the two
-    # calls have to be given the same values, or this compares two different inputs.
+    degree = fixture[1]
+    space, points = _space_and_points(fixture, knot_dtype, point_dtype)
+    # Both widened *from the narrow arrays*, never parsed afresh at the wide width.
+    # `float32(0.1)` and `float64(0.1)` are different numbers, so building the wide
+    # space from the literals would compare two different problems and the difference
+    # would read as the promotion failing.
+    wide_space = BsplineSpace1D(np.asarray(space.knots).astype(promoted), degree)
     wide_points = points.astype(promoted)
 
     call = (
@@ -91,18 +118,53 @@ def test_a_mixed_call_equals_the_fully_widened_one(
     np.testing.assert_array_equal(mixed_first, wide_first)
 
 
-@pytest.mark.parametrize(("knots", "degree"), [_GENERAL, _BEZIER_LIKE], ids=["general", "bezier"])
+@pytest.mark.parametrize("fixture", [_GENERAL, _BEZIER_LIKE], ids=["general", "bezier"])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_a_same_width_call_is_untouched(knots: list[float], degree: int, dtype: Any) -> None:
+def test_a_same_width_call_is_untouched(
+    fixture: tuple[list[float], int, list[float]], dtype: Any
+) -> None:
     # The promotion must fire on mixed widths only: a `float32` space at `float32`
     # points still computes and returns `float32`, which is the whole of what the
     # narrow storage is for.
-    space, points = _space_and_points(knots, degree, dtype, dtype)
+    space, points = _space_and_points(fixture, dtype, dtype)
     values, _ = space.tabulate_basis(points)
     derivs, _ = space.tabulate_basis_derivatives(points, 1)
 
     assert values.dtype == np.dtype(dtype)
     assert derivs.dtype == np.dtype(dtype)
+
+
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_a_multi_dimensional_space_obeys_the_same_rule(dim: int) -> None:
+    # The tensor-product path combines the per-direction results with
+    # `np.multiply(..., out=out_basis)`, whose default casting downcasts silently, so
+    # sizing that buffer from the space's own dtype narrowed a promoted computation
+    # on the way out: float32 back, and 2.4e-8 from the widened answer. No mixed-width
+    # case reached this module before.
+    knots, degree, points = _GENERAL
+    narrow = np.array(knots, dtype=np.float32)
+
+    mixed = BsplineSpace([BsplineSpace1D(narrow, degree) for _ in range(dim)])
+    widened = BsplineSpace([BsplineSpace1D(narrow.astype(np.float64), degree) for _ in range(dim)])
+    pts = np.array([[value] * dim for value in points], dtype=np.float64)
+
+    mixed_basis, mixed_first = mixed.tabulate_basis(pts)
+    wide_basis, wide_first = widened.tabulate_basis(pts)
+
+    assert mixed_basis.dtype == np.float64
+    np.testing.assert_array_equal(mixed_basis, wide_basis)
+    np.testing.assert_array_equal(mixed_first, wide_first)
+
+
+def test_a_multi_dimensional_same_width_call_is_untouched() -> None:
+    # The promotion must not widen a space that was asked for in `float32` throughout.
+    knots, degree, points = _GENERAL
+    space = BsplineSpace([BsplineSpace1D(np.array(knots, dtype=np.float32), degree)] * 2)
+    pts = np.array([[value, value] for value in points], dtype=np.float32)
+
+    basis, _ = space.tabulate_basis(pts)
+
+    assert basis.dtype == np.float32
 
 
 def test_the_mixed_result_differs_from_the_narrow_computation() -> None:
@@ -111,8 +173,8 @@ def test_the_mixed_result_differs_from_the_narrow_computation() -> None:
     Without this the rest of the file could pass on a library that still truncated
     every intermediate to the knots' width and merely cast the result on the way out.
     """
-    space, points = _space_and_points(*_GENERAL, np.float32, np.float64)
-    narrow_space, narrow_points = _space_and_points(*_GENERAL, np.float32, np.float32)
+    space, points = _space_and_points(_GENERAL, np.float32, np.float64)
+    narrow_space, narrow_points = _space_and_points(_GENERAL, np.float32, np.float32)
 
     wide, _ = space.tabulate_basis(points)
     narrow, _ = narrow_space.tabulate_basis(narrow_points)


### PR DESCRIPTION
## Context

A space stores its knots at one width and may be evaluated at points of another. The
oracle answered that by opening its general-knot kernels with `dtype = knots.dtype` for
their scratch while reading points at the points' own width, so a `float32` space
evaluated at `float64` points **truncated every intermediate to `float32`** and returned
an array that was `float64` in name only. Nobody decided that; it is what those two
lines happen to do.

The C++ kernels are templated on one scalar type and cannot express that shape at all.
That left three answers — refuse the call, promote both sides, or run Numba for it under
both backends — and the port took the third, because it was the only one that decided
nothing. `_the_cpp_kernels_cannot_serve` said so in its own docstring, and it was the
port's **only documented case of a selected backend not running**, which is exactly what
`pantr._backend`'s never-fall-back rule exists to prevent.

## Specification

**A mixed-width call computes at the wider of the two widths, and returns it.**

`_promote_for_mixed_width` applies the promotion in Layer 2, *above* the backend seam,
so both backends are handed arrays of one dtype: `design/backend_parity.md` Rule 1, a
shared map on the common side cancels exactly. A same-width call is untouched and
neither array is copied. The fallback and its predicate are deleted.

Measured, on both backends, for `[0,0,0,1,2,3,3,3]` at degree 2 and `pts[0] = 0.3`:

| knots / points | before (oracle) | after (both backends) |
|---|---|---|
| f32 / f64 | `0.4899999833106996`, float64 | `0.48999999999999994`, float64 |
| f64 / f32 | `0.48999998`, float32 | `0.4899999833106996`, **float64** |
| f64 / f64 | unchanged | unchanged |
| f32 / f32 | unchanged | unchanged |

**Two decisions inside this that are worth disputing explicitly.**

1. *The promoted width governs the output dtype too, not only the computation.* The
   `float64`-knots/`float32`-points direction therefore changes its return dtype.
   Returning the narrow width would discard the precision the promotion just bought and
   would add a narrowing rounding that is a new parity surface of its own. Every test
   that asserts a `float32` result today is a same-width call, so none is affected.
2. *The space's tolerance is not promoted with the knots.* It is an absolute parametric
   tolerance fixed at construction from that vector's own extent and storage format, and
   widening the array moves no knot.

**Three paths, not one.** A review found the contract stated library-wide while two
paths broke it, and both were invisible to the tests as first written:

- the **tensor-product** entry point sized its output buffer from the space's own dtype
  and combined the per-direction results into it with `np.multiply(..., out=...)`, whose
  default `casting="same_kind"` narrows silently. A multi-dimensional mixed call
  computed wide per direction and returned `float32`, 2.4e-8 from the widened answer.
  That module had **no** mixed-width coverage at all before;
- the **Bernstein fast path** computed `k1 - k0` scalar-against-scalar at the space's
  storage width, carrying the narrow span's rounding into every point and every
  chain-rule factor: 8.4e-8 on bounds not representable in `float32`. The fixture used
  `0.0` and `3.0`, exact at either width, so the bit-for-bit assertion passed however
  the code was written. The fixtures now use bounds that are not, and reverting the fix
  fails them.

**What the promotion does not make equal.** The space keeps its own tolerance, which is
derived from its storage width, so a narrow space's domain-membership gate stays looser
than its widened twin's by 5.4e8: a point 1.4e-6 past the right endpoint is accepted by
the `float32` space and refused by the `float64` one. That is right — widening adds no
resolution to knots that were already rounded — and it is now stated in the helper's
docstring and in the design note instead of being implied away.

## Acceptance

- AC1: a mixed call equals, bit for bit, the call whose two sides the caller widened
  himself — through the general-knot kernels and the Bernstein fast path, for values and
  for derivatives, in both directions, with knot values that are **not** representable at
  the narrow width so the two spaces really differ.
- AC1b: the same holds for a tensor-product space, in one, two and three directions.
- AC2: a mixed call returns the promoted dtype.
- AC3: a same-width call is unchanged in value and in dtype.
- AC4: the C++ binding **is** reached for a mixed call, so no fallback survives.
- AC5: the two backends agree bitwise on a mixed call.
- AC6 (non-vacuity): the mixed result differs from the all-`float32` computation, so the
  suite would notice a library that still truncated and merely cast on the way out.

## Non-goals

`_promote_for_mixed_width` copies the knot array on every mixed call rather than once
per space. That is negligible against an O(n_pts · degree) kernel for a real batch, but
a per-cell assembly loop calling it with a handful of points pays a cost proportional to
the knot vector instead. A per-space cache is the better shape and is left as a
follow-up, because it adds state the C++ side would have to mirror.

Nothing here changes a same-width call, and nothing changes how a *kernel* chooses its
accumulation width internally — Rule 9 still governs that, and the new section says why
this one case is a contract rather than a reading of the oracle.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
