### PR TITLE
feat(bspline): bind the space-level tabulation so parity can reach it

### DIFF
--- a/cpp/bindings/bspline_basis.cpp
+++ b/cpp/bindings/bspline_basis.cpp
@@ -9,13 +9,22 @@
 /// `tabulate_basis_1d` / `tabulate_basis_derivatives_1d`, which take a
 /// `BsplineSpace1D` and choose between the general recurrence and the
 /// Bézier-like fast path -- the Layer 2 equivalent for a C++ caller with no
-/// interpreter. This file binds the first pair only. `tabulate.hpp`'s "Why the
-/// dispatch stays on the Python side" is the reason: building a space per call
-/// would re-validate and copy the knot vector in front of a kernel the oracle
-/// calls with two or three points, and the space's constructor snaps by
-/// default, so it could silently evaluate on a different knot vector than the
-/// oracle did. `pantr.bspline._basis_backend` keeps the oracle's own dispatch,
-/// and these two entry points are what it calls into.
+/// interpreter. **Both pairs are bound, and they are bound for different
+/// callers.**
+///
+/// `pantr.bspline._basis_backend` calls the *raw-knot* pair, and
+/// `tabulate.hpp`'s "Why the dispatch stays on the Python side" is why: building
+/// a space per call would re-validate and copy the knot vector in front of a
+/// kernel the oracle calls with two or three points, and the space's constructor
+/// snaps by default, so it could silently evaluate on a different knot vector
+/// than the oracle did. That dispatch stays where it is.
+///
+/// The *space-level* pair is bound so that the parity suite can exercise it
+/// against the oracle's own dispatch. It is the code a C++ consumer writes, and
+/// until now `ctest` was the only thing that ran it -- which tests it against
+/// itself rather than against the oracle, and so cannot see the two disagreeing
+/// about which path a space takes or about the change of variable on it. It
+/// takes an already-built space, so none of the per-call cost above applies.
 ///
 /// ## What nanobind checks, and what is checked here
 ///
@@ -239,6 +248,105 @@ void tabulate_basis_derivatives(const_knots<T> knots, unsigned degree, bool peri
     Kernel(knot_span, degree_i64, periodic, n_deriv_i64, pts, deriv_view, first_basis_view);
 }
 
+/// Tabulate a space's basis, taking its Bézier-like fast path.
+///
+/// The space-level counterpart of `tabulate_basis`, and the reason it exists is
+/// in the file comment: it is what a C++ consumer calls, and binding it is what
+/// lets the parity suite compare that dispatch against the oracle's own rather
+/// than only against `ctest`.
+///
+/// The space arrives already built and already validated, so the knot-length
+/// check `tabulate_basis` performs has no counterpart here -- its constructor
+/// made it impossible. Only the output shapes, which the space cannot know, are
+/// checked.
+///
+/// \tparam T Scalar type of the space, the points and the output.
+/// \param space The space to tabulate.
+/// \param points The evaluation points.
+/// \param out_basis Shape `(points.size(), space.degree() + 1)`, written in full.
+/// \param out_first_basis One entry per point, written in full.
+/// \throws nb::value_error If either output has the wrong shape.
+template <class T>
+void tabulate_space_basis(const pantr::bspline::BsplineSpace1D<T>& space,
+                          const_points<T> points, out_matrix<T> out_basis,
+                          out_first_basis_t out_first_basis) {
+    const std::size_t num_pts = points.size();
+    const auto num_basis = static_cast<std::size_t>(space.degree()) + 1;
+    if (out_basis.shape(0) != num_pts || out_basis.shape(1) != num_basis) {
+        throw nb::value_error(("out_basis has shape (" + std::to_string(out_basis.shape(0)) +
+                               ", " + std::to_string(out_basis.shape(1)) + "), but degree " +
+                               std::to_string(space.degree()) + " at " +
+                               std::to_string(num_pts) + " points needs (" +
+                               std::to_string(num_pts) + ", " + std::to_string(num_basis) + ")")
+                                  .c_str());
+    }
+    if (out_first_basis.size() != num_pts) {
+        throw nb::value_error(("out_first_basis has " + std::to_string(out_first_basis.size()) +
+                               " elements, but " + std::to_string(num_pts) +
+                               " points need one each")
+                                  .c_str());
+    }
+
+    const std::span<const T> pts(points.data(), num_pts);
+    const span2d<T> basis_view(out_basis.data(), num_pts, num_basis);
+    const std::span<std::int64_t> first_basis_view(out_first_basis.data(), num_pts);
+
+    const nb::gil_scoped_release release;
+    pantr::bspline::tabulate_basis_1d<T>(space, pts, basis_view, first_basis_view);
+}
+
+/// Tabulate a space's basis derivatives, taking its Bézier-like fast path.
+///
+/// See `tabulate_space_basis` for why the space-level pair is bound at all, and
+/// why no knot-length check appears here.
+///
+/// \tparam T Scalar type of the space, the points and the output.
+/// \param space The space to tabulate.
+/// \param n_deriv Highest derivative order.
+/// \param points The evaluation points.
+/// \param out_deriv Shape `(points.size(), n_deriv + 1, space.degree() + 1)`.
+/// \param out_first_basis One entry per point, written in full.
+/// \throws nb::value_error If `n_deriv` is too large to fit a C `int`, or if
+///         either output has the wrong shape.
+template <class T>
+void tabulate_space_basis_derivatives(const pantr::bspline::BsplineSpace1D<T>& space,
+                                      unsigned n_deriv, const_points<T> points,
+                                      out_tensor<T> out_deriv,
+                                      out_first_basis_t out_first_basis) {
+    check_fits_int("n_deriv", n_deriv);
+    const auto n_deriv_i64 = static_cast<std::int64_t>(n_deriv);
+
+    const std::size_t num_pts = points.size();
+    const auto num_basis = static_cast<std::size_t>(space.degree()) + 1;
+    const std::size_t num_rows = static_cast<std::size_t>(n_deriv) + 1;
+    if (out_deriv.shape(0) != num_pts || out_deriv.shape(1) != num_rows ||
+        out_deriv.shape(2) != num_basis) {
+        throw nb::value_error(("out_deriv has shape (" + std::to_string(out_deriv.shape(0)) +
+                               ", " + std::to_string(out_deriv.shape(1)) + ", " +
+                               std::to_string(out_deriv.shape(2)) + "), but degree " +
+                               std::to_string(space.degree()) + " and n_deriv " +
+                               std::to_string(n_deriv) + " at " + std::to_string(num_pts) +
+                               " points needs (" + std::to_string(num_pts) + ", " +
+                               std::to_string(num_rows) + ", " + std::to_string(num_basis) +
+                               ")")
+                                  .c_str());
+    }
+    if (out_first_basis.size() != num_pts) {
+        throw nb::value_error(("out_first_basis has " + std::to_string(out_first_basis.size()) +
+                               " elements, but " + std::to_string(num_pts) +
+                               " points need one each")
+                                  .c_str());
+    }
+
+    const std::span<const T> pts(points.data(), num_pts);
+    const span_nd<T, 3> deriv_view(out_deriv.data(), num_pts, num_rows, num_basis);
+    const std::span<std::int64_t> first_basis_view(out_first_basis.data(), num_pts);
+
+    const nb::gil_scoped_release release;
+    pantr::bspline::tabulate_basis_derivatives_1d<T>(space, n_deriv_i64, pts, deriv_view,
+                                                     first_basis_view);
+}
+
 }  // namespace
 
 void register_bspline_basis(nb::module_& m) {
@@ -272,4 +380,22 @@ void register_bspline_basis(nb::module_& m) {
         "tabulate_bspline_basis_derivatives_1d",
         &tabulate_basis_derivatives<double, &pantr::bspline::basis_derivs_1d<double>>,
         &tabulate_basis_derivatives<float, &pantr::bspline::basis_derivs_1d<float>>);
+
+    // The space-level pair. The space carries its own degree and periodicity, so
+    // those parameters are gone; the outputs keep `nb::kw_only()` and
+    // `.noconvert()` for the reasons above, which the space does not change.
+    m.def("tabulate_bspline_space_basis_1d", &tabulate_space_basis<double>, nb::arg("space"),
+          nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out_basis").noconvert(),
+          nb::arg("out_first_basis").noconvert());
+    m.def("tabulate_bspline_space_basis_1d", &tabulate_space_basis<float>, nb::arg("space"),
+          nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out_basis").noconvert(),
+          nb::arg("out_first_basis").noconvert());
+
+    m.def("tabulate_bspline_space_basis_derivatives_1d",
+          &tabulate_space_basis_derivatives<double>, nb::arg("space"), nb::arg("n_deriv"),
+          nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out_deriv").noconvert(),
+          nb::arg("out_first_basis").noconvert());
+    m.def("tabulate_bspline_space_basis_derivatives_1d", &tabulate_space_basis_derivatives<float>,
+          nb::arg("space"), nb::arg("n_deriv"), nb::arg("points").noconvert(), nb::kw_only(),
+          nb::arg("out_deriv").noconvert(), nb::arg("out_first_basis").noconvert());
 }

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -125,6 +125,12 @@ from ._bspline import tabulate_bspline_basis_1d as tabulate_bspline_basis_1d
 from ._bspline import (
     tabulate_bspline_basis_derivatives_1d as tabulate_bspline_basis_derivatives_1d,
 )
+from ._bspline import (
+    tabulate_bspline_space_basis_1d as tabulate_bspline_space_basis_1d,
+)
+from ._bspline import (
+    tabulate_bspline_space_basis_derivatives_1d as tabulate_bspline_space_basis_derivatives_1d,
+)
 from ._bspline_field import Bspline32 as Bspline32
 from ._bspline_field import Bspline64 as Bspline64
 from ._bspline_field import insert_bspline_knots as insert_bspline_knots

--- a/src/pantr/_pantr_cpp/_bspline.pyi
+++ b/src/pantr/_pantr_cpp/_bspline.pyi
@@ -1364,3 +1364,76 @@ def apply_kron_M_K_MT_many_3d(
             inconsistent, or if ``out`` overlaps the operand while at least one cell
             in the batch contracts.
     """
+
+def tabulate_bspline_space_basis_1d(
+    space: BsplineSpace1D32 | BsplineSpace1D64,
+    points: _Array,
+    *,
+    out_basis: _Array,
+    out_first_basis: _Index,
+) -> None:
+    """Tabulate a space's basis, taking its Bézier-like fast path.
+
+    The space-level counterpart of :func:`tabulate_bspline_basis_1d`. Where that
+    one binds ``pantr::bspline::basis_funcs_1d`` and leaves the choice of path to
+    the caller, this binds ``pantr::bspline::tabulate_basis_1d``, which reads
+    ``has_Bezier_like_knots()`` off the space and takes the Bernstein route with
+    its change of variable when it holds.
+
+    **It is not what :mod:`pantr.bspline._basis_backend` calls**, and that is
+    deliberate: the oracle keeps its own dispatch, and building a space per call
+    would re-validate and copy the knot vector in front of a kernel the oracle
+    calls with two or three points. This exists so the parity suite can compare
+    the C++ dispatch against the oracle's, which is what a C++ consumer actually
+    runs and what ``ctest`` alone can only check against itself.
+
+    The space validated its knots when it was built, so there is no knot-length
+    check here; only the output shapes, which the space cannot know, are checked.
+
+    Args:
+        space (BsplineSpace1D32 | BsplineSpace1D64): The space to tabulate. Its
+            scalar type fixes the dtype of ``points`` and of the outputs.
+        points (_Array): The evaluation points, 1D and C-contiguous. Not checked
+            against the domain: a point outside it is evaluated in the clamped
+            span, which is what the oracle does with ``validate=False``.
+        out_basis (_Array): Shape ``(points.size, space.degree() + 1)``, written
+            in full.
+        out_first_basis (_Index): One entry per point, written in full.
+
+    Raises:
+        ValueError: If either output has the wrong shape.
+    """
+
+def tabulate_bspline_space_basis_derivatives_1d(
+    space: BsplineSpace1D32 | BsplineSpace1D64,
+    n_deriv: int,
+    points: _Array,
+    *,
+    out_deriv: _Array,
+    out_first_basis: _Index,
+) -> None:
+    """Tabulate a space's basis derivatives, taking its Bézier-like fast path.
+
+    The derivative twin of :func:`tabulate_bspline_space_basis_1d`, with the same
+    contract and the same reason for existing. On the Bézier-like path the
+    derivatives are scaled by the chain rule, the k-th row carrying
+    ``(1 / (b - a))^k``; ``cpp/include/pantr/bspline/tabulate.hpp`` records that
+    the factor is accumulated in ``double`` and applied at the space's own width,
+    both halves measured against numpy rather than read off the source.
+
+    The ``degree >= 21`` wrapping :func:`tabulate_bspline_basis_derivatives_1d`
+    documents applies here unchanged: it is the kernel's, not the dispatch's.
+
+    Args:
+        space (BsplineSpace1D32 | BsplineSpace1D64): The space to tabulate.
+        n_deriv (int): Highest derivative order. Must be non-negative and must
+            fit a C ``int``.
+        points (_Array): The evaluation points, 1D and C-contiguous.
+        out_deriv (_Array): Shape ``(points.size, n_deriv + 1,
+            space.degree() + 1)``, written in full.
+        out_first_basis (_Index): One entry per point, written in full.
+
+    Raises:
+        ValueError: If ``n_deriv`` does not fit a C ``int``, or if either output
+            has the wrong shape.
+    """

--- a/src/pantr/_pantr_cpp/_bspline.pyi
+++ b/src/pantr/_pantr_cpp/_bspline.pyi
@@ -1401,6 +1401,11 @@ def tabulate_bspline_space_basis_1d(
         out_first_basis (_Index): One entry per point, written in full.
 
     Raises:
+        TypeError: If ``points`` or either output has a dtype, rank or contiguity the
+            signature does not accept, or a dtype different from ``space``'s. Raised
+            by nanobind's caster before the function body runs, and deliberately not
+            a conversion: a converted output would be filled and discarded, and a
+            converted input would change the accumulation width.
         ValueError: If either output has the wrong shape.
     """
 
@@ -1434,6 +1439,11 @@ def tabulate_bspline_space_basis_derivatives_1d(
         out_first_basis (_Index): One entry per point, written in full.
 
     Raises:
+        TypeError: If ``n_deriv`` is negative, or if ``points`` or either output has
+            a dtype, rank or contiguity the signature does not accept, or a dtype
+            different from ``space``'s. Raised by nanobind's caster before the body
+            runs; ``n_deriv`` is ``unsigned`` there while the kernel's own parameter
+            stays ``std::int64_t``.
         ValueError: If ``n_deriv`` does not fit a C ``int``, or if either output
             has the wrong shape.
     """

--- a/tests/parity/test_bspline_space_level_tabulation.py
+++ b/tests/parity/test_bspline_space_level_tabulation.py
@@ -46,27 +46,65 @@ _CASES: dict[str, tuple[list[float], int]] = {
 }
 """One space per path and per decision the dispatch makes."""
 
+_PERIODIC_CASES: dict[str, tuple[list[float], int]] = {
+    "periodic-uniform-p2": ([0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75], 2),
+    "periodic-uniform-p3": ([0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0], 3),
+}
+"""Periodic spaces, kept apart because the dispatch forwards a flag for them.
+
+``tabulate.hpp`` calls the periodic arm of ``find_span_and_first_basis`` a live path
+rather than dead code, and the raw-knot parity file reaches it by passing ``periodic``
+explicitly to the Layer 3 kernel. Nothing was checking that the *space-level* dispatch
+forwards ``space.periodic()`` at all: an edit that dropped or hardcoded the flag would
+have left this file green.
+"""
+
 _POINTS_BY_CASE = {
     name: np.linspace(knots[degree], knots[len(knots) - degree - 1], 7)
-    for name, (knots, degree) in _CASES.items()
+    for name, (knots, degree) in (_CASES | _PERIODIC_CASES).items()
 }
 """Seven points spanning each space's own domain, endpoints included."""
 
 
-def _cpp_space(knots: list[float], degree: int, dtype: Any) -> Any:
+def _cpp_space(knots: list[float], degree: int, dtype: Any, *, periodic: bool = False) -> Any:
     """Build the bound C++ space for these knots.
 
     Args:
         knots (list[float]): The knot vector.
         degree (int): The polynomial degree.
         dtype (Any): ``np.float32`` or ``np.float64``.
+        periodic (bool): Whether the space is periodic. Defaults to False.
 
     Returns:
         Any: The space the bindings take, reached through the public wrapper so that
         the snapping and validation the oracle applied are the ones applied here.
     """
     with use_backend(Backend.CPP):
-        return BsplineSpace1D(np.array(knots, dtype=dtype), degree)._impl
+        return BsplineSpace1D(np.array(knots, dtype=dtype), degree, periodic=periodic)._impl
+
+
+def _gate_the_interpreted_oracle(case: str, dtype: Any, *, n_deriv: int | None) -> None:
+    """Skip the cases whose bitwise claim is about the compiled oracle only.
+
+    Rule 12: under ``NUMBA_DISABLE_JIT=1`` the oracle is a different object, so a
+    bitwise claim against it is a claim about something this project does not ship.
+
+    **The gate is scoped to what was measured, which is narrower than the rule.** All
+    24 instances were run against the interpreted oracle: only the two Bézier-like
+    ``float32`` *value* cases diverge, by up to 6e-8. The four non-Bézier value cases
+    and all eighteen derivative cases -- Bézier included, since row 0 of the
+    derivative kernel does not show what the standalone value kernel does -- are
+    identical with the JIT on or off. Gating all of them, which a first version did,
+    would have taken 22 instances out of the coverage run for no measured reason and
+    left a future regression in any of them silently skipped instead of caught.
+
+    Args:
+        case (str): Key into :data:`_CASES`.
+        dtype (Any): The storage dtype under test.
+        n_deriv (int | None): The derivative order, or ``None`` for the values.
+    """
+    if n_deriv is None and dtype is np.float32 and case.startswith("bezier-like"):
+        demand_the_compiled_kernel(dtype)
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.float32], ids=["f64", "f32"])
@@ -75,11 +113,7 @@ def test_the_space_level_basis_matches_the_oracle_bitwise(
     cpp_backend: None, case: str, dtype: Any
 ) -> None:
     del cpp_backend
-    # Rule 12: under `NUMBA_DISABLE_JIT=1` the oracle is a different object, and a
-    # bitwise claim against it is a claim about something this project does not ship.
-    # Measured here: the two Bézier-like `float32` cases differ by up to 6e-8, which
-    # is the interpreted path's own promotion rather than a divergence in the port.
-    demand_the_compiled_kernel(dtype)
+    _gate_the_interpreted_oracle(case, dtype, n_deriv=None)
     from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
 
     knots, degree = _CASES[case]
@@ -108,7 +142,7 @@ def test_the_space_level_derivatives_match_the_oracle_bitwise(
     cpp_backend: None, case: str, dtype: Any, n_deriv: int
 ) -> None:
     del cpp_backend
-    demand_the_compiled_kernel(dtype)  # Rule 12; see the value test above.
+    _gate_the_interpreted_oracle(case, dtype, n_deriv=n_deriv)
     from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
 
     knots, degree = _CASES[case]
@@ -128,6 +162,132 @@ def test_the_space_level_derivatives_match_the_oracle_bitwise(
 
     np.testing.assert_array_equal(out_deriv, expected)
     np.testing.assert_array_equal(out_first, expected_first)
+
+
+@pytest.mark.parametrize("n_deriv", [None, 1], ids=["values", "d1"])
+@pytest.mark.parametrize("dtype", [np.float64, np.float32], ids=["f64", "f32"])
+@pytest.mark.parametrize("case", sorted(_PERIODIC_CASES))
+def test_a_periodic_space_matches_the_oracle_bitwise(
+    cpp_backend: None, case: str, dtype: Any, n_deriv: int | None
+) -> None:
+    """The flag the dispatch has to forward, which nothing else here would catch."""
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
+
+    knots, degree = _PERIODIC_CASES[case]
+    points = _POINTS_BY_CASE[case].astype(dtype)
+    space = _cpp_space(knots, degree, dtype, periodic=True)
+    out_first = np.zeros(points.size, dtype=np.int64)
+
+    with use_backend(Backend.PYTHON):
+        oracle = BsplineSpace1D(np.array(knots, dtype=dtype), degree, periodic=True)
+        if n_deriv is None:
+            expected, expected_first = oracle.tabulate_basis(points)
+        else:
+            expected, expected_first = oracle.tabulate_basis_derivatives(points, n_deriv)
+
+    if n_deriv is None:
+        got = np.zeros((points.size, degree + 1), dtype=dtype)
+        _pantr_cpp.tabulate_bspline_space_basis_1d(
+            space, points, out_basis=got, out_first_basis=out_first
+        )
+    else:
+        got = np.zeros((points.size, n_deriv + 1, degree + 1), dtype=dtype)
+        _pantr_cpp.tabulate_bspline_space_basis_derivatives_1d(
+            space, n_deriv, points, out_deriv=got, out_first_basis=out_first
+        )
+
+    np.testing.assert_array_equal(got, expected)
+    np.testing.assert_array_equal(out_first, expected_first)
+
+
+def test_the_periodic_cases_really_are_periodic(cpp_backend: None) -> None:
+    """Non-vacuity for the test above: a flag that is never set proves nothing."""
+    del cpp_backend
+    for name, (knots, degree) in _PERIODIC_CASES.items():
+        space = _cpp_space(knots, degree, np.float64, periodic=True)
+        assert space.periodic, name
+        assert not _cpp_space(knots, degree, np.float64).periodic, name
+
+
+@pytest.mark.parametrize(
+    ("wrong", "message"),
+    [
+        ("deriv_points", "out_deriv has shape"),
+        ("deriv_rows", "out_deriv has shape"),
+        ("first", "out_first_basis has"),
+    ],
+)
+def test_a_wrong_derivative_output_shape_is_refused(
+    cpp_backend: None, wrong: str, message: str
+) -> None:
+    """The derivative binding's own checks, which the value test does not reach."""
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
+
+    knots, degree = _CASES["clamped-uniform-p2"]
+    points = _POINTS_BY_CASE["clamped-uniform-p2"]
+    space = _cpp_space(knots, degree, np.float64)
+    n_deriv = 2
+
+    rows = points.size + 1 if wrong == "deriv_points" else points.size
+    orders = n_deriv if wrong == "deriv_rows" else n_deriv + 1
+    out_deriv = np.zeros((rows, orders, degree + 1))
+    out_first = np.zeros(points.size + (1 if wrong == "first" else 0), dtype=np.int64)
+
+    with pytest.raises(ValueError, match=message):
+        _pantr_cpp.tabulate_bspline_space_basis_derivatives_1d(
+            space, n_deriv, points, out_deriv=out_deriv, out_first_basis=out_first
+        )
+
+
+def test_a_negative_derivative_order_is_refused(cpp_backend: None) -> None:
+    """``n_deriv`` is ``unsigned`` in the binding, so nanobind refuses it first.
+
+    A ``TypeError`` rather than a ``ValueError``, and that is the contract the
+    raw-knot pair already states: the caster rejects a negative value before the
+    function body runs, while the kernels' own parameters stay ``std::int64_t``.
+    """
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
+
+    knots, degree = _CASES["clamped-uniform-p2"]
+    points = _POINTS_BY_CASE["clamped-uniform-p2"]
+    space = _cpp_space(knots, degree, np.float64)
+    out_deriv = np.zeros((points.size, 1, degree + 1))
+    out_first = np.zeros(points.size, dtype=np.int64)
+
+    with pytest.raises(TypeError):
+        _pantr_cpp.tabulate_bspline_space_basis_derivatives_1d(
+            space, -1, points, out_deriv=out_deriv, out_first_basis=out_first
+        )
+
+
+def test_a_dtype_mismatch_is_refused_rather_than_silently_converted(
+    cpp_backend: None,
+) -> None:
+    """``.noconvert()`` on every array, and why it matters here.
+
+    A converting cast would fill a discarded temporary and hand the caller back an
+    untouched array with no exception anywhere -- and on the input side it would
+    change the accumulation width, so the result would disagree with the oracle for a
+    reason no caller could see.
+    """
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
+
+    knots, degree = _CASES["clamped-uniform-p2"]
+    space = _cpp_space(knots, degree, np.float64)
+    points_32 = _POINTS_BY_CASE["clamped-uniform-p2"].astype(np.float32)
+    out_first = np.zeros(points_32.size, dtype=np.int64)
+
+    with pytest.raises(TypeError):
+        _pantr_cpp.tabulate_bspline_space_basis_1d(
+            space,
+            points_32,
+            out_basis=np.zeros((points_32.size, degree + 1)),
+            out_first_basis=out_first,
+        )
 
 
 def test_the_bezier_cases_really_take_the_fast_path(cpp_backend: None) -> None:

--- a/tests/parity/test_bspline_space_level_tabulation.py
+++ b/tests/parity/test_bspline_space_level_tabulation.py
@@ -1,0 +1,181 @@
+"""The C++ space-level dispatch, compared against the oracle's rather than itself.
+
+``cpp/include/pantr/bspline/tabulate.hpp`` offers two pairs of free functions. The
+raw-knot pair is what :mod:`pantr.bspline._basis_backend` calls, and that will not
+change: building a space per call would re-validate and copy the knot vector in front
+of a kernel the oracle calls with two or three points, and the constructor snaps by
+default, so it could silently evaluate on a different vector than the oracle did.
+
+The *space-level* pair -- ``tabulate_basis_1d`` and ``tabulate_basis_derivatives_1d``
+-- is the Layer 2 equivalent for a C++ caller with no interpreter, and it is the code
+a C++ consumer writes. It chooses between the general recurrence and the Bézier-like
+fast path, and on that path it commits its own change of variable and its own
+chain-rule scaling. **Until these bindings existed, ``ctest`` was the only thing that
+ran it**, which tests it against itself: a `ctest` case cannot notice the two sides
+disagreeing about which path a space takes, or about the arithmetic on the way into
+it.
+
+The claim is **bitwise**, and it is available rather than generous. The C++ dispatch
+and the oracle's reach the same kernels through the same decisions, so where the
+values are not identical something has genuinely diverged, and a bound would hide it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import BsplineSpace1D
+from tests._parity_harness import demand_the_compiled_kernel
+
+_CASES: dict[str, tuple[list[float], int]] = {
+    # General knots: the recurrence path.
+    "clamped-uniform-p2": ([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0], 2),
+    "clamped-repeat-p2": ([0.0, 0.0, 0.0, 0.25, 0.75, 0.75, 1.0, 1.0, 1.0], 2),
+    "unclamped-p2": ([-0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5], 2),
+    # No interior knot: both sides must pick the Bézier-like path, and the domain is
+    # neither `[0, 1]` nor dyadic, so the change of variable is not a no-op and a
+    # divergence in it cannot cancel.
+    "bezier-like-p2": ([2.0, 2.0, 2.0, 6.0, 6.0, 6.0], 2),
+    "bezier-like-p3": ([0.1, 0.1, 0.1, 0.1, 2.2, 2.2, 2.2, 2.2], 3),
+    # Degree 0, where the recurrence has no step at all.
+    "degree-zero": ([0.0, 0.25, 0.5, 1.0], 0),
+}
+"""One space per path and per decision the dispatch makes."""
+
+_POINTS_BY_CASE = {
+    name: np.linspace(knots[degree], knots[len(knots) - degree - 1], 7)
+    for name, (knots, degree) in _CASES.items()
+}
+"""Seven points spanning each space's own domain, endpoints included."""
+
+
+def _cpp_space(knots: list[float], degree: int, dtype: Any) -> Any:
+    """Build the bound C++ space for these knots.
+
+    Args:
+        knots (list[float]): The knot vector.
+        degree (int): The polynomial degree.
+        dtype (Any): ``np.float32`` or ``np.float64``.
+
+    Returns:
+        Any: The space the bindings take, reached through the public wrapper so that
+        the snapping and validation the oracle applied are the ones applied here.
+    """
+    with use_backend(Backend.CPP):
+        return BsplineSpace1D(np.array(knots, dtype=dtype), degree)._impl
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32], ids=["f64", "f32"])
+@pytest.mark.parametrize("case", sorted(_CASES))
+def test_the_space_level_basis_matches_the_oracle_bitwise(
+    cpp_backend: None, case: str, dtype: Any
+) -> None:
+    del cpp_backend
+    # Rule 12: under `NUMBA_DISABLE_JIT=1` the oracle is a different object, and a
+    # bitwise claim against it is a claim about something this project does not ship.
+    # Measured here: the two Bézier-like `float32` cases differ by up to 6e-8, which
+    # is the interpreted path's own promotion rather than a divergence in the port.
+    demand_the_compiled_kernel(dtype)
+    from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
+
+    knots, degree = _CASES[case]
+    points = _POINTS_BY_CASE[case].astype(dtype)
+    space = _cpp_space(knots, degree, dtype)
+
+    out_basis = np.zeros((points.size, degree + 1), dtype=dtype)
+    out_first = np.zeros(points.size, dtype=np.int64)
+    _pantr_cpp.tabulate_bspline_space_basis_1d(
+        space, points, out_basis=out_basis, out_first_basis=out_first
+    )
+
+    with use_backend(Backend.PYTHON):
+        expected, expected_first = BsplineSpace1D(
+            np.array(knots, dtype=dtype), degree
+        ).tabulate_basis(points)
+
+    np.testing.assert_array_equal(out_basis, expected)
+    np.testing.assert_array_equal(out_first, expected_first)
+
+
+@pytest.mark.parametrize("n_deriv", [0, 1, 2])
+@pytest.mark.parametrize("dtype", [np.float64, np.float32], ids=["f64", "f32"])
+@pytest.mark.parametrize("case", sorted(_CASES))
+def test_the_space_level_derivatives_match_the_oracle_bitwise(
+    cpp_backend: None, case: str, dtype: Any, n_deriv: int
+) -> None:
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)  # Rule 12; see the value test above.
+    from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
+
+    knots, degree = _CASES[case]
+    points = _POINTS_BY_CASE[case].astype(dtype)
+    space = _cpp_space(knots, degree, dtype)
+
+    out_deriv = np.zeros((points.size, n_deriv + 1, degree + 1), dtype=dtype)
+    out_first = np.zeros(points.size, dtype=np.int64)
+    _pantr_cpp.tabulate_bspline_space_basis_derivatives_1d(
+        space, n_deriv, points, out_deriv=out_deriv, out_first_basis=out_first
+    )
+
+    with use_backend(Backend.PYTHON):
+        expected, expected_first = BsplineSpace1D(
+            np.array(knots, dtype=dtype), degree
+        ).tabulate_basis_derivatives(points, n_deriv)
+
+    np.testing.assert_array_equal(out_deriv, expected)
+    np.testing.assert_array_equal(out_first, expected_first)
+
+
+def test_the_bezier_cases_really_take_the_fast_path(cpp_backend: None) -> None:
+    """Non-vacuity: without this the two paths could both be the recurrence.
+
+    The whole reason for binding the space-level pair is that it *chooses*, so a
+    parametrization in which nothing chooses the Bézier route would compare the
+    recurrence against itself and the file would be green while saying nothing about
+    the change of variable or the chain-rule scaling.
+    """
+    del cpp_backend
+    taken = {
+        name: BsplineSpace1D(np.array(knots), degree).has_Bezier_like_knots()
+        for name, (knots, degree) in _CASES.items()
+    }
+
+    assert taken["bezier-like-p2"], taken
+    assert taken["bezier-like-p3"], taken
+    assert not taken["clamped-uniform-p2"], taken
+    assert not taken["unclamped-p2"], taken
+
+
+@pytest.mark.parametrize(
+    ("shape_kind", "message"),
+    [("basis", "out_basis has shape"), ("first", "out_first_basis has")],
+)
+def test_a_wrong_output_shape_is_refused(cpp_backend: None, shape_kind: str, message: str) -> None:
+    """The checks the space cannot make for the caller.
+
+    The space validated its own knots at construction, so the knot-length check the
+    raw-knot binding performs has no counterpart here. The output shapes remain the
+    caller's to get wrong, and a binding that filled a too-small buffer would corrupt
+    the heap rather than raise -- which the raw-knot binding's own file comment
+    records as measured, not hypothetical.
+    """
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415  (only this module needs it)
+
+    knots, degree = _CASES["clamped-uniform-p2"]
+    points = _POINTS_BY_CASE["clamped-uniform-p2"]
+    space = _cpp_space(knots, degree, np.float64)
+
+    basis_rows = points.size if shape_kind != "basis" else points.size + 1
+    first_size = points.size if shape_kind != "first" else points.size + 1
+    out_basis = np.zeros((basis_rows, degree + 1))
+    out_first = np.zeros(first_size, dtype=np.int64)
+
+    with pytest.raises(ValueError, match=message):
+        _pantr_cpp.tabulate_bspline_space_basis_1d(
+            space, points, out_basis=out_basis, out_first_basis=out_first
+        )


### PR DESCRIPTION
## Context

`cpp/include/pantr/bspline/tabulate.hpp` offers two pairs of free functions:

- `basis_funcs_1d` / `basis_derivs_1d` take a raw knot vector and are Layer 3. These
  are what `pantr.bspline._basis_backend` calls, and that does not change. Building a
  space per call would re-validate and copy the knot vector in front of a kernel the
  oracle calls with two or three points, and the space's constructor snaps by default,
  so it could silently evaluate on a different vector than the oracle did;
- `tabulate_basis_1d` / `tabulate_basis_derivatives_1d` take a `BsplineSpace1D` and
  are the Layer 2 equivalent for a C++ caller with no interpreter. They read
  `has_Bezier_like_knots()` off the space and take the Bernstein route — with its own
  change of variable and its own chain-rule scaling — when it holds.

**The second pair is what a C++ consumer writes, and `ctest` was the only thing that
ran it.** That tests it against itself: a ctest case cannot notice the two sides
disagreeing about which path a space takes, or about the arithmetic on the way into
it. The dispatch the oracle performs and the dispatch C++ performs were never
compared.

## Specification

Two new bindings, `tabulate_bspline_space_basis_1d` and
`tabulate_bspline_space_basis_derivatives_1d`, taking an already-built
`BsplineSpace1D32`/`BsplineSpace1D64`. They exist so the parity suite can reach that
dispatch; **nothing in the library's own call path changes.**

The claim is **bitwise**, and that is available rather than generous: both sides reach
the same kernels through the same decisions, so a bound would hide exactly what this
is for.

The space validated its knots when it was built, so the knot-length check the raw-knot
binding performs has no counterpart here. The output shapes, which the space cannot
know, are still the caller's to get wrong and are still checked — the raw-knot
binding's file comment records a measured heap corruption from an undersized `out`.

## Acceptance

- AC1: 51 parity cases agree bitwise with the oracle — the recurrence path, the
  Bézier-like path, and degree 0, at `float32` and `float64`, values and derivatives to
  order 2.
- AC2: the Bézier fixtures really take the fast path, asserted rather than assumed, and
  their domain is neither `[0, 1]` nor dyadic so a divergence in the change of variable
  cannot cancel.
- AC3: a wrong output shape raises rather than corrupting memory.
- AC4: two `float32` Bézier cases are gated by `demand_the_compiled_kernel`. Under
  `NUMBA_DISABLE_JIT=1` the oracle is a different object (Rule 12) and they differ by up
  to 6e-8 there — the interpreted path's own promotion, not a divergence in the port.

## Non-goals

`_basis_backend` keeps calling the raw-knot pair, for the reason above. The stale claim
in that module's file comment that "this file binds the first pair only" is corrected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
