### PR TITLE
fix(bspline): open only the differentiated direction in the keep-degree derivative

### DIFF
--- a/src/pantr/bspline/_bspline_derivative.py
+++ b/src/pantr/bspline/_bspline_derivative.py
@@ -18,6 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
+from ._bspline_knot_insertion import _to_open_bspline_1d_impl
 from ._bspline_knots import _get_Bspline_num_basis_1D_impl
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_nd import BsplineSpace
@@ -289,8 +290,9 @@ def _derivative_keep_degree_nonrational(bspline: Bspline, direction: int) -> Bsp
 
     Returns:
         ~pantr.bspline.Bspline: Derivative B-spline of the same degree as the
-        input.  Periodic directions in the differentiated axis are converted
-        to open representation (degree elevation does not support periodic).
+        input.  A periodic ``direction`` comes back in open representation
+        (degree elevation does not support periodic); every other direction
+        keeps the representation it had.
 
     Raises:
         ValueError: If the direction's degree exceeds the exactness envelope of the
@@ -316,15 +318,16 @@ def _derivative_keep_degree_nonrational(bspline: Bspline, direction: int) -> Bsp
     # ``keep_degree`` or not.
     _check_bincoeff_envelope(p, f"Degree-preserving derivative of a degree-{p} B-spline")
 
-    # Degree elevation requires open knot vectors. For periodic B-splines,
-    # convert to open representation first, then recurse.
-    if space_d.periodic:
-        return _derivative_keep_degree_nonrational(bspline.to_open_bspline(), direction)
-
     knots = space_d.knots
     ctrl = bspline.control_points
 
     pts_2d, trailing_shape = _flatten_along_axis(ctrl, direction)
+
+    # Degree elevation requires an open knot vector.  Convert ``direction`` alone:
+    # ``Bspline.to_open_bspline`` would open every direction, so an operation on
+    # ``direction`` would change the representation of the axes it never touches.
+    if space_d.periodic:
+        knots, pts_2d = _to_open_bspline_1d_impl(knots, p, pts_2d, True, float(space_d.tolerance))
 
     # Derivative (degree p → p-1) + degree elevation (p-1 → p) on arrays.
     deriv_pts = _derivative_ctrl_1d(knots, p, pts_2d)

--- a/tests/test_bspline_derivative.py
+++ b/tests/test_bspline_derivative.py
@@ -597,6 +597,37 @@ class TestKeepDegreeNonRational:
         assert not f_prime.space.spaces[1].periodic
         np.testing.assert_array_equal(f_prime.space.spaces[1].knots, knots1)
 
+    def test_2d_periodic_float32(self) -> None:
+        """The periodic keep_degree path preserves float32 and the other direction."""
+        knots0 = create_uniform_periodic_knots(4, 2, domain=(0.0, 1.0)).astype(np.float32)
+        knots1 = create_uniform_periodic_knots(5, 2, domain=(0.0, 1.0)).astype(np.float32)
+        s0 = BsplineSpace1D(knots0, 2, periodic=True)
+        s1 = BsplineSpace1D(knots1, 2, periodic=True)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(23)
+        ctrl = rng.standard_normal((*space.num_basis, 1)).astype(np.float32)
+        f = Bspline(space, ctrl)
+
+        f_prime = f.derivative(direction=0, keep_degree=True)
+
+        assert f_prime.dtype == np.float32
+        assert f_prime.space.spaces[0].knots.dtype == np.float32
+        assert f_prime.space.spaces[1].periodic
+        np.testing.assert_array_equal(f_prime.space.spaces[1].knots, knots1)
+
+        pts = rng.uniform(0.0, 1.0, (41, 2)).astype(np.float32)
+        expected = f.evaluate_derivatives(pts, [1, 0])
+        actual = f_prime.evaluate(pts)
+
+        # Opening the periodic direction and re-elevating are convex combinations,
+        # so they contribute O(degree) units of eps relative to the control points;
+        # the divided difference in between amplifies by degree / knot-span, which
+        # is the scale of the derivative values themselves.  Hence a bound of
+        # O(degree) * eps * max|f'|; the factor below leaves room for degree 2.
+        eps32 = float(np.finfo(np.float32).eps)
+        bound = 32.0 * eps32 * float(np.max(np.abs(expected)))
+        assert float(np.max(np.abs(actual - expected))) <= bound
+
 
 class TestKeepDegreeRational:
     """Derivative with keep_degree=True for rational (NURBS) B-splines.

--- a/tests/test_bspline_derivative.py
+++ b/tests/test_bspline_derivative.py
@@ -559,6 +559,44 @@ class TestKeepDegreeNonRational:
         assert f_prime.space.spaces[0].degree == 2
         assert f_prime.space.spaces[1].degree == 3  # unchanged
 
+    def test_2d_periodic_keeps_other_direction_periodic(self) -> None:
+        """Differentiating direction 0 leaves direction 1 periodic."""
+        knots0 = create_uniform_periodic_knots(4, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_periodic_knots(5, 2, domain=(0.0, 1.0))
+        s0 = BsplineSpace1D(knots0, 2, periodic=True)
+        s1 = BsplineSpace1D(knots1, 2, periodic=True)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(7)
+        ctrl = rng.standard_normal((*space.num_basis, 2))
+        f = Bspline(space, ctrl)
+
+        f_prime = _assert_keep_degree_matches_evaluate(f, direction=0, atol=1e-8)
+
+        # Direction 1 is untouched: same knot vector, still periodic.
+        assert f_prime.space.spaces[1].periodic
+        np.testing.assert_array_equal(f_prime.space.spaces[1].knots, knots1)
+        # Direction 0 is the one that degree elevation needs open.
+        assert not f_prime.space.spaces[0].periodic
+        assert f_prime.space.spaces[1].degree == 2
+
+    def test_2d_periodic_keeps_other_direction_unclamped(self) -> None:
+        """Differentiating a periodic direction 0 leaves an unclamped direction 1 alone."""
+        knots0 = create_uniform_periodic_knots(4, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_periodic_knots(5, 2, domain=(0.0, 1.0))
+        s0 = BsplineSpace1D(knots0, 2, periodic=True)
+        s1 = BsplineSpace1D(knots1, 2, periodic=False)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(11)
+        ctrl = rng.standard_normal((*space.num_basis, 1))
+        f = Bspline(space, ctrl)
+
+        f_prime = _assert_keep_degree_matches_evaluate(f, direction=0, atol=1e-8)
+
+        # Direction 1 is untouched: still unclamped, same knot vector.
+        assert not f_prime.space.spaces[1].has_open_knots()
+        assert not f_prime.space.spaces[1].periodic
+        np.testing.assert_array_equal(f_prime.space.spaces[1].knots, knots1)
+
 
 class TestKeepDegreeRational:
     """Derivative with keep_degree=True for rational (NURBS) B-splines.


### PR DESCRIPTION
## Context

`_derivative_keep_degree_nonrational` needs an open knot vector, because degree elevation does
not accept a periodic one. It got there by calling `Bspline.to_open_bspline()`, which converts
**every** parametric direction, and then recursing. So an operation on direction `d` silently
rewrote the representation of every direction it never touched.

Measured on a 2D B-spline periodic in both directions:

```
before                                     : periodic flags = (True, True)
derivative(direction=0, keep_degree=True)  : (False, False)   <- direction 1 lost it
derivative(direction=0, keep_degree=False) : (True, True)     <- the correct path
```

The sibling operations in the same package already get this right: `_degree_elevate_bspline` and
`_degree_reduce_bspline` use the single-direction `_to_open_bspline_1d_impl` on the axis flattened
by `_flatten_along_axis`, never the whole-object conversion.

## Specification

An operation on direction `d` must not alter the representation of any direction `e != d`.

The differentiated direction's own output is deliberately unchanged: a periodic `direction` still
comes back open, exactly as before. Verified bit for bit — over 15 one-dimensional cases spanning
degrees 1 to 5, the new path and the old whole-object path agree on degree, on the knot vector,
and on the control points with a maximum difference of `0.0`. This change does not alter what the
operation writes; it stops it writing what it never should have.

## Acceptance

Three regression tests in `TestKeepDegreeNonRational`, each failing on the parent commit for the
right reason — structural drift in the untouched direction, not a value mismatch:

- a 2D spline periodic in both directions keeps direction 1 periodic;
- the merely **unclamped** flavour of the same thing, where direction 1 came back clamped with a
  changed knot vector;
- a float32 case pinning dtype through the new insertion path, since
  `_to_open_bspline_1d_impl` builds its insertion vector with `dtype=knots.dtype`. Its bound is
  derived, not fitted.

Full suite 10752 passed / 62 skipped / 7 xfailed. ruff, ruff format, mypy (331 files),
import-linter (2 contracts kept), doctests and the `-W` docs build all green.

## Non-goals

**The rational derivative's crash on a periodic differentiated direction is not fixed here**, and
this change was never able to reach it. `derivative(direction=0)` on a rational spline periodic in
direction 0 still raises a multiplicity error from `_refine_to_common_space_1d`. It reproduces in
**one** dimension, so it is not a multi-direction defect: `_derivative_rational` routes A' and w'
through this function, which returns them open in `d`, while the denominator built from
`w_bspline.multiply(w_bspline)` keeps the periodic form. Reconciling those two means deciding what
a periodic direction's derivative should look like, which is a contract question and not this
PR's to answer.

Two further defects were found while working here and deliberately left alone, both reproduced:
`derivative(keep_degree=True)` on an unclamped, non-periodic direction returns a wrong function
(max error 18.5 against finite differences, versus 3.2e-10 without the flag) — pre-existing,
identical on the parent commit, and a numerical wrong-answer bug; and the public docstring still
says nothing about periodicity, which cannot honestly be stated while the rational path raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDsgxeS1roqbGuLYbyR2zH
