### PR TITLE
docs(bspline): correct three claims the degree family's code contradicts

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -940,17 +940,19 @@ class Bspline:
         all other directions (or ``p`` when ``keep_degree=True``).
 
         For rational B-splines (NURBS), the quotient rule is applied, producing
-        a rational B-spline of degree ``2p`` in direction ``d`` (or the
-        original degree when ``keep_degree=True``).
+        a rational B-spline of degree ``2p`` in direction ``d``. That already
+        exceeds ``p``, so ``keep_degree`` has no effect on a rational B-spline:
+        both settings return degree ``2p``.
 
         Args:
             direction (int): Parametric direction for differentiation.
                 Must be in ``[0, dim)``. Defaults to 0.
-            keep_degree (bool): If ``True``, the result preserves the same
-                degree as the original B-spline by applying degree elevation
-                after differentiation. This is useful, for instance, when
-                computing derivatives of rational polynomials (in the
-                numerator). Defaults to ``False``.
+            keep_degree (bool): If ``True``, a non-rational result preserves the
+                degree of the original B-spline by applying degree elevation after
+                differentiation. This is useful, for instance, when computing
+                derivatives of rational polynomials (in the numerator). It is
+                ignored for a rational B-spline, whose derivative is already of
+                higher degree than the original. Defaults to ``False``.
 
         Returns:
             Bspline: A new B-spline representing the derivative.
@@ -958,6 +960,11 @@ class Bspline:
         Raises:
             ValueError: If ``direction`` is out of range ``[0, dim)``.
             ValueError: If the degree in the given direction is 0.
+            ValueError: If the degree the result has to be built at exceeds the
+                exactness envelope of the binomial-coefficient kernel
+                (``_BINCOEFF_MAX_N``). Reachable with ``keep_degree=True``, and
+                for a rational B-spline with either setting, since that path
+                always re-elevates.
 
         Example:
             >>> import numpy as np
@@ -1004,6 +1011,8 @@ class Bspline:
             ValueError: If any degree increment is negative.
             ValueError: If all degree increments are zero.
             ValueError: If the number of increments does not match the dimension.
+            ValueError: If an elevated degree would exceed the exactness envelope
+                of the binomial-coefficient kernel (``_BINCOEFF_MAX_N``).
 
         References:
             Degree elevation of spline curves :cite:p:`piegl1997nurbs`.

--- a/src/pantr/bspline/_bspline_degree.py
+++ b/src/pantr/bspline/_bspline_degree.py
@@ -164,7 +164,12 @@ def _coarsen_knots_after_reduction(  # noqa: PLR0913
         num_to_remove = bezier_mult - target_mult
         if num_to_remove <= 0:
             continue
-        # Use a large tolerance for deviation since reduction is approximate.
+        # `inf` does not loosen the kernel's acceptance test (`dist <= tol`), it
+        # removes it.  That is deliberate: this removal is structural, restoring the
+        # continuity the original spline had, so the requested count is what must
+        # hold and the deviation is not a criterion.  `Bspline.reduce_degree`
+        # documents that this forced removal, not the per-segment reduction, is what
+        # sets the final error.
         tol_dev = np.inf
         knots, ctrl, _removed = _remove_knot_bspline_1d_impl(
             knots, new_degree, ctrl, knot_val, num_to_remove, tol_space, tol_dev

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -1215,6 +1215,66 @@ class TestBsplineReduceDegreeDiscontinuous:
         assert new_knots.shape[0] == new_ctrl.shape[0] + new_degree + 1
 
 
+class TestBsplineReduceDegreeForcedRemoval:
+    """The coarsening removal is structural: no deviation can veto it.
+
+    ``_coarsen_knots_after_reduction`` passes ``tol_dev = np.inf`` to the removal
+    kernel, whose acceptance test is ``dist <= tol``.  That does not loosen the
+    test, it removes it -- which is the documented contract: the continuity
+    structure is what the step has to restore, and the forced removal is what sets
+    the method's error.  These tests pin that, so replacing the ``inf`` with any
+    finite bound fails here rather than silently returning a spline with a knot
+    vector nobody asked for.
+    """
+
+    def test_a_grossly_inexact_reduction_still_coarsens(self) -> None:
+        """A knot is removed even when the reduced curve misses by more than its range."""
+        bsp = _make_bspline_1d(
+            [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0],
+            3,
+            [[0.0], [1.0], [-1.0], [1.0], [0.0]],
+        )
+        assert _bspline_multiplicity(bsp, 0.5) == 1
+
+        reduced = bsp.reduce_degree(1)
+
+        # The deviation is not small, and not small relative to anything: it exceeds
+        # the spline's own peak-to-peak range.  Asserted so the test still means what
+        # it says if the reduction operator is ever changed.
+        pts = np.linspace(0.0, 1.0, 101)
+        values = bsp.evaluate(pts)
+        deviation = float(np.max(np.abs(values - reduced.evaluate(pts))))
+        value_range = float(np.max(values) - np.min(values))
+        assert deviation > value_range
+
+        # Removed anyway, down to the structural target max(1, m - t) = 1.
+        assert reduced.degree == (2,)
+        assert _bspline_multiplicity(reduced, 0.5) == 1
+
+    def test_every_interior_knot_reaches_its_structural_target(self) -> None:
+        """Multiplicities land on max(1, m - t) whatever the fit does."""
+        degree, dec = 4, 2
+        knots = np.concatenate(
+            [
+                np.zeros(degree + 1),
+                [0.2],
+                np.full(3, 0.5),
+                np.full(4, 0.8),
+                np.ones(degree + 1),
+            ]
+        ).tolist()
+        rng = np.random.default_rng(20260911)
+        n_basis = len(knots) - degree - 1
+        bsp = _make_bspline_1d(knots, degree, rng.standard_normal((n_basis, 2)).tolist())
+
+        reduced = bsp.reduce_degree(dec)
+
+        assert reduced.degree == (degree - dec,)
+        for xi, mult in ((0.2, 1), (0.5, 3), (0.8, 4)):
+            assert _bspline_multiplicity(reduced, xi) == max(1, mult - dec)
+        assert reduced.control_points.shape[0] == reduced.space.spaces[0].num_basis
+
+
 class TestBsplineReduceDegreePeriodicSeam:
     """The seam multiplicity is floored at 1, exactly as interior knots are."""
 


### PR DESCRIPTION
## Context

Three claims in the B-spline degree family said something the code beside them contradicts.
None of them could fail a test, which is what makes this class of defect worth a pass of its
own: the prose is what a caller reads, and in two of these three cases the prose also
contradicted another part of the project that had it right.

## What changed

**The reduction's deviation bound.** `_coarsen_knots_after_reduction` passed `tol_dev = np.inf`
under a comment calling it "a large tolerance for deviation since reduction is approximate".
The removal kernel accepts on `dist <= tol`, so infinity does not loosen that test, it
suppresses it: no deviation can veto the removal. That is the intended contract, and
`Bspline.reduce_degree` already documents it ("a forced removal with no deviation bound"), so
the comment contradicted its own public API as well as the line under it. Corrected, and the
behaviour it described wrongly is now pinned by two tests.

Measured on a degree-3 spline reduced to degree 2: the reduced curve misses the original by
0.75 against a peak-to-peak range of 0.444 — 169% of the range — and the interior knot is
removed regardless, landing on the structural target `max(1, m - t)`. The tests assert the
deviation-exceeds-range fact *before* asserting the structure held, so they keep meaning what
they say if the reduction operator ever changes. Checked non-vacuous: replacing the `inf` with
`1.0e-10` fails both; with `inf` both pass.

**A false degree promise.** `Bspline.derivative`'s docstring promised that `keep_degree=True`
returns a rational B-spline "of the original degree". It does not, and was never meant to: the
rational derivative is already degree `2p`, which exceeds `p`, so the flag is a deliberate no-op
on that path. The code comment beside the branch and `TestKeepDegreeRational`'s own class
docstring both say so. Measured on a degree-2 rational spline: both settings return degree 4.
Fixed in the summary and in the `keep_degree` argument description, which repeated the promise.

**Two incomplete `Raises:` sections.** `derivative` and `elevate_degree` can both refuse a degree
past the exactness envelope of the binomial-coefficient kernel, and neither listed it. Verified
reachable by running all three routes: `elevate_degree(2)` on a degree-60 spline,
`derivative(keep_degree=True)` on a degree-62 spline, and plain `derivative()` on a degree-62
*rational* spline — that one needs no flag, because the rational path always re-elevates.

## Not in this PR

A review pass over the same region turned up two Critical defects that are **not** touched here,
because each needs a contract decision rather than a bounded fix, and one of them is a numerical
wrong-answer bug, which this project's rule says to abort rather than fold in. Both are
reproduced and written up for triage:

- `_derivative_keep_degree_nonrational` converts the **whole** field to open form rather than
  just the differentiated direction. A 2D spline periodic in both directions loses periodicity
  in the direction nobody differentiated, and the **default** rational derivative crashes with an
  opaque multiplicity error. Sibling code in the same region uses the single-direction conversion
  and gets this right.
- Rational degree reduction applies the endpoint-interpolating operator to the weight column.
  That operator is not a convex combination (it has negative entries), so a weight can go
  non-positive: 61 of 600 forced rational reductions across degrees 2-5, worst weight `-1.69`.
  The project already guards exactly this failure on the auto-detecting `minimize_degree` path;
  the guard was never extended to the forced one.

## Non-goals

No behaviour changes. Every code path in this diff computes what it computed before; the two new
tests pin behaviour that was already there and undescribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDsgxeS1roqbGuLYbyR2zH
