### PR TITLE
feat(bspline): port the degree family's two clean paths to C++

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -126,7 +126,7 @@ if(PANTR_NANOBIND_SPLIT)
                       bspline_extraction.cpp bspline_extraction_operators.cpp
                       bspline_basis.cpp
                       bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp
-                      bspline_structural.cpp)
+                      bspline_structural.cpp bspline_degree.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
@@ -137,7 +137,7 @@ else()
                       bspline_extraction.cpp bspline_extraction_operators.cpp
                       bspline_basis.cpp
                       bspline_thb_space.cpp bspline_type.cpp bspline_refinement.cpp
-                      bspline_structural.cpp)
+                      bspline_structural.cpp bspline_degree.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bspline_degree.cpp
+++ b/cpp/bindings/bspline_degree.cpp
@@ -1,0 +1,101 @@
+/// \file
+/// nanobind bindings for changing a `pantr::bspline::Bspline`'s degree.
+///
+/// Two entry points, `differentiate_bspline` and `elevate_bspline_degree`, each
+/// registered twice -- once per storage format -- exactly as
+/// `bspline_refinement.cpp` registers `insert_bspline_knots` and
+/// `subdivide_bspline`. Overload resolution separates the two instantiations on
+/// the field handle's own class, so neither needs a dtype argument and neither
+/// can be reached with a mismatched one.
+///
+/// ## What crosses, and what does not
+///
+/// **The field itself crosses, not its arrays**, for the same reason
+/// `bspline_refinement.cpp` gives: these are operations on a domain type C++ has
+/// owned since the 2026-08-27 amendment to `design/cross_backend_types.md`, so
+/// the binding is handed the `Bspline32`/`Bspline64` handle the Python wrapper
+/// already holds and hands back a new one.
+///
+/// What does cross as plain data is the *arguments*: `direction` is a scalar
+/// axis index, and `increments` is one degree increment per direction. Neither
+/// carries an invariant to lose, and neither is a numpy array -- unlike
+/// `bspline_refinement.cpp`'s knot lists, so there is no `const_vec<T>` alias
+/// here and no `.noconvert()` to reason about: nanobind's `std::vector<T>`
+/// caster converts a Python sequence of integers regardless, and there is no
+/// narrowing it could silently perform on an integer count.
+///
+/// ## What this file validates: nothing
+///
+/// `pantr/bspline/degree.hpp` validates its own arguments and throws
+/// `std::invalid_argument`, which nanobind maps to `ValueError` preserving
+/// `what()`. The messages are the oracle's character for character;
+/// `tests/parity/test_bspline_degree.py` compares the two texts rather than
+/// just the exception type.
+///
+/// ## The GIL is held through the computation, unlike the kernels
+///
+/// `pantr_cpp.cpp` records that the GIL is released around a kernel, because a
+/// kernel touches no Python object. These two are not kernels and the reason is
+/// specific rather than stylistic: the space handles reachable from the field
+/// were created by `nanobind/stl/shared_ptr.h`, so their deleter is
+/// `py_deleter`, which touches a Python refcount. Dropping the last reference
+/// to one with the GIL released would be a crash rather than a slowdown, and
+/// while no path here *can* drop a last reference -- the caller's field keeps
+/// every handle alive for the whole call -- that is an argument about the
+/// current body rather than a property of the signature.
+/// `bspline_refinement.cpp` holds the GIL through its own two entry points for
+/// the identical reason.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/vector.h>
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/degree.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+/// Differentiate a field along one direction, returning a new one.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field The field to differentiate.
+/// \param direction The direction to differentiate, in `[0, field.dim())`.
+/// \return The hodograph.
+template <class T>
+pantr::bspline::Bspline<T> bind_differentiate(const pantr::bspline::Bspline<T>& field,
+                                              std::int64_t direction) {
+    return pantr::bspline::derivative<T>(field, direction);
+}
+
+/// Elevate a field's degree per direction, returning a new one.
+///
+/// \tparam T The scalar type the field stores.
+/// \param field The field to elevate.
+/// \param increments Degrees to add per direction, in axis order.
+/// \return The elevated field.
+template <class T>
+pantr::bspline::Bspline<T> bind_elevate_degree(const pantr::bspline::Bspline<T>& field,
+                                               const std::vector<std::int64_t>& increments) {
+    return pantr::bspline::elevate_degree<T>(field, std::span<const std::int64_t>(increments));
+}
+
+}  // namespace
+
+void register_bspline_degree(nb::module_& m) {
+    m.def("differentiate_bspline", &bind_differentiate<double>, nb::arg("bspline"),
+          nb::arg("direction"));
+    m.def("differentiate_bspline", &bind_differentiate<float>, nb::arg("bspline"),
+          nb::arg("direction"));
+
+    m.def("elevate_bspline_degree", &bind_elevate_degree<double>, nb::arg("bspline"),
+          nb::arg("increments"));
+    m.def("elevate_bspline_degree", &bind_elevate_degree<float>, nb::arg("bspline"),
+          nb::arg("increments"));
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -91,6 +91,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_bspline_type(m);
     register_bspline_refinement(m);
     register_bspline_structural(m);
+    register_bspline_degree(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -150,6 +150,17 @@ void register_bspline_refinement(nanobind::module_& m);
 /// refinement, none of these refuses a periodic direction.
 void register_bspline_structural(nanobind::module_& m);
 
+/// Register the degree operations on a `pantr.bspline.Bspline`.
+///
+/// Its own entry point rather than two more functions inside
+/// `register_bspline_structural`, for the reason that one is separate from
+/// `register_bspline_type`: changing a field's degree and cutting one down are
+/// separate ports with separate parity claims, and this one's decisions -- why
+/// `derivative` has no `keep_degree` parameter and no rational path, why
+/// `elevate_degree` refuses a periodic or unclamped direction -- argue from
+/// somewhere else entirely.
+void register_bspline_degree(nanobind::module_& m);
+
 /// Register `pantr.bspline`'s Bézier extraction operator builder and its mask.
 ///
 /// Separate from `register_bspline_extraction` because the two are separate ports

--- a/cpp/include/pantr/bezier/degree.hpp
+++ b/cpp/include/pantr/bezier/degree.hpp
@@ -96,6 +96,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -112,26 +113,6 @@
 namespace pantr::bezier {
 
 namespace detail {
-
-/// Refuse a degree the exact-integer binomial recurrence cannot reach.
-///
-/// The message is the oracle's, character for character
-/// (`_bspline_degree_core._check_bincoeff_envelope`), because
-/// `tests/parity/test_bezier_degree.py` compares it.
-///
-/// \param n Largest upper index the elevation will need.
-/// \param what Description of the operation, opening the message.
-/// \throws std::invalid_argument If `n` exceeds `core::kBincoeffMaxN`.
-inline void require_bincoeff_envelope(std::size_t n, const std::string& what) {
-    if (n > static_cast<std::size_t>(core::kBincoeffMaxN)) {
-        throw std::invalid_argument(
-            what + " needs binomial coefficients up to C(" + std::to_string(n)
-            + ", k), beyond the largest upper index " + std::to_string(core::kBincoeffMaxN)
-            + " that pantr's exact-integer binomial kernel can compute without an int64 "
-              "overflow. Past that the coefficients wrap silently and the result is "
-              "corrupted rather than merely inaccurate.");
-    }
-}
 
 /// Refuse a per-direction argument whose length is not the parametric dimension.
 ///
@@ -170,10 +151,10 @@ template <Real T>
     for (std::size_t d = 0; d < dim; ++d) {
         if (increments[d] > 0) {
             const std::size_t elevated = bezier.degree(d) + increments[d];
-            detail::require_bincoeff_envelope(elevated, "Degree elevation to degree "
-                                                            + std::to_string(elevated)
-                                                            + " in direction "
-                                                            + std::to_string(d));
+            core::require_bincoeff_envelope(static_cast<std::int64_t>(elevated),
+                                            "Degree elevation to degree "
+                                                + std::to_string(elevated) + " in direction "
+                                                + std::to_string(d));
         }
     }
 

--- a/cpp/include/pantr/bezier/product.hpp
+++ b/cpp/include/pantr/bezier/product.hpp
@@ -206,6 +206,7 @@
 /// Python to raise for it.
 
 #include <cstddef>
+#include <cstdint>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -216,6 +217,7 @@
 #include "pantr/bezier/bezier.hpp"
 #include "pantr/bezier/degree.hpp"
 #include "pantr/bezier/kernels_1d.hpp"
+#include "pantr/core/binomial.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/core/scalar.hpp"
 
@@ -904,9 +906,9 @@ template <Real T>
     // message is `_check_bincoeff_envelope`'s.
     if (use_1d_kernel && (dim_outer > 1 || outer.degree(0) > 1)) {
         const std::size_t composed = total_degree * inner.degree(0);
-        detail::require_bincoeff_envelope(composed, "Composition to degree "
-                                                        + std::to_string(composed)
-                                                        + " with a 1D inner Bézier");
+        core::require_bincoeff_envelope(static_cast<std::int64_t>(composed),
+                                        "Composition to degree " + std::to_string(composed)
+                                            + " with a 1D inner Bézier");
     }
 
     const std::size_t order = composition_table_order<T>(outer, inner);

--- a/cpp/include/pantr/bspline/degree.hpp
+++ b/cpp/include/pantr/bspline/degree.hpp
@@ -1,0 +1,871 @@
+#pragma once
+
+/// \file
+/// Changing a B-spline field's degree: the hodograph, and degree elevation.
+///
+/// Ports `pantr.bspline.Bspline.derivative` on its non-rational, degree-lowering path
+/// -- `_bspline_derivative.py`'s `_derivative_nonrational_nd` over `_derivative_ctrl_1d`
+/// -- and `pantr.bspline.Bspline.elevate_degree` on an open direction, whose substance
+/// is `_bspline_degree.py`'s `_degree_elevate_bspline` over `_bspline_degree_core.py`'s
+/// `_degree_elevate_1d_core` (Piegl and Tiller, *The NURBS Book*, A5.9). The Python side
+/// stays as the parity oracle.
+///
+/// ## What this file adds, and what it only calls
+///
+/// The two new numerics are `derivative_along_axis` and `degree_elevate_1d`. Everything
+/// structural around them is already here and is called rather than rewritten:
+/// `pantr/bspline/structural.hpp`'s `select_rows_along_axis` performs both of the
+/// derivative's periodic row moves -- the modulo expansion on the way in and the trim on
+/// the way out -- and its `extents_before`, `extents_after`, `require_axis` and
+/// `assemble` carry the axis bookkeeping. `pantr/bspline/knots.hpp`'s `num_basis` decides
+/// how many rows the trim keeps, and `pantr/core/binomial.hpp`'s `bincoeff` and
+/// `require_bincoeff_envelope` supply A5.9's coefficient table and the refusal that keeps
+/// it inside the exact-integer envelope.
+///
+/// So the only recurrences below are the two the oracle spells out itself.
+///
+/// ## Free functions, not methods
+///
+/// `pantr/bspline/bspline.hpp` lists these among the computations *over* a field rather
+/// than properties *of* one, and states that each is "a separate port over free functions
+/// taking a `const Bspline&`". `pantr/bspline/refinement.hpp` and
+/// `pantr/bspline/structural.hpp` draw the same line. So `derivative` and
+/// `elevate_degree` take a `const Bspline<T>&` and return a new field; the type has no
+/// mutator and this file adds none.
+///
+/// ## The floating-point discipline, quantity by quantity
+///
+/// **The derivative's coefficients are computed entirely in `T`, and nothing in them can
+/// fuse.** `_derivative_ctrl_1d` is plain numpy rather than a numba kernel, so NEP 50
+/// decides its widths: `knots[p + 1 : n + p] - knots[1 : n]` and `ctrl[1:] - ctrl[:-1]`
+/// are array expressions in the storage format, the Python `int` degree is *weak* and is
+/// converted to that format rather than promoting it, and `np.divide`'s output array is
+/// allocated at `diff.dtype`. Each output coefficient is therefore
+/// `fl(fl(p * fl(c[i+1] - c[i])) / fl(k[i+p+1] - k[i+1]))` with every rounding in `T`,
+/// which is what the sweep below computes operand for operand.
+///
+/// That expression contains no sum of a product, so **no site in it can contract**, and
+/// the bitwise claim for the hodograph is a property of the code rather than of the host.
+/// That is worth stating because the two sibling ports say the opposite of their own
+/// kernels: `pantr/bspline/refinement.hpp` and the elevation below both carry an
+/// `a * b + c * d` that a target with a fused multiply-add would contract, and both
+/// condition their claims on `pantr._pantr_cpp.__fp_contract__` per
+/// `design/backend_parity.md` Rule 7.
+///
+/// **A zero denominator produces an exact zero rather than a division.** The oracle
+/// divides under `where=denom != 0.0` into a pre-zeroed array, so an interior knot of
+/// multiplicity `degree + 1` -- a `C^-1` breakpoint, where the two sides share no
+/// coefficient -- leaves its derivative coefficient at zero without evaluating the
+/// quotient. The sweep skips the same rows. Reproducing the division instead would raise
+/// a division-by-zero the oracle deliberately never performs.
+///
+/// **Degree elevation mixes three widths inside one kernel, and every one of them had to
+/// be measured.** `design/backend_parity.md` Rule 9 says an accumulation width is a
+/// per-kernel fact; `_degree_elevate_1d_core` is sharper than that, because the width
+/// varies *within* the kernel and follows numba's SSA type inference rather than anything
+/// a reader can see. Its `tmp1` is assigned in four places, and the four do not agree:
+/// `alfs[q - s] * bpts[q, ii]` reads a `float64` table and is `float64`, while
+/// `alf * ic[i, ii]`, `gam * ebpts[kj, ii]` and `bet * ebpts[kj, ii]` read scalars that
+/// are themselves `T` and are `float32` on a `float32` net. `tmp2` is `float64` at all
+/// five of its assignments, because each carries the literal `1.0` or a `float64` table
+/// entry. `scripts/measure_bspline_degree_widths.py` prints numba's own inferred type for
+/// every one of these, so the table is reproducible rather than asserted:
+///
+/// | quantity | oracle's width at a `float32` net | what this file does |
+/// |---|---|---|
+/// | `bezalfs[j, i] = inv * C(d, j) * C(t, i - j)` | `float64` throughout | `double` throughout |
+/// | `alfs[q - mul - 1] = numer / (knots[a + q] - ua)` | divides in `T`, widens on the store | divides in `T`, stores into a `double` |
+/// | `bpts[q, ii] = tmp1 + tmp2` (Boehm insertion) | both terms `float64`, narrows on the store | both terms `double`, narrows on the store |
+/// | `ebpts[i, ii] += bezalfs[j, i] * bpts[j, ii]` | term `float64`, **narrows every term** | term `double`, narrows every term |
+/// | `ic[i, ii] = tmp1 + tmp2` and the two `ebpts` blends | `tmp1` in `T`, `tmp2` in `float64` | product in `T`, companion in `double` |
+///
+/// The last row is the one no reading of the source gives: `alf`, `gam` and `bet` are
+/// quotients of `T` knots and stay `T`, so `alf * ic[i, ii]` rounds to `float32` before it
+/// is added to a `float64` companion, and a C++ side that formed both products in `double`
+/// would be exact at `float64` and quietly wrong at `float32` -- which Rule 9 names as the
+/// half of the matrix nobody reads first.
+///
+/// **The elevated knot vector is written, not computed.** Every entry of `ik` is a copy of
+/// `ua` or `ub`, which are elements of the input vector, so the output knots carry no
+/// arithmetic at all and a difference there could only be a lost value or a miscount.
+///
+/// **The elevation sweeps outer blocks rather than transposing.** The oracle calls
+/// `_flatten_along_axis`, which is `np.moveaxis` plus `np.ascontiguousarray`: a
+/// permutation of values, not an arithmetic step. Under the `(outer, num_rows, inner)`
+/// reading this package uses, each outer block is already contiguous and is handed to the
+/// curve kernel as it stands, with `inner` in the role of A5.9's `rank`. Nothing in A5.9
+/// mixes two components -- every array it touches is indexed `[., ii]` and every scalar it
+/// forms is a function of the knots alone -- so the blocks are independent destinations
+/// and the permutation changes no operation and no operand.
+///
+/// The cost of not transposing is that the scalar bookkeeping runs once per outer block
+/// instead of once: `bezalfs`, `alfs`, and the `alf`/`bet`/`gam` blends are recomputed
+/// identically each time. That is also why the first block's knot vector is the one
+/// returned -- the bookkeeping reads the knots and the degree and nothing else, so every
+/// block writes the same vector.
+///
+/// ## What is not ported, and it is a declared boundary
+///
+/// **`reduce_degree` is not here, and neither is degree elevation on a periodic
+/// direction.** Both round-trip through conversions `pantr/bspline/structural.hpp` has
+/// already declared as its own boundary: `_degree_elevate_bspline` converts a periodic
+/// direction to its open form, elevates, and calls `_to_periodic_bspline_1d_impl` to
+/// convert it back, and `_degree_reduce_bspline` additionally calls
+/// `_remove_knot_bspline_1d_impl` for every interior breakpoint it has to coarsen. That
+/// file states why neither conversion is here -- each decides *whether an operation is
+/// admissible* by a tolerance on a geometric quantity, and the periodic one reaches
+/// `numpy.linalg.qr` for a least-squares residual whose factorization is LAPACK's on one
+/// side and Eigen's on the other. Porting either under cover of this file would be
+/// porting that operation, not this one.
+///
+/// So `elevate_degree` refuses a periodic direction that is to be elevated, exactly as
+/// `pantr/bspline/refinement.hpp` refuses one that is to receive knots; a direction with a
+/// zero increment is untouched and its space handle is carried over whatever it is.
+///
+/// **`elevate_degree` also refuses a direction whose knot vector is not clamped, and that
+/// one is a defect in the oracle rather than a missing port.** A5.9 walks one segment per
+/// knot run and stops when the run it is on reaches the last index of the vector, which
+/// only happens where the vector closes with `degree + 1` equal knots. Given an unclamped
+/// vector it walks past the end and reads `ctrl[b - degree + j]` for a `b` the coefficient
+/// array does not have. On a degree-3 curve over
+/// `[-0.3, -0.2, -0.1, 0, 0.25, 0.5, 0.75, 1, 1.1, 1.2, 1.3]` with seven coefficients the
+/// walk asks for `ctrl[7]`. Interpreted, under `NUMBA_DISABLE_JIT=1`, that call raises
+/// `IndexError: index 7 is out of bounds for axis 0 with size 7`; compiled, numba does not
+/// bounds check in `nopython` mode, so it returns whatever the read found and nothing
+/// reports it in the configuration the library normally runs in. What those last
+/// coefficients hold is not quoted here, because it is not a measurement of anything.
+/// `scripts/measure_bspline_degree_widths.py` prints both halves.
+///
+/// That is not a boundary this port may quietly adopt a different answer for, so the
+/// refusal is paired with a route: `pantr.bspline._degree_backend` sends an unclamped
+/// direction to the oracle, exactly as it sends a periodic one, and what the library
+/// accepts does not change with `PANTR_BACKEND`. What the refusal does buy is that the
+/// C++ core never performs the read, which in C++ would be undefined behaviour rather
+/// than a wrong number.
+///
+/// **`derivative` has no `keep_degree` parameter and no rational path, and the reason is
+/// not that they are hard.** Both are reachable in the oracle and both currently have an
+/// open defect, so there is nothing stable for a C++ side to be at parity with:
+///
+/// - `derivative(keep_degree=True)` on an **unclamped, non-periodic** direction returns a
+///   wrong function. Measured against a central finite difference, its worst error is
+///   18.5 where the plain path below gives 3.2e-10 on the same field.
+/// - the **rational** derivative raises a multiplicity error whenever the differentiated
+///   direction is periodic, so the call does not complete at all.
+///
+/// Both are with the repository's owner. A port pinned to a result that is about to change
+/// would have to be re-derived when it does, and a parity test over it would be asserting
+/// that two backends reproduce the same wrong answer -- which
+/// `design/backend_parity.md` opens by warning is invisible to every parity test that will
+/// ever be written. `keep_degree` is therefore absent from the signature rather than
+/// refused at run time: the strongest way to declare a boundary is not to offer the door.
+/// A rational field *is* refused, because `Bspline<T>` carries the flag and a C++ caller
+/// could hand one over.
+///
+/// ## Validating rather than asserting
+///
+/// This is the C++ counterpart of Layer 2, so it validates and throws in a release build
+/// as much as in a debug one, with the oracle's messages character for character.
+/// `pantr/core/error.hpp` sets the split: value and range checks here, type-kind checks in
+/// the Python wrapper.
+///
+/// Five of the refusals below are the oracle's **Layer 1** checks -- the direction range,
+/// the degree-0 derivative, and degree elevation's three argument checks. They are
+/// near-vacuous on the Python path, where `pantr.bspline.Bspline` has already made them,
+/// and load-bearing for a C++ caller with no wrapper in front of it. That is the same
+/// reason `pantr/bspline/refinement.hpp` restates three of `insert_knots`' Layer 1 checks.
+///
+/// One refusal of the oracle's cannot live here and stays the wrapper's:
+/// `Bspline.elevate_degree` accepts a bare `int` and broadcasts it over the directions,
+/// and a `std::span` cannot tell a scalar from a sequence of one.
+///
+/// ## Thread safety
+///
+/// Both entry points read their argument and allocate their result, and every type they
+/// touch is immutable. They are safe to call concurrently on the same field with no
+/// external locking, which is the contract `design/bspline_derived_caches.md` states for
+/// this package.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/knots.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/space_nd.hpp"
+#include "pantr/bspline/structural.hpp"
+#include "pantr/core/binomial.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bspline {
+
+/// Differentiate one axis of a row-major array by the B-spline derivative formula.
+///
+/// The array is read as `(outer, num_rows, inner)` and written as
+/// `(outer, num_rows - 1, inner)`, with
+///
+///     out(o, i, k) = degree * (values(o, i + 1, k) - values(o, i, k))
+///                    / (knots[i + degree + 1] - knots[i + 1]),
+///
+/// every operation in `T`, and an exact `T(0)` wherever that denominator vanishes. For a
+/// control net of shape `(e_0, ..., e_{d-1}, num_components)` differentiated along
+/// direction `d`, `outer` is the product of the extents before `d` and `inner` the
+/// product of those after it, the component axis included --
+/// `pantr/bspline/structural.hpp`'s own convention.
+///
+/// A vanishing denominator is an interior knot of multiplicity `degree + 1`, where the
+/// field is `C^-1` and the two sides share no coefficient. The oracle's
+/// `np.divide(..., where=denom != 0.0)` leaves the pre-zeroed output alone there, and so
+/// does this; the quotient is never formed.
+///
+/// \param knots The direction's knot vector, at least `num_rows + degree + 1` entries.
+/// \param degree The direction's polynomial degree, at least 1.
+/// \param values The coefficients, row-major under `(outer, num_rows, inner)`.
+/// \param num_rows The differentiated direction's extent in `values`.
+/// \param outer The product of the extents ahead of that axis; 1 when it is the first.
+/// \param inner The product of the extents behind it, component axis included.
+/// \return `outer * (num_rows - 1) * inner` coefficients, row-major.
+/// \throws std::invalid_argument If `degree` is below 1, if an extent is negative, if
+///         `num_rows` is below 2, if the knot vector is too short, or if `values.size()`
+///         is not `outer * num_rows * inner`.
+///
+/// \note Every rounding is in `T` and no site can contract; see the file comment for why
+///       that makes the claim independent of the host, unlike this file's elevation.
+template <Real T>
+[[nodiscard]] std::vector<T> derivative_along_axis(std::span<const T> knots, std::int64_t degree,
+                                                   std::span<const T> values,
+                                                   std::int64_t num_rows, std::int64_t outer,
+                                                   std::int64_t inner) {
+    if (degree < 1) {
+        throw std::invalid_argument("derivative_along_axis: the degree must be at least 1, got "
+                                    + std::to_string(degree) + ".");
+    }
+    if (outer < 0 || inner < 0) {
+        throw std::invalid_argument("derivative_along_axis: the extents are counts, so none of "
+                                    "them can be negative.");
+    }
+    if (num_rows < 2) {
+        throw std::invalid_argument("derivative_along_axis: a direction needs at least two "
+                                    "coefficients to differentiate, got "
+                                    + std::to_string(num_rows) + ".");
+    }
+    const auto knot_count = static_cast<std::int64_t>(knots.size());
+    if (knot_count < num_rows + degree + 1) {
+        throw std::invalid_argument(
+            "derivative_along_axis: " + std::to_string(num_rows) + " coefficients at degree "
+            + std::to_string(degree) + " need at least " + std::to_string(num_rows + degree + 1)
+            + " knots, got " + std::to_string(knot_count) + ".");
+    }
+    const std::int64_t expected = outer * num_rows * inner;
+    if (static_cast<std::int64_t>(values.size()) != expected) {
+        throw std::invalid_argument(
+            "derivative_along_axis: the buffer holds " + std::to_string(values.size())
+            + " coefficients and the shape (" + std::to_string(outer) + ", "
+            + std::to_string(num_rows) + ", " + std::to_string(inner) + ") needs "
+            + std::to_string(expected) + ".");
+    }
+
+    const std::int64_t out_rows = num_rows - 1;
+    std::vector<T> out(static_cast<std::size_t>(outer * out_rows * inner), T(0));
+
+    // The oracle forms the whole `denom` array before dividing, so it is built here too
+    // rather than recomputed per outer block: same subtraction, same operands, once.
+    std::vector<T> denominators(static_cast<std::size_t>(out_rows));
+    for (std::int64_t i = 0; i < out_rows; ++i) {
+        denominators[static_cast<std::size_t>(i)] =
+            knots[static_cast<std::size_t>(i + degree + 1)] - knots[static_cast<std::size_t>(i + 1)];
+    }
+
+    // Exact for every degree this library admits: `T` holds an integer below 2^24 at its
+    // narrowest, and `require_bincoeff_envelope` caps a degree at 61 well before that.
+    const T scale = static_cast<T>(degree);
+
+    for (std::int64_t o = 0; o < outer; ++o) {
+        const T* const in_block = values.data() + o * num_rows * inner;
+        T* const out_block = out.data() + o * out_rows * inner;
+        for (std::int64_t i = 0; i < out_rows; ++i) {
+            const T denominator = denominators[static_cast<std::size_t>(i)];
+            if (denominator == T(0)) {
+                // The oracle's `where=denom != 0.0`: the row keeps the zero it was
+                // allocated with, and the quotient is never formed.
+                continue;
+            }
+            const T* const lower = in_block + i * inner;
+            const T* const upper = in_block + (i + 1) * inner;
+            T* const row = out_block + i * inner;
+            for (std::int64_t k = 0; k < inner; ++k) {
+                // The oracle's `np.divide(degree * diff, denom, ...)`, operand for
+                // operand: the difference, then the scaling, then the single division,
+                // all three in `T`.
+                row[k] = scale * (upper[k] - lower[k]) / denominator;
+            }
+        }
+    }
+    return out;
+}
+
+/// One direction's coefficients and knots after degree elevation.
+///
+/// \tparam T The scalar type the coefficients and knots are stored in.
+template <Real T>
+struct ElevatedAxis {
+    /// The elevated coefficients, row-major under `(outer, num_rows, inner)`.
+    std::vector<T> values;
+    /// The elevated knot vector.
+    std::vector<T> knots;
+    /// The elevated direction's extent in `values`.
+    std::int64_t num_rows;
+};
+
+/// Degree-elevate one B-spline curve, Piegl and Tiller A5.9.
+///
+/// Elevation preserves smoothness: a breakpoint where the curve is `C^s` stays `C^s`, so
+/// its multiplicity goes from `m` to `m + increment`, which is what the knot-writing step
+/// emits. That includes `m = degree + 1`, a `C^-1` breakpoint -- the two adjacent Bézier
+/// segments share no coefficient there, so the segment after it starts contributing at its
+/// own index 0 rather than at 1. This is the oracle's amended A5.9 rather than the
+/// published one, in the two places `_degree_elevate_1d_core` says so: that `lbz = 0` case,
+/// and a `b <= m` loop bound in place of `b < m` so that a degree-0 curve keeps its last
+/// segment.
+///
+/// The output is over-allocated and trimmed, as the oracle does: neither side derives a
+/// tight size from the multiplicity structure, and deriving one here would be a second
+/// answer to a question the oracle answers by counting as it writes.
+///
+/// \param degree The curve's polynomial degree.
+/// \param coefficients The coefficients, row-major `(num_rows, rank)`.
+/// \param num_rows The number of coefficients, which is the space's basis count.
+/// \param rank The number of components per coefficient.
+/// \param knots The knot vector, at least `num_rows + degree + 1` entries, **clamped**:
+///        its last `degree + 1` entries must be equal, or the segment walk reads past the
+///        coefficients. `elevate_degree` refuses an unclamped direction for that reason;
+///        see the file comment.
+/// \param increment Degrees to add, at least 1. `degree + increment` must be inside the
+///        exact-integer binomial envelope; the caller establishes that.
+/// \return The elevated coefficients, knots and coefficient count.
+/// \throws std::invalid_argument If `degree` is negative, if `increment` is below 1, if an
+///         extent is below 1, if the knot vector is too short, or if
+///         `coefficients.size()` is not `num_rows * rank`.
+///
+/// \note The widths are the oracle's, site by site, and they are not uniform; the file
+///       comment tabulates them and names the script that measures them.
+template <Real T>
+[[nodiscard]] ElevatedAxis<T> degree_elevate_1d(std::int64_t degree,
+                                                std::span<const T> coefficients,
+                                                std::int64_t num_rows, std::int64_t rank,
+                                                std::span<const T> knots,
+                                                std::int64_t increment) {
+    if (degree < 0) {
+        throw std::invalid_argument("degree_elevate_1d: the degree is a count, so it cannot be "
+                                    "negative, got " + std::to_string(degree) + ".");
+    }
+    if (increment < 1) {
+        throw std::invalid_argument("degree_elevate_1d: the increment must be at least 1, got "
+                                    + std::to_string(increment) + ".");
+    }
+    if (num_rows < 1 || rank < 1) {
+        throw std::invalid_argument("degree_elevate_1d: a curve needs at least one coefficient "
+                                    "of at least one component.");
+    }
+    const auto knot_count = static_cast<std::int64_t>(knots.size());
+    if (knot_count < num_rows + degree + 1) {
+        throw std::invalid_argument(
+            "degree_elevate_1d: " + std::to_string(num_rows) + " coefficients at degree "
+            + std::to_string(degree) + " need at least " + std::to_string(num_rows + degree + 1)
+            + " knots, got " + std::to_string(knot_count) + ".");
+    }
+    if (static_cast<std::int64_t>(coefficients.size()) != num_rows * rank) {
+        throw std::invalid_argument(
+            "degree_elevate_1d: the buffer holds " + std::to_string(coefficients.size())
+            + " coefficients and the shape (" + std::to_string(num_rows) + ", "
+            + std::to_string(rank) + ") needs " + std::to_string(num_rows * rank) + ".");
+    }
+
+    const std::int64_t d = degree;
+    const std::int64_t t = increment;
+    const std::int64_t n = num_rows - 1;
+    const std::int64_t ph = d + t;
+    const std::int64_t ph2 = ph / 2;
+    const std::int64_t m = n + d + 1;
+
+    // The segment walk ends when a run of equal knots reaches index `m`, and nothing else
+    // stops it: without that run it steps past the coefficients. Checked here rather than
+    // assumed, because the oracle does not check it and reads out of bounds instead; the
+    // file comment records the measurement.
+    for (std::int64_t i = m - d; i < m; ++i) {
+        if (knots[static_cast<std::size_t>(i)] != knots[static_cast<std::size_t>(m)]) {
+            throw std::invalid_argument(
+                "degree_elevate_1d: the knot vector must close with " + std::to_string(d + 1)
+                + " equal knots, and knots[" + std::to_string(i) + "] differs from knots["
+                + std::to_string(m) + "].");
+        }
+    }
+
+    // `bezalfs` and `alfs` are `float64` in the oracle whatever the net stores, and
+    // `bpts`, `ebpts`, `next_bpts` and `ic` follow the net; see the file comment's table.
+    std::vector<double> bezalfs(static_cast<std::size_t>((d + 1) * (ph + 1)), 0.0);
+    std::vector<double> alfs(static_cast<std::size_t>(d), 0.0);
+    std::vector<T> bpts(static_cast<std::size_t>((d + 1) * rank), T(0));
+    std::vector<T> ebpts(static_cast<std::size_t>((ph + 1) * rank), T(0));
+    std::vector<T> next_bpts(static_cast<std::size_t>((d + 1) * rank), T(0));
+
+    const auto bez = [ph](std::int64_t j, std::int64_t i) {
+        return static_cast<std::size_t>(j * (ph + 1) + i);
+    };
+
+    bezalfs[bez(0, 0)] = 1.0;
+    bezalfs[bez(d, ph)] = 1.0;
+    for (std::int64_t i = 1; i <= ph2; ++i) {
+        const double inv = 1.0 / core::bincoeff(static_cast<int>(ph), static_cast<int>(i));
+        const std::int64_t mpi = std::min(d, i);
+        for (std::int64_t j = std::max<std::int64_t>(0, i - t); j <= mpi; ++j) {
+            bezalfs[bez(j, i)] = inv * core::bincoeff(static_cast<int>(d), static_cast<int>(j))
+                                 * core::bincoeff(static_cast<int>(t), static_cast<int>(i - j));
+        }
+    }
+    for (std::int64_t i = ph2 + 1; i < ph; ++i) {
+        const std::int64_t mpi = std::min(d, i);
+        for (std::int64_t j = std::max<std::int64_t>(0, i - t); j <= mpi; ++j) {
+            bezalfs[bez(j, i)] = bezalfs[bez(d - j, ph - i)];
+        }
+    }
+
+    std::int64_t kind = ph + 1;
+    std::int64_t r = -1;
+    std::int64_t a = d;
+    std::int64_t b = d + 1;
+    std::int64_t cind = 1;
+    T ua = knots[0];
+
+    // The oracle's own over-allocation, reproduced rather than tightened.
+    std::vector<T> ik(static_cast<std::size_t>(knot_count + t * knot_count), T(0));
+    std::vector<T> ic(static_cast<std::size_t>((num_rows + t * knot_count) * rank), T(0));
+
+    for (std::int64_t ii = 0; ii < rank; ++ii) {
+        ic[static_cast<std::size_t>(ii)] = coefficients[static_cast<std::size_t>(ii)];
+    }
+    for (std::int64_t i = 0; i <= ph; ++i) {
+        ik[static_cast<std::size_t>(i)] = ua;
+    }
+    for (std::int64_t i = 0; i <= d; ++i) {
+        for (std::int64_t ii = 0; ii < rank; ++ii) {
+            bpts[static_cast<std::size_t>(i * rank + ii)] =
+                coefficients[static_cast<std::size_t>(i * rank + ii)];
+        }
+    }
+
+    while (b <= m) {
+        const std::int64_t run_start = b;
+        while (b < m
+               && knots[static_cast<std::size_t>(b)] == knots[static_cast<std::size_t>(b + 1)]) {
+            ++b;
+        }
+        const std::int64_t mul = b - run_start + 1;
+        const T ub = knots[static_cast<std::size_t>(b)];
+        const std::int64_t oldr = r;
+        r = d - mul;
+
+        std::int64_t lbz = 1;
+        if (oldr > 0) {
+            lbz = (oldr + 2) / 2;
+        } else if (oldr < 0 && a != d) {
+            lbz = 0;
+        }
+        const std::int64_t rbz = (r > 0) ? ph - (r + 1) / 2 : ph;
+
+        if (r > 0) {
+            // `numer` and the knot difference are both `T`, so the quotient is formed in
+            // `T` and widens only on the store into a `float64` table.
+            const T numer = ub - ua;
+            for (std::int64_t q = d; q > mul; --q) {
+                alfs[static_cast<std::size_t>(q - mul - 1)] = static_cast<double>(
+                    numer / (knots[static_cast<std::size_t>(a + q)] - ua));
+            }
+            for (std::int64_t j = 1; j <= r; ++j) {
+                const std::int64_t save = r - j;
+                const std::int64_t s = mul + j;
+                for (std::int64_t q = d; q >= s; --q) {
+                    const double alf = alfs[static_cast<std::size_t>(q - s)];
+                    for (std::int64_t ii = 0; ii < rank; ++ii) {
+                        // Both terms are `float64` in the oracle -- a `float64` table entry
+                        // against a `T` array element -- and the sum narrows on the store.
+                        const double kept =
+                            alf * static_cast<double>(bpts[static_cast<std::size_t>(q * rank + ii)]);
+                        const double carried =
+                            (1.0 - alf)
+                            * static_cast<double>(bpts[static_cast<std::size_t>((q - 1) * rank + ii)]);
+                        bpts[static_cast<std::size_t>(q * rank + ii)] =
+                            static_cast<T>(kept + carried);
+                    }
+                }
+                for (std::int64_t ii = 0; ii < rank; ++ii) {
+                    next_bpts[static_cast<std::size_t>(save * rank + ii)] =
+                        bpts[static_cast<std::size_t>(d * rank + ii)];
+                }
+            }
+        }
+
+        for (std::int64_t i = lbz; i <= ph; ++i) {
+            for (std::int64_t ii = 0; ii < rank; ++ii) {
+                ebpts[static_cast<std::size_t>(i * rank + ii)] = T(0);
+            }
+            const std::int64_t mpi = std::min(d, i);
+            for (std::int64_t j = std::max<std::int64_t>(0, i - t); j <= mpi; ++j) {
+                for (std::int64_t ii = 0; ii < rank; ++ii) {
+                    // The oracle's `ebpts[i, ii] += bezalfs[j, i] * bpts[j, ii]`: a
+                    // `float64` term added to a `T` accumulator, so **every** term rounds
+                    // to `T` rather than the sum rounding once.
+                    const double term =
+                        bezalfs[bez(j, i)]
+                        * static_cast<double>(bpts[static_cast<std::size_t>(j * rank + ii)]);
+                    ebpts[static_cast<std::size_t>(i * rank + ii)] = static_cast<T>(
+                        static_cast<double>(ebpts[static_cast<std::size_t>(i * rank + ii)]) + term);
+                }
+            }
+        }
+
+        if (oldr > 1) {
+            std::int64_t first = kind - 2;
+            std::int64_t last = kind;
+            const T den = ub - ua;
+            const T bet = (ub - ik[static_cast<std::size_t>(kind - 1)]) / den;
+
+            for (std::int64_t tr = 1; tr < oldr; ++tr) {
+                std::int64_t i = first;
+                std::int64_t j = last;
+                std::int64_t kj = j - kind + 1;
+                while (j - i > tr) {
+                    if (i < cind) {
+                        const T alf = (ub - ik[static_cast<std::size_t>(i)])
+                                      / (ua - ik[static_cast<std::size_t>(i)]);
+                        for (std::int64_t ii = 0; ii < rank; ++ii) {
+                            // `alf` is `T`, so its product rounds to `T` before the sum;
+                            // the companion carries the literal `1.0` and is `double`.
+                            const T kept = alf * ic[static_cast<std::size_t>(i * rank + ii)];
+                            const double carried =
+                                (1.0 - static_cast<double>(alf))
+                                * static_cast<double>(ic[static_cast<std::size_t>((i - 1) * rank + ii)]);
+                            ic[static_cast<std::size_t>(i * rank + ii)] =
+                                static_cast<T>(static_cast<double>(kept) + carried);
+                        }
+                    }
+                    if (j >= lbz) {
+                        const T weight = (j - tr <= kind - ph + oldr)
+                                             ? (ub - ik[static_cast<std::size_t>(j - tr)]) / den
+                                             : bet;
+                        for (std::int64_t ii = 0; ii < rank; ++ii) {
+                            const T kept = weight * ebpts[static_cast<std::size_t>(kj * rank + ii)];
+                            const double carried =
+                                (1.0 - static_cast<double>(weight))
+                                * static_cast<double>(ebpts[static_cast<std::size_t>((kj + 1) * rank + ii)]);
+                            ebpts[static_cast<std::size_t>(kj * rank + ii)] =
+                                static_cast<T>(static_cast<double>(kept) + carried);
+                        }
+                    }
+                    ++i;
+                    --j;
+                    --kj;
+                }
+                --first;
+                ++last;
+            }
+        }
+
+        if (a != d) {
+            for (std::int64_t written = 0; written < ph - oldr; ++written) {
+                ik[static_cast<std::size_t>(kind)] = ua;
+                ++kind;
+            }
+        }
+
+        for (std::int64_t j = lbz; j <= rbz; ++j) {
+            for (std::int64_t ii = 0; ii < rank; ++ii) {
+                ic[static_cast<std::size_t>(cind * rank + ii)] =
+                    ebpts[static_cast<std::size_t>(j * rank + ii)];
+            }
+            ++cind;
+        }
+
+        if (b < m) {
+            for (std::int64_t j = 0; j < r; ++j) {
+                for (std::int64_t ii = 0; ii < rank; ++ii) {
+                    bpts[static_cast<std::size_t>(j * rank + ii)] =
+                        next_bpts[static_cast<std::size_t>(j * rank + ii)];
+                }
+            }
+            // The oracle's `for j in range(r, d + 1)`, whose `r` is `-1` at a `C^-1`
+            // breakpoint. Python indexes `bpts[-1]` as the last row and `ctrl[b - d - 1]`
+            // as a real row, so that pass writes row `d` from the coefficient before the
+            // segment -- and `j = d` then overwrites row `d` with `ctrl[b]`, which happens
+            // on every path since `d` is always in the range. The wrapped write is
+            // therefore dead, and skipping it is the same computation rather than an
+            // approximation of it. Reproducing the wrap instead would be reproducing an
+            // accident; performing the negative index is undefined behaviour here.
+            for (std::int64_t j = std::max<std::int64_t>(0, r); j <= d; ++j) {
+                for (std::int64_t ii = 0; ii < rank; ++ii) {
+                    bpts[static_cast<std::size_t>(j * rank + ii)] =
+                        coefficients[static_cast<std::size_t>((b - d + j) * rank + ii)];
+                }
+            }
+            a = b;
+            ++b;
+            ua = ub;
+        } else {
+            for (std::int64_t i = 0; i <= ph; ++i) {
+                ik[static_cast<std::size_t>(kind + i)] = ub;
+            }
+            break;
+        }
+    }
+
+    return ElevatedAxis<T>{
+        std::vector<T>(ic.begin(), ic.begin() + static_cast<std::ptrdiff_t>(cind * rank)),
+        std::vector<T>(ik.begin(), ik.begin() + static_cast<std::ptrdiff_t>(kind + ph + 1)), cind};
+}
+
+/// Degree-elevate one axis of a row-major array, block by block.
+///
+/// The array is read as `(outer, num_rows, inner)` and written as
+/// `(outer, elevated_rows, inner)`. Each outer block is contiguous and is handed to
+/// `degree_elevate_1d` as a curve of `inner` components; see the file comment for why the
+/// blocks are independent and why the first one's knot vector is the result's.
+///
+/// \param degree The direction's polynomial degree.
+/// \param knots The direction's knot vector.
+/// \param increment Degrees to add, at least 1.
+/// \param values The coefficients, row-major under `(outer, num_rows, inner)`.
+/// \param num_rows The elevated direction's extent in `values`.
+/// \param outer The product of the extents ahead of that axis; 1 when it is the first.
+/// \param inner The product of the extents behind it, component axis included.
+/// \return The elevated coefficients, knot vector and row count.
+/// \throws std::invalid_argument If an extent is negative, if `values.size()` is not
+///         `outer * num_rows * inner`, or if `degree_elevate_1d` refuses the block.
+template <Real T>
+[[nodiscard]] ElevatedAxis<T> elevate_along_axis(std::int64_t degree, std::span<const T> knots,
+                                                 std::int64_t increment, std::span<const T> values,
+                                                 std::int64_t num_rows, std::int64_t outer,
+                                                 std::int64_t inner) {
+    if (outer < 1 || inner < 1) {
+        throw std::invalid_argument("elevate_along_axis: the extents are counts, so neither of "
+                                    "them can be below one.");
+    }
+    const std::int64_t expected = outer * num_rows * inner;
+    if (static_cast<std::int64_t>(values.size()) != expected) {
+        throw std::invalid_argument(
+            "elevate_along_axis: the buffer holds " + std::to_string(values.size())
+            + " coefficients and the shape (" + std::to_string(outer) + ", "
+            + std::to_string(num_rows) + ", " + std::to_string(inner) + ") needs "
+            + std::to_string(expected) + ".");
+    }
+
+    ElevatedAxis<T> result{};
+    for (std::int64_t o = 0; o < outer; ++o) {
+        const std::span<const T> block =
+            values.subspan(static_cast<std::size_t>(o * num_rows * inner),
+                           static_cast<std::size_t>(num_rows * inner));
+        ElevatedAxis<T> elevated =
+            degree_elevate_1d<T>(degree, block, num_rows, inner, knots, increment);
+        if (o == 0) {
+            result.knots = std::move(elevated.knots);
+            result.num_rows = elevated.num_rows;
+            result.values.resize(static_cast<std::size_t>(outer * elevated.num_rows * inner));
+        }
+        std::copy(elevated.values.begin(), elevated.values.end(),
+                  result.values.begin()
+                      + static_cast<std::ptrdiff_t>(o * result.num_rows * inner));
+    }
+    return result;
+}
+
+/// The field's first partial derivative in one direction, as a B-spline field.
+///
+/// The hodograph: a field of degree `p - 1` in `direction` and unchanged degree elsewhere,
+/// whose value at every parametric point is this field's partial derivative there. The
+/// differentiated direction's knot vector loses its first and last entry; every other
+/// direction's space handle is carried into the result rather than rebuilt.
+///
+/// A periodic direction stays periodic. Its coefficients are expanded by their own modulo
+/// wrap to the count the knot vector implies, differentiated, and trimmed back to the
+/// periodic count the derivative's own knot vector implies -- which is
+/// `_derivative_nonrational_nd`'s route and reaches no boundary or periodic conversion.
+///
+/// \param field The field to differentiate. Must not be rational; see the file comment.
+/// \param direction The direction to differentiate, in `[0, field.dim())`.
+/// \return The hodograph.
+/// \throws std::invalid_argument If `direction` is out of range or its degree is 0, both
+///         with the oracle's Layer 1 messages, or if the field is rational.
+template <Real T>
+[[nodiscard]] Bspline<T> derivative(const Bspline<T>& field, std::int64_t direction) {
+    const BsplineSpace<T>& space = field.space_ref();
+    const std::int64_t dim = space.dim();
+    detail::require_axis("direction", direction, dim);
+
+    const BsplineSpace1D<T>& along = space.space_ref(direction);
+    const std::int64_t p = along.degree();
+    if (p < 1) {
+        throw std::invalid_argument("Derivative of a degree-0 B-spline is not defined.");
+    }
+    if (field.is_rational()) {
+        throw std::invalid_argument(
+            "the derivative of a rational B-spline is not part of pantr's C++ core; it "
+            "applies the quotient rule, and direction " + std::to_string(direction)
+            + " belongs to a rational field.");
+    }
+
+    const std::span<const T> knots = along.knots();
+    std::vector<std::size_t> shape(field.net().shape().begin(), field.net().shape().end());
+    const std::int64_t outer =
+        detail::extents_before(std::span<const std::size_t>(shape), direction);
+    const std::int64_t inner =
+        detail::extents_after(std::span<const std::size_t>(shape), direction);
+
+    std::vector<T> values(field.net().values().begin(), field.net().values().end());
+    auto num_rows = static_cast<std::int64_t>(shape[static_cast<std::size_t>(direction)]);
+
+    if (along.periodic()) {
+        // The oracle's `ctrl[np.arange(n_full) % n_periodic]`, spelled as the row list
+        // `select_rows_along_axis` already exists for.
+        const std::int64_t full = static_cast<std::int64_t>(knots.size()) - p - 1;
+        std::vector<std::int64_t> rows(static_cast<std::size_t>(full));
+        for (std::int64_t i = 0; i < full; ++i) {
+            rows[static_cast<std::size_t>(i)] = i % num_rows;
+        }
+        values = select_rows_along_axis<T>(std::span<const T>(values), num_rows,
+                                           std::span<const std::int64_t>(rows), outer, inner);
+        num_rows = full;
+    }
+
+    values = derivative_along_axis<T>(knots, p, std::span<const T>(values), num_rows, outer, inner);
+    std::int64_t out_rows = num_rows - 1;
+
+    // The oracle's `knots[1:-1]`, and the vector the trim's count is read off: the space
+    // built from it may snap a near-duplicate, and the count has to come from the same
+    // vector the oracle counts on.
+    const std::vector<T> derived_knots(knots.begin() + 1, knots.end() - 1);
+
+    if (along.periodic()) {
+        const std::int64_t kept = num_basis<T>(std::span<const T>(derived_knots), p - 1, true,
+                                               along.tolerance());
+        std::vector<std::int64_t> rows(static_cast<std::size_t>(kept));
+        for (std::int64_t i = 0; i < kept; ++i) {
+            rows[static_cast<std::size_t>(i)] = i;
+        }
+        values = select_rows_along_axis<T>(std::span<const T>(values), out_rows,
+                                           std::span<const std::int64_t>(rows), outer, inner);
+        out_rows = kept;
+    }
+
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions(space.spaces().begin(),
+                                                                     space.spaces().end());
+    directions[static_cast<std::size_t>(direction)] = std::make_shared<const BsplineSpace1D<T>>(
+        std::span<const T>(derived_knots), p - 1, along.periodic(),
+        KnotSnapping::merge_near_duplicates);
+    shape[static_cast<std::size_t>(direction)] = static_cast<std::size_t>(out_rows);
+
+    return detail::assemble<T>(std::move(directions), values, shape, false);
+}
+
+/// The field written at a higher degree, over the same geometry.
+///
+/// Exact: the elevated field is the same map, written on a richer space. Each direction
+/// with a positive increment has its degree raised by it and its knot vector re-emitted
+/// with every multiplicity raised by the same amount, which keeps the field's continuity
+/// at every breakpoint. A direction whose increment is zero is left alone and its space
+/// handle is carried into the result.
+///
+/// \param field The field to elevate.
+/// \param increments Degrees to add per direction, in axis order, `field.dim()` of them.
+///        At least one must be positive and none may be negative.
+/// \return The elevated field, rational exactly when `field` is.
+/// \throws std::invalid_argument If `increments` has the wrong length, if one is negative,
+///         if all are zero, if an elevated degree would leave the exact-integer binomial
+///         envelope, or if a direction to be elevated is periodic or unclamped.
+///
+/// \note The first four refusals are the oracle's, in the oracle's order: the argument
+///       checks first, then every direction's envelope check before any direction is
+///       elevated. The periodic and unclamped refusals are this file's own declared
+///       boundaries and are reached only after all of them.
+template <Real T>
+[[nodiscard]] Bspline<T> elevate_degree(const Bspline<T>& field,
+                                        std::span<const std::int64_t> increments) {
+    const BsplineSpace<T>& space = field.space_ref();
+    const std::int64_t dim = space.dim();
+    if (static_cast<std::int64_t>(increments.size()) != dim) {
+        throw std::invalid_argument("Number of degree increments ("
+                                    + std::to_string(increments.size())
+                                    + ") must match dimension (" + std::to_string(dim) + ").");
+    }
+    for (const std::int64_t increment : increments) {
+        if (increment < 0) {
+            throw std::invalid_argument("Degree increments must be non-negative.");
+        }
+    }
+    bool any = false;
+    for (const std::int64_t increment : increments) {
+        any = any || increment > 0;
+    }
+    if (!any) {
+        throw std::invalid_argument("At least one degree increment must be positive.");
+    }
+
+    // Every envelope check runs before any elevation, which is the oracle's order: two
+    // directions out of range must produce the first one's message on both sides.
+    for (std::int64_t d = 0; d < dim; ++d) {
+        const std::int64_t increment = increments[static_cast<std::size_t>(d)];
+        if (increment > 0) {
+            const std::int64_t elevated = space.space_ref(d).degree() + increment;
+            core::require_bincoeff_envelope(elevated, "Degree elevation to degree "
+                                                          + std::to_string(elevated)
+                                                          + " in direction " + std::to_string(d));
+        }
+    }
+
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions(space.spaces().begin(),
+                                                                     space.spaces().end());
+    std::vector<std::size_t> shape(field.net().shape().begin(), field.net().shape().end());
+    std::vector<T> values(field.net().values().begin(), field.net().values().end());
+
+    for (std::int64_t d = 0; d < dim; ++d) {
+        const std::int64_t increment = increments[static_cast<std::size_t>(d)];
+        if (increment == 0) {
+            continue;
+        }
+        const BsplineSpace1D<T>& along = *directions[static_cast<std::size_t>(d)];
+        if (along.periodic()) {
+            throw std::invalid_argument(
+                "elevating a periodic direction needs the open-to-periodic conversion, which "
+                "is not part of pantr's C++ core; direction "
+                + std::to_string(d) + " is periodic.");
+        }
+        if (!along.has_open_knots()) {
+            throw std::invalid_argument(
+                "elevating a direction whose knot vector is not clamped is not part of pantr's "
+                "C++ core: A5.9 walks segments until it reaches the closing run of `degree + 1` "
+                "equal knots, and direction "
+                + std::to_string(d) + " has none.");
+        }
+        const std::int64_t degree = along.degree();
+        ElevatedAxis<T> elevated = elevate_along_axis<T>(
+            degree, along.knots(), increment, std::span<const T>(values),
+            static_cast<std::int64_t>(shape[static_cast<std::size_t>(d)]),
+            detail::extents_before(std::span<const std::size_t>(shape), d),
+            detail::extents_after(std::span<const std::size_t>(shape), d));
+
+        values = std::move(elevated.values);
+        shape[static_cast<std::size_t>(d)] = static_cast<std::size_t>(elevated.num_rows);
+        directions[static_cast<std::size_t>(d)] = std::make_shared<const BsplineSpace1D<T>>(
+            std::span<const T>(elevated.knots), degree + increment, false,
+            KnotSnapping::merge_near_duplicates);
+    }
+
+    return detail::assemble<T>(std::move(directions), values, shape, field.is_rational());
+}
+
+}  // namespace pantr::bspline

--- a/cpp/include/pantr/bspline/degree.hpp
+++ b/cpp/include/pantr/bspline/degree.hpp
@@ -85,6 +85,20 @@
 /// would be exact at `float64` and quietly wrong at `float32` -- which Rule 9 names as the
 /// half of the matrix nobody reads first.
 ///
+/// **The companion halves of those last three blends are the one place in the table where
+/// the width cannot matter, and saying so is what stops the parity suite being asked for
+/// a case that does not exist.** All three weights are at least one: `ik` is built
+/// non-decreasingly out of knots at or below the segment's own left endpoint `ua`, so
+/// `alf = (ub - ik[i]) / (ua - ik[i])` and `bet`, `gam` = `(ub - ik[.]) / (ub - ua)` each
+/// have a numerator at least their denominator. For any `w >= 1` representable in `float`,
+/// `float(1) - w` is exact -- the exact difference is a multiple of `ulp(w)` and lands in a
+/// binade whose own `ulp` is no coarser -- so it equals `1.0 - double(w)` bit for bit.
+/// Written in the storage format or in `double`, that subtraction is the same number, and
+/// a mutation of it passes every parity test there could be. Measured over a sweep of
+/// three thousand knot vectors to degree 8: the smallest `alf` was 1.0007, the smallest
+/// `bet` 1.0001 and the smallest `gam` 1.0073, and `float(1) - w` was inexact on none of
+/// 200000 sampled `w >= 1`.
+///
 /// **The elevated knot vector is written, not computed.** Every entry of `ik` is a copy of
 /// `ua` or `ub`, which are elements of the input vector, so the output knots carry no
 /// arithmetic at all and a difference there could only be a lost value or a miscount.
@@ -148,8 +162,13 @@
 /// open defect, so there is nothing stable for a C++ side to be at parity with:
 ///
 /// - `derivative(keep_degree=True)` on an **unclamped, non-periodic** direction returns a
-///   wrong function. Measured against a central finite difference, its worst error is
-///   18.5 where the plain path below gives 3.2e-10 on the same field.
+///   wrong function, and the cause is very likely the one the next section documents:
+///   that path re-elevates through A5.9, and the vector it hands it is `knots[1:-1]` of
+///   an unclamped vector, which is unclamped too -- so it meets the same out-of-bounds
+///   walk. On a curve where the counts happen to line up the walk returns rather than
+///   raising and the result is simply wrong; on one where they do not, the field's own
+///   constructor refuses it on the coefficient count. No figure is quoted for how wrong,
+///   because none taken here would be reproducible by anything in this tree.
 /// - the **rational** derivative raises a multiplicity error whenever the differentiated
 ///   direction is periodic, so the call does not complete at all.
 ///
@@ -283,8 +302,11 @@ template <Real T>
             knots[static_cast<std::size_t>(i + degree + 1)] - knots[static_cast<std::size_t>(i + 1)];
     }
 
-    // Exact for every degree this library admits: `T` holds an integer below 2^24 at its
-    // narrowest, and `require_bincoeff_envelope` caps a degree at 61 well before that.
+    // Exact while `degree` is below 2^24, which is where `float` stops holding every
+    // integer. Nothing on this path enforces that -- `require_bincoeff_envelope` guards
+    // the elevation below and not the hodograph, and `BsplineSpace1D` caps no degree at
+    // construction -- so it is a property of the degrees anyone builds rather than of a
+    // check, and it is said that way rather than attributed to one.
     const T scale = static_cast<T>(degree);
 
     for (std::int64_t o = 0; o < outer; ++o) {
@@ -600,14 +622,17 @@ template <Real T>
                         next_bpts[static_cast<std::size_t>(j * rank + ii)];
                 }
             }
-            // The oracle's `for j in range(r, d + 1)`, whose `r` is `-1` at a `C^-1`
-            // breakpoint. Python indexes `bpts[-1]` as the last row and `ctrl[b - d - 1]`
-            // as a real row, so that pass writes row `d` from the coefficient before the
-            // segment -- and `j = d` then overwrites row `d` with `ctrl[b]`, which happens
-            // on every path since `d` is always in the range. The wrapped write is
-            // therefore dead, and skipping it is the same computation rather than an
-            // approximation of it. Reproducing the wrap instead would be reproducing an
-            // accident; performing the negative index is undefined behaviour here.
+            // The oracle's `for j in range(r, d + 1)`, whose `r` is negative at a `C^-1`
+            // breakpoint -- `-1` there, and `r = d - mul` cannot go below that for a
+            // multiplicity within `degree + 1`. Python indexes `bpts[j]` for a negative
+            // `j` as row `d + 1 + j` and reads `ctrl[b - d + j]` as a real row, so each
+            // such pass writes a row from a coefficient before the segment; and the
+            // matching non-negative `j = d + 1 + j` later in the *same* range overwrites
+            // that row, since the range runs to `d` and `j` increases monotonically
+            // through it. Every wrapped write is therefore dead whatever `r` is, and
+            // skipping it is the same computation rather than an approximation of it.
+            // Reproducing the wrap would be reproducing an accident; performing the
+            // negative index is undefined behaviour here.
             for (std::int64_t j = std::max<std::int64_t>(0, r); j <= d; ++j) {
                 for (std::int64_t ii = 0; ii < rank; ++ii) {
                     bpts[static_cast<std::size_t>(j * rank + ii)] =

--- a/cpp/include/pantr/bspline/degree.hpp
+++ b/cpp/include/pantr/bspline/degree.hpp
@@ -90,9 +90,13 @@
 /// a case that does not exist.** All three weights are at least one: `ik` is built
 /// non-decreasingly out of knots at or below the segment's own left endpoint `ua`, so
 /// `alf = (ub - ik[i]) / (ua - ik[i])` and `bet`, `gam` = `(ub - ik[.]) / (ub - ua)` each
-/// have a numerator at least their denominator. For any `w >= 1` representable in `float`,
-/// `float(1) - w` is exact -- the exact difference is a multiple of `ulp(w)` and lands in a
-/// binade whose own `ulp` is no coarser -- so it equals `1.0 - double(w)` bit for bit.
+/// have a numerator at least their denominator. For `1 <= w < 2^24` in `float`,
+/// `float(1) - w` is exact -- the exact difference is a multiple of `ulp(w)`, and `1` is
+/// itself such a multiple exactly while `ulp(w) <= 1`, which is the `2^24` -- so it equals
+/// `1.0 - double(w)` bit for bit. The upper hypothesis is real rather than a formality:
+/// `float(1) - 16777218` is off by one ulp. It holds here because these weights are ratios
+/// of knot differences within one vector, and a vector whose spans differ by a factor of
+/// `2^24` has other problems; a sweep of three thousand vectors to degree 8 reached 623.
 /// Written in the storage format or in `double`, that subtraction is the same number, and
 /// a mutation of it passes every parity test there could be. Measured over a sweep of
 /// three thousand knot vectors to degree 8: the smallest `alf` was 1.0007, the smallest

--- a/cpp/include/pantr/core/binomial.hpp
+++ b/cpp/include/pantr/core/binomial.hpp
@@ -30,16 +30,22 @@
 ///
 /// **The consequence of exceeding it is not shared.** Numba wraps on int64
 /// overflow and returns a corrupted value; in C++ signed overflow is undefined
-/// behaviour, so the same input is worse here than there. The two callers in
-/// `bezier` are guarded on the Python side by `_check_bincoeff_envelope`, which
-/// runs in Layer 2 before any kernel is entered, and `cpp/bindings/bezier.cpp`
-/// re-checks it for a caller that reaches the extension directly. `bincoeff` is the
-/// Layer 3 form and validates nothing, as Layer 3 does not.
+/// behaviour, so the same input is worse here than there. The callers in
+/// `bezier` and `bspline` are guarded on the Python side by
+/// `_check_bincoeff_envelope`, which runs in Layer 2 before any kernel is entered,
+/// and `require_bincoeff_envelope` below re-checks it for a caller that reaches the
+/// C++ core directly. `bincoeff` is the Layer 3 form and validates nothing, as Layer
+/// 3 does not.
 ///
 /// A `checked_bincoeff` wrapper lived here briefly and was deleted as dead code. It
 /// had no caller, and the binding had independently written the same check with a
 /// different message -- which is the divergence this file's first paragraph warns
-/// about, one layer up. The check now exists once.
+/// about, one layer up. `require_bincoeff_envelope` is that check rewritten with
+/// callers: `pantr/bezier/degree.hpp`, `pantr/bezier/product.hpp` and
+/// `pantr/bspline/degree.hpp` share it, and it carries the oracle's message verbatim.
+/// `cpp/bindings/bezier.cpp` still phrases its own refusal differently for the two
+/// Bézier entry points a Python caller reaches directly; that one is a binding
+/// concern rather than a second answer to this question.
 ///
 /// ## The other answer to the same question, and why both are here
 ///
@@ -66,6 +72,8 @@
 /// rounded operand is all a ratio can use.
 
 #include <cstdint>
+#include <stdexcept>
+#include <string>
 
 namespace pantr::core {
 
@@ -90,8 +98,7 @@ inline constexpr int kBincoeffExactDoubleMaxN = 56;
 ///
 /// \note No input validation is performed. Passing `n > kBincoeffMaxN` is
 ///       undefined behaviour, not a wrong answer. The caller establishes the
-///       envelope; `cpp/bindings/bezier.cpp`'s `require_bincoeff_envelope` is where
-///       the library does so.
+///       envelope; `require_bincoeff_envelope` below is where the library does so.
 [[nodiscard]] constexpr double bincoeff(int n, int k) noexcept {
     if (k < 0 || k > n) {
         return 0.0;
@@ -120,6 +127,32 @@ inline constexpr int kBincoeffExactDoubleMaxN = 56;
 [[nodiscard]] constexpr std::int64_t wrapping_mul(std::int64_t a, std::int64_t b) noexcept {
     return static_cast<std::int64_t>(static_cast<std::uint64_t>(a) *
                                      static_cast<std::uint64_t>(b));
+}
+
+/// Refuse an upper index the exact-integer recurrence cannot reach.
+///
+/// The message is the oracle's, character for character
+/// (`pantr.bspline._bspline_degree_core._check_bincoeff_envelope`), because the parity
+/// suites compare it.
+///
+/// It lives here rather than beside either caller for this file's opening reason: two
+/// packages need the same refusal, and the message has to match the oracle's exactly, so
+/// two copies of it is how the two come to refuse the same degree in different words.
+/// `cpp/bindings/bezier.cpp` still carries a third spelling with its own wording, for the
+/// Bézier entry points a Python caller reaches directly.
+///
+/// \param n Largest upper index the computation will need.
+/// \param what Description of the operation, opening the message.
+/// \throws std::invalid_argument If `n` exceeds `kBincoeffMaxN`.
+inline void require_bincoeff_envelope(std::int64_t n, const std::string& what) {
+    if (n > kBincoeffMaxN) {
+        throw std::invalid_argument(
+            what + " needs binomial coefficients up to C(" + std::to_string(n)
+            + ", k), beyond the largest upper index " + std::to_string(kBincoeffMaxN)
+            + " that pantr's exact-integer binomial kernel can compute without an int64 "
+              "overflow. Past that the coefficients wrap silently and the result is "
+              "corrupted rather than merely inaccurate.");
+    }
 }
 
 }  // namespace pantr::core

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(PANTR_TEST_SOURCES
     test_bspline_knot_insertion.cpp
     test_bspline_refinement.cpp
     test_bspline_structural.cpp
+    test_bspline_degree.cpp
     test_thb_space.cpp
     test_bspline_type.cpp)
 

--- a/cpp/tests/test_bspline_degree.cpp
+++ b/cpp/tests/test_bspline_degree.cpp
@@ -51,9 +51,14 @@
 ///    the input the formula then propagates: `1`.
 ///  - **The formula itself**: the coefficient difference, the knot difference, the
 ///    scaling by the degree and the division: `4`.
-///  - **The store into the result**, symmetric to the cast in: `1`.
+///  - **The multiply by `r`** on the expected side, which turns `e_{r-1}`'s closed form
+///    into `r u^{r-1}`'s: `1`.
+///  - **The store into the result**: `1`. It is charged although the quotient is already
+///    in the storage format and writing it costs nothing -- over-charging by one is the
+///    conservative direction and keeps this count the same shape as the elevation's.
 ///
-/// `K = 4p + 5`. The magnitude is **not** the result's own: the difference
+/// `K = 4p + 7`, which is what `hodograph_roundings` returns. The magnitude is **not**
+/// the result's own: the difference
 /// `A_{i+1} - A_i` can cancel to nothing while its operands do not, so the relative
 /// budget has to be charged against what was subtracted. Rule 2 of
 /// `design/backend_parity.md` is the same point in the other direction. So
@@ -89,11 +94,16 @@
 ///  - the two `e_r` recurrences, on the input vector at degree `p` and on the elevated
 ///    one at degree `p + t`: `2p + 1` and `2(p + t) + 1`;
 ///  - the cast in and the store out: `2`;
-///  - **the kernel's own chain**, `min(p, t) + 1` stages of three accumulator roundings
-///    each. That stage count is `design/backend_parity.md` Rule 10's for the Bézier
-///    elevation and it is the right one here for the same reason: the accumulation into
-///    `ebpts[i]` runs `j` from `max(0, i - t)` to `min(p, i)`. Charging `p + 1` instead
-///    is the over-count that rule records.
+///  - **the kernel's own chain**, four roundings per stage -- three in the accumulator and
+///    one narrowing store, which is `Roundings(stages, 3, 1)` in the parity harness's
+///    vocabulary. A5.9's chain has three blocks and an earlier version of this file
+///    charged only the middle one: at most `p - 1` Boehm insertion passes, then
+///    `min(p, t) + 1` terms accumulated into one elevated Bézier coefficient, then at most
+///    `p - 2` knot-removal passes. The middle count is
+///    `design/backend_parity.md` Rule 10's own for the Bézier elevation, and it is right
+///    here for the same reason -- the accumulation into `ebpts[i]` runs `j` from
+///    `max(0, i - t)` to `min(p, i)` -- while charging `p + 1` for it is the over-count
+///    that rule records. `elevation_stages` and `elevation_roundings` are the two counts.
 ///
 /// The test asserts that the majorant **dominates** every observed deviation, which is
 /// the premise, and separately that the bound is **approached** rather than merely
@@ -163,6 +173,58 @@ double gamma_of(std::int64_t m) {
 template <class T>
 double underflow_floor() {
     return static_cast<double>(std::numeric_limits<T>::min());
+}
+
+/// Roundings on the comparison between a hodograph and Marsden's closed form.
+///
+/// Counted rather than fitted, and itemised in the file comment: `2p + 1` for the input
+/// window's `e_r` recurrence, `2p - 1` for the derived window's at degree `p - 1`, one for
+/// the cast of the closed form into the field's storage, four for the formula itself, one
+/// for the multiply by `r` on the expected side, and one for the store.
+///
+/// The store is charged although the quotient is already in the storage format and writing
+/// it costs nothing. Over-charging by one is the conservative direction and it keeps the
+/// count the same shape as the elevation's.
+///
+/// \param degree The original degree.
+/// \return `4 * degree + 7`.
+std::int64_t hodograph_roundings(std::int64_t degree) {
+    return 4 * degree + 7;
+}
+
+/// Stages in A5.9's dependency chain from an input coefficient to an output one.
+///
+/// Three blocks contribute, and an earlier version of this file charged only the middle
+/// one: at most `degree - 1` Boehm insertion passes (`for j in 1..r`, `r = degree - mul`),
+/// then `min(degree, increment) + 1` terms accumulated into one elevated Bezier
+/// coefficient -- which is `design/backend_parity.md` Rule 10's own count for the Bezier
+/// elevation, and the count that rule records charging `p + 1` for by mistake -- then at
+/// most `degree - 2` knot-removal passes (`for tr in 1..oldr - 1`, `oldr <= degree - 1`).
+///
+/// \param degree The original degree.
+/// \param increment Degrees added.
+/// \return The stage count, at least one.
+std::int64_t elevation_stages(std::int64_t degree, std::int64_t increment) {
+    const std::int64_t boehm = std::max<std::int64_t>(0, degree - 1);
+    const std::int64_t removal = std::max<std::int64_t>(0, degree - 2);
+    return std::max<std::int64_t>(1, boehm + std::min(degree, increment) + 1 + removal);
+}
+
+/// Roundings on the comparison between an elevated curve and Marsden's closed form.
+///
+/// `2p + 1` for the input window's `e_r` recurrence and `2(p + t) + 1` for the elevated
+/// window's, one for the cast into the field's storage and one for the store, and four per
+/// stage of :func:`elevation_stages` -- three in the accumulator and one narrowing store,
+/// which is `Roundings(stages, 3, 1)` in the parity harness's vocabulary. The accumulator
+/// roundings are charged at the storage format's unit roundoff although they happen in
+/// `double`; that over-states the `float32` case and keeps one derivation for both.
+///
+/// \param degree The original degree.
+/// \param increment Degrees added.
+/// \return The rounding count.
+std::int64_t elevation_roundings(std::int64_t degree, std::int64_t increment) {
+    return (2 * degree + 1) + (2 * (degree + increment) + 1) + 2
+           + 4 * elevation_stages(degree, increment);
 }
 
 /// The binomial coefficient `C(n, k)`, by the multiplicative form.
@@ -464,9 +526,7 @@ Margin check_elevation_case(const std::vector<T>& knots, std::int64_t degree,
                         label + ": the majorant and the elevation disagree on the coefficient "
                                 "count, so one of them walked a different set of segments");
 
-        const std::int64_t stages = std::min(degree, increment) + 1;
-        const std::int64_t roundings =
-            (2 * degree + 1) + (2 * (degree + increment) + 1) + 2 + 3 * stages;
+        const std::int64_t roundings = elevation_roundings(degree, increment);
         const double relative = gamma_of<T>(roundings);
         const double floor = static_cast<double>(roundings) * underflow_floor<T>();
         for (std::size_t i = 0; i < expected.size(); ++i) {
@@ -597,7 +657,7 @@ void check_the_hodograph_is_the_analytic_derivative(const std::string& label) {
                 }
             }
 
-            const std::int64_t roundings = (2 * p + 1) + (2 * (p - 1) + 1) + 2 + 4;
+            const std::int64_t roundings = hodograph_roundings(p);
             const double relative = gamma_of<T>(roundings);
             const double floor = static_cast<double>(roundings) * underflow_floor<T>();
             const std::span<const T> got = hodograph.net().values();
@@ -792,13 +852,22 @@ void check_the_axis_sweeps_touch_only_their_own_axis() {
                 for (std::size_t j = 0; j < table_second.size(); ++j) {
                     const double want = static_cast<double>(r0) * lowered_first[i]
                                         * table_second[j];
-                    const double bound =
-                        gamma_of<double>(8 * degree_second + 16)
-                            * (std::abs(static_cast<double>(degree_first)
-                                        * (std::abs(table_first[i]) + std::abs(table_first[i + 1]))
-                                        / std::abs(first[i + degree_first + 1] - first[i + 1]))
-                               * std::abs(table_second[j]))
-                        + 16.0 * underflow_floor<double>();
+                    // The 1-D hodograph budget plus what the second direction adds: its
+                    // own `e_r` recurrence, the product that forms the net value, and the
+                    // product that forms the expected one.
+                    const std::int64_t roundings =
+                        hodograph_roundings(degree_first) + (2 * degree_second + 1) + 2;
+                    // The 1-D amplification in the differentiated direction, times the
+                    // untouched direction's factor, which the sweep carries through
+                    // unchanged.
+                    const double amplification =
+                        static_cast<double>(degree_first)
+                        * (std::abs(table_first[i]) + std::abs(table_first[i + 1]))
+                        / std::abs(first[i + degree_first + 1] - first[i + 1])
+                        * std::abs(table_second[j]);
+                    const double bound = gamma_of<double>(roundings) * amplification
+                                         + static_cast<double>(roundings)
+                                               * underflow_floor<double>();
                     PANTR_CHECK_MSG(
                         std::abs(got_first[i * table_second.size() + j] - want) <= bound,
                         "differentiating direction 0 gave a wrong fibre at ("
@@ -823,9 +892,11 @@ void check_the_axis_sweeps_touch_only_their_own_axis() {
             }
             const std::vector<double> amplification =
                 elevate_majorant(degree_second, magnitudes, second, 2);
-            const std::int64_t roundings = (2 * degree_second + 1)
-                                           + (2 * (degree_second + 2) + 1) + 2
-                                           + 3 * (std::min<std::int64_t>(degree_second, 2) + 1);
+            // The 1-D elevation budget plus what the untouched direction adds: its own
+            // `e_r` recurrence and the two products, one forming the net value and one the
+            // expected one.
+            const std::int64_t roundings =
+                elevation_roundings(degree_second, 2) + (2 * degree_first + 1) + 2;
             for (std::size_t i = 0; i < table_first.size(); ++i) {
                 for (std::size_t j = 0; j < raised_second.size(); ++j) {
                     const double want = table_first[i] * raised_second[j];

--- a/cpp/tests/test_bspline_degree.cpp
+++ b/cpp/tests/test_bspline_degree.cpp
@@ -94,16 +94,15 @@
 ///  - the two `e_r` recurrences, on the input vector at degree `p` and on the elevated
 ///    one at degree `p + t`: `2p + 1` and `2(p + t) + 1`;
 ///  - the cast in and the store out: `2`;
-///  - **the kernel's own chain**, four roundings per stage -- three in the accumulator and
-///    one narrowing store, which is `Roundings(stages, 3, 1)` in the parity harness's
-///    vocabulary. A5.9's chain has three blocks and an earlier version of this file
-///    charged only the middle one: at most `p - 1` Boehm insertion passes, then
-///    `min(p, t) + 1` terms accumulated into one elevated Bézier coefficient, then at most
-///    `p - 2` knot-removal passes. The middle count is
-///    `design/backend_parity.md` Rule 10's own for the Bézier elevation, and it is right
-///    here for the same reason -- the accumulation into `ebpts[i]` runs `j` from
-///    `max(0, i - t)` to `min(p, i)` -- while charging `p + 1` for it is the over-count
-///    that rule records. `elevation_stages` and `elevation_roundings` are the two counts.
+///  - **the kernel's own chain**, whose three blocks do not cost the same and are counted
+///    separately by `elevation_chain_roundings`: at most `p - 1` Boehm insertion passes at
+///    five roundings each, `min(p, t) + 1` accumulated terms at three, and at most `p - 2`
+///    knot-removal passes at five. The middle count is `design/backend_parity.md`
+///    Rule 10's own for the Bézier elevation, and it is right here for the same reason --
+///    the accumulation into `ebpts[i]` runs `j` from `max(0, i - t)` to `min(p, i)` --
+///    while charging `p + 1` for it is the over-count that rule records. Charging a flat
+///    count across the three blocks is what an earlier version did, and it under-charges
+///    the two blend blocks by two roundings each.
 ///
 /// The test asserts that the majorant **dominates** every observed deviation, which is
 /// the premise, and separately that the bound is **approached** rather than merely
@@ -192,39 +191,47 @@ std::int64_t hodograph_roundings(std::int64_t degree) {
     return 4 * degree + 7;
 }
 
-/// Stages in A5.9's dependency chain from an input coefficient to an output one.
+/// Roundings A5.9's own chain commits along a path from an input coefficient to an output.
 ///
-/// Three blocks contribute, and an earlier version of this file charged only the middle
-/// one: at most `degree - 1` Boehm insertion passes (`for j in 1..r`, `r = degree - mul`),
-/// then `min(degree, increment) + 1` terms accumulated into one elevated Bezier
-/// coefficient -- which is `design/backend_parity.md` Rule 10's own count for the Bezier
-/// elevation, and the count that rule records charging `p + 1` for by mistake -- then at
-/// most `degree - 2` knot-removal passes (`for tr in 1..oldr - 1`, `oldr <= degree - 1`).
+/// Three blocks contribute and they do not cost the same, which two earlier versions of
+/// this file got wrong in opposite directions -- the first charged only the middle block,
+/// the second charged all three at a flat four:
+///
+///  - at most `degree - 1` **Boehm insertion** passes (`for j in 1..r`,
+///    `r = degree - mul`), each `bpts[q] = alf * bpts[q] + (1 - alf) * bpts[q-1]`: one
+///    subtraction, two multiplications, one addition and one narrowing store, so **five**;
+///  - `min(degree, increment) + 1` terms accumulated into one elevated Bézier coefficient,
+///    each `ebpts[i] += bezalfs[j, i] * bpts[j]`: one multiplication, one addition and one
+///    narrowing store, so **three**. That term count is `design/backend_parity.md`
+///    Rule 10's own for the Bézier elevation, and the count that rule records charging
+///    `p + 1` for by mistake;
+///  - at most `degree - 2` **knot-removal** passes (`for tr in 1..oldr - 1`,
+///    `oldr <= degree - 1`), each the same shape as a Boehm pass, so **five**.
 ///
 /// \param degree The original degree.
 /// \param increment Degrees added.
-/// \return The stage count, at least one.
-std::int64_t elevation_stages(std::int64_t degree, std::int64_t increment) {
-    const std::int64_t boehm = std::max<std::int64_t>(0, degree - 1);
-    const std::int64_t removal = std::max<std::int64_t>(0, degree - 2);
-    return std::max<std::int64_t>(1, boehm + std::min(degree, increment) + 1 + removal);
+/// \return The rounding count, at least one.
+std::int64_t elevation_chain_roundings(std::int64_t degree, std::int64_t increment) {
+    const std::int64_t boehm = 5 * std::max<std::int64_t>(0, degree - 1);
+    const std::int64_t accumulation = 3 * (std::min(degree, increment) + 1);
+    const std::int64_t removal = 5 * std::max<std::int64_t>(0, degree - 2);
+    return std::max<std::int64_t>(1, boehm + accumulation + removal);
 }
 
 /// Roundings on the comparison between an elevated curve and Marsden's closed form.
 ///
 /// `2p + 1` for the input window's `e_r` recurrence and `2(p + t) + 1` for the elevated
-/// window's, one for the cast into the field's storage and one for the store, and four per
-/// stage of :func:`elevation_stages` -- three in the accumulator and one narrowing store,
-/// which is `Roundings(stages, 3, 1)` in the parity harness's vocabulary. The accumulator
-/// roundings are charged at the storage format's unit roundoff although they happen in
-/// `double`; that over-states the `float32` case and keeps one derivation for both.
+/// window's, one for the cast into the field's storage and one for the store, and
+/// :func:`elevation_chain_roundings` for the kernel itself. Every one is charged at the
+/// storage format's unit roundoff, including the ones that happen in `double`; that
+/// over-states the `float32` case and keeps one derivation for both.
 ///
 /// \param degree The original degree.
 /// \param increment Degrees added.
 /// \return The rounding count.
 std::int64_t elevation_roundings(std::int64_t degree, std::int64_t increment) {
     return (2 * degree + 1) + (2 * (degree + increment) + 1) + 2
-           + 4 * elevation_stages(degree, increment);
+           + elevation_chain_roundings(degree, increment);
 }
 
 /// The binomial coefficient `C(n, k)`, by the multiplicative form.

--- a/cpp/tests/test_bspline_degree.cpp
+++ b/cpp/tests/test_bspline_degree.cpp
@@ -1,0 +1,1075 @@
+/// \file
+/// Changing a B-spline field's degree: the hodograph, and degree elevation.
+///
+/// ## The independent oracle, and why it is not a rerun of the code
+///
+/// Both operations are checked against **Marsden's identity**, which gives the B-spline
+/// coefficients of a monomial in closed form. For a knot vector `t` and degree `p`,
+///
+///     u^r = sum_i [ e_r(t_{i+1}, ..., t_{i+p}) / C(p, r) ] * N_{i,p}(u),
+///
+/// with `e_r` the elementary symmetric polynomial;
+/// `cpp/tests/test_bspline_refinement.cpp` derives it there and this file forms the same
+/// closed form independently, from elementary symmetric polynomials and a binomial
+/// coefficient and nothing else.
+///
+/// It gives each operation its own corollary.
+///
+/// **Elevation.** A field whose coefficients are the closed form *is* the map
+/// `u -> u^r`. Elevation must not move it, so the elevated coefficients must be the same
+/// closed form evaluated on the **elevated** knot vector at the **elevated** degree.
+/// Taking every `r` in `[0, p]` pins each row completely rather than up to an affine
+/// map, which is the argument the refinement file spells out.
+///
+/// **The hodograph, and here the corollary is an identity rather than a statement about
+/// the answer.** Differentiating `u^r` gives `r u^{r-1}`, whose coefficients on the
+/// derived vector `t[1:-1]` at degree `p - 1` are
+/// `r e_{r-1}(t_{i+2}, ..., t_{i+p}) / C(p-1, r-1)`. That the code's formula produces
+/// exactly those numbers is provable in two lines, and the proof is worth having here
+/// because it says the check is exact rather than approximate:
+///
+///     A_{i+1} - A_i = [e_r(t_{i+2..i+p+1}) - e_r(t_{i+1..i+p})] / C(p, r)
+///                   = (t_{i+p+1} - t_{i+1}) e_{r-1}(t_{i+2..i+p}) / C(p, r),
+///
+/// using `e_r(S + {x}) = e_r(S) + x e_{r-1}(S)` on the shared window
+/// `S = {t_{i+2..i+p}}`. So `p (A_{i+1} - A_i) / (t_{i+p+1} - t_{i+1})` is
+/// `p e_{r-1}(S) / C(p, r)`, and `C(p, r) = (p/r) C(p-1, r-1)` makes that equal to
+/// `r e_{r-1}(S) / C(p-1, r-1)`, which is the derived vector's own closed form. The
+/// identity holds for **any** knot vector, clamped or not, wherever the denominator is
+/// non-zero.
+///
+/// ## The bound for the hodograph
+///
+/// `gamma_K = K u / (1 - K u)` times the magnitude the value is built from, with `K`
+/// counted rather than fitted:
+///
+///  - **The oracle's own formation on each side.** `e_r` by the recurrence
+///    `E_j <- E_j + x E_{j-1}` commits two roundings per knot along the dominant chain,
+///    then one division by a binomial: `2p + 1` for the input window of `p` knots and
+///    `2(p-1) + 1` for the derived window of `p - 1`.
+///  - **The cast into the field's storage**, which at `float32` is a real rounding on
+///    the input the formula then propagates: `1`.
+///  - **The formula itself**: the coefficient difference, the knot difference, the
+///    scaling by the degree and the division: `4`.
+///  - **The store into the result**, symmetric to the cast in: `1`.
+///
+/// `K = 4p + 5`. The magnitude is **not** the result's own: the difference
+/// `A_{i+1} - A_i` can cancel to nothing while its operands do not, so the relative
+/// budget has to be charged against what was subtracted. Rule 2 of
+/// `design/backend_parity.md` is the same point in the other direction. So
+///
+///     amplification_i = p (|A_i| + |A_{i+1}|) / |t_{i+p+1} - t_{i+1}|,
+///
+/// which majorises both the computed value and every partial result that fed it, since
+/// the only operations are one subtraction, one scaling and one division.
+///
+/// ## The bound for the elevation, and why a convex companion will not do
+///
+/// The finished elevation operator is non-negative with rows summing to one -- degree
+/// elevation writes each `N_{i,p}` as a non-negative combination of the elevated basis --
+/// so every *output* coefficient is a convex combination of input ones and `max |c|`
+/// bounds it. **That is not the bound this needs**, and the distinction is
+/// `design/backend_parity.md` Rule 10's, recorded there for another kernel: a rounding
+/// budget has to be charged against the intermediates, and A5.9's are not convex
+/// combinations of anything. Its knot-removal step blends with
+/// `alf = (ub - ik[i]) / (ua - ik[i])`, whose numerator exceeds its denominator whenever
+/// `ik[i] < ua < ub`, so `alf > 1` and `1 - alf < 0`. Partial results there can exceed
+/// every input coefficient, and a companion built from the finished row would be
+/// exceeded rather than merely loose.
+///
+/// What works is Rule 10's own answer: **the majorant of the recursion itself**. Run A5.9
+/// with every coefficient replaced by its modulus and every blending weight by its, which
+/// bounds each intermediate by induction on a linear recursion with signed coefficients;
+/// with the signs gone every partial sum is monotone, so the final value majorises all of
+/// them. `elevate_majorant` below is that run, and it is a bound rather than a second
+/// answer: it never produces the value the test compares, which comes from Marsden.
+///
+/// `K` for the elevation is counted the same way:
+///
+///  - the two `e_r` recurrences, on the input vector at degree `p` and on the elevated
+///    one at degree `p + t`: `2p + 1` and `2(p + t) + 1`;
+///  - the cast in and the store out: `2`;
+///  - **the kernel's own chain**, `min(p, t) + 1` stages of three accumulator roundings
+///    each. That stage count is `design/backend_parity.md` Rule 10's for the Bézier
+///    elevation and it is the right one here for the same reason: the accumulation into
+///    `ebpts[i]` runs `j` from `max(0, i - t)` to `min(p, i)`. Charging `p + 1` instead
+///    is the over-count that rule records.
+///
+/// The test asserts that the majorant **dominates** every observed deviation, which is
+/// the premise, and separately that the bound is **approached** rather than merely
+/// satisfied -- a bound nothing comes near asserts nothing, and a dyadic sweep would
+/// round too little to ask it a question.
+///
+/// ## Where the oracles do not hold, and the vacuity guards that say so
+///
+/// A row of the hodograph whose knot difference vanishes -- an interior knot of
+/// multiplicity `degree + 1`, where the field is `C^-1` -- is left at an exact zero by
+/// both backends, while Marsden's closed form there is whatever it is. The basis function
+/// that coefficient multiplies has empty support, so every value gives the same map and
+/// the row is excluded; the count of excluded rows is asserted non-zero on the case built
+/// to produce them, so the exclusion cannot silently become the whole check.
+///
+/// A **periodic** direction has no monomial to be the coefficients of: `u^r` is not
+/// periodic, so Marsden's closed form is not a periodic field and the identity says
+/// nothing about one. What is checked there instead is stated at the check itself, and it
+/// is weaker on purpose: the exact zero hodograph of a constant field, the periodicity of
+/// the expanded derivative net, and the structure of the result.
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bezier/control_net.hpp"
+#include "pantr/bspline/bspline.hpp"
+#include "pantr/bspline/degree.hpp"
+#include "pantr/bspline/space_1d.hpp"
+#include "pantr/bspline/space_nd.hpp"
+
+namespace {
+
+using pantr::bspline::Bspline;
+using pantr::bspline::BsplineSpace;
+using pantr::bspline::BsplineSpace1D;
+using pantr::bspline::degree_elevate_1d;
+using pantr::bspline::derivative;
+using pantr::bspline::derivative_along_axis;
+using pantr::bspline::elevate_degree;
+using pantr::bspline::KnotSnapping;
+
+/// `gamma_m = m u / (1 - m u)`, the standard accumulation constant.
+///
+/// \tparam T The format the roundings are charged in.
+/// \param m The number of roundings.
+/// \return The constant, in units of the value being bounded.
+template <class T>
+double gamma_of(std::int64_t m) {
+    const double u = 0.5 * static_cast<double>(std::numeric_limits<T>::epsilon());
+    const double mu = static_cast<double>(m) * u;
+    return mu / (1.0 - mu);
+}
+
+/// The smallest positive normal of `T`, the absolute floor of Higham's model.
+///
+/// \tparam T The storage format.
+/// \return The floor, one per rounding charged.
+template <class T>
+double underflow_floor() {
+    return static_cast<double>(std::numeric_limits<T>::min());
+}
+
+/// The binomial coefficient `C(n, k)`, by the multiplicative form.
+///
+/// \param n The upper index, non-negative.
+/// \param k The lower index, in `[0, n]`.
+/// \return `C(n, k)`, exact in `std::int64_t` over the degrees this file reaches.
+std::int64_t binomial(std::int64_t n, std::int64_t k) {
+    std::int64_t result = 1;
+    for (std::int64_t i = 0; i < k; ++i) {
+        result = result * (n - i) / (i + 1);
+    }
+    return result;
+}
+
+/// The Marsden coefficients of `u^r` in one direction's B-spline basis.
+///
+/// `A_i = e_r(t_{i+1}, ..., t_{i+degree}) / C(degree, r)`; see the file comment. Formed
+/// in `double` whatever the knots are stored in, by the elementary symmetric recurrence,
+/// so nothing here re-runs the code under test.
+///
+/// \tparam T The scalar type the knots are stored in.
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param r The monomial power, in `[0, degree]`.
+/// \return One coefficient per basis function, `knots.size() - degree - 1` of them.
+template <class T>
+std::vector<double> marsden_coefficients(std::span<const T> knots, std::int64_t degree,
+                                         std::int64_t r) {
+    const std::int64_t count = static_cast<std::int64_t>(knots.size()) - degree - 1;
+    std::vector<double> out(static_cast<std::size_t>(count), 0.0);
+    for (std::int64_t i = 0; i < count; ++i) {
+        std::vector<double> e(static_cast<std::size_t>(degree) + 1, 0.0);
+        e[0] = 1.0;
+        for (std::int64_t k = 1; k <= degree; ++k) {
+            const double x = static_cast<double>(knots[static_cast<std::size_t>(i + k)]);
+            for (std::int64_t j = k; j >= 1; --j) {
+                e[static_cast<std::size_t>(j)] += x * e[static_cast<std::size_t>(j - 1)];
+            }
+        }
+        out[static_cast<std::size_t>(i)] =
+            e[static_cast<std::size_t>(r)] / static_cast<double>(binomial(degree, r));
+    }
+    return out;
+}
+
+/// A one-direction field over given knots, degree and coefficients.
+///
+/// \tparam T The scalar type the field stores.
+/// \param knots The knot vector.
+/// \param degree The polynomial degree.
+/// \param periodic Whether the direction wraps.
+/// \param coefficients One scalar coefficient per basis function.
+/// \return The field, non-rational, of rank 1.
+template <class T>
+Bspline<T> curve(std::span<const T> knots, std::int64_t degree, bool periodic,
+                 const std::vector<double>& coefficients) {
+    auto space = std::make_shared<const BsplineSpace1D<T>>(knots, degree, periodic,
+                                                           KnotSnapping::merge_near_duplicates);
+    std::vector<std::shared_ptr<const BsplineSpace1D<T>>> directions{space};
+    std::vector<T> values(coefficients.size());
+    for (std::size_t i = 0; i < coefficients.size(); ++i) {
+        values[i] = static_cast<T>(coefficients[i]);
+    }
+    const std::vector<std::size_t> shape{coefficients.size(), std::size_t{1}};
+    return Bspline<T>(std::make_shared<const BsplineSpace<T>>(std::move(directions)),
+                      typename Bspline<T>::net_type(std::span<const T>(values),
+                                                    std::span<const std::size_t>(shape)),
+                      false);
+}
+
+/// The majorant of A5.9, run on the moduli of the coefficients and of the weights.
+///
+/// A transliteration of `degree_elevate_1d`'s recursion with every sign removed, in
+/// `double` throughout. It bounds every intermediate of the real run by induction, and
+/// because every term is non-negative its partial sums are monotone, so the value it
+/// returns for an output coefficient majorises everything that fed that coefficient. See
+/// the file comment for why a companion built from the finished operator does not.
+///
+/// It computes no value the test compares against; it computes only a magnitude.
+///
+/// \param degree The original degree.
+/// \param magnitudes One non-negative magnitude per coefficient.
+/// \param knots The knot vector.
+/// \param increment Degrees to add.
+/// \return One majorant per elevated coefficient.
+std::vector<double> elevate_majorant(std::int64_t degree, const std::vector<double>& magnitudes,
+                                     const std::vector<double>& knots, std::int64_t increment) {
+    const auto num_rows = static_cast<std::int64_t>(magnitudes.size());
+    const auto knot_count = static_cast<std::int64_t>(knots.size());
+    const std::int64_t d = degree;
+    const std::int64_t t = increment;
+    const std::int64_t ph = d + t;
+    const std::int64_t ph2 = ph / 2;
+    const std::int64_t m = (num_rows - 1) + d + 1;
+
+    std::vector<double> bezalfs(static_cast<std::size_t>((d + 1) * (ph + 1)), 0.0);
+    std::vector<double> alfs(static_cast<std::size_t>(std::max<std::int64_t>(d, 1)), 0.0);
+    std::vector<double> bpts(static_cast<std::size_t>(d + 1), 0.0);
+    std::vector<double> ebpts(static_cast<std::size_t>(ph + 1), 0.0);
+    std::vector<double> next_bpts(static_cast<std::size_t>(d + 1), 0.0);
+
+    const auto bez = [ph](std::int64_t j, std::int64_t i) {
+        return static_cast<std::size_t>(j * (ph + 1) + i);
+    };
+    bezalfs[bez(0, 0)] = 1.0;
+    bezalfs[bez(d, ph)] = 1.0;
+    for (std::int64_t i = 1; i <= ph2; ++i) {
+        const double inv = 1.0 / static_cast<double>(binomial(ph, i));
+        for (std::int64_t j = std::max<std::int64_t>(0, i - t); j <= std::min(d, i); ++j) {
+            bezalfs[bez(j, i)] = inv * static_cast<double>(binomial(d, j))
+                                 * static_cast<double>(binomial(t, i - j));
+        }
+    }
+    for (std::int64_t i = ph2 + 1; i < ph; ++i) {
+        for (std::int64_t j = std::max<std::int64_t>(0, i - t); j <= std::min(d, i); ++j) {
+            bezalfs[bez(j, i)] = bezalfs[bez(d - j, ph - i)];
+        }
+    }
+
+    std::int64_t kind = ph + 1;
+    std::int64_t r = -1;
+    std::int64_t a = d;
+    std::int64_t b = d + 1;
+    std::int64_t cind = 1;
+    double ua = knots[0];
+    std::vector<double> ik(static_cast<std::size_t>(knot_count + t * knot_count), 0.0);
+    std::vector<double> ic(static_cast<std::size_t>(num_rows + t * knot_count), 0.0);
+
+    ic[0] = std::abs(magnitudes[0]);
+    for (std::int64_t i = 0; i <= ph; ++i) {
+        ik[static_cast<std::size_t>(i)] = ua;
+    }
+    for (std::int64_t i = 0; i <= d; ++i) {
+        bpts[static_cast<std::size_t>(i)] = std::abs(magnitudes[static_cast<std::size_t>(i)]);
+    }
+
+    while (b <= m) {
+        const std::int64_t run_start = b;
+        while (b < m
+               && knots[static_cast<std::size_t>(b)] == knots[static_cast<std::size_t>(b + 1)]) {
+            ++b;
+        }
+        const std::int64_t mul = b - run_start + 1;
+        const double ub = knots[static_cast<std::size_t>(b)];
+        const std::int64_t oldr = r;
+        r = d - mul;
+
+        std::int64_t lbz = 1;
+        if (oldr > 0) {
+            lbz = (oldr + 2) / 2;
+        } else if (oldr < 0 && a != d) {
+            lbz = 0;
+        }
+        const std::int64_t rbz = (r > 0) ? ph - (r + 1) / 2 : ph;
+
+        if (r > 0) {
+            const double numer = ub - ua;
+            for (std::int64_t q = d; q > mul; --q) {
+                alfs[static_cast<std::size_t>(q - mul - 1)] =
+                    numer / (knots[static_cast<std::size_t>(a + q)] - ua);
+            }
+            for (std::int64_t j = 1; j <= r; ++j) {
+                const std::int64_t save = r - j;
+                const std::int64_t s = mul + j;
+                for (std::int64_t q = d; q >= s; --q) {
+                    const double alf = alfs[static_cast<std::size_t>(q - s)];
+                    bpts[static_cast<std::size_t>(q)] =
+                        std::abs(alf) * bpts[static_cast<std::size_t>(q)]
+                        + std::abs(1.0 - alf) * bpts[static_cast<std::size_t>(q - 1)];
+                }
+                next_bpts[static_cast<std::size_t>(save)] = bpts[static_cast<std::size_t>(d)];
+            }
+        }
+
+        for (std::int64_t i = lbz; i <= ph; ++i) {
+            ebpts[static_cast<std::size_t>(i)] = 0.0;
+            for (std::int64_t j = std::max<std::int64_t>(0, i - t); j <= std::min(d, i); ++j) {
+                ebpts[static_cast<std::size_t>(i)] +=
+                    std::abs(bezalfs[bez(j, i)]) * bpts[static_cast<std::size_t>(j)];
+            }
+        }
+
+        if (oldr > 1) {
+            std::int64_t first = kind - 2;
+            std::int64_t last = kind;
+            const double den = ub - ua;
+            const double bet = (ub - ik[static_cast<std::size_t>(kind - 1)]) / den;
+            for (std::int64_t tr = 1; tr < oldr; ++tr) {
+                std::int64_t i = first;
+                std::int64_t j = last;
+                std::int64_t kj = j - kind + 1;
+                while (j - i > tr) {
+                    if (i < cind) {
+                        const double alf = (ub - ik[static_cast<std::size_t>(i)])
+                                           / (ua - ik[static_cast<std::size_t>(i)]);
+                        ic[static_cast<std::size_t>(i)] =
+                            std::abs(alf) * ic[static_cast<std::size_t>(i)]
+                            + std::abs(1.0 - alf) * ic[static_cast<std::size_t>(i - 1)];
+                    }
+                    if (j >= lbz) {
+                        const double weight = (j - tr <= kind - ph + oldr)
+                                                  ? (ub - ik[static_cast<std::size_t>(j - tr)]) / den
+                                                  : bet;
+                        ebpts[static_cast<std::size_t>(kj)] =
+                            std::abs(weight) * ebpts[static_cast<std::size_t>(kj)]
+                            + std::abs(1.0 - weight) * ebpts[static_cast<std::size_t>(kj + 1)];
+                    }
+                    ++i;
+                    --j;
+                    --kj;
+                }
+                --first;
+                ++last;
+            }
+        }
+
+        if (a != d) {
+            for (std::int64_t written = 0; written < ph - oldr; ++written) {
+                ik[static_cast<std::size_t>(kind)] = ua;
+                ++kind;
+            }
+        }
+        for (std::int64_t j = lbz; j <= rbz; ++j) {
+            ic[static_cast<std::size_t>(cind)] = ebpts[static_cast<std::size_t>(j)];
+            ++cind;
+        }
+        if (b < m) {
+            for (std::int64_t j = 0; j < r; ++j) {
+                bpts[static_cast<std::size_t>(j)] = next_bpts[static_cast<std::size_t>(j)];
+            }
+            for (std::int64_t j = std::max<std::int64_t>(0, r); j <= d; ++j) {
+                bpts[static_cast<std::size_t>(j)] =
+                    std::abs(magnitudes[static_cast<std::size_t>(b - d + j)]);
+            }
+            a = b;
+            ++b;
+            ua = ub;
+        } else {
+            for (std::int64_t i = 0; i <= ph; ++i) {
+                ik[static_cast<std::size_t>(kind + i)] = ub;
+            }
+            break;
+        }
+    }
+    return std::vector<double>(ic.begin(), ic.begin() + static_cast<std::ptrdiff_t>(cind));
+}
+
+/// How close a comparison came to its own bound, and whether it stayed inside it.
+struct Margin {
+    /// The largest `|deviation| / bound` seen, which must not exceed 1.
+    double worst_ratio = 0.0;
+    /// How many elements were compared, so that a filter matching nothing is visible.
+    std::int64_t compared = 0;
+};
+
+/// Compare one elevated curve against Marsden's closed form on the elevated vector.
+///
+/// \tparam T The scalar type the field stores.
+/// \param knots The original knot vector, stored in `T`.
+/// \param degree The original degree.
+/// \param increment Degrees to add.
+/// \param label What to name the case in a failure message.
+/// \return The margin over every power `r` in `[0, degree]`.
+template <class T>
+Margin check_elevation_case(const std::vector<T>& knots, std::int64_t degree,
+                            std::int64_t increment, const std::string& label) {
+    Margin margin;
+    const std::vector<double> knots_wide(knots.begin(), knots.end());
+    for (std::int64_t r = 0; r <= degree; ++r) {
+        const std::vector<double> coefficients =
+            marsden_coefficients<T>(std::span<const T>(knots), degree, r);
+        const Bspline<T> field = curve<T>(std::span<const T>(knots), degree, false, coefficients);
+        const std::vector<std::int64_t> increments{increment};
+        const Bspline<T> raised =
+            elevate_degree<T>(field, std::span<const std::int64_t>(increments));
+
+        const BsplineSpace1D<T>& space = raised.space_ref().space_ref(0);
+        PANTR_CHECK_MSG(space.degree() == degree + increment,
+                        label + ": the elevated degree is " + std::to_string(space.degree()));
+        const std::vector<double> expected =
+            marsden_coefficients<T>(space.knots(), space.degree(), r);
+        const std::span<const T> got = raised.net().values();
+        if (static_cast<std::int64_t>(got.size()) != static_cast<std::int64_t>(expected.size())) {
+            PANTR_CHECK_MSG(false, label + ": the elevation returned "
+                                       + std::to_string(got.size()) + " coefficients and the "
+                                       "elevated vector calls for "
+                                       + std::to_string(expected.size()));
+            continue;
+        }
+
+        std::vector<double> magnitudes(coefficients.size());
+        for (std::size_t i = 0; i < coefficients.size(); ++i) {
+            magnitudes[i] = std::abs(static_cast<double>(static_cast<T>(coefficients[i])));
+        }
+        const std::vector<double> amplification =
+            elevate_majorant(degree, magnitudes, knots_wide, increment);
+        PANTR_CHECK_MSG(amplification.size() == expected.size(),
+                        label + ": the majorant and the elevation disagree on the coefficient "
+                                "count, so one of them walked a different set of segments");
+
+        const std::int64_t stages = std::min(degree, increment) + 1;
+        const std::int64_t roundings =
+            (2 * degree + 1) + (2 * (degree + increment) + 1) + 2 + 3 * stages;
+        const double relative = gamma_of<T>(roundings);
+        const double floor = static_cast<double>(roundings) * underflow_floor<T>();
+        for (std::size_t i = 0; i < expected.size(); ++i) {
+            const double bound = relative * amplification[i] + floor;
+            const double deviation = std::abs(static_cast<double>(got[i]) - expected[i]);
+            ++margin.compared;
+            margin.worst_ratio = std::max(margin.worst_ratio, deviation / bound);
+            PANTR_CHECK_MSG(deviation <= bound,
+                            label + ": elevated coefficient " + std::to_string(i) + " of u^"
+                                + std::to_string(r) + " is off by "
+                                + std::to_string(deviation) + " against a bound of "
+                                + std::to_string(bound));
+        }
+    }
+    return margin;
+}
+
+/// Degree elevation reproduces the polynomial, on every multiplicity structure.
+///
+/// \tparam T The scalar type the field stores.
+/// \param label The storage format, for failure messages.
+template <class T>
+void check_the_elevation_reproduces_the_polynomial(const std::string& label) {
+    struct Case {
+        std::vector<T> knots;
+        std::int64_t degree;
+        std::int64_t increment;
+        const char* name;
+    };
+    // Every case carries a non-dyadic knot so that the arithmetic rounds and the bound is
+    // asked a question; a halving sweep alone would report agreement without one.
+    const std::vector<Case> cases{
+        {{T(0), T(0), T(0), T(1), T(1), T(1)}, 2, 1, "one quadratic Bezier span"},
+        {{T(0), T(0), T(0), T(0), T(1), T(1), T(1), T(1)}, 3, 3, "one cubic span, t = 3"},
+        {{T(0), T(0), T(0), T(0.3), T(0.7), T(1), T(1), T(1)}, 2, 2, "simple interior knots"},
+        {{T(0), T(0), T(0), T(0), T(0.25), T(0.5), T(0.75), T(1), T(1), T(1), T(1)},
+         3,
+         1,
+         "cubic, four simple interior knots"},
+        {{T(0), T(0), T(0), T(0), T(0.5), T(0.5), T(0.5), T(1), T(1), T(1), T(1)},
+         3,
+         2,
+         "cubic, a C^0 breakpoint"},
+        {{T(0), T(0), T(0), T(0), T(0.5), T(0.5), T(0.5), T(0.5), T(1), T(1), T(1), T(1)},
+         3,
+         1,
+         "cubic, a C^-1 breakpoint"},
+        {{T(0), T(0), T(0), T(0), T(0), T(0), T(0.1), T(0.15), T(0.9), T(1), T(1), T(1), T(1),
+          T(1), T(1)},
+         5,
+         2,
+         "quintic, a narrow span"},
+    };
+
+    Margin total;
+    for (const Case& one : cases) {
+        const Margin margin = check_elevation_case<T>(one.knots, one.degree, one.increment,
+                                                      label + " " + one.name);
+        total.compared += margin.compared;
+        total.worst_ratio = std::max(total.worst_ratio, margin.worst_ratio);
+    }
+    PANTR_CHECK_MSG(total.compared > 0, label + ": the elevation check compared nothing");
+    // The bound has to be approached, or it asserts nothing. A tenth of it is the
+    // acknowledged slack: the budget charges the two oracle recurrences at the storage
+    // format although they run in `double`, which alone over-states the float64 case by
+    // most of `K`.
+    PANTR_CHECK_MSG(total.worst_ratio > 0.01,
+                    label + ": the elevation bound was never approached, worst ratio "
+                        + std::to_string(total.worst_ratio)
+                        + "; either nothing rounded or the bound is vacuous");
+}
+
+/// The hodograph is the analytic derivative, on every knot vector shape.
+///
+/// \tparam T The scalar type the field stores.
+/// \param label The storage format, for failure messages.
+template <class T>
+void check_the_hodograph_is_the_analytic_derivative(const std::string& label) {
+    struct Case {
+        std::vector<T> knots;
+        std::int64_t degree;
+        const char* name;
+    };
+    const std::vector<Case> cases{
+        {{T(0), T(0), T(0), T(0.3), T(0.7), T(1), T(1), T(1)}, 2, "quadratic, simple knots"},
+        {{T(0), T(0), T(0), T(0), T(0.25), T(0.5), T(0.75), T(1), T(1), T(1), T(1)}, 3,
+         "cubic, four simple knots"},
+        {{T(0), T(0), T(0), T(0), T(0.5), T(0.5), T(0.5), T(1), T(1), T(1), T(1)}, 3,
+         "cubic, a C^0 breakpoint"},
+        // Unclamped, and legal: `BsplineSpace1D` accepts it with `periodic = false`. The
+        // hodograph identity is a statement about the coefficient formula and does not
+        // need a clamp, unlike A5.9 -- which is exactly why elevation refuses this vector
+        // and the derivative does not.
+        {{T(-0.3), T(-0.2), T(-0.1), T(0), T(0.25), T(0.5), T(0.75), T(1), T(1.1), T(1.2),
+          T(1.3)},
+         3,
+         "unclamped"},
+        {{T(0), T(0), T(0), T(0), T(0), T(0), T(0.1), T(0.15), T(0.9), T(1), T(1), T(1), T(1),
+          T(1), T(1)},
+         5,
+         "quintic, a narrow span"},
+    };
+
+    std::int64_t compared = 0;
+    double worst_ratio = 0.0;
+    for (const Case& one : cases) {
+        const std::int64_t p = one.degree;
+        const std::vector<T> derived(one.knots.begin() + 1, one.knots.end() - 1);
+        for (std::int64_t r = 0; r <= p; ++r) {
+            const std::vector<double> coefficients =
+                marsden_coefficients<T>(std::span<const T>(one.knots), p, r);
+            const Bspline<T> field =
+                curve<T>(std::span<const T>(one.knots), p, false, coefficients);
+            const Bspline<T> hodograph = derivative<T>(field, 0);
+
+            const BsplineSpace1D<T>& space = hodograph.space_ref().space_ref(0);
+            PANTR_CHECK_MSG(space.degree() == p - 1,
+                            label + " " + one.name + ": the hodograph's degree is "
+                                + std::to_string(space.degree()));
+
+            // `r u^{r-1}`, and an exact zero for the constant.
+            std::vector<double> expected(coefficients.size() - 1, 0.0);
+            if (r >= 1) {
+                const std::vector<double> lower =
+                    marsden_coefficients<T>(std::span<const T>(derived), p - 1, r - 1);
+                for (std::size_t i = 0; i < expected.size(); ++i) {
+                    expected[i] = static_cast<double>(r) * lower[i];
+                }
+            }
+
+            const std::int64_t roundings = (2 * p + 1) + (2 * (p - 1) + 1) + 2 + 4;
+            const double relative = gamma_of<T>(roundings);
+            const double floor = static_cast<double>(roundings) * underflow_floor<T>();
+            const std::span<const T> got = hodograph.net().values();
+            for (std::size_t i = 0; i < expected.size(); ++i) {
+                const double denominator =
+                    static_cast<double>(one.knots[i + static_cast<std::size_t>(p) + 1])
+                    - static_cast<double>(one.knots[i + 1]);
+                if (denominator == 0.0) {
+                    // A `C^-1` breakpoint: the basis function this coefficient multiplies
+                    // has empty support, so both backends leave it at an exact zero and
+                    // Marsden's closed form says nothing about it.
+                    PANTR_CHECK_MSG(got[i] == T(0), label + " " + one.name
+                                                        + ": a zero-width span did not give an "
+                                                          "exact zero");
+                    continue;
+                }
+                const double amplification =
+                    static_cast<double>(p)
+                    * (std::abs(coefficients[i]) + std::abs(coefficients[i + 1]))
+                    / std::abs(denominator);
+                const double bound = relative * amplification + floor;
+                const double deviation = std::abs(static_cast<double>(got[i]) - expected[i]);
+                ++compared;
+                worst_ratio = std::max(worst_ratio, deviation / bound);
+                PANTR_CHECK_MSG(deviation <= bound,
+                                label + " " + one.name + ": hodograph coefficient "
+                                    + std::to_string(i) + " of u^" + std::to_string(r)
+                                    + " is off by " + std::to_string(deviation)
+                                    + " against a bound of " + std::to_string(bound));
+            }
+        }
+    }
+    PANTR_CHECK_MSG(compared > 0, label + ": the hodograph check compared nothing");
+    PANTR_CHECK_MSG(worst_ratio > 0.0,
+                    label + ": every hodograph coefficient was exact, so the bound was never "
+                            "asked a question");
+}
+
+/// A `C^-1` breakpoint leaves an exact zero, and the case really contains one.
+void check_a_zero_width_span_is_left_alone() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0};
+    const std::vector<double> coefficients{1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0};
+    const Bspline<double> field = curve<double>(std::span<const double>(knots), 3, false,
+                                                coefficients);
+    const Bspline<double> hodograph = derivative<double>(field, 0);
+    const std::span<const double> got = hodograph.net().values();
+
+    std::int64_t zeros = 0;
+    for (std::size_t i = 0; i + 1 < coefficients.size(); ++i) {
+        if (knots[i + 4] == knots[i + 1]) {
+            ++zeros;
+            PANTR_CHECK_MSG(got[i] == 0.0,
+                            "a zero-width span gave " + std::to_string(got[i])
+                                + " rather than an exact zero");
+        }
+    }
+    // The guard that stops the check above from being about nothing: a `C^-1` breakpoint
+    // at multiplicity `degree + 1` collapses exactly one span of the derived vector.
+    PANTR_CHECK_MSG(zeros == 1, "the C^-1 case produced " + std::to_string(zeros)
+                                    + " zero-width spans, and it was built for one");
+}
+
+/// The hodograph of a periodic direction: what can be checked without a monomial.
+///
+/// `u^r` is not periodic, so Marsden gives no periodic field and the identity says
+/// nothing here. Three statements that do not need one are checked instead: a constant
+/// field differentiates to an exact zero, the expanded derivative net is itself periodic,
+/// and the result's structure is the derived vector at one degree less, still periodic.
+void check_the_periodic_hodograph() {
+    const std::vector<double> knots{-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    const std::int64_t degree = 2;
+    const auto space = std::make_shared<const BsplineSpace1D<double>>(
+        std::span<const double>(knots), degree, true, KnotSnapping::merge_near_duplicates);
+    const std::int64_t count = space->num_basis();
+    PANTR_CHECK_MSG(count > 0, "the periodic fixture has no basis functions");
+
+    // A constant field: a periodic B-spline basis is a partition of unity, so equal
+    // coefficients are the constant map and its derivative is identically zero. Nothing
+    // about the derivative formula is assumed -- the differences are exact zeros and the
+    // quotient of an exact zero is one.
+    const std::vector<double> ones(static_cast<std::size_t>(count), 1.0);
+    const Bspline<double> flat = curve<double>(std::span<const double>(knots), degree, true, ones);
+    const Bspline<double> flat_derivative = derivative<double>(flat, 0);
+    for (const double value : flat_derivative.net().values()) {
+        PANTR_CHECK_MSG(value == 0.0, "the hodograph of a constant periodic field is "
+                                          + std::to_string(value) + " rather than zero");
+    }
+
+    const BsplineSpace1D<double>& derived = flat_derivative.space_ref().space_ref(0);
+    PANTR_CHECK_MSG(derived.periodic(), "the hodograph of a periodic direction came back open");
+    PANTR_CHECK_MSG(derived.degree() == degree - 1,
+                    "the periodic hodograph's degree is " + std::to_string(derived.degree()));
+    PANTR_CHECK_MSG(derived.knots().size() == knots.size() - 2,
+                    "the periodic hodograph kept " + std::to_string(derived.knots().size())
+                        + " knots and the derived vector has " + std::to_string(knots.size() - 2));
+
+    // The other half: on data that is not constant, the derivative net must still be the
+    // periodic representation of a periodic function, so expanding it by its own modulo
+    // wrap has to agree with differentiating the expanded original. That is a property of
+    // the result rather than a rerun of the formula: it says the trim kept the right rows.
+    std::vector<double> varied(static_cast<std::size_t>(count));
+    for (std::size_t i = 0; i < varied.size(); ++i) {
+        varied[i] = static_cast<double>(i) - 1.5;
+    }
+    const Bspline<double> wave = curve<double>(std::span<const double>(knots), degree, true,
+                                               varied);
+    const Bspline<double> wave_derivative = derivative<double>(wave, 0);
+    const std::span<const double> got = wave_derivative.net().values();
+    const std::int64_t derived_count = wave_derivative.space_ref().space_ref(0).num_basis();
+    PANTR_CHECK_MSG(static_cast<std::int64_t>(got.size()) == derived_count,
+                    "the periodic hodograph carries " + std::to_string(got.size())
+                        + " coefficients on a space of " + std::to_string(derived_count));
+
+    // Differentiating the expanded net directly, with the expansion the result implies.
+    const std::int64_t full = static_cast<std::int64_t>(knots.size()) - degree - 1;
+    std::vector<double> expanded(static_cast<std::size_t>(full));
+    for (std::int64_t i = 0; i < full; ++i) {
+        expanded[static_cast<std::size_t>(i)] = varied[static_cast<std::size_t>(i % count)];
+    }
+    const std::vector<double> whole = derivative_along_axis<double>(
+        std::span<const double>(knots), degree, std::span<const double>(expanded), full, 1, 1);
+    for (std::size_t i = 0; i < got.size(); ++i) {
+        PANTR_CHECK_MSG(got[i] == whole[i],
+                        "the periodic trim kept a different row at " + std::to_string(i));
+    }
+    // And the expanded derivative wraps with the derived space's own period, which is what
+    // makes the trim lossless rather than merely short.
+    std::int64_t wrapped = 0;
+    for (std::size_t i = 0; i + static_cast<std::size_t>(derived_count) < whole.size(); ++i) {
+        ++wrapped;
+        PANTR_CHECK_MSG(whole[i] == whole[i + static_cast<std::size_t>(derived_count)],
+                        "the expanded hodograph is not periodic at " + std::to_string(i));
+    }
+    PANTR_CHECK_MSG(wrapped > 0, "no wrapped row was checked, so the trim is untested");
+}
+
+/// Each operation touches its own axis and leaves every other one alone.
+///
+/// A rank-1 field over two directions whose coefficients are `A^0_{i,r0} A^1_{j,r1}` is
+/// the map `u^r0 v^r1`. Operating on direction `d` must move that direction's factor to
+/// its own new closed form and leave the other factor exactly where it was, which is what
+/// catches a sweep applied to the wrong axis, a transposed stride, or a component axis
+/// mistaken for a parametric one. The degrees differ between the directions so that a
+/// transposition cannot pass by symmetry.
+void check_the_axis_sweeps_touch_only_their_own_axis() {
+    const std::vector<double> first{0.0, 0.0, 0.0, 0.4, 1.0, 1.0, 1.0};
+    const std::vector<double> second{0.0, 0.0, 0.0, 0.0, 0.3, 0.6, 1.0, 1.0, 1.0, 1.0};
+    const std::int64_t degree_first = 2;
+    const std::int64_t degree_second = 3;
+
+    for (std::int64_t r0 = 0; r0 <= degree_first; ++r0) {
+        for (std::int64_t r1 = 0; r1 <= degree_second; ++r1) {
+            const std::vector<double> table_first =
+                marsden_coefficients<double>(std::span<const double>(first), degree_first, r0);
+            const std::vector<double> table_second =
+                marsden_coefficients<double>(std::span<const double>(second), degree_second, r1);
+
+            std::vector<std::shared_ptr<const BsplineSpace1D<double>>> directions;
+            directions.push_back(std::make_shared<const BsplineSpace1D<double>>(
+                std::span<const double>(first), degree_first, false,
+                KnotSnapping::merge_near_duplicates));
+            directions.push_back(std::make_shared<const BsplineSpace1D<double>>(
+                std::span<const double>(second), degree_second, false,
+                KnotSnapping::merge_near_duplicates));
+            std::vector<double> values(table_first.size() * table_second.size());
+            for (std::size_t i = 0; i < table_first.size(); ++i) {
+                for (std::size_t j = 0; j < table_second.size(); ++j) {
+                    values[i * table_second.size() + j] = table_first[i] * table_second[j];
+                }
+            }
+            const std::vector<std::size_t> shape{table_first.size(), table_second.size(),
+                                                 std::size_t{1}};
+            const Bspline<double> field(
+                std::make_shared<const BsplineSpace<double>>(std::move(directions)),
+                Bspline<double>::net_type(std::span<const double>(values),
+                                          std::span<const std::size_t>(shape)),
+                false);
+
+            // Differentiating direction 0.
+            const Bspline<double> along_first = derivative<double>(field, 0);
+            PANTR_CHECK_MSG(along_first.space_ref().space_ref(1).knots().size() == second.size(),
+                            "differentiating direction 0 moved direction 1's knots");
+            PANTR_CHECK_MSG(along_first.space_ref().space_ref(1).degree() == degree_second,
+                            "differentiating direction 0 moved direction 1's degree");
+            const std::vector<double> lowered_first =
+                (r0 == 0) ? std::vector<double>(table_first.size() - 1, 0.0)
+                          : marsden_coefficients<double>(
+                                along_first.space_ref().space_ref(0).knots(), degree_first - 1,
+                                r0 - 1);
+            const std::span<const double> got_first = along_first.net().values();
+            for (std::size_t i = 0; i + 1 < table_first.size(); ++i) {
+                for (std::size_t j = 0; j < table_second.size(); ++j) {
+                    const double want = static_cast<double>(r0) * lowered_first[i]
+                                        * table_second[j];
+                    const double bound =
+                        gamma_of<double>(8 * degree_second + 16)
+                            * (std::abs(static_cast<double>(degree_first)
+                                        * (std::abs(table_first[i]) + std::abs(table_first[i + 1]))
+                                        / std::abs(first[i + degree_first + 1] - first[i + 1]))
+                               * std::abs(table_second[j]))
+                        + 16.0 * underflow_floor<double>();
+                    PANTR_CHECK_MSG(
+                        std::abs(got_first[i * table_second.size() + j] - want) <= bound,
+                        "differentiating direction 0 gave a wrong fibre at ("
+                            + std::to_string(i) + ", " + std::to_string(j) + ")");
+                }
+            }
+
+            // Elevating direction 1 alone.
+            const std::vector<std::int64_t> increments{0, 2};
+            const Bspline<double> raised =
+                elevate_degree<double>(field, std::span<const std::int64_t>(increments));
+            PANTR_CHECK_MSG(raised.space_ref().space_ref(0).degree() == degree_first,
+                            "elevating direction 1 moved direction 0's degree");
+            PANTR_CHECK_MSG(raised.space_ref().space_ref(0).knots().size() == first.size(),
+                            "elevating direction 1 moved direction 0's knots");
+            const std::vector<double> raised_second = marsden_coefficients<double>(
+                raised.space_ref().space_ref(1).knots(), degree_second + 2, r1);
+            const std::span<const double> got_raised = raised.net().values();
+            std::vector<double> magnitudes(table_second.size());
+            for (std::size_t j = 0; j < table_second.size(); ++j) {
+                magnitudes[j] = std::abs(table_second[j]);
+            }
+            const std::vector<double> amplification =
+                elevate_majorant(degree_second, magnitudes, second, 2);
+            const std::int64_t roundings = (2 * degree_second + 1)
+                                           + (2 * (degree_second + 2) + 1) + 2
+                                           + 3 * (std::min<std::int64_t>(degree_second, 2) + 1);
+            for (std::size_t i = 0; i < table_first.size(); ++i) {
+                for (std::size_t j = 0; j < raised_second.size(); ++j) {
+                    const double want = table_first[i] * raised_second[j];
+                    const double bound =
+                        gamma_of<double>(roundings) * std::abs(table_first[i]) * amplification[j]
+                        + static_cast<double>(roundings) * underflow_floor<double>();
+                    PANTR_CHECK_MSG(
+                        std::abs(got_raised[i * raised_second.size() + j] - want) <= bound,
+                        "elevating direction 1 gave a wrong fibre at (" + std::to_string(i)
+                            + ", " + std::to_string(j) + ")");
+                }
+            }
+        }
+    }
+}
+
+/// Elevation raises every knot's multiplicity by the increment, and nothing else.
+///
+/// Exact integers and exact knot values, so no tolerance enters. It is the statement the
+/// Marsden check leans on -- that file's closed form is evaluated on the vector the code
+/// produced -- so it is asserted rather than assumed.
+void check_the_elevated_knot_vector() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.0, 0.25, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0};
+    const std::int64_t degree = 3;
+    for (std::int64_t increment = 1; increment <= 3; ++increment) {
+        const std::vector<double> coefficients =
+            marsden_coefficients<double>(std::span<const double>(knots), degree, 1);
+        const Bspline<double> field =
+            curve<double>(std::span<const double>(knots), degree, false, coefficients);
+        const std::vector<std::int64_t> increments{increment};
+        const Bspline<double> raised =
+            elevate_degree<double>(field, std::span<const std::int64_t>(increments));
+        const BsplineSpace1D<double>& space = raised.space_ref().space_ref(0);
+
+        // Every distinct knot survives, with its multiplicity raised by the increment.
+        std::vector<double> distinct;
+        std::vector<std::int64_t> multiplicity;
+        for (const double knot : knots) {
+            if (distinct.empty() || knot != distinct.back()) {
+                distinct.push_back(knot);
+                multiplicity.push_back(1);
+            } else {
+                ++multiplicity.back();
+            }
+        }
+        std::vector<double> want;
+        for (std::size_t i = 0; i < distinct.size(); ++i) {
+            for (std::int64_t k = 0; k < multiplicity[i] + increment; ++k) {
+                want.push_back(distinct[i]);
+            }
+        }
+        const std::span<const double> got = space.knots();
+        PANTR_CHECK_MSG(got.size() == want.size(),
+                        "elevating by " + std::to_string(increment) + " gave "
+                            + std::to_string(got.size()) + " knots and the multiplicity rule "
+                            "calls for " + std::to_string(want.size()));
+        if (got.size() == want.size()) {
+            for (std::size_t i = 0; i < want.size(); ++i) {
+                PANTR_CHECK_MSG(got[i] == want[i], "elevated knot " + std::to_string(i)
+                                                       + " is " + std::to_string(got[i])
+                                                       + " and should be "
+                                                       + std::to_string(want[i]));
+            }
+        }
+        PANTR_CHECK_MSG(
+            static_cast<std::int64_t>(raised.net().values().size()) == space.num_basis(),
+            "the elevated net and the elevated space disagree on the coefficient count");
+    }
+}
+
+/// Every refusal, by its message.
+void check_the_refusals() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.4, 1.0, 1.0, 1.0};
+    const std::vector<double> coefficients{1.0, 2.0, 3.0, 4.0};
+    const Bspline<double> field =
+        curve<double>(std::span<const double>(knots), 2, false, coefficients);
+
+    const auto refuses = [](auto&& call, const std::string& fragment, const std::string& what) {
+        bool refused = false;
+        try {
+            call();
+        } catch (const std::invalid_argument& error) {
+            refused = true;
+            PANTR_CHECK_MSG(std::string(error.what()).find(fragment) != std::string::npos,
+                            what + ": the message was \"" + error.what() + "\"");
+        }
+        PANTR_CHECK_MSG(refused, what + ": nothing was refused");
+    };
+
+    // The oracle's Layer 1 messages, character for character.
+    refuses([&] { static_cast<void>(derivative<double>(field, 1)); },
+            "direction must be in [0, 1), got 1.", "an out-of-range direction");
+    refuses([&] { static_cast<void>(derivative<double>(field, -1)); },
+            "direction must be in [0, 1), got -1.", "a negative direction");
+
+    const std::vector<double> flat_knots{0.0, 0.4, 1.0};
+    const std::vector<double> flat{1.0, 2.0};
+    const Bspline<double> degree_zero =
+        curve<double>(std::span<const double>(flat_knots), 0, false, flat);
+    refuses([&] { static_cast<void>(derivative<double>(degree_zero, 0)); },
+            "Derivative of a degree-0 B-spline is not defined.", "a degree-0 direction");
+
+    const std::vector<std::int64_t> two{1, 1};
+    refuses([&] {
+                static_cast<void>(
+                    elevate_degree<double>(field, std::span<const std::int64_t>(two)));
+            },
+            "Number of degree increments (2) must match dimension (1).",
+            "the wrong number of increments");
+    const std::vector<std::int64_t> negative{-1};
+    refuses([&] {
+                static_cast<void>(
+                    elevate_degree<double>(field, std::span<const std::int64_t>(negative)));
+            },
+            "Degree increments must be non-negative.", "a negative increment");
+    const std::vector<std::int64_t> zero{0};
+    refuses([&] {
+                static_cast<void>(
+                    elevate_degree<double>(field, std::span<const std::int64_t>(zero)));
+            },
+            "At least one degree increment must be positive.", "an all-zero increment");
+    const std::vector<std::int64_t> beyond{60};
+    refuses([&] {
+                static_cast<void>(
+                    elevate_degree<double>(field, std::span<const std::int64_t>(beyond)));
+            },
+            "Degree elevation to degree 62 in direction 0 needs binomial coefficients up to "
+            "C(62, k)",
+            "an elevated degree past the binomial envelope");
+
+    // The two declared boundaries.
+    const std::vector<double> periodic_knots{-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    const auto periodic_space = std::make_shared<const BsplineSpace1D<double>>(
+        std::span<const double>(periodic_knots), 2, true, KnotSnapping::merge_near_duplicates);
+    const std::vector<double> periodic_coefficients(
+        static_cast<std::size_t>(periodic_space->num_basis()), 1.0);
+    const Bspline<double> periodic = curve<double>(std::span<const double>(periodic_knots), 2,
+                                                   true, periodic_coefficients);
+    const std::vector<std::int64_t> one{1};
+    refuses([&] {
+                static_cast<void>(
+                    elevate_degree<double>(periodic, std::span<const std::int64_t>(one)));
+            },
+            "elevating a periodic direction needs the open-to-periodic conversion",
+            "elevating a periodic direction");
+
+    const std::vector<double> unclamped_knots{-0.3, -0.2, -0.1, 0.0,  0.25, 0.5,
+                                              0.75, 1.0,  1.1,  1.2, 1.3};
+    const std::vector<double> unclamped_coefficients{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    const Bspline<double> unclamped = curve<double>(std::span<const double>(unclamped_knots), 3,
+                                                    false, unclamped_coefficients);
+    refuses([&] {
+                static_cast<void>(
+                    elevate_degree<double>(unclamped, std::span<const std::int64_t>(one)));
+            },
+            "elevating a direction whose knot vector is not clamped",
+            "elevating an unclamped direction");
+    // And the primitive refuses it too, so a caller reaching past the field entry point
+    // cannot perform the read either.
+    refuses([&] {
+                static_cast<void>(degree_elevate_1d<double>(
+                    3, std::span<const double>(unclamped_coefficients), 7, 1,
+                    std::span<const double>(unclamped_knots), 1));
+            },
+            "the knot vector must close with 4 equal knots",
+            "the elevation kernel on an unclamped vector");
+
+    // A rational field. Unreachable from Python, which routes a rational derivative to the
+    // oracle, and reachable by a C++ caller holding the flag.
+    const auto rational_space = std::make_shared<const BsplineSpace1D<double>>(
+        std::span<const double>(knots), 2, false, KnotSnapping::merge_near_duplicates);
+    std::vector<std::shared_ptr<const BsplineSpace1D<double>>> rational_directions{
+        rational_space};
+    const std::vector<double> weighted{1.0, 1.0, 2.0, 1.0, 3.0, 1.0, 4.0, 1.0};
+    const std::vector<std::size_t> rational_shape{std::size_t{4}, std::size_t{2}};
+    const Bspline<double> rational(
+        std::make_shared<const BsplineSpace<double>>(std::move(rational_directions)),
+        Bspline<double>::net_type(std::span<const double>(weighted),
+                                  std::span<const std::size_t>(rational_shape)),
+        true);
+    refuses([&] { static_cast<void>(derivative<double>(rational, 0)); },
+            "the derivative of a rational B-spline is not part of pantr's C++ core",
+            "the derivative of a rational field");
+}
+
+/// The primitives refuse a shape they cannot serve.
+void check_the_primitives_refuse_a_bad_shape() {
+    const std::vector<double> knots{0.0, 0.0, 0.0, 0.4, 1.0, 1.0, 1.0};
+    const std::vector<double> values{1.0, 2.0, 3.0, 4.0};
+
+    const auto refuses = [](auto&& call, const std::string& what) {
+        bool refused = false;
+        try {
+            call();
+        } catch (const std::invalid_argument&) {
+            refused = true;
+        }
+        PANTR_CHECK_MSG(refused, what + " was accepted");
+    };
+
+    refuses([&] {
+                static_cast<void>(derivative_along_axis<double>(
+                    std::span<const double>(knots), 0, std::span<const double>(values), 4, 1, 1));
+            },
+            "a degree-0 hodograph");
+    refuses([&] {
+                static_cast<void>(derivative_along_axis<double>(
+                    std::span<const double>(knots), 2, std::span<const double>(values), 4, -1, 1));
+            },
+            "a negative extent");
+    refuses([&] {
+                static_cast<void>(derivative_along_axis<double>(
+                    std::span<const double>(knots), 2, std::span<const double>(values), 3, 1, 1));
+            },
+            "a buffer that does not match its shape");
+    refuses([&] {
+                static_cast<void>(derivative_along_axis<double>(
+                    std::span<const double>(knots), 2, std::span<const double>(values), 1, 1, 1));
+            },
+            "a direction with one coefficient");
+    refuses([&] {
+                static_cast<void>(degree_elevate_1d<double>(
+                    2, std::span<const double>(values), 4, 1, std::span<const double>(knots), 0));
+            },
+            "a zero increment");
+    refuses([&] {
+                static_cast<void>(degree_elevate_1d<double>(
+                    2, std::span<const double>(values), 4, 2, std::span<const double>(knots), 1));
+            },
+            "a rank the buffer cannot hold");
+}
+
+}  // namespace
+
+int main() {
+    check_the_hodograph_is_the_analytic_derivative<double>("float64");
+    check_the_hodograph_is_the_analytic_derivative<float>("float32");
+    check_a_zero_width_span_is_left_alone();
+    check_the_periodic_hodograph();
+    check_the_elevation_reproduces_the_polynomial<double>("float64");
+    check_the_elevation_reproduces_the_polynomial<float>("float32");
+    check_the_elevated_knot_vector();
+    check_the_axis_sweeps_touch_only_their_own_axis();
+    check_the_refusals();
+    check_the_primitives_refuse_a_bad_shape();
+    return pantr::test::summary("test_bspline_degree");
+}

--- a/scripts/measure_bspline_degree_widths.py
+++ b/scripts/measure_bspline_degree_widths.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python
+"""Measure the arithmetic width of every site in the B-spline degree kernels.
+
+``design/backend_parity.md`` Rule 9 says an oracle's accumulation width is a
+**per-kernel fact, not a module convention**. ``_degree_elevate_1d_core`` is sharper
+than that: the width varies *within* the kernel, because Numba types each SSA version
+of a variable separately and the four assignments to ``tmp1`` do not agree. This script
+is the measurement ``cpp/include/pantr/bspline/degree.hpp`` is written against.
+
+    PYTHONPATH="$(pwd)/src" python scripts/measure_bspline_degree_widths.py
+
+Three things are printed, and the middle one is the one that would catch a wrong
+transliteration.
+
+**One, Numba's own inferred type for every arithmetic site**, read out of
+``inspect_types`` rather than out of the source. That says what the compiler decided;
+it does not say whether the decision is observable.
+
+**Two, a behavioural check.** A rival model of A5.9 is run against the kernel, bit for
+bit, once per width policy. The policies differ from the true one at a single site
+each, so a policy that fails names the site that is load-bearing -- and the true policy
+matching is only evidence because the others do not. Everything coincides at
+``float64``, which is exactly Rule 9's warning, so the table is reported per dtype.
+
+**Three, the reason ``elevate_degree`` refuses an unclamped direction in C++.** A5.9
+walks segments until a run of equal knots reaches the last index of the vector, and an
+unclamped vector has no such run, so the walk reads past the control array. Numba does
+not bounds check in ``nopython`` mode: compiled, the call returns uninitialised memory;
+interpreted, the same call raises ``IndexError``. Both halves are printed.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import sys
+from typing import Any, Final
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr.bspline._bspline_degree_core import _bincoeff, _degree_elevate_1d_core
+from pantr.bspline._bspline_derivative import _derivative_ctrl_1d
+
+FloatArray = npt.NDArray[np.floating[Any]]
+
+_SITES: Final[tuple[str, ...]] = (
+    "inv",
+    "numer",
+    "ua",
+    "ub",
+    "den",
+    "bet",
+    "gam",
+    "alf",
+    "tmp1",
+    "tmp2",
+)
+"""Every variable in ``_degree_elevate_1d_core`` that holds a rounded value."""
+
+_POLICIES: Final[tuple[str, ...]] = (
+    "oracle",
+    "wide-blend-product",
+    "wide-ebpts-accumulator",
+    "wide-alfs-division",
+    "wide-knot-weights",
+)
+"""The true width policy, and one rival differing from it at a single site."""
+
+
+def _inferred_types(kernel: Any, dtype: npt.DTypeLike) -> dict[str, str]:  # noqa: ANN401 -- see Args
+    """Read Numba's inferred type for every site of the elevation kernel.
+
+    Args:
+        kernel (Any): The elevation kernel as a numba dispatcher.
+            ``numba.core.registry.CPUDispatcher`` is not statically typed and is
+            private, so there is no narrower annotation -- the same reason
+            ``scripts/measure_bspline_tabulation_widths.py`` gives.
+        dtype (npt.DTypeLike): Storage format to compile the kernel for.
+
+    Returns:
+        dict[str, str]: SSA variable name to its Numba type, for the sites of
+        :data:`_SITES`.
+
+    Raises:
+        RuntimeError: If no ``inspect_types`` block matches the requested format,
+            which means numba's dump format moved.
+    """
+    knots = np.array([0, 0, 0, 0, 0.25, 0.5, 0.5, 1, 1, 1, 1], dtype=dtype)
+    ctrl = np.arange(7.0, dtype=dtype).reshape(7, 1)
+    kernel(3, ctrl, knots, 2)
+
+    buffer = io.StringIO()
+    kernel.inspect_types(file=buffer)
+
+    # One block per compiled signature, and the kernel is compiled for both formats by
+    # the time this runs, so the block has to be selected rather than the first match
+    # taken -- which is how an earlier version of this script reported float32 widths
+    # under the float64 heading.
+    wanted = f"Array({np.dtype(dtype).name}, 2,"
+    found: dict[str, str] = {}
+    in_block = False
+    for line in buffer.getvalue().splitlines():
+        if line.startswith("_degree_elevate_1d_core ("):
+            in_block = wanted in line
+            continue
+        if not in_block:
+            continue
+        match = re.match(r"\s*#\s+([A-Za-z_][A-Za-z_0-9.]*)\s*=\s*.*::\s*(\S+)\s*$", line)
+        if match and match.group(1).split(".")[0] in _SITES:
+            found.setdefault(match.group(1), match.group(2))
+    if not found:
+        raise RuntimeError(f"no inspect_types block for {wanted}; the dump format moved")
+    return found
+
+
+def _elevate_model(  # noqa: PLR0912, PLR0915
+    degree: int,
+    ctrl: FloatArray,
+    knots: FloatArray,
+    increment: int,
+    policy: str,
+) -> tuple[FloatArray, FloatArray]:
+    """Run A5.9 with the widths a given policy prescribes.
+
+    A transliteration of ``_degree_elevate_1d_core`` in plain Python, with every
+    rounding written out, so that one site at a time can be given the wrong width.
+
+    Args:
+        degree (int): Original degree.
+        ctrl (FloatArray): Control points of shape ``(n_pts, rank)``.
+        knots (FloatArray): Knot vector.
+        increment (int): Degrees to add.
+        policy (str): One of :data:`_POLICIES`.
+
+    Returns:
+        tuple[FloatArray, FloatArray]: Elevated control points and knot vector.
+    """
+    fmt = ctrl.dtype.type
+    n_pts, rank = ctrl.shape
+    d, t = degree, increment
+    n = n_pts - 1
+    ph, ph2 = d + t, (d + t) // 2
+    m = n + d + 1
+
+    bezalfs = np.zeros((d + 1, ph + 1), dtype=np.float64)
+    alfs = np.zeros(d, dtype=np.float64)
+    bpts = np.zeros((d + 1, rank), dtype=ctrl.dtype)
+    ebpts = np.zeros((ph + 1, rank), dtype=ctrl.dtype)
+    nextbpts = np.zeros((d + 1, rank), dtype=ctrl.dtype)
+
+    bezalfs[0, 0] = 1.0
+    bezalfs[d, ph] = 1.0
+    for i in range(1, ph2 + 1):
+        inv = 1.0 / _bincoeff(ph, i)
+        for j in range(max(0, i - t), min(d, i) + 1):
+            bezalfs[j, i] = inv * _bincoeff(d, j) * _bincoeff(t, i - j)
+    for i in range(ph2 + 1, ph):
+        for j in range(max(0, i - t), min(d, i) + 1):
+            bezalfs[j, i] = bezalfs[d - j, ph - i]
+
+    kind, r, a, b, cind = ph + 1, -1, d, d + 1, 1
+    ua = knots[0]
+    ik = np.zeros(len(knots) + t * len(knots), dtype=knots.dtype)
+    ic = np.zeros((n_pts + t * len(knots), rank), dtype=ctrl.dtype)
+
+    ic[0] = ctrl[0]
+    ik[: ph + 1] = ua
+    bpts[: d + 1] = ctrl[: d + 1]
+
+    while b <= m:
+        run_start = b
+        while b < m and knots[b] == knots[b + 1]:
+            b += 1
+        mul = b - run_start + 1
+        ub = knots[b]
+        oldr, r = r, d - mul
+
+        if oldr > 0:
+            lbz = (oldr + 2) // 2
+        elif oldr < 0 and a != d:
+            lbz = 0
+        else:
+            lbz = 1
+        rbz = ph - (r + 1) // 2 if r > 0 else ph
+
+        if r > 0:
+            numer = ub - ua
+            for q in range(d, mul, -1):
+                if policy == "wide-alfs-division":
+                    alfs[q - mul - 1] = float(numer) / (float(knots[a + q]) - float(ua))
+                else:
+                    alfs[q - mul - 1] = numer / (knots[a + q] - ua)
+            for j in range(1, r + 1):
+                save, s = r - j, mul + j
+                for q in range(d, s - 1, -1):
+                    for ii in range(rank):
+                        kept = alfs[q - s] * float(bpts[q, ii])
+                        carried = (1.0 - alfs[q - s]) * float(bpts[q - 1, ii])
+                        bpts[q, ii] = fmt(kept + carried)
+                nextbpts[save] = bpts[d]
+
+        for i in range(lbz, ph + 1):
+            ebpts[i] = 0.0
+            wide = np.zeros(rank, dtype=np.float64)
+            for j in range(max(0, i - t), min(d, i) + 1):
+                for ii in range(rank):
+                    term = bezalfs[j, i] * float(bpts[j, ii])
+                    if policy == "wide-ebpts-accumulator":
+                        wide[ii] += term
+                        ebpts[i, ii] = fmt(wide[ii])
+                    else:
+                        ebpts[i, ii] = fmt(float(ebpts[i, ii]) + term)
+
+        if oldr > 1:
+            first, last = kind - 2, kind
+            if policy == "wide-knot-weights":
+                den = float(ub) - float(ua)
+                bet = (float(ub) - float(ik[kind - 1])) / den
+            else:
+                den = ub - ua
+                bet = (ub - ik[kind - 1]) / den
+            for tr in range(1, oldr):
+                i, j = first, last
+                kj = j - kind + 1
+                while j - i > tr:
+                    if i < cind:
+                        if policy == "wide-knot-weights":
+                            alf = (float(ub) - float(ik[i])) / (float(ua) - float(ik[i]))
+                        else:
+                            alf = (ub - ik[i]) / (ua - ik[i])
+                        for ii in range(rank):
+                            if policy == "wide-blend-product":
+                                kept = float(alf) * float(ic[i, ii])
+                            else:
+                                kept = alf * ic[i, ii]
+                            carried = (1.0 - float(alf)) * float(ic[i - 1, ii])
+                            ic[i, ii] = fmt(float(kept) + carried)
+                    if j >= lbz:
+                        if j - tr <= kind - ph + oldr:
+                            if policy == "wide-knot-weights":
+                                weight = (float(ub) - float(ik[j - tr])) / den
+                            else:
+                                weight = (ub - ik[j - tr]) / den
+                        else:
+                            weight = bet
+                        for ii in range(rank):
+                            if policy == "wide-blend-product":
+                                kept = float(weight) * float(ebpts[kj, ii])
+                            else:
+                                kept = weight * ebpts[kj, ii]
+                            carried = (1.0 - float(weight)) * float(ebpts[kj + 1, ii])
+                            ebpts[kj, ii] = fmt(float(kept) + carried)
+                    i, j, kj = i + 1, j - 1, kj - 1
+                first, last = first - 1, last + 1
+
+        if a != d:
+            for _ in range(ph - oldr):
+                ik[kind] = ua
+                kind += 1
+
+        for j in range(lbz, rbz + 1):
+            ic[cind] = ebpts[j]
+            cind += 1
+
+        if b < m:
+            bpts[:r] = nextbpts[:r]
+            for j in range(max(0, r), d + 1):
+                bpts[j] = ctrl[b - d + j]
+            a, b, ua = b, b + 1, ub
+        else:
+            ik[kind : kind + ph + 1] = ub
+            break
+
+    return ic[:cind].copy(), ik[: kind + ph + 1].copy()
+
+
+def _sweep() -> list[tuple[int, FloatArray, int]]:
+    """Build the case list the policies are compared over.
+
+    Returns:
+        list[tuple[int, FloatArray, int]]: ``(degree, knots, increment)`` per case,
+        clamped at both ends and covering interior multiplicities 1 to ``degree + 1``.
+    """
+    rng = np.random.default_rng(20260911)
+    cases: list[tuple[int, FloatArray, int]] = []
+    for _ in range(120):
+        degree = int(rng.integers(1, 7))
+        interior: list[float] = []
+        for value in np.sort(rng.uniform(0.05, 0.95, int(rng.integers(0, 5)))):
+            interior += [round(float(value), 3)] * int(rng.integers(1, degree + 2))
+        knots = np.array([0.0] * (degree + 1) + interior + [1.0] * (degree + 1))
+        if len(knots) - degree - 1 < degree + 1:
+            continue
+        cases.append((degree, knots, int(rng.integers(1, 4))))
+    return cases
+
+
+def _compare_policies(dtype: npt.DTypeLike) -> dict[str, tuple[int, int]]:
+    """Run every policy against the kernel and count exact reproductions.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format for the control points and knots.
+
+    Returns:
+        dict[str, tuple[int, int]]: Policy to ``(matched, compared)`` array counts.
+    """
+    rng = np.random.default_rng(7)
+    tally = {policy: [0, 0] for policy in _POLICIES}
+    for degree, knots_64, increment in _sweep():
+        knots = knots_64.astype(dtype)
+        rows = len(knots) - degree - 1
+        ctrl = rng.uniform(-1e3, 1e3, (rows, 2)).astype(dtype)
+        truth, truth_knots = _degree_elevate_1d_core(degree, ctrl, knots, increment)
+        for policy in _POLICIES:
+            model, model_knots = _elevate_model(degree, ctrl, knots, increment, policy)
+            tally[policy][1] += 1
+            same = model.shape == truth.shape and np.array_equal(
+                model.view(np.uint8), truth.view(np.uint8)
+            )
+            same = same and np.array_equal(model_knots.view(np.uint8), truth_knots.view(np.uint8))
+            tally[policy][0] += int(same)
+    return {policy: (count[0], count[1]) for policy, count in tally.items()}
+
+
+def _derivative_widths(dtype: npt.DTypeLike) -> tuple[int, int]:
+    """Count how often a `float64` derivative model differs from the oracle.
+
+    ``_derivative_ctrl_1d`` is plain numpy, so NEP 50 decides its widths: the Python
+    ``int`` degree is weak and is converted to the array's format rather than promoting
+    it, and the output array is allocated at the control points' dtype.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format for the control points and knots.
+
+    Returns:
+        tuple[int, int]: ``(arrays where a float64 model differs, arrays compared)``.
+    """
+    rng = np.random.default_rng(11)
+    differed = 0
+    compared = 0
+    for degree, knots_64, _ in _sweep():
+        knots = knots_64.astype(dtype)
+        rows = len(knots) - degree - 1
+        ctrl = rng.uniform(-1e3, 1e3, (rows, 2)).astype(dtype)
+        truth = _derivative_ctrl_1d(knots, degree, ctrl)
+
+        wide_knots = knots.astype(np.float64)
+        wide = _derivative_ctrl_1d(wide_knots, degree, ctrl.astype(np.float64)).astype(dtype)
+        compared += 1
+        differed += int(not np.array_equal(wide.view(np.uint8), truth.view(np.uint8)))
+    return differed, compared
+
+
+def _unclamped_walk() -> None:
+    """Demonstrate that A5.9 steps past its control array on an unclamped vector.
+
+    The compiled half returns whatever the read found, so the values it prints are not
+    a measurement of anything and must not be quoted: two calls on the same input are
+    compared here so that the report says *that* rather than a number. The interpreted
+    half is the reproducible one.
+    """
+    knots = np.array([-0.3, -0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.1, 1.2, 1.3])
+    ctrl = np.arange(7.0).reshape(7, 1)
+    print("  knots  :", knots.tolist())
+    print("  ctrl   : 7 rows, degree 3, increment 1")
+    print("  the walk needs ctrl[7], and ctrl has 7 rows")
+    state = "interpreted" if os.environ.get("NUMBA_DISABLE_JIT") == "1" else "compiled"
+    try:
+        runs = [_degree_elevate_1d_core(3, ctrl, knots, 1)[0] for _ in range(2)]
+    except IndexError as error:
+        print(f"  {state}: IndexError: {error}")
+    else:
+        agree = np.array_equal(runs[0], runs[1])
+        print(f"  {state}: returned {runs[0].shape[0]} coefficients, no exception raised")
+        print(f"  two calls on the same input agree bit for bit: {agree}")
+        print("  the tail holds whatever the out-of-bounds read found, so it is not a figure")
+    other = "without NUMBA_DISABLE_JIT" if state == "interpreted" else "with NUMBA_DISABLE_JIT=1"
+    print(f"  Run again {other} to see the other half.")
+
+
+def main() -> int:
+    """Print the three measurements.
+
+    Returns:
+        int: 0.
+    """
+    compiled = hasattr(_degree_elevate_1d_core, "inspect_types")
+    if not compiled:
+        # `design/backend_parity.md` Rule 12: under `NUMBA_DISABLE_JIT=1` the oracle is
+        # a different object. There is no inferred type to read and no width to measure
+        # -- CPython's `float()` widens where numba's does not -- so the two sections
+        # that are about widths are not merely skipped, they would be about something
+        # else. The out-of-bounds walk is the half this configuration answers, and it
+        # answers it better than the compiled one does.
+        print("NUMBA_DISABLE_JIT is set, so the kernel is interpreted python.")
+        print("The width sections need the compiled kernel and are not run.\n")
+        print("== A5.9 on an unclamped knot vector ==")
+        _unclamped_walk()
+        return 0
+
+    for dtype in (np.float32, np.float64):
+        name = np.dtype(dtype).name
+        print(f"== Numba's inferred type per site, at {name} ==")
+        for site, inferred in sorted(_inferred_types(_degree_elevate_1d_core, dtype).items()):
+            print(f"  {site:<10} {inferred}")
+        print()
+
+    print("== A5.9 width policies against the kernel, exact array agreement ==")
+    for dtype in (np.float32, np.float64):
+        name = np.dtype(dtype).name
+        print(f"  {name}:")
+        for policy, (matched, compared) in _compare_policies(dtype).items():
+            print(f"    {policy:<24} {matched:>4} / {compared}")
+    print()
+
+    print("== The derivative's width: a float64 model against the oracle ==")
+    for dtype in (np.float32, np.float64):
+        differed, compared = _derivative_widths(dtype)
+        print(f"  {np.dtype(dtype).name}: differs on {differed} of {compared} arrays")
+    print()
+
+    print("== A5.9 on an unclamped knot vector ==")
+    _unclamped_walk()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -141,6 +141,22 @@ windowed restriction. The module's *kernels* are a separate question with its ow
 answer: the tensor-product extraction kernels are ported and dispatch through
 ``pantr.bspline._extraction_backend``, which is why this paragraph is about types.
 
+**A handful of :class:`~pantr.bspline.Bspline`'s own operations dispatch too, and
+that is a third category again -- not a module-level kernel, and not a ported type,
+since ``Bspline`` itself stays a Python wrapper under either backend.**
+``insert_knots`` and ``subdivide`` reach ``cpp/include/pantr/bspline/refinement.hpp``
+through ``pantr.bspline._refinement_backend``; ``slice``, ``split`` and ``to_open``
+reach ``cpp/include/pantr/bspline/structural.hpp`` through
+``pantr.bspline._structural_backend``; and ``derivative`` and ``elevate_degree``
+reach ``cpp/include/pantr/bspline/degree.hpp`` through
+``pantr.bspline._degree_backend``. Each catalogue records its own boundary rather
+than this paragraph restating them: a periodic direction keeps ``insert_knots``,
+``subdivide`` and ``elevate_degree`` on the oracle, a rational field or a
+``keep_degree=True`` request keep ``derivative`` on it, and an unclamped direction
+keeps ``elevate_degree`` on it too -- the last one not because the port is missing
+but because the oracle's own answer there is a defect ``degree.hpp`` declines to
+reproduce in undefined-behaviour form.
+
 **This list was wrong for two releases and that is worth a sentence.** It said three
 modules and named neither half of ``bezier`` while both were merged and dispatching.
 It was then wrong again through the type epic, naming one of the nine types above and

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -133,6 +133,8 @@ from ._bspline import (
 )
 from ._bspline_field import Bspline32 as Bspline32
 from ._bspline_field import Bspline64 as Bspline64
+from ._bspline_field import differentiate_bspline as differentiate_bspline
+from ._bspline_field import elevate_bspline_degree as elevate_bspline_degree
 from ._bspline_field import insert_bspline_knots as insert_bspline_knots
 from ._bspline_field import open_bspline as open_bspline
 from ._bspline_field import slice_bspline as slice_bspline

--- a/src/pantr/_pantr_cpp/_bspline_field.pyi
+++ b/src/pantr/_pantr_cpp/_bspline_field.pyi
@@ -1,10 +1,11 @@
 """Type stub for `pantr.bspline.Bspline`, bound in `cpp/bindings/bspline_type.cpp`.
 
-The two refinement entry points come from ``cpp/bindings/bspline_refinement.cpp`` and
-the four structural ones from ``cpp/bindings/bspline_structural.cpp`` instead, and
-they are here rather than in further stub modules because they are operations on the
-classes above: a stub split by binding file would put a function's argument type in
-one module and the function in another for no reader's benefit.
+The two refinement entry points come from ``cpp/bindings/bspline_refinement.cpp``, the
+four structural ones from ``cpp/bindings/bspline_structural.cpp``, and the two degree
+ones from ``cpp/bindings/bspline_degree.cpp`` instead, and they are here rather than
+in further stub modules because they are operations on the classes above: a stub
+split by binding file would put a function's argument type in one module and the
+function in another for no reader's benefit.
 
 ``bspline_structural.cpp`` binds no ``bspline_boundary``, so none is declared here.
 ``pantr.bspline.Bspline.boundary`` is a ``slice`` at a domain endpoint and reaches C++
@@ -131,6 +132,32 @@ def subdivide_bspline(
 
     A count of 1 skips its direction. ``regularity`` is ``None`` for ``degree - 1`` per
     direction, the maximal smoothness each degree admits.
+    """
+
+def differentiate_bspline(
+    bspline: Bspline32 | Bspline64,
+    direction: int,
+) -> Bspline32 | Bspline64:
+    """The field's first partial derivative in ``direction``, as a new field.
+
+    Every other direction's space handle is carried into the result. Raises
+    ``ValueError`` for a direction out of range, for a degree-0 direction, or for a
+    rational field; there is no ``keep_degree`` parameter here at all --
+    ``cpp/include/pantr/bspline/degree.hpp`` explains why that path and the rational
+    one are declared boundaries rather than missing ports.
+    """
+
+def elevate_bspline_degree(
+    bspline: Bspline32 | Bspline64,
+    increments: Sequence[int],
+) -> Bspline32 | Bspline64:
+    """Raise a field's degree per direction by ``increments``, over the same geometry.
+
+    A direction whose increment is 0 is left alone and its space handle carried into
+    the result. Raises ``ValueError`` for a length mismatch, a negative increment, an
+    all-zero argument, an elevated degree outside the exact-integer binomial envelope,
+    or a direction to elevate that is periodic or not clamped --
+    ``cpp/include/pantr/bspline/degree.hpp`` explains the last two.
     """
 
 def open_bspline(bspline: Bspline32 | Bspline64) -> Bspline32 | Bspline64:

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -56,8 +56,7 @@ from numpy import typing as npt
 
 from .._backend import Backend, active_backend, available_backends
 from .._transform_control_points import _apply_affine_to_control_points
-from ._bspline_degree import _degree_elevate_bspline, _degree_reduce_bspline
-from ._bspline_derivative import _derivative_bspline
+from ._bspline_degree import _degree_reduce_bspline
 from ._bspline_eval import _evaluate_Bspline, _evaluate_Bspline_deriv
 from ._bspline_knot_insertion import _to_periodic_bspline_impl
 from ._bspline_knot_removal import _remove_knots_bspline
@@ -66,6 +65,7 @@ from ._bspline_restrict import _restrict_bspline_impl
 from ._bspline_space_nd import BsplineSpace as _BsplineSpace
 from ._bspline_space_nd import _impl_class as _space_impl_class
 from ._bspline_to_beziers import _to_beziers_impl
+from ._degree_backend import derivative_of_field, elevate_field_degree
 from ._refinement_backend import insert_knots_into_field, subdivide_field
 from ._structural_backend import slice_field, split_field, to_open_field
 
@@ -965,6 +965,11 @@ class Bspline:
                 (``_BINCOEFF_MAX_N``). Reachable with ``keep_degree=True``, and
                 for a rational B-spline with either setting, since that path
                 always re-elevates.
+            TypeError: If this field was built under the other backend. New with the
+                C++ dispatch: differentiation crosses the boundary as a *field*, and
+                ``_cpp_handle`` refuses a foreign one rather than converting it.
+                Unreachable with ``keep_degree=True`` or a rational field, both of
+                which stay on the oracle regardless of backend.
 
         Example:
             >>> import numpy as np
@@ -988,7 +993,7 @@ class Bspline:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
         if self.space.spaces[direction].degree < 1:
             raise ValueError("Derivative of a degree-0 B-spline is not defined.")
-        return _derivative_bspline(self, direction, keep_degree=keep_degree)
+        return derivative_of_field(self, direction, keep_degree=keep_degree)
 
     def elevate_degree(self, degree_increments: int | Sequence[int]) -> Bspline:
         """Elevate the polynomial degree of the B-spline.
@@ -1013,6 +1018,11 @@ class Bspline:
             ValueError: If the number of increments does not match the dimension.
             ValueError: If an elevated degree would exceed the exactness envelope
                 of the binomial-coefficient kernel (``_BINCOEFF_MAX_N``).
+            TypeError: If this field was built under the other backend. New with the
+                C++ dispatch: degree elevation crosses the boundary as a *field*, and
+                ``_cpp_handle`` refuses a foreign one rather than converting it.
+                Unreachable when every direction to elevate is periodic or not
+                clamped, since that case stays on the oracle regardless of backend.
 
         References:
             Degree elevation of spline curves :cite:p:`piegl1997nurbs`.
@@ -1034,7 +1044,7 @@ class Bspline:
         if all(inc == 0 for inc in increments):
             raise ValueError("At least one degree increment must be positive.")
 
-        return _degree_elevate_bspline(self, increments)
+        return elevate_field_degree(self, increments)
 
     def reduce_degree(self, degree_decrements: int | Sequence[int]) -> Bspline:
         r"""Reduce the polynomial degree of the B-spline.

--- a/src/pantr/bspline/_degree_backend.py
+++ b/src/pantr/bspline/_degree_backend.py
@@ -26,8 +26,17 @@ the adapter hands the binding the handle the wrapper already holds and wraps the
 handle that comes back. The *arguments* cross as a scalar direction and a tuple of
 increments, neither of which carries an invariant to lose.
 
-Where the two backends differ, and there are three places
------------------------------------------------------------
+Where the two backends differ, and there are four places
+--------------------------------------------------------
+
+**An argument with nothing to elevate runs the oracle**, which is the one divergence
+here that is neither a boundary nor a defect but an asymmetry between the two sides'
+own argument checking: ``cpp/include/pantr/bspline/degree.hpp`` refuses an all-zero or
+negative increment with :meth:`pantr.bspline.Bspline.elevate_degree`'s own Layer 1
+message, while ``_degree_elevate_bspline`` never checks and returns the field unchanged.
+The public method refuses such an argument before either is reached, so this closes a gap
+only a direct caller of :func:`elevate_field_degree` could open -- which is the same
+reason :mod:`pantr.bspline._refinement_backend` closes its own.
 
 **A rational field, or a ``keep_degree=True`` request, always runs the oracle.**
 ``cpp/include/pantr/bspline/degree.hpp`` gives ``derivative`` no ``keep_degree``
@@ -163,6 +172,15 @@ def _the_cpp_backend_can_elevate(bspline: Bspline, degree_increments: tuple[int,
         return False
     if Backend.CPP not in available_backends():
         raise RuntimeError("the CPP backend is not available in this installation")
+    # An argument with nothing to elevate goes to the oracle, which is the guard
+    # `_refinement_backend._the_cpp_backend_can_take_it` makes for the same reason: the
+    # two sides disagree about it. `Bspline.elevate_degree` refuses such an argument above
+    # this branch, so no public caller reaches it -- but these entry points are importable
+    # private symbols of a package whose private symbols a downstream consumer already
+    # imports, and the C++ half refuses what the oracle silently returns unchanged. The
+    # `all()` below would say yes to it vacuously.
+    if not any(increment > 0 for increment in degree_increments):
+        return False
     spaces = bspline.space.spaces
     return all(
         not spaces[direction].periodic and spaces[direction].has_open_knots()

--- a/src/pantr/bspline/_degree_backend.py
+++ b/src/pantr/bspline/_degree_backend.py
@@ -1,0 +1,271 @@
+"""Which implementation changes a B-spline field's degree: Numba, or C++.
+
+:mod:`pantr._backend` owns the **policy**. This module owns the **catalogue** for the
+two degree-changing operations, exactly as :mod:`pantr.bspline._refinement_backend`
+and :mod:`pantr.bspline._structural_backend` do for theirs, and for the same reason: a
+catalogue imports the implementations it hands out, so keeping each one beside its own
+is what stops the policy module from importing the library it must stay independent of.
+
+Two entry points rather than accessors
+--------------------------------------
+
+:func:`derivative_of_field` and :func:`elevate_field_degree` are functions that *do*
+the work, not accessors that return a callable, for the reason
+:mod:`pantr.bspline._refinement_backend` gives: these are not kernels selected by a
+caller that then invokes them. What crosses the seam is a :class:`~pantr.bspline.Bspline`,
+the branch is decided by more than the active backend, and there is exactly one
+consumer per entry point.
+
+What crosses the boundary
+-------------------------
+
+**The field, not its arrays**, for the reason
+:mod:`pantr.bspline._refinement_backend` gives: these are operations on a domain type
+C++ has owned since the 2026-08-27 amendment to ``design/cross_backend_types.md``, so
+the adapter hands the binding the handle the wrapper already holds and wraps the
+handle that comes back. The *arguments* cross as a scalar direction and a tuple of
+increments, neither of which carries an invariant to lose.
+
+Where the two backends differ, and there are three places
+-----------------------------------------------------------
+
+**A rational field, or a ``keep_degree=True`` request, always runs the oracle.**
+``cpp/include/pantr/bspline/degree.hpp`` gives ``derivative`` no ``keep_degree``
+parameter at all and refuses a rational field outright, and says why: both of the
+oracle's corresponding paths currently have an open defect --
+``derivative(keep_degree=True)`` on an unclamped, non-periodic direction returns a
+wrong function, and the rational derivative raises whenever the differentiated
+direction is periodic -- so there is nothing stable for a C++ side to be at parity
+with yet. :func:`_the_cpp_backend_can_differentiate` keeps both cases on the Python
+path rather than letting a caller meet that refusal or, worse, a silently absent
+parameter.
+
+**A periodic direction to be elevated always runs the oracle.** Elevating one
+round-trips through ``_to_periodic_bspline_1d_impl``, which
+``cpp/include/pantr/bspline/structural.hpp`` declares as its own boundary and gives its
+reasons for; ``cpp/include/pantr/bspline/degree.hpp`` refuses such a direction rather
+than porting that conversion under cover of this one. It is the same declared boundary
+:mod:`pantr.bspline._refinement_backend` draws around a periodic direction that receives
+knots. A direction with a zero increment is not
+affected: C++ carries its space handle into the result untouched.
+
+**An unclamped direction to be elevated also always runs the oracle, and that one is
+not a missing port -- it is a defect in the oracle that this port deliberately does
+not reproduce.** A5.9 walks past the end of the coefficient array on an unclamped
+knot vector, and the C++ core refuses the read rather than perform it, because in C++
+an out-of-bounds read is undefined behaviour rather than a wrong number; the same
+header explains the read is silently wrong in the oracle itself, under numba, and
+raises ``IndexError`` only when JIT is disabled. **What the library accepts must not
+change with ``PANTR_BACKEND``, so an unclamped direction is routed to the oracle here
+rather than refused**, and whatever the oracle does with it is what a caller gets on
+either backend, unchanged. On the shapes exercised so far that is a ``ValueError`` from
+``Bspline``'s own constructor about the coefficient count, which is the out-of-bounds
+walk surfacing one step later rather than a diagnosis of it;
+``tests/parity/test_bspline_degree.py`` pins that behaviour on purpose, so that fixing
+the oracle is a visible change rather than a silent one.
+
+Cross-backend fields
+--------------------
+
+:func:`_cpp_handle` refuses a field built under the other backend rather than
+converting it, exactly as :func:`pantr.bspline._refinement_backend._cpp_handle` does
+and for the same reason: :meth:`pantr.bspline.Bspline._mutate` already refuses the
+same conversion for the three ``in_place=`` methods, and
+``design/cross_backend_types.md`` forbids it generally. The refusal is a property of
+*taking the C++ route*, so it fires under the C++ backend and not under the Python
+one.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+
+from .._backend import Backend, active_backend, available_backends
+from ._bspline_degree import _degree_elevate_bspline
+from ._bspline_derivative import _derivative_bspline
+
+if TYPE_CHECKING:
+    from .._pantr_cpp import Bspline32 as _CppBspline32
+    from .._pantr_cpp import Bspline64 as _CppBspline64
+    from ._bspline import Bspline
+
+    _CppHandle: TypeAlias = "_CppBspline32 | _CppBspline64"
+    """A field's C++ implementation, of either storage format."""
+
+
+def _cpp_handle(bspline: Bspline, operation: str) -> _CppHandle:
+    """The C++ implementation a field holds, refusing a Python one.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field whose handle is wanted.
+        operation (str): The verb naming the operation, for the error message.
+
+    Returns:
+        _CppHandle: The ``Bspline32`` or ``Bspline64`` handle.
+
+    Raises:
+        TypeError: If the field holds the Python implementation. That means the active
+            backend changed after it was built, and converting one implementation into
+            the other is what ``design/cross_backend_types.md`` forbids.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    impl = bspline._impl  # same package; the wrapper exposes no public handle
+    if not isinstance(impl, _pantr_cpp.Bspline32 | _pantr_cpp.Bspline64):
+        raise TypeError(
+            f"Bspline: cannot {operation} a Bspline built under a different backend "
+            f"({type(impl).__name__} against the active C++ one); the backend is "
+            f"chosen per process, so this means the active one changed after this "
+            f"Bspline was built."
+        )
+    return impl
+
+
+def _the_cpp_backend_can_differentiate(bspline: Bspline, *, keep_degree: bool) -> bool:
+    """Report whether the C++ path covers a :func:`derivative_of_field` call.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to differentiate.
+        keep_degree (bool): Whether the caller asked for the degree-preserving path.
+
+    Returns:
+        bool: True when :func:`_cpp_derivative` may run.
+
+    Raises:
+        RuntimeError: If the C++ backend is the active one and is not available. That
+            cannot happen through :func:`pantr._backend.active_backend`, which refuses
+            an unavailable backend at import; the check is here so that this module
+            states the never-fall-back rule rather than relying on where it was
+            enforced.
+    """
+    if active_backend() is Backend.PYTHON:
+        return False
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    return not keep_degree and not bspline.is_rational
+
+
+def _the_cpp_backend_can_elevate(bspline: Bspline, degree_increments: tuple[int, ...]) -> bool:
+    """Report whether the C++ path covers a :func:`elevate_field_degree` call.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to elevate.
+        degree_increments (tuple[int, ...]): The increments requested, in axis order.
+
+    Returns:
+        bool: True when :func:`_cpp_elevate_degree` may run.
+
+    Raises:
+        RuntimeError: If the C++ backend is the active one and is not available; see
+            :func:`_the_cpp_backend_can_differentiate` for why the check is here.
+    """
+    if active_backend() is Backend.PYTHON:
+        return False
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    spaces = bspline.space.spaces
+    return all(
+        not spaces[direction].periodic and spaces[direction].has_open_knots()
+        for direction, increment in enumerate(degree_increments)
+        if increment > 0
+    )
+
+
+def _cpp_derivative(bspline: Bspline, direction: int) -> Bspline:
+    """Differentiate through the C++ binding.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field, holding a C++ handle.
+        direction (int): The direction to differentiate.
+
+    Returns:
+        ~pantr.bspline.Bspline: The hodograph, wrapping a C++ handle.
+
+    Raises:
+        ValueError: If ``direction`` is out of range, if the degree in that direction
+            is 0, or if the field is rational. Every message is the oracle's, except
+            the rational one, which names a boundary
+            :func:`_the_cpp_backend_can_differentiate` never lets a caller reach.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bspline import Bspline as BsplineCls  # noqa: PLC0415  (cycle)
+
+    handle = _cpp_handle(bspline, "differentiate")
+    return BsplineCls._wrap_over(
+        _pantr_cpp.differentiate_bspline(handle, direction), bspline.space.spaces
+    )
+
+
+def _cpp_elevate_degree(bspline: Bspline, degree_increments: tuple[int, ...]) -> Bspline:
+    """Elevate degree through the C++ binding.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field, holding a C++ handle.
+        degree_increments (tuple[int, ...]): Increments for each dimension.
+
+    Returns:
+        ~pantr.bspline.Bspline: The elevated field, wrapping a C++ handle.
+
+    Raises:
+        ValueError: If an elevated degree would exceed the exactness envelope of the
+            binomial-coefficient kernel. The length, sign and all-zero refusals were
+            made by :meth:`pantr.bspline.Bspline.elevate_degree` above the branch, so
+            both backends refuse the same argument with the same message.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bspline import Bspline as BsplineCls  # noqa: PLC0415  (cycle)
+
+    handle = _cpp_handle(bspline, "elevate the degree of")
+    return BsplineCls._wrap_over(
+        _pantr_cpp.elevate_bspline_degree(handle, list(degree_increments)),
+        bspline.space.spaces,
+    )
+
+
+def derivative_of_field(bspline: Bspline, direction: int, *, keep_degree: bool) -> Bspline:
+    """Differentiate a B-spline field, on whichever backend covers the call.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to differentiate.
+        direction (int): Parametric direction for differentiation.
+        keep_degree (bool): Whether the result should preserve the original degree by
+            re-elevating after differentiation. Forces the Python path; see the module
+            docstring.
+
+    Returns:
+        ~pantr.bspline.Bspline: The hodograph.
+
+    Raises:
+        TypeError: If the C++ backend is active and the field was built under the
+            other one.
+        ValueError: If ``direction`` is out of range, if the degree in that direction
+            is 0, or if the degree the result has to be built at exceeds the
+            exactness envelope of the binomial-coefficient kernel.
+    """
+    if _the_cpp_backend_can_differentiate(bspline, keep_degree=keep_degree):
+        return _cpp_derivative(bspline, direction)
+    return _derivative_bspline(bspline, direction, keep_degree=keep_degree)
+
+
+def elevate_field_degree(bspline: Bspline, degree_increments: tuple[int, ...]) -> Bspline:
+    """Elevate a B-spline field's degree, on whichever backend covers the call.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The field to elevate.
+        degree_increments (tuple[int, ...]): Increments for each dimension, already
+            validated by :meth:`pantr.bspline.Bspline.elevate_degree`.
+
+    Returns:
+        ~pantr.bspline.Bspline: The elevated field.
+
+    Raises:
+        TypeError: If the C++ backend is active and the field was built under the
+            other one.
+        ValueError: If an elevated degree would exceed the exactness envelope of the
+            binomial-coefficient kernel.
+    """
+    if _the_cpp_backend_can_elevate(bspline, degree_increments):
+        return _cpp_elevate_degree(bspline, degree_increments)
+    return _degree_elevate_bspline(bspline, degree_increments)

--- a/src/pantr/bspline/_degree_backend.py
+++ b/src/pantr/bspline/_degree_backend.py
@@ -89,6 +89,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeAlias
 
+import numpy as np
+
 from .._backend import Backend, active_backend, available_backends
 from ._bspline_degree import _degree_elevate_bspline
 from ._bspline_derivative import _derivative_bspline
@@ -97,6 +99,7 @@ if TYPE_CHECKING:
     from .._pantr_cpp import Bspline32 as _CppBspline32
     from .._pantr_cpp import Bspline64 as _CppBspline64
     from ._bspline import Bspline
+    from ._bspline_space_1d import BsplineSpace1D
 
     _CppHandle: TypeAlias = "_CppBspline32 | _CppBspline64"
     """A field's C++ implementation, of either storage format."""
@@ -183,10 +186,35 @@ def _the_cpp_backend_can_elevate(bspline: Bspline, degree_increments: tuple[int,
         return False
     spaces = bspline.space.spaces
     return all(
-        not spaces[direction].periodic and spaces[direction].has_open_knots()
+        not spaces[direction].periodic and _closes_bit_exactly(spaces[direction])
         for direction, increment in enumerate(degree_increments)
         if increment > 0
     )
+
+
+def _closes_bit_exactly(space: BsplineSpace1D) -> bool:
+    """Report whether a direction's last ``degree + 1`` knots are bit-identical.
+
+    This is deliberately **not** :meth:`~pantr.bspline.BsplineSpace1D.has_open_knots`, which
+    compares the closing run within the space's tolerance.  The C++ elevation refuses a knot
+    vector whose closing run is not bit-identical, because A5.9 walks segments until a run of
+    equal knots reaches the last index and steps past its coefficients without one.  Routing
+    on the looser predicate would hand C++ a vector it then refuses in its own words, while
+    the oracle refuses the same vector in different words diagnosing a different cause -- so
+    the error a caller sees would depend on ``PANTR_BACKEND``, which this module promises it
+    does not.  Mirroring the refusal here sends every such vector to the oracle instead.
+
+    A direction that closes within tolerance but not bit-exactly needs ``snap_knots=False``
+    to build, since snapping collapses the near-tie.
+
+    Args:
+        space (~pantr.bspline.BsplineSpace1D): The direction to test.
+
+    Returns:
+        bool: True when the closing run is bit-identical, so C++ will accept it.
+    """
+    knots = space.knots
+    return bool(np.all(knots[-space.degree - 1 :] == knots[-1]))
 
 
 def _cpp_derivative(bspline: Bspline, direction: int) -> Bspline:

--- a/tests/parity/test_bspline_degree.py
+++ b/tests/parity/test_bspline_degree.py
@@ -1,0 +1,1430 @@
+"""Parity of the two degree operations: `Bspline.derivative` and `.elevate_degree`.
+
+Like :mod:`tests.parity.test_bspline_refinement` and unlike
+:mod:`tests.parity.test_bspline_type`, what this file compares is a **computation**: a
+control net is pushed through a difference quotient or through Piegl and Tiller A5.9, so
+there is real arithmetic on every coefficient and the criterion has to be argued rather
+than assumed. It is argued per quantity in :func:`_fields`, not once in bulk.
+
+## The criterion, and the one claim here that does not depend on the host
+
+**Bitwise, for the coefficients and the knots, on both operations.** The two backends run
+the same IEEE-754 operations in the same order; ``cpp/include/pantr/bspline/degree.hpp``
+carries the argument beside the code and it differs between the two.
+
+**The hodograph's claim is a property of the code rather than of the host, and that is
+worth saying because both sibling ports say the opposite of their own kernels.**
+``_derivative_ctrl_1d`` is plain numpy rather than a numba kernel, so NEP 50 decides its
+widths: the knot and coefficient differences are array expressions in the storage format,
+the Python ``int`` degree is *weak* and is converted to that format rather than promoting
+it, and ``np.divide``'s output is allocated at the control points' dtype. Every rounding
+is therefore in ``T``, and the expression is a difference, a scaling and a division --
+**no sum of a product, so no site in it can contract**. ``design/backend_parity.md``
+Rule 7 is what makes that remark necessary rather than decorative: a bitwise claim is
+normally about the build, and this one is not.
+
+**A5.9's claim is about this build, per Rule 7.** Its inner statements are
+``tmp1 + tmp2`` with both terms products, and ``ebpts[i, ii] += bezalfs[j, i] *
+bpts[j, ii]``; a target with a fused multiply-add would contract them. On the baseline
+x86-64 this project compiles for there is none.
+:func:`~tests._parity_harness.contraction_may_fuse` is the gate, and where it reports a
+fusing build the claim is skipped rather than weakened -- Rule 10's budget would apply
+and no host here can execute that branch to check it.
+
+**The widths inside A5.9 are three, they vary within the kernel, and Rule 9 is sharper
+here than it is anywhere else in the port.** Numba types each SSA version of a variable
+separately, so ``tmp1``'s four assignments do not agree: ``alfs[q - s] * bpts[q, ii]``
+reads a ``float64`` table and is ``float64``, while ``alf * ic[i, ii]``,
+``gam * ebpts[kj, ii]`` and ``bet * ebpts[kj, ii]`` read knot quotients that are
+themselves the storage format and are ``float32`` on a ``float32`` net. ``ebpts``
+narrows on **every term** of its accumulation rather than once at the end, and the Boehm
+quotient divides narrow and widens only on the store into a ``float64`` table.
+``scripts/measure_bspline_degree_widths.py`` prints numba's own inferred type per site
+and runs a rival model per site against the kernel; none of it is visible at ``float64``,
+which is Rule 9's own warning.
+
+**The interpreted oracle differs for the elevation and not for the hodograph, and the
+mechanism is Rule 12's first divergence reached by a route that rule does not name.**
+Rule 12 lists three things that change under ``NUMBA_DISABLE_JIT=1`` -- a storage width,
+``pow``, and an integer accumulator that wraps when compiled -- and attributes the width
+one to ``float()``, which numba's ``nopython`` mode does not treat as a promotion and
+CPython does. A5.9 contains no ``float()`` call, and its width moves anyway:
+``tmp2 = (1.0 - alf) * ic[i - 1, ii]`` carries a **Python float literal** against an
+``alf`` that is the storage format, and numba types that literal ``float64`` while NEP 50
+makes it *weak* and lets the ``float32`` operand decide. So the product is ``float64``
+compiled and ``float32`` interpreted, and the two answers are different numbers. The same
+applies to the `ebpts` blend's companion.
+
+Measured: with the JIT disabled, every ``float32`` elevation case in this file's
+field-by-field comparison fails and every ``float64`` one passes, which is the
+signature of a width rather than of an algorithm.
+:func:`~tests._parity_harness.demand_the_compiled_kernel` is the gate that owns exactly
+that question, and it is applied to the elevation.
+
+The hodograph needs no gate and that is a guarantee rather than an observation:
+``_derivative_ctrl_1d`` is plain numpy and is **not compiled in either configuration**,
+so it is the same object under both. Its own weak operand -- the Python ``int`` degree --
+is weak to numba too, the kernels being absent, so nothing about it moves. Neither kernel
+carries ``pow``, and the only integer accumulator in reach is ``_bincoeff``'s, which casts
+each step to ``np.int64`` explicitly and so wraps identically either way; Rule 12 names
+that kernel as its deliberate counter-example.
+
+## The independent check, and what it covers
+
+``design/backend_parity.md`` opens with the fact everything else follows from: parity
+says the two backends agree and not that either is right, so a shared error is invisible
+to every comparison above.
+
+**Marsden's identity.** For a knot vector ``t`` and degree ``p``,
+
+    u^r = sum_i [ e_r(t_{i+1}, ..., t_{i+p}) / C(p, r) ] N_{i,p}(u),
+
+with ``e_r`` the elementary symmetric polynomial, so the B-spline coefficients of a
+monomial are a closed form in the knots alone. A field carrying those numbers *is* the map
+``u -> u^r``, and each operation has to move it to the right place:
+
+- **elevation** must reproduce the same closed form on the **elevated** vector at the
+  **elevated** degree, since it does not change the map;
+- **the hodograph** must reproduce ``r u^{r-1}``'s closed form on ``t[1:-1]`` at degree
+  ``p - 1``. That one is an identity rather than a statement about the answer, provable
+  from ``e_r(S + {x}) = e_r(S) + x e_{r-1}(S)`` in two lines --
+  ``cpp/tests/test_bspline_degree.cpp``'s file comment writes them out -- and it holds
+  for any knot vector, clamped or not.
+
+Taking every ``r`` in ``[0, p]`` pins each row completely rather than up to an affine map;
+``r = 1`` alone is the Greville abscissa and ``r = 0`` alone is the partition of unity.
+Nothing in :func:`_marsden_column` consults either backend.
+
+## The accuracy bounds, and why the elevation's is a majorant
+
+**The hodograph.** ``gamma_K`` times an elementwise amplification, with ``K`` counted:
+``2p + 1`` for the input window's ``e_r`` recurrence and ``2(p-1) + 1`` for the derived
+one, one for the cast of the closed form into the field's storage, four for the formula
+itself -- the coefficient difference, the knot difference, the scaling by the degree and
+the division -- and one for the store. ``K = 4p + 5``. The magnitude is **not** the
+result's own: ``A_{i+1} - A_i`` can cancel to nothing while its operands do not, so the
+relative budget is charged against what was subtracted,
+
+    amplification_i = p (|A_i| + |A_{i+1}|) / |t_{i+p+1} - t_{i+1}|,
+
+which majorises the computed value and every partial result that fed it, there being only
+one subtraction, one scaling and one division.
+
+**The elevation, and here the obvious amplification is wrong rather than loose.** The
+finished elevation operator is non-negative with rows summing to one -- degree elevation
+writes each ``N_{i,p}`` as a non-negative combination of the elevated basis -- so every
+*output* coefficient is a convex combination and ``max |c|`` bounds it. A rounding budget
+is charged against the **intermediates**, though, and A5.9's are not convex combinations
+of anything: its knot-removal step blends with ``alf = (ub - ik[i]) / (ua - ik[i])``,
+whose numerator exceeds its denominator whenever ``ik[i] < ua < ub``, so ``alf > 1`` and
+``1 - alf < 0``. That is ``design/backend_parity.md`` Rule 10's recorded shortfall met on
+a second kernel, and its answer is what :func:`_elevate_majorant` uses: **run the
+recursion on the moduli of the coefficients and of the weights**. For a linear recursion
+with signed coefficients that bounds every intermediate by induction, and with the signs
+gone the partial sums are monotone, so the final value majorises all of them. It computes
+no value this file compares against -- those come from Marsden -- only a magnitude.
+
+``K`` for the elevation: the two ``e_r`` recurrences at degree ``p`` and ``p + t``, the
+cast in and the store out, and ``min(p, t) + 1`` stages of three accumulator roundings
+each. That stage count is Rule 10's for the Bézier elevation and it is right here for the
+same reason -- the accumulation into ``ebpts[i]`` runs ``j`` from ``max(0, i - t)`` to
+``min(p, i)`` -- and charging ``p + 1`` instead is the over-count that rule records.
+
+Both bounds add ``K`` underflow floors, the absolute half of Higham's model, because a
+closed form can be an exact zero and a relative bound of zero asserts bit-identity
+nothing here has grounds for.
+
+## The four places the backends do not meet
+
+All four are recorded in :mod:`pantr.bspline._degree_backend` and all four are pinned
+here rather than left to be met. The first two are boundaries of the port; the last two
+are defects in the oracle that the port deliberately does not inherit and deliberately
+does not change.
+
+- **`keep_degree=True` and a rational derivative run the oracle**, because the oracle's
+  own answers on those paths are under review and there is nothing stable to be at parity
+  with. ``keep_degree`` is absent from the C++ signature outright; a rational field is
+  refused by the binding, which
+  :func:`test_a_rational_derivative_is_refused_by_the_binding_and_served_by_the_oracle`
+  pins.
+- **A periodic direction being elevated runs the oracle**, because elevating one
+  round-trips through ``_to_periodic_bspline_1d_impl``, which
+  ``cpp/include/pantr/bspline/structural.hpp`` declares as its own boundary. The
+  derivative does **not** share that boundary and serves a periodic direction in C++;
+  :func:`test_the_periodic_hodograph_reaches_the_cpp_path` is the other half of that rule,
+  which an over-broad condition would get wrong.
+- **An unclamped direction being elevated runs the oracle, and the oracle is wrong
+  there.** A5.9 walks segments until a run of equal knots reaches the last index of the
+  vector; an unclamped vector has none, so the walk reads past the control array. Numba
+  does not bounds check in ``nopython`` mode, so it returns whatever the read found. The
+  C++ half refuses rather than reproducing undefined behaviour, and the routing sends the
+  call to the oracle anyway so that what the library accepts does not change with
+  ``PANTR_BACKEND``.
+  :func:`test_an_unclamped_elevation_fails_the_same_way_under_both_backends` pins the
+  oracle's current behaviour on purpose, so that fixing it is a visible change rather than
+  a silent one -- including that the symptom depends on the configuration: compiled, the
+  walk returns and the field's constructor refuses the coefficient count; interpreted,
+  numpy bounds checks and the read itself raises ``IndexError``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Final, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline._bspline_degree_core import _bincoeff
+from tests._parity_harness import (
+    AccuracyClaim,
+    Field,
+    assert_accuracy,
+    assert_object_parity,
+    bitwise_parity,
+    contraction_may_fuse,
+    demand_the_compiled_kernel,
+    derived_accuracy,
+    exact_parity,
+    the_jit_is_disabled,
+    underflow_floor,
+    unit_roundoff,
+)
+
+pytestmark = pytest.mark.usefixtures("cpp_backend")
+
+DTYPES: Final = (np.float64, np.float32)
+"""Both storage formats: a field stores `float32` too, so the C++ side has two classes."""
+
+_FUSING: Final = (
+    "this build's target ISA has a fused multiply-add, so A5.9's `tmp1 + tmp2` and its "
+    "`ebpts[i, ii] += bezalfs[j, i] * bpts[j, ii]` may contract and the bitwise claim "
+    "does not hold. design/backend_parity.md Rule 10's budget would apply; no host in "
+    "this project can execute that branch to check it, so it is skipped rather than "
+    "written blind."
+)
+"""Skip reason for the elevation's bitwise claims on a build that can fuse."""
+
+
+# ---------------------------------------------------------------------------
+# The independent oracle: Marsden's identity
+# ---------------------------------------------------------------------------
+
+
+def _marsden_column(
+    knots: npt.NDArray[np.float32 | np.float64], degree: int, power: int
+) -> npt.NDArray[np.float64]:
+    """The B-spline coefficients of ``u ** power`` over one knot vector.
+
+    ``A_i = e_power(knots[i+1], ..., knots[i+degree]) / C(degree, power)``; see the
+    module docstring. Formed in ``float64`` whatever the knots are stored in, by the
+    elementary-symmetric recurrence, so nothing here re-runs either backend.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): The knot vector.
+        degree (int): The polynomial degree.
+        power (int): The monomial power, in ``[0, degree]``.
+
+    Returns:
+        npt.NDArray[np.float64]: One coefficient per basis function,
+        ``len(knots) - degree - 1`` of them.
+    """
+    count = len(knots) - degree - 1
+    out = np.zeros(count, dtype=np.float64)
+    for i in range(count):
+        symmetric = np.zeros(degree + 1, dtype=np.float64)
+        symmetric[0] = 1.0
+        for k in range(1, degree + 1):
+            knot = float(knots[i + k])
+            for j in range(k, 0, -1):
+                symmetric[j] += knot * symmetric[j - 1]
+        out[i] = symmetric[power] / float(math.comb(degree, power))
+    return out
+
+
+def _elevate_majorant(  # noqa: PLR0912, PLR0915
+    degree: int,
+    magnitudes: npt.NDArray[np.float64],
+    knots: npt.NDArray[np.float64],
+    increment: int,
+) -> npt.NDArray[np.float64]:
+    """Run A5.9 on the moduli of its coefficients and of its blending weights.
+
+    The amplification the elevation's bound multiplies. A linear recursion with signed
+    coefficients is bounded term by term by the same recursion on the moduli, by
+    induction; with the signs gone every partial sum is monotone, so the value returned
+    for an output coefficient majorises every intermediate that fed it. See the module
+    docstring for why a companion built from the finished operator does not.
+
+    It computes no value this file compares against, only a magnitude.
+
+    Args:
+        degree (int): The original degree.
+        magnitudes (npt.NDArray[np.float64]): One non-negative magnitude per
+            coefficient.
+        knots (npt.NDArray[np.float64]): The knot vector.
+        increment (int): Degrees to add.
+
+    Returns:
+        npt.NDArray[np.float64]: One majorant per elevated coefficient.
+    """
+    mag = np.abs(np.asarray(magnitudes, dtype=np.float64))
+    kn = np.asarray(knots, dtype=np.float64)
+    num_rows = mag.shape[0]
+    d, t = degree, increment
+    ph, ph2 = d + t, (d + t) // 2
+    m = (num_rows - 1) + d + 1
+
+    bezalfs = np.zeros((d + 1, ph + 1))
+    alfs = np.zeros(max(d, 1))
+    bpts = np.zeros(d + 1)
+    ebpts = np.zeros(ph + 1)
+    nextbpts = np.zeros(d + 1)
+
+    bezalfs[0, 0] = 1.0
+    bezalfs[d, ph] = 1.0
+    for i in range(1, ph2 + 1):
+        inv = 1.0 / _bincoeff(ph, i)
+        for j in range(max(0, i - t), min(d, i) + 1):
+            bezalfs[j, i] = inv * _bincoeff(d, j) * _bincoeff(t, i - j)
+    for i in range(ph2 + 1, ph):
+        for j in range(max(0, i - t), min(d, i) + 1):
+            bezalfs[j, i] = bezalfs[d - j, ph - i]
+
+    kind, r, a, b, cind = ph + 1, -1, d, d + 1, 1
+    ua = kn[0]
+    ik = np.zeros(len(kn) + t * len(kn))
+    ic = np.zeros(num_rows + t * len(kn))
+    ic[0] = mag[0]
+    ik[: ph + 1] = ua
+    bpts[: d + 1] = mag[: d + 1]
+
+    while b <= m:
+        run_start = b
+        while b < m and kn[b] == kn[b + 1]:
+            b += 1
+        mul = b - run_start + 1
+        ub = kn[b]
+        oldr, r = r, d - mul
+        if oldr > 0:
+            lbz = (oldr + 2) // 2
+        elif oldr < 0 and a != d:
+            lbz = 0
+        else:
+            lbz = 1
+        rbz = ph - (r + 1) // 2 if r > 0 else ph
+
+        if r > 0:
+            numer = ub - ua
+            for q in range(d, mul, -1):
+                alfs[q - mul - 1] = numer / (kn[a + q] - ua)
+            for j in range(1, r + 1):
+                save, s = r - j, mul + j
+                for q in range(d, s - 1, -1):
+                    bpts[q] = abs(alfs[q - s]) * bpts[q] + abs(1.0 - alfs[q - s]) * bpts[q - 1]
+                nextbpts[save] = bpts[d]
+
+        for i in range(lbz, ph + 1):
+            ebpts[i] = 0.0
+            for j in range(max(0, i - t), min(d, i) + 1):
+                ebpts[i] += abs(bezalfs[j, i]) * bpts[j]
+
+        if oldr > 1:
+            first, last = kind - 2, kind
+            den = ub - ua
+            bet = (ub - ik[kind - 1]) / den
+            for tr in range(1, oldr):
+                i, j = first, last
+                kj = j - kind + 1
+                while j - i > tr:
+                    if i < cind:
+                        alf = (ub - ik[i]) / (ua - ik[i])
+                        ic[i] = abs(alf) * ic[i] + abs(1.0 - alf) * ic[i - 1]
+                    if j >= lbz:
+                        weight = (ub - ik[j - tr]) / den if j - tr <= kind - ph + oldr else bet
+                        ebpts[kj] = abs(weight) * ebpts[kj] + abs(1.0 - weight) * ebpts[kj + 1]
+                    i, j, kj = i + 1, j - 1, kj - 1
+                first, last = first - 1, last + 1
+
+        if a != d:
+            for _ in range(ph - oldr):
+                ik[kind] = ua
+                kind += 1
+        for j in range(lbz, rbz + 1):
+            ic[cind] = ebpts[j]
+            cind += 1
+        if b < m:
+            bpts[:r] = nextbpts[:r]
+            for j in range(max(0, r), d + 1):
+                bpts[j] = mag[b - d + j]
+            a, b, ua = b, b + 1, ub
+        else:
+            ik[kind : kind + ph + 1] = ub
+            break
+    return ic[:cind].copy()
+
+
+# ---------------------------------------------------------------------------
+# The case table
+# ---------------------------------------------------------------------------
+
+
+class _Case(NamedTuple):
+    """One field to operate on, and what to do to it.
+
+    Attributes:
+        label (str): The id a parametrized test reports.
+        knots (tuple[tuple[float, ...], ...]): One knot vector per direction.
+        degrees (tuple[int, ...]): One degree per direction.
+        periodic (tuple[bool, ...]): Whether each direction wraps.
+        increments (tuple[int, ...]): Degrees to add per direction, for the elevation.
+        direction (int): The direction to differentiate.
+        is_rational (bool): Whether the last component is a weight.
+    """
+
+    label: str
+    knots: tuple[tuple[float, ...], ...]
+    degrees: tuple[int, ...]
+    periodic: tuple[bool, ...]
+    increments: tuple[int, ...]
+    direction: int
+    is_rational: bool
+
+
+CASES: Final = (
+    _Case(
+        "cubic curve, four simple knots",
+        ((0.0, 0.0, 0.0, 0.0, 0.2, 0.5, 0.7, 1.0, 1.0, 1.0, 1.0),),
+        (3,),
+        (False,),
+        (2,),
+        0,
+        False,
+    ),
+    _Case(
+        "quadratic curve, a C^0 breakpoint",
+        ((0.0, 0.0, 0.0, 1.0 / 3.0, 1.0 / 3.0, 1.0, 1.0, 1.0),),
+        (2,),
+        (False,),
+        (1,),
+        0,
+        False,
+    ),
+    _Case(
+        "cubic curve, a C^-1 breakpoint",
+        ((0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0),),
+        (3,),
+        (False,),
+        (1,),
+        0,
+        False,
+    ),
+    _Case(
+        "one quartic Bezier span",
+        ((0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0),),
+        (4,),
+        (False,),
+        (3,),
+        0,
+        False,
+    ),
+    _Case(
+        "surface, direction 1 differentiated and elevated",
+        (
+            (0.0, 0.0, 0.0, 0.4, 1.0, 1.0, 1.0),
+            (-1.0, -1.0, -1.0, -1.0, 1.0 / 7.0, 2.0, 2.0, 2.0, 2.0),
+        ),
+        (2, 3),
+        (False, False),
+        (0, 2),
+        1,
+        False,
+    ),
+    _Case(
+        "rational surface, direction 0 only",
+        (
+            (0.0, 0.0, 0.0, 0.0, 0.3, 1.0, 1.0, 1.0, 1.0),
+            (0.0, 0.0, 1.0 / 7.0, 1.0, 1.0),
+        ),
+        (3, 1),
+        (False, False),
+        (1, 0),
+        0,
+        True,
+    ),
+    _Case(
+        "volume, the middle direction",
+        (
+            (0.0, 0.0, 1.0, 1.0),
+            (0.0, 0.0, 0.0, 0.3, 1.0, 1.0, 1.0),
+            (0.0, 0.0, 0.0, 0.0, 1.0 / 3.0, 0.6, 1.0, 1.0, 1.0, 1.0),
+        ),
+        (1, 2, 3),
+        (False, False, False),
+        (0, 1, 0),
+        1,
+        False,
+    ),
+    _Case(
+        "quintic curve, three simple interior knots",
+        ((0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 / 3.0, 0.6, 0.82, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),),
+        (5,),
+        (False,),
+        (1,),
+        0,
+        False,
+    ),
+    _Case(
+        "cubic curve, a span 500 times narrower than its neighbour",
+        ((0.0, 0.0, 0.0, 0.0, 0.001, 0.5, 1.0, 1.0, 1.0, 1.0),),
+        (3,),
+        (False,),
+        (1,),
+        0,
+        False,
+    ),
+    _Case(
+        "periodic curve",
+        ((-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0),),
+        (2,),
+        (True,),
+        (1,),
+        0,
+        False,
+    ),
+    _Case(
+        "unclamped curve",
+        ((-0.3, -0.2, -0.1, 0.0, 0.25, 0.5, 0.75, 1.0, 1.1, 1.2, 1.3),),
+        (3,),
+        (False,),
+        (1,),
+        0,
+        False,
+    ),
+)
+"""The shapes the two operations are compared over.
+
+Two of them are here for A5.9's knot-removal block, which a table of cubics does not
+reach even though it runs, and the reasons are worth writing down because they are the
+difference between a bitwise claim that pins a width and one that cannot.
+
+**The quintic is the only case whose `ebpts` blends survive to the output.** That block
+modifies `ebpts[kj]` with `kj` running 1, 2, 3, ... over its `tr` passes, while the
+segment's coefficients are emitted from `lbz = (oldr + 2) // 2` upwards. At degree 3 with
+simple interior knots `oldr` is 2 and `lbz` is 2, so the only write the block makes --
+`kj = 1` -- is to a coefficient never emitted, and a variant of
+`cpp/include/pantr/bspline/degree.hpp` computing either of that blend's two terms at the
+wrong width passed this whole file. `oldr` first reaches 4, and `kj` first reaches `lbz`,
+at degree 5.
+
+**The narrow span is for the bound rather than for a width**: it takes A5.9's blending
+weights far from one, which is where the majorant the accuracy check uses has to earn its
+place against a convex companion. It is *not* what makes the `ic` blend's own companion
+observable, and nothing is: that one forms `1 - alf` with
+`alf = (ub - ik[i]) / (ua - ik[i])`, and `ik[i] <= ua < ub` makes `alf >= 1`, for which
+the subtraction is exact in `float32` for every representable value. Computing it in the
+storage format there is a choice with no consequence, which is why no case in this table
+tries to catch it.
+"""
+
+
+def _spaces(case: _Case, dtype: npt.DTypeLike) -> list[BsplineSpace1D]:
+    """The univariate spaces of one case.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        list[BsplineSpace1D]: One space per direction, in axis order.
+    """
+    return [
+        BsplineSpace1D(np.array(knots, dtype=dtype), degree, periodic=periodic)
+        for knots, degree, periodic in zip(case.knots, case.degrees, case.periodic, strict=True)
+    ]
+
+
+def _make_field(case: _Case, dtype: npt.DTypeLike) -> Bspline:
+    """Build one case's field, with control points that are not a symmetric pattern.
+
+    The coefficients are a fixed deterministic sequence rather than the Marsden net: the
+    field-by-field comparison wants data that would expose a transposition or a dropped
+    row, and the accuracy check builds its own field from the closed form.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        ~pantr.bspline.Bspline: The field.
+    """
+    spaces = _spaces(case, dtype)
+    space = BsplineSpace(spaces)
+    rank = 2 + int(case.is_rational)
+    shape = (*(s.num_basis for s in spaces), rank)
+    count = math.prod(shape)
+    # A sequence with no repeats and no symmetry, so a permuted or dropped coefficient
+    # shows up as a value rather than only as a count -- and **not dyadic**, which is
+    # load-bearing rather than decorative. Coefficients of the form `k / 16` are exact in
+    # `float32`, so their differences are exact too and the hodograph's quotient is then
+    # the one case where computing it in `double` and narrowing once agrees with
+    # computing it narrow. A bitwise claim over such data is blind to the width it exists
+    # to pin: measured, a `double` variant of `derivative_along_axis` passed the whole of
+    # this file before the divisor below was 97 rather than 16.
+    # `test_the_case_table_earns_its_keep` asserts the values really do round.
+    values = np.array([(7.0 + ((i * 37) % 101)) / 97.0 for i in range(count)], dtype=dtype)
+    control_points = values.reshape(shape)
+    if case.is_rational:
+        # Weights must be positive, and distinct from each other.
+        control_points = control_points.copy()
+        control_points[..., -1] = np.abs(control_points[..., -1]) + 1.0
+    return Bspline(space, control_points, is_rational=case.is_rational)
+
+
+def _elevatable(case: _Case) -> bool:
+    """Whether every direction this case elevates is one the C++ half will take.
+
+    Args:
+        case (_Case): The shape.
+
+    Returns:
+        bool: ``True`` when no elevated direction is periodic or unclamped.
+    """
+    spaces = _spaces(case, np.float64)
+    return all(
+        increment == 0 or (not space.periodic and space.has_open_knots())
+        for increment, space in zip(case.increments, spaces, strict=True)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The field-by-field comparison
+# ---------------------------------------------------------------------------
+
+
+def _fields(dim: int, *, elevated: bool) -> tuple[Field, ...]:
+    """Every piece of a result field's state, one field each, with its own argument.
+
+    Args:
+        dim (int): The field's number of parametric directions.
+        elevated (bool): Whether the result came from the elevation rather than the
+            derivative, which changes the coefficients' argument and nothing else.
+
+    Returns:
+        tuple[Field, ...]: The field list for
+        :func:`~tests._parity_harness.assert_object_parity`.
+    """
+    coefficients_why = (
+        (
+            "the elevated coefficients. The two backends run A5.9's operations in the "
+            "same order and at the same widths: the Bezier coefficient table entirely "
+            "in `float64`, the Boehm quotient divided in the storage format and widened "
+            "only on its store into that table, the segment blend's two products both "
+            "`float64` and narrowed on the store, the elevated-Bezier accumulation "
+            "narrowed on *every* term rather than once, and the knot-removal blend's "
+            "first product in the storage format against a `float64` companion. See "
+            "the module docstring for why those are read off numba's own type inference "
+            "rather than off the source, and for the build this claim depends on."
+        )
+        if elevated
+        else (
+            "the hodograph's coefficients, and the only quantity here arithmetic "
+            "touches. `p * (c[i+1] - c[i]) / (k[i+p+1] - k[i+1])`, three roundings, all "
+            "in the storage format because NEP 50 converts the weak Python `int` degree "
+            "to the array's dtype rather than promoting it and `np.divide`'s output is "
+            "allocated at the control points'. A row whose denominator vanishes keeps "
+            "the exact zero it was allocated with on both sides, the quotient never "
+            "being formed. There is no sum of a product anywhere in it, so unlike every "
+            "other bitwise claim in this port it does not depend on the target ISA."
+        )
+    )
+    per_direction: list[Field] = []
+    for direction in range(dim):
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].knots",
+                bitwise_parity(
+                    why=(
+                        "the result's knot vector, and no arithmetic touches a knot in "
+                        "either operation: the hodograph drops the first and last entry "
+                        "of the input vector, and A5.9 writes copies of `ua` and `ub`, "
+                        "which are elements of it. A difference could only be a lost "
+                        "value, a miscount or a narrowing cast. The space then snaps "
+                        "near duplicates, identically on both sides, from identical "
+                        "input."
+                    )
+                ),
+                read=lambda field, d=direction: field.space.spaces[d].knots,  # type: ignore[misc]
+            )
+        )
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].tolerance",
+                bitwise_parity(
+                    why=(
+                        "the result's space derives its own tolerance from its knots, "
+                        "so it is a new quantity of the result rather than one carried "
+                        "over, and it is what every later domain and multiplicity "
+                        "comparison on that space will use. The knots above agree bit "
+                        "for bit and `knot_tolerance` is the same reduction over them "
+                        "on both sides. A difference would mean the two backends "
+                        "disagree about which knots are the same knot, which no "
+                        "comparison of the knots themselves would reveal."
+                    )
+                ),
+                read=lambda field, d=direction: field.space.spaces[d].tolerance,  # type: ignore[misc]
+            )
+        )
+        per_direction.append(
+            Field(
+                f"space.spaces[{direction}].periodic",
+                exact_parity(
+                    why=(
+                        "a flag, and the two operations treat it oppositely: the "
+                        "hodograph keeps a periodic direction periodic, while the "
+                        "elevation refuses one outright and never sees it. So a "
+                        "direction that came back with the wrong wrap would mean a "
+                        "conversion happened that neither operation performs, and "
+                        "nothing in the coefficients or the knots would say so."
+                    )
+                ),
+                read=lambda field, d=direction: field.space.spaces[d].periodic,  # type: ignore[misc]
+            )
+        )
+    return (
+        Field("control_points", bitwise_parity(why=coefficients_why)),
+        *per_direction,
+        Field(
+            "space.num_basis",
+            exact_parity(
+                why=(
+                    "the per-direction basis counts the result's net is laid out on. "
+                    "Exact integer counts, and the field's business rather than the "
+                    "space's: this is the tuple the C++ constructor checks the net's "
+                    "extents against, so a disagreement means the two backends laid one "
+                    "result out on two different grids. A5.9 sizes its output by "
+                    "counting as it writes rather than from a closed form, so this is "
+                    "where a segment walk that took a wrong turn surfaces."
+                )
+            ),
+        ),
+        Field(
+            "degree",
+            exact_parity(
+                why=(
+                    "one integer per direction, in axis order, and it is what each "
+                    "operation is *for* -- one less in the differentiated direction, "
+                    "one more per increment in an elevated one, unchanged everywhere "
+                    "else. The order is the load-bearing part: nothing about a degree "
+                    "reveals a transposition on a field whose directions happen to "
+                    "agree, which is why every multi-direction case here differs in it."
+                )
+            ),
+        ),
+        Field(
+            "rank",
+            exact_parity(
+                why=(
+                    "the stored component count less the weight column. Neither "
+                    "operation touches a component axis, so a rank that moved means the "
+                    "sweep consumed or produced an axis -- and it is the one field that "
+                    "folds the rationality flag against the shape, so it catches a "
+                    "result that preserved the coefficient count while moving which "
+                    "axis carries the components."
+                )
+            ),
+        ),
+        Field(
+            "is_rational",
+            exact_parity(
+                why=(
+                    "the flag is carried through the elevation and is `False` by "
+                    "construction on every hodograph the C++ half serves, since it "
+                    "refuses a rational field. It is named as its own field rather than "
+                    "left implicit because it is what `rank` subtracts, so a flag "
+                    "dropped shows up here as well as one field away, and reading only "
+                    "`rank` could not say which moved."
+                )
+            ),
+        ),
+        Field(
+            "dtype",
+            exact_parity(
+                why=(
+                    "the storage format the result reports, carried by the class of the "
+                    "C++ handle. A disagreement means the operation changed precision, "
+                    "which for a coefficient representable in both formats -- most of "
+                    "them -- the bitwise claim above would not see."
+                )
+            ),
+        ),
+    )
+
+
+def _both_derivatives(case: _Case, dtype: npt.DTypeLike) -> tuple[Bspline, Bspline]:
+    """The hodograph under each backend.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, ~pantr.bspline.Bspline]: The Python and C++
+        results, in that order.
+    """
+    with use_backend(Backend.PYTHON):
+        py = _make_field(case, dtype).derivative(case.direction)
+    with use_backend(Backend.CPP):
+        cpp = _make_field(case, dtype).derivative(case.direction)
+    return py, cpp
+
+
+def _both_elevations(case: _Case, dtype: npt.DTypeLike) -> tuple[Bspline, Bspline]:
+    """The elevated field under each backend.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, ~pantr.bspline.Bspline]: The Python and C++
+        results, in that order.
+    """
+    with use_backend(Backend.PYTHON):
+        py = _make_field(case, dtype).elevate_degree(case.increments)
+    with use_backend(Backend.CPP):
+        cpp = _make_field(case, dtype).elevate_degree(case.increments)
+    return py, cpp
+
+
+_DERIVATIVE_CASES: Final = tuple(case for case in CASES if not case.is_rational)
+"""Every case the C++ hodograph serves; a rational field routes to the oracle."""
+
+_ELEVATION_CASES: Final = tuple(case for case in CASES if any(case.increments))
+"""Every case with something to elevate."""
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", _DERIVATIVE_CASES, ids=lambda case: case.label)
+def test_the_hodograph_agrees_field_by_field(case: _Case, dtype: npt.DTypeLike) -> None:
+    """Every piece of the hodograph's state agrees, under its own claim.
+
+    No contraction gate: the difference quotient carries no sum of a product, so the
+    bitwise claim holds on a fusing build too. See the module docstring.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    py, cpp = _both_derivatives(case, dtype)
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=_fields(len(case.degrees), elevated=False),
+        context=f"derivative(direction={case.direction}) on {case.label} at {dtype}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("case", _ELEVATION_CASES, ids=lambda case: case.label)
+def test_the_elevation_agrees_field_by_field(case: _Case, dtype: npt.DTypeLike) -> None:
+    """Every piece of the elevated field's state agrees, under its own claim.
+
+    Args:
+        case (_Case): The shape to build.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    if contraction_may_fuse():
+        pytest.skip(_FUSING)
+    # A5.9's `(1.0 - alf)` is `float64` compiled and `float32` interpreted, so the
+    # oracle is a different computation there; see the module docstring.
+    demand_the_compiled_kernel(dtype)
+    if not _elevatable(case):
+        pytest.skip("this case elevates a direction the C++ half refuses; see its own test")
+    py, cpp = _both_elevations(case, dtype)
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=_fields(len(case.degrees), elevated=True),
+        context=f"elevate_degree({case.increments}) on {case.label} at {dtype}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The independent accuracy check
+# ---------------------------------------------------------------------------
+
+
+def _monomial_curve(
+    knots: npt.NDArray[np.float32 | np.float64], degree: int, power: int
+) -> tuple[Bspline, npt.NDArray[np.float64]]:
+    """A curve whose control points are Marsden's coefficients of ``u ** power``.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): The knot vector.
+        degree (int): The polynomial degree.
+        power (int): The monomial power.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, npt.NDArray[np.float64]]: The field, and the
+        closed form in ``float64`` before the cast into the field's storage.
+    """
+    closed_form = _marsden_column(knots, degree, power)
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    control_points = closed_form.astype(knots.dtype).reshape(-1, 1)
+    return Bspline(space, control_points, is_rational=False), closed_form
+
+
+def _hodograph_accuracy(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    closed_form: npt.NDArray[np.float64],
+    live: npt.NDArray[np.bool_],
+) -> AccuracyClaim:
+    """The elementwise bound between a hodograph and ``r u^(r-1)``'s closed form.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): The original knot vector.
+        degree (int): The original degree.
+        closed_form (npt.NDArray[np.float64]): The input coefficients, in ``float64``.
+        live (npt.NDArray[np.bool_]): Which rows have a non-vanishing denominator. The
+            bound is returned over those rows alone, since a row whose span collapsed is
+            not compared at all and a placeholder in the bound array would have to be
+            invented for it.
+
+    Returns:
+        AccuracyClaim: The bound over the live rows, and its derivation.
+    """
+    denominator = np.asarray(knots[degree + 1 : len(closed_form) + degree], dtype=np.float64) - (
+        np.asarray(knots[1 : len(closed_form)], dtype=np.float64)
+    )
+    magnitude = np.abs(closed_form[1:]) + np.abs(closed_form[:-1])
+    # The vanishing rows are excluded from the comparison; a positive placeholder keeps
+    # the bound array finite and the harness's own guards meaningful.
+    amplification = degree * magnitude[live] / np.abs(denominator[live])
+
+    # `2p + 1` for the input window's `e_r` recurrence, `2p - 1` for the derived window's
+    # at degree `p - 1`, one for the cast into the field's storage, four for the formula,
+    # one for the multiply by `r` on the expected side and one for the store -- charged
+    # although the quotient is already in the storage format, which is the conservative
+    # direction and keeps this count the same shape as the elevation's.
+    roundings = 4 * degree + 7
+    unit = unit_roundoff(knots.dtype)
+    relative = roundings * unit / (1.0 - roundings * unit)
+    return derived_accuracy(
+        bound=relative * amplification + roundings * underflow_floor(knots.dtype),
+        why=(
+            f"Marsden's identity gives the coefficients of u**r in closed form, and the "
+            f"derivative formula applied to them is exactly the closed form of "
+            f"r*u**(r-1) on the derived knot vector -- an identity, proved in two lines "
+            f"in cpp/tests/test_bspline_degree.cpp's file comment from "
+            f"e_r(S + x) = e_r(S) + x e_(r-1)(S). gamma_{roundings} at unit roundoff "
+            f"{unit:.3e}, times p*(|A_i| + |A_(i+1)|)/|t_(i+p+1) - t_(i+1)| elementwise: "
+            f"{2 * degree + 1} roundings form the input window's closed form and "
+            f"{2 * degree - 1} the derived window's, one is the cast into the field's "
+            f"storage, four are the formula itself -- the coefficient difference, the "
+            f"knot difference, the scaling by the degree and the division -- one is the "
+            f"multiply by r on the expected side, and one is the store. The magnitude is "
+            f"what was subtracted rather than the result, because that difference can "
+            f"cancel to nothing while its operands do not. "
+            f"{roundings} underflow floors are added for the rows whose closed form is "
+            f"an exact zero, where a relative bound asserts bit-identity it has no "
+            f"grounds for."
+        ),
+    )
+
+
+def _elevation_accuracy(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    increment: int,
+    stored: npt.NDArray[np.float64],
+) -> AccuracyClaim:
+    """The elementwise bound between an elevated curve and Marsden's closed form.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): The original knot vector.
+        degree (int): The original degree.
+        increment (int): Degrees added.
+        stored (npt.NDArray[np.float64]): The input coefficients as the field stores
+            them, already cast, which is what the kernel actually reads.
+
+    Returns:
+        AccuracyClaim: The bound and its derivation.
+    """
+    amplification = _elevate_majorant(
+        degree, np.abs(stored), np.asarray(knots, dtype=np.float64), increment
+    )
+    # A5.9's chain has three blocks: at most `p - 1` Boehm insertion passes, then
+    # `min(p, t) + 1` terms accumulated into one elevated Bezier coefficient -- Rule 10's
+    # own count for the Bezier elevation -- then at most `p - 2` knot-removal passes. Each
+    # stage costs four roundings, three in the accumulator and one narrowing store.
+    stages = max(1, max(0, degree - 1) + min(degree, increment) + 1 + max(0, degree - 2))
+    roundings = (2 * degree + 1) + (2 * (degree + increment) + 1) + 2 + 4 * stages
+    unit = unit_roundoff(knots.dtype)
+    relative = roundings * unit / (1.0 - roundings * unit)
+    return derived_accuracy(
+        bound=relative * amplification + roundings * underflow_floor(knots.dtype),
+        why=(
+            f"Marsden's identity gives the coefficients of u**r in closed form, so an "
+            f"elevation that does not move the map must reproduce it on the elevated "
+            f"knots at the elevated degree. gamma_{roundings} at unit roundoff "
+            f"{unit:.3e}, times the majorant of A5.9 run on the moduli of its "
+            f"coefficients and of its blending weights: {2 * degree + 1} roundings form "
+            f"the input closed form and {2 * (degree + increment) + 1} the elevated "
+            f"one, one is the cast into the field's storage, {4 * stages} are the "
+            f"kernel's own {stages} stages at four roundings each -- three in the "
+            f"accumulator and one narrowing store -- counting at most p - 1 Boehm "
+            f"insertion passes, min(p, t) + 1 accumulated terms and at most p - 2 "
+            f"knot-removal passes, and one is the store. The amplification is the "
+            f"majorant "
+            f"rather than a convex companion because A5.9's knot-removal step blends "
+            f"with a weight above one, so its intermediates are not convex combinations "
+            f"and a bound built from the finished operator would be exceeded rather "
+            f"than merely loose -- design/backend_parity.md Rule 10. "
+            f"{roundings} underflow floors are added for the coefficients whose closed "
+            f"form is an exact zero."
+        ),
+    )
+
+
+_ACCURACY_KNOTS: Final = (
+    ((0.0, 0.0, 0.0, 0.0, 0.2, 0.5, 0.7, 1.0, 1.0, 1.0, 1.0), 3),
+    ((0.0, 0.0, 0.0, 1.0 / 3.0, 1.0 / 3.0, 1.0, 1.0, 1.0), 2),
+    ((0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0), 3),
+    ((0.0, 0.0, 0.0, 0.0, 0.0, 1.0 / 7.0, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0), 4),
+)
+"""Knot vectors for the independent check, each with a knot no binary format represents.
+
+A dyadic vector rounds nothing and would report agreement without asking the bound a
+question, which is why every entry carries a third or a seventh.
+"""
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+@pytest.mark.parametrize("knots_and_degree", _ACCURACY_KNOTS, ids=lambda pair: f"degree{pair[1]}")
+def test_the_hodograph_is_the_analytic_derivative(
+    knots_and_degree: tuple[tuple[float, ...], int],
+    backend: Backend,
+    dtype: npt.DTypeLike,
+) -> None:
+    """Each backend's hodograph is ``r u^(r-1)``, against a closed form neither computes.
+
+    Args:
+        knots_and_degree (tuple[tuple[float, ...], int]): The knot vector and degree.
+        backend (Backend): Which backend to exercise.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    raw, degree = knots_and_degree
+    knots = np.array(raw, dtype=dtype)
+    derived = knots[1:-1]
+    checked = 0
+    for power in range(degree + 1):
+        with use_backend(backend):
+            field, closed_form = _monomial_curve(knots, degree, power)
+            hodograph = field.derivative()
+        denominator = np.asarray(
+            knots[degree + 1 : len(closed_form) + degree], dtype=np.float64
+        ) - np.asarray(knots[1 : len(closed_form)], dtype=np.float64)
+        live = denominator != 0.0
+
+        expected = np.zeros(len(closed_form) - 1, dtype=np.float64)
+        if power >= 1:
+            expected = power * _marsden_column(derived, degree - 1, power - 1)
+
+        got = hodograph.control_points.reshape(-1).astype(np.float64)
+        assert np.all(got[~live] == 0.0), "a zero-width span did not give an exact zero"
+        checked += int(np.count_nonzero(live))
+        assert_accuracy(
+            computed=got[live],
+            exact=expected[live],
+            claim=_hodograph_accuracy(knots, degree, closed_form, live),
+            context=f"the hodograph of u**{power} at degree {degree}, {dtype}, {backend.name}",
+        )
+    assert checked > 0, "every row was excluded, so the check compared nothing"
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP], ids=["python", "cpp"])
+@pytest.mark.parametrize("increment", [1, 2, 3])
+@pytest.mark.parametrize("knots_and_degree", _ACCURACY_KNOTS, ids=lambda pair: f"degree{pair[1]}")
+def test_the_elevation_reproduces_the_polynomial(
+    knots_and_degree: tuple[tuple[float, ...], int],
+    increment: int,
+    backend: Backend,
+    dtype: npt.DTypeLike,
+) -> None:
+    """Each backend's elevation is the same map, against a closed form neither computes.
+
+    Args:
+        knots_and_degree (tuple[tuple[float, ...], int]): The knot vector and degree.
+        increment (int): Degrees to add.
+        backend (Backend): Which backend to exercise.
+        dtype (npt.DTypeLike): The storage format.
+    """
+    raw, degree = knots_and_degree
+    knots = np.array(raw, dtype=dtype)
+    for power in range(degree + 1):
+        with use_backend(backend):
+            field, closed_form = _monomial_curve(knots, degree, power)
+            raised = field.elevate_degree(increment)
+        stored = field.control_points.reshape(-1).astype(np.float64)
+        space = raised.space.spaces[0]
+        assert space.degree == degree + increment
+        expected = _marsden_column(space.knots, space.degree, power)
+        got = raised.control_points.reshape(-1).astype(np.float64)
+        assert got.size == expected.size, (
+            f"the elevation returned {got.size} coefficients and the elevated vector "
+            f"calls for {expected.size}"
+        )
+        assert_accuracy(
+            computed=got,
+            exact=expected,
+            claim=_elevation_accuracy(knots, degree, increment, stored),
+            context=(
+                f"elevating u**{power} at degree {degree} by {increment}, {dtype}, {backend.name}"
+            ),
+        )
+
+
+def _worst_margin(dtype: npt.DTypeLike) -> float:
+    """The largest ratio to its own bound either accuracy check reaches at one format.
+
+    Args:
+        dtype (npt.DTypeLike): The storage format.
+
+    Returns:
+        float: The worst ``|deviation| / bound`` over the sweep, which must not exceed 1
+        and must not be so far below it that the bound asserts nothing.
+    """
+    worst = 0.0
+    for raw, degree in _ACCURACY_KNOTS:
+        knots = np.array(raw, dtype=dtype)
+        derived = knots[1:-1]
+        for power in range(degree + 1):
+            with use_backend(Backend.CPP):
+                field, closed_form = _monomial_curve(knots, degree, power)
+                hodograph = field.derivative()
+            denominator = np.asarray(
+                knots[degree + 1 : len(closed_form) + degree], dtype=np.float64
+            ) - np.asarray(knots[1 : len(closed_form)], dtype=np.float64)
+            live = denominator != 0.0
+            expected = (
+                np.zeros(len(closed_form) - 1, dtype=np.float64)
+                if power == 0
+                else power * _marsden_column(derived, degree - 1, power - 1)
+            )
+            got = hodograph.control_points.reshape(-1).astype(np.float64)
+            worst = max(
+                worst,
+                assert_accuracy(
+                    computed=got[live],
+                    exact=expected[live],
+                    claim=_hodograph_accuracy(knots, degree, closed_form, live),
+                    context="the margin sweep",
+                ).max_ratio_to_bound,
+            )
+            for increment in (1, 2, 3):
+                with use_backend(Backend.CPP):
+                    source, _ = _monomial_curve(knots, degree, power)
+                    raised = source.elevate_degree(increment)
+                stored = source.control_points.reshape(-1).astype(np.float64)
+                space = raised.space.spaces[0]
+                worst = max(
+                    worst,
+                    assert_accuracy(
+                        computed=raised.control_points.reshape(-1).astype(np.float64),
+                        exact=_marsden_column(space.knots, space.degree, power),
+                        claim=_elevation_accuracy(knots, degree, increment, stored),
+                        context="the margin sweep",
+                    ).max_ratio_to_bound,
+                )
+    return worst
+
+
+def test_the_accuracy_bounds_are_approached_rather_than_merely_satisfied() -> None:
+    """Both bounds come within an order of magnitude of being violated.
+
+    A bound nothing approaches asserts nothing, and the two above are built from counted
+    roundings times an amplification, either of which could be over-stated without any
+    test noticing. This runs the same sweep the two accuracy tests do and asserts the
+    worst ratio to the bound clears a floor.
+
+    **The floor is a hundredth, and it is an acknowledged slack rather than a
+    derivation.** What it has to absorb is the one deliberate over-statement in both
+    budgets: every rounding is charged at the *storage* format's unit roundoff, the
+    oracle's own ``e_r`` recurrences included, although those run in ``float64`` whatever
+    the field stores. At ``float32`` that alone over-states roughly ``4p + 2`` of the
+    counted roundings by ``2**29``. A tighter floor would be pinning the size of that
+    slack, which is not a quantity anything here derives.
+    """
+    worst = max(_worst_margin(dtype) for dtype in DTYPES)
+    assert worst > 0.01, (
+        f"the accuracy bounds were never approached, worst ratio {worst:.3g}; either "
+        f"nothing in the sweep rounded or one of the two bounds is vacuous"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The four places the backends do not meet
+# ---------------------------------------------------------------------------
+
+
+def _binding() -> Any:
+    """The compiled extension, imported late so a missing one skips rather than errors.
+
+    Returns:
+        Any: The :mod:`pantr._pantr_cpp` module.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    return _pantr_cpp
+
+
+def _case(label: str) -> _Case:
+    """Look one case up by its label.
+
+    Args:
+        label (str): The case's label.
+
+    Returns:
+        _Case: The case.
+    """
+    return next(case for case in CASES if case.label == label)
+
+
+def test_a_periodic_direction_is_refused_by_the_binding_and_served_by_the_oracle() -> None:
+    """The C++ half refuses to elevate a periodic direction; the public API still does it.
+
+    The two assertions together are what say the routing happened. Neither alone would:
+    a result is a result whichever path produced it, and a refusal proves only that the
+    binding has the boundary, not that the wrapper routes around it.
+    """
+    with use_backend(Backend.CPP):
+        field = _make_field(_case("periodic curve"), np.float64)
+        with pytest.raises(ValueError, match="open-to-periodic conversion"):
+            _binding().elevate_bspline_degree(field._impl, [1])
+        raised = field.elevate_degree(1)
+
+    assert raised.space.spaces[0].periodic, "the periodic direction lost its wrap"
+    assert raised.space.spaces[0].degree == field.space.spaces[0].degree + 1
+
+
+def test_an_unclamped_direction_is_refused_by_the_binding() -> None:
+    """The C++ half refuses to elevate an unclamped direction, rather than reading past.
+
+    A5.9 walks segments until a run of equal knots reaches the last index of the knot
+    vector, and an unclamped vector has none. The oracle performs the read; in C++ that
+    would be undefined behaviour, so the boundary is declared and the routing sends the
+    call to the oracle -- which is the subject of
+    :func:`test_an_unclamped_elevation_fails_the_same_way_under_both_backends`.
+    """
+    with use_backend(Backend.CPP):
+        field = _make_field(_case("unclamped curve"), np.float64)
+        with pytest.raises(ValueError, match="not clamped"):
+            _binding().elevate_bspline_degree(field._impl, [1])
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_an_unclamped_elevation_fails_the_same_way_under_both_backends(
+    dtype: npt.DTypeLike,
+) -> None:
+    """An unclamped elevation raises the oracle's own error under either backend.
+
+    **This pins a defect on purpose.** A5.9 needs a clamped vector and the oracle does
+    not check for one; what a caller currently sees is the count mismatch its
+    out-of-bounds walk produces, raised by ``Bspline``'s own constructor. The C++ half
+    refuses such a direction outright and :mod:`pantr.bspline._degree_backend` routes it
+    to the oracle, so what the library accepts does not change with ``PANTR_BACKEND`` --
+    and the day the oracle is fixed, this test fails and says so rather than the change
+    landing silently.
+
+    Args:
+        dtype (npt.DTypeLike): The storage format.
+    """
+    # The defect's *symptom* depends on the configuration, which is worth pinning rather
+    # than gating away: numba does not bounds check, so compiled the walk returns and the
+    # field's own constructor refuses the coefficient count; interpreted, numpy checks and
+    # the read itself raises. Both are the same out-of-bounds walk.
+    if the_jit_is_disabled():
+        expected_type: type[Exception] = IndexError
+        fragment = "is out of bounds for axis 0"
+    else:
+        expected_type = ValueError
+        fragment = "must be a multiple of the number of basis functions"
+
+    messages = []
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            field = _make_field(_case("unclamped curve"), dtype)
+            with pytest.raises(expected_type) as raised:
+                field.elevate_degree(1)
+            messages.append(str(raised.value))
+    assert messages[0] == messages[1], (
+        "the two backends refuse an unclamped elevation differently, so the routing is "
+        "not sending it to the oracle"
+    )
+    assert fragment in messages[0], (
+        f"the oracle's unclamped elevation no longer fails with {fragment!r}; if it now "
+        f"refuses the vector properly, cpp/include/pantr/bspline/degree.hpp's boundary "
+        f"and pantr.bspline._degree_backend's routing should both be revisited"
+    )
+
+
+def test_a_rational_derivative_is_refused_by_the_binding_and_served_by_the_oracle() -> None:
+    """The C++ half refuses a rational hodograph; the public API still computes one.
+
+    The oracle's quotient-rule path is under review, so there is nothing stable for a
+    C++ side to be at parity with and it is not ported.
+    """
+    with use_backend(Backend.CPP):
+        field = _make_field(_case("rational surface, direction 0 only"), np.float64)
+        with pytest.raises(ValueError, match="rational B-spline is not part of"):
+            _binding().differentiate_bspline(field._impl, 0)
+        hodograph = field.derivative(0)
+
+    assert hodograph.is_rational, "the rational hodograph came back non-rational"
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_keep_degree_runs_the_oracle_under_both_backends(dtype: npt.DTypeLike) -> None:
+    """``keep_degree=True`` is absent from the C++ signature, so both backends agree.
+
+    **Common mode**, said out loud rather than counted as evidence: one implementation
+    ran twice. What this pins is that the routing produces a complete field under the
+    C++ backend and that no half-ported path leaks into it.
+
+    Args:
+        dtype (npt.DTypeLike): The storage format.
+    """
+    case = _case("cubic curve, four simple knots")
+    with use_backend(Backend.PYTHON):
+        py = _make_field(case, dtype).derivative(keep_degree=True)
+    with use_backend(Backend.CPP):
+        cpp = _make_field(case, dtype).derivative(keep_degree=True)
+    assert cpp.degree == py.degree == case.degrees
+    assert np.array_equal(cpp.control_points.view(np.uint8), py.control_points.view(np.uint8)), (
+        "the two backends disagree on a path neither of them ports"
+    )
+
+
+def test_the_periodic_hodograph_reaches_the_cpp_path() -> None:
+    """A periodic direction does not push the *derivative* onto the oracle.
+
+    The other half of the routing rule, and the one an over-broad condition would get
+    wrong. ``_derivative_nonrational_nd`` handles a periodic direction by expanding the
+    net with its own modulo wrap and trimming afterwards, reaching no boundary or
+    periodic conversion, so the C++ half serves it. Pinned by the binding accepting the
+    same call the public method makes.
+    """
+    with use_backend(Backend.CPP):
+        field = _make_field(_case("periodic curve"), np.float64)
+        through_the_binding = _binding().differentiate_bspline(field._impl, 0)
+        hodograph = field.derivative()
+
+    assert np.array_equal(hodograph.control_points, through_the_binding.control_points)
+    assert hodograph.space.spaces[0].periodic, "the periodic direction lost its wrap"
+
+
+def test_the_unclamped_hodograph_reaches_the_cpp_path() -> None:
+    """An unclamped direction does not push the *derivative* onto the oracle either.
+
+    The elevation's clamp requirement is A5.9's, not the difference quotient's: the
+    hodograph formula is elementwise and assumes nothing about the ends. A condition
+    written once for both operations would send this to the oracle for no reason.
+    """
+    with use_backend(Backend.CPP):
+        field = _make_field(_case("unclamped curve"), np.float64)
+        through_the_binding = _binding().differentiate_bspline(field._impl, 0)
+        hodograph = field.derivative()
+
+    assert np.array_equal(hodograph.control_points, through_the_binding.control_points)
+    assert not hodograph.space.spaces[0].has_open_knots(), (
+        "the unclamped direction came back clamped"
+    )
+
+
+def test_an_untouched_direction_keeps_its_wrapper() -> None:
+    """A direction neither operation changed is carried over rather than rebuilt.
+
+    ``result.space.spaces[d] is field.space.spaces[d]`` is the contract ``_wrap_over``
+    exists for, and it is what says the C++ half reported which directions it left alone
+    rather than the wrapper rebuilding them all.
+    """
+    with use_backend(Backend.CPP):
+        case = _case("surface, direction 1 differentiated and elevated")
+        field = _make_field(case, np.float64)
+        hodograph = field.derivative(case.direction)
+        raised = field.elevate_degree(case.increments)
+
+    assert hodograph.space.spaces[0] is field.space.spaces[0]
+    assert raised.space.spaces[0] is field.space.spaces[0]
+    assert hodograph.space.spaces[1] is not field.space.spaces[1]
+    assert raised.space.spaces[1] is not field.space.spaces[1]
+
+
+# ---------------------------------------------------------------------------
+# The case table
+# ---------------------------------------------------------------------------
+
+
+def test_the_case_table_earns_its_keep() -> None:
+    """Each case is asymmetric where a symmetric one would hide a defect.
+
+    Six properties the module docstring and ``CASES`` rely on, asserted rather than
+    believed: every multi-direction case differs between its directions in the degree and
+    the basis count; some case is rational, some periodic, some unclamped; some carries a
+    knot no binary format represents; and both operations really do change the field.
+    """
+    multi = [case for case in CASES if len(case.degrees) > 1]
+    assert multi, "no multi-direction case, so nothing here could see a transposition"
+    for case in multi:
+        assert len(set(case.degrees)) == len(case.degrees), f"{case.label}: repeated degree"
+        counts = [
+            len(knots) - degree - 1 for knots, degree in zip(case.knots, case.degrees, strict=True)
+        ]
+        assert len(set(counts)) == len(counts), f"{case.label}: repeated basis count"
+
+    assert any(case.is_rational for case in CASES), "no rational case"
+    assert any(any(case.periodic) for case in CASES), "no periodic case"
+    assert any(not _elevatable(case) for case in CASES), "no case the C++ elevation refuses"
+    assert any(
+        any(
+            knot not in (0.0, 0.25, 0.5, 0.75, 1.0, -1.0, 2.0)
+            for knots in case.knots
+            for knot in knots
+        )
+        for case in CASES
+    ), "every knot in the table is dyadic, so no operation here has to round"
+
+    # And the coefficients round too. A field of exactly representable values makes the
+    # hodograph's subtraction and quotient exact, and a bitwise claim over it cannot tell
+    # the storage format's arithmetic from `double` narrowed once -- which is the very
+    # thing the claim is for. See :func:`_make_field`.
+    for case in CASES:
+        narrow = _make_field(case, np.float32).control_points
+        wide = _make_field(case, np.float64).control_points
+        assert not np.array_equal(narrow.astype(np.float64), wide), (
+            f"{case.label}: every control point is exactly representable in float32, so "
+            f"the bitwise claims over it are blind to the arithmetic width"
+        )
+
+    with use_backend(Backend.PYTHON):
+        for case in _DERIVATIVE_CASES:
+            field = _make_field(case, np.float64)
+            hodograph = field.derivative(case.direction)
+            assert hodograph.degree[case.direction] == case.degrees[case.direction] - 1, (
+                f"{case.label}: the hodograph did not lower a degree"
+            )
+        for case in _ELEVATION_CASES:
+            if not _elevatable(case):
+                continue
+            field = _make_field(case, np.float64)
+            raised = field.elevate_degree(case.increments)
+            assert raised.control_points.size > field.control_points.size, (
+                f"{case.label}: the elevation produced no new coefficients"
+            )

--- a/tests/parity/test_bspline_degree.py
+++ b/tests/parity/test_bspline_degree.py
@@ -199,7 +199,7 @@ import pytest
 from pantr._backend import Backend, use_backend
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.bspline._bspline_degree_core import _bincoeff
-from pantr.bspline._degree_backend import elevate_field_degree
+from pantr.bspline._degree_backend import _closes_bit_exactly, elevate_field_degree
 from tests._parity_harness import (
     AccuracyClaim,
     Field,
@@ -611,17 +611,23 @@ def _make_field(case: _Case, dtype: npt.DTypeLike) -> Bspline:
 
 
 def _elevatable(case: _Case) -> bool:
-    """Whether every direction this case elevates is one the C++ half will take.
+    """Whether every direction this case elevates is one the routing sends to C++.
+
+    Calls the routing's own predicate rather than restating it, so the two cannot drift:
+    the routing is deliberately stricter than the C++ entry point's tolerance-based
+    clamped check, and a case whose closing run only ties within tolerance goes to the
+    oracle even though C++ would have taken it.
 
     Args:
         case (_Case): The shape.
 
     Returns:
-        bool: ``True`` when no elevated direction is periodic or unclamped.
+        bool: ``True`` when no elevated direction is periodic, and every one of them
+        closes bit-exactly.
     """
     spaces = _spaces(case, np.float64)
     return all(
-        increment == 0 or (not space.periodic and space.has_open_knots())
+        increment == 0 or (not space.periodic and _closes_bit_exactly(space))
         for increment, space in zip(case.increments, spaces, strict=True)
     )
 
@@ -1313,6 +1319,48 @@ def test_an_unclamped_elevation_fails_the_same_way_under_both_backends(
         f"the oracle's unclamped elevation no longer fails with {fragment!r}; if it now "
         f"refuses the vector properly, cpp/include/pantr/bspline/degree.hpp's boundary "
         f"and pantr.bspline._degree_backend's routing should both be revisited"
+    )
+
+
+def test_a_tail_that_closes_only_within_tolerance_still_goes_to_the_oracle() -> None:
+    """A closing run that ties within tolerance but not bitwise routes to the oracle.
+
+    The C++ elevation refuses a closing run that is not bit-identical, while
+    :meth:`~pantr.bspline.BsplineSpace1D.has_open_knots` compares it within the space's
+    tolerance.  Routing on the looser predicate hands C++ a vector it then refuses in its
+    own words while the oracle refuses the same vector in different words, so the error a
+    caller sees would depend on ``PANTR_BACKEND``.  Building the near-tie needs
+    ``snap_knots=False``, since snapping collapses it.
+
+    This is the boundary between the two predicates, which
+    :func:`test_an_unclamped_elevation_fails_the_same_way_under_both_backends` does not
+    reach: its vector is grossly unclamped, so both predicates agree on it.
+    """
+    knots = np.array([0.0, 0.0, 0.0, 0.5, 0.9999999999999998, 1.0, 1.0])
+    space_1d = BsplineSpace1D(knots, 2, snap_knots=False)
+    # The premise, asserted rather than assumed: the two predicates disagree here.
+    assert space_1d.has_open_knots()
+    assert knots[-3] != knots[-1]
+
+    # Which exception the oracle raises depends on the configuration, for the same reason
+    # as in `test_an_unclamped_elevation_fails_the_same_way_under_both_backends`: compiled,
+    # A5.9's out-of-bounds walk returns and a later check refuses the result; interpreted,
+    # numpy checks the read itself. What this test pins is that both backends agree,
+    # whichever of the two it is.
+    expected_type: type[Exception] = IndexError if the_jit_is_disabled() else ValueError
+
+    messages = []
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            space = BsplineSpace([BsplineSpace1D(knots, 2, snap_knots=False)])
+            field = Bspline(space, np.arange(space.num_total_basis, dtype=float).reshape(-1, 1))
+            with pytest.raises(expected_type) as raised:
+                field.elevate_degree(1)
+            messages.append(str(raised.value))
+
+    assert messages[0] == messages[1], (
+        "the two backends refuse a near-tie closing run differently, so the routing "
+        "predicate is not shadowing the C++ refusal"
     )
 
 

--- a/tests/parity/test_bspline_degree.py
+++ b/tests/parity/test_bspline_degree.py
@@ -55,9 +55,13 @@ makes it *weak* and lets the ``float32`` operand decide. So the product is ``flo
 compiled and ``float32`` interpreted, and the two answers are different numbers. The same
 applies to the `ebpts` blend's companion.
 
-Measured: with the JIT disabled, every ``float32`` elevation case in this file's
-field-by-field comparison fails and every ``float64`` one passes, which is the
-signature of a width rather than of an algorithm.
+Measured, with the JIT disabled: every ``float64`` elevation case in this file's
+field-by-field comparison still agrees bit for bit, and five of the nine ``float32`` ones
+no longer do. The four that survive are the four whose knot vectors never make
+``oldr > 1`` -- a single Bézier span, a ``C^0`` breakpoint, a ``C^-1`` breakpoint and a
+degree-2 direction -- so they never execute the block the divergent literal is in. That
+the split falls exactly along that line, and along the storage format rather than along
+the algorithm, is what identifies the cause as a width.
 :func:`~tests._parity_harness.demand_the_compiled_kernel` is the gate that owns exactly
 that question, and it is applied to the elevation.
 
@@ -98,12 +102,14 @@ Nothing in :func:`_marsden_column` consults either backend.
 ## The accuracy bounds, and why the elevation's is a majorant
 
 **The hodograph.** ``gamma_K`` times an elementwise amplification, with ``K`` counted:
-``2p + 1`` for the input window's ``e_r`` recurrence and ``2(p-1) + 1`` for the derived
-one, one for the cast of the closed form into the field's storage, four for the formula
-itself -- the coefficient difference, the knot difference, the scaling by the degree and
-the division -- and one for the store. ``K = 4p + 5``. The magnitude is **not** the
-result's own: ``A_{i+1} - A_i`` can cancel to nothing while its operands do not, so the
-relative budget is charged against what was subtracted,
+``2p + 1`` for the input window's ``e_r`` recurrence and ``2p - 1`` for the derived one at
+degree ``p - 1``, one for the cast of the closed form into the field's storage, four for
+the formula itself -- the coefficient difference, the knot difference, the scaling by the
+degree and the division -- one for the multiply by ``r`` that turns the derived window's
+closed form into ``r u^(r-1)``'s, and one for the store. ``K = 4p + 7``, which is what
+:func:`_hodograph_accuracy` computes. The magnitude is **not** the result's own:
+``A_{i+1} - A_i`` can cancel to nothing while its operands do not, so the relative budget
+is charged against what was subtracted,
 
     amplification_i = p (|A_i| + |A_{i+1}|) / |t_{i+p+1} - t_{i+1}|,
 
@@ -125,10 +131,17 @@ gone the partial sums are monotone, so the final value majorises all of them. It
 no value this file compares against -- those come from Marsden -- only a magnitude.
 
 ``K`` for the elevation: the two ``e_r`` recurrences at degree ``p`` and ``p + t``, the
-cast in and the store out, and ``min(p, t) + 1`` stages of three accumulator roundings
-each. That stage count is Rule 10's for the Bézier elevation and it is right here for the
-same reason -- the accumulation into ``ebpts[i]`` runs ``j`` from ``max(0, i - t)`` to
+cast in and the store out, and the kernel's own chain, whose **three blocks do not cost
+the same** and are counted separately. At most ``p - 1`` Boehm insertion passes, each
+``bpts[q] = alf * bpts[q] + (1 - alf) * bpts[q-1]`` -- a subtraction, two products, an
+addition and a narrowing store, so five; then ``min(p, t) + 1`` terms accumulated into one
+elevated Bézier coefficient, each a product, an addition and a narrowing store, so three;
+then at most ``p - 2`` knot-removal passes, the same shape as a Boehm pass, so five. The
+middle count is Rule 10's for the Bézier elevation and it is right here for the same
+reason -- the accumulation into ``ebpts[i]`` runs ``j`` from ``max(0, i - t)`` to
 ``min(p, i)`` -- and charging ``p + 1`` instead is the over-count that rule records.
+Charging one flat number across all three blocks under-charges the two blend blocks, which
+is a defect a review found in an earlier version of this file.
 
 Both bounds add ``K`` underflow floors, the absolute half of Higham's model, because a
 closed form can be an exact zero and a relative bound of zero asserts bit-identity
@@ -136,10 +149,11 @@ nothing here has grounds for.
 
 ## The four places the backends do not meet
 
-All four are recorded in :mod:`pantr.bspline._degree_backend` and all four are pinned
-here rather than left to be met. The first two are boundaries of the port; the last two
-are defects in the oracle that the port deliberately does not inherit and deliberately
-does not change.
+Four, counted as :mod:`pantr.bspline._degree_backend` counts them, and all four are
+recorded there and pinned here rather than left to be met. Two are boundaries of the
+port, one is a defect in the oracle that the port deliberately does not inherit and
+deliberately does not change, and one is an asymmetry between the two sides' own argument
+checking.
 
 - **`keep_degree=True` and a rational derivative run the oracle**, because the oracle's
   own answers on those paths are under review and there is nothing stable to be at parity
@@ -165,6 +179,12 @@ does not change.
   a silent one -- including that the symptom depends on the configuration: compiled, the
   walk returns and the field's constructor refuses the coefficient count; interpreted,
   numpy bounds checks and the read itself raises ``IndexError``.
+- **An increment tuple with nothing to elevate runs the oracle.** The C++ half refuses an
+  all-zero or negative one with :meth:`~pantr.bspline.Bspline.elevate_degree`'s own Layer 1
+  message while ``_degree_elevate_bspline`` never checks and returns the field unchanged.
+  No public caller reaches it, the method refusing such an argument first;
+  :func:`test_an_argument_with_nothing_to_elevate_goes_to_the_oracle` pins the private
+  entry point, which a downstream consumer of this package's private symbols could call.
 """
 
 from __future__ import annotations
@@ -179,6 +199,7 @@ import pytest
 from pantr._backend import Backend, use_backend
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.bspline._bspline_degree_core import _bincoeff
+from pantr.bspline._degree_backend import elevate_field_degree
 from tests._parity_harness import (
     AccuracyClaim,
     Field,
@@ -517,17 +538,22 @@ segment's coefficients are emitted from `lbz = (oldr + 2) // 2` upwards. At degr
 simple interior knots `oldr` is 2 and `lbz` is 2, so the only write the block makes --
 `kj = 1` -- is to a coefficient never emitted, and a variant of
 `cpp/include/pantr/bspline/degree.hpp` computing either of that blend's two terms at the
-wrong width passed this whole file. `oldr` first reaches 4, and `kj` first reaches `lbz`,
-at degree 5.
+wrong width passed this whole file. `kj` first reaches `lbz` at **degree 4** (`oldr = 3`,
+`lbz = 2`, and the `tr = 2` pass writes `kj = 2`); the quintic is here because no other
+case in this table is a curve with several simple interior knots above degree 3, not
+because degree 4 could not have served.
 
 **The narrow span is for the bound rather than for a width**: it takes A5.9's blending
 weights far from one, which is where the majorant the accuracy check uses has to earn its
 place against a convex companion. It is *not* what makes the `ic` blend's own companion
-observable, and nothing is: that one forms `1 - alf` with
-`alf = (ub - ik[i]) / (ua - ik[i])`, and `ik[i] <= ua < ub` makes `alf >= 1`, for which
-the subtraction is exact in `float32` for every representable value. Computing it in the
-storage format there is a choice with no consequence, which is why no case in this table
-tries to catch it.
+observable, and nothing in reach is: that one forms `1 - alf` with
+`alf = (ub - ik[i]) / (ua - ik[i])`, and `ik[i] <= ua < ub` makes `alf >= 1`, for which the
+subtraction is exact in `float32` **while `alf < 2^24`** -- above that the exact difference
+needs a bit `float32` no longer has, and `float32(1) - 16777218` is off by one. The weights
+these knot vectors produce top out near 500, so the hypothesis holds by a wide margin here;
+it is stated rather than assumed because the claim is otherwise false. Computing that
+companion in the storage format is therefore a choice with no consequence, which is why no
+case in this table tries to catch it.
 """
 
 
@@ -575,7 +601,7 @@ def _make_field(case: _Case, dtype: npt.DTypeLike) -> Bspline:
     # to pin: measured, a `double` variant of `derivative_along_axis` passed the whole of
     # this file before the divisor below was 97 rather than 16.
     # `test_the_case_table_earns_its_keep` asserts the values really do round.
-    values = np.array([(7.0 + ((i * 37) % 101)) / 97.0 for i in range(count)], dtype=dtype)
+    values = np.array([(7.0 + ((i * 37) % 101)) / 109.0 for i in range(count)], dtype=dtype)
     control_points = values.reshape(shape)
     if case.is_rational:
         # Weights must be positive, and distinct from each other.
@@ -958,12 +984,17 @@ def _elevation_accuracy(
     amplification = _elevate_majorant(
         degree, np.abs(stored), np.asarray(knots, dtype=np.float64), increment
     )
-    # A5.9's chain has three blocks: at most `p - 1` Boehm insertion passes, then
-    # `min(p, t) + 1` terms accumulated into one elevated Bezier coefficient -- Rule 10's
-    # own count for the Bezier elevation -- then at most `p - 2` knot-removal passes. Each
-    # stage costs four roundings, three in the accumulator and one narrowing store.
-    stages = max(1, max(0, degree - 1) + min(degree, increment) + 1 + max(0, degree - 2))
-    roundings = (2 * degree + 1) + (2 * (degree + increment) + 1) + 2 + 4 * stages
+    # A5.9's chain has three blocks and they do not cost the same. At most `p - 1` Boehm
+    # insertion passes, each `alf * bpts[q] + (1 - alf) * bpts[q-1]`: a subtraction, two
+    # products, an addition and a narrowing store, so five. Then `min(p, t) + 1` terms
+    # accumulated into one elevated Bezier coefficient -- Rule 10's own count -- each a
+    # product, an addition and a narrowing store, so three. Then at most `p - 2`
+    # knot-removal passes, the same shape as a Boehm pass, so five.
+    boehm = 5 * max(0, degree - 1)
+    accumulation = 3 * (min(degree, increment) + 1)
+    removal = 5 * max(0, degree - 2)
+    chain = max(1, boehm + accumulation + removal)
+    roundings = (2 * degree + 1) + (2 * (degree + increment) + 1) + 2 + chain
     unit = unit_roundoff(knots.dtype)
     relative = roundings * unit / (1.0 - roundings * unit)
     return derived_accuracy(
@@ -975,12 +1006,11 @@ def _elevation_accuracy(
             f"{unit:.3e}, times the majorant of A5.9 run on the moduli of its "
             f"coefficients and of its blending weights: {2 * degree + 1} roundings form "
             f"the input closed form and {2 * (degree + increment) + 1} the elevated "
-            f"one, one is the cast into the field's storage, {4 * stages} are the "
-            f"kernel's own {stages} stages at four roundings each -- three in the "
-            f"accumulator and one narrowing store -- counting at most p - 1 Boehm "
-            f"insertion passes, min(p, t) + 1 accumulated terms and at most p - 2 "
-            f"knot-removal passes, and one is the store. The amplification is the "
-            f"majorant "
+            f"one, one is the cast into the field's storage, {chain} are the kernel's "
+            f"own chain -- {boehm} for at most p - 1 Boehm insertion passes at five "
+            f"roundings each, {accumulation} for min(p, t) + 1 accumulated terms at "
+            f"three, {removal} for at most p - 2 knot-removal passes at five -- and one "
+            f"is the store. The amplification is the majorant "
             f"rather than a convex companion because A5.9's knot-removal step blends "
             f"with a weight above one, so its intermediates are not convex combinations "
             f"and a bound built from the finished operator would be exceeded rather "
@@ -996,11 +1026,22 @@ _ACCURACY_KNOTS: Final = (
     ((0.0, 0.0, 0.0, 1.0 / 3.0, 1.0 / 3.0, 1.0, 1.0, 1.0), 2),
     ((0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0), 3),
     ((0.0, 0.0, 0.0, 0.0, 0.0, 1.0 / 7.0, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0), 4),
+    (
+        (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 / 3.0, 0.6, 0.82, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+        5,
+    ),
 )
 """Knot vectors for the independent check, each with a knot no binary format represents.
 
 A dyadic vector rounds nothing and would report agreement without asking the bound a
 question, which is why every entry carries a third or a seventh.
+
+The degree-5 entry is here for the elevation budget rather than for the oracle. That
+budget's Boehm-insertion and knot-removal terms grow with the degree while its
+accumulation term is capped by the increment, so the three-block count above is only
+tested where the first two dominate -- which needs a degree past 4 and several simple
+interior knots. A review found the budget under-charging those two blocks and could not
+say whether it mattered, because no accuracy case reached them.
 """
 
 
@@ -1348,6 +1389,31 @@ def test_the_unclamped_hodograph_reaches_the_cpp_path() -> None:
     )
 
 
+def test_an_argument_with_nothing_to_elevate_goes_to_the_oracle() -> None:
+    """A degenerate increment tuple is served by the oracle, not refused by the binding.
+
+    The public method refuses an all-zero or negative increment before either backend is
+    reached, so this is about the private entry point: `elevate_field_degree` is an
+    importable symbol of a package whose private symbols a downstream consumer already
+    imports, and the two sides disagree about such an argument -- the C++ half raises
+    `Bspline.elevate_degree`'s own Layer 1 message while `_degree_elevate_bspline` never
+    checks and returns the field unchanged. Found by a review of the routing predicate,
+    which said yes vacuously because `all()` over an empty filter is true.
+    """
+    case = _case("surface, direction 1 differentiated and elevated")
+    for increments in ((0, 0), (-1, -1)):
+        results = []
+        for backend in (Backend.PYTHON, Backend.CPP):
+            with use_backend(backend):
+                results.append(elevate_field_degree(_make_field(case, np.float64), increments))
+        assert results[0].degree == results[1].degree == case.degrees, (
+            f"{increments} changed a degree on some backend"
+        )
+        assert np.array_equal(results[0].control_points, results[1].control_points), (
+            f"the two backends disagree about the increment tuple {increments}"
+        )
+
+
 def test_an_untouched_direction_keeps_its_wrapper() -> None:
     """A direction neither operation changed is carried over rather than rebuilt.
 
@@ -1408,9 +1474,11 @@ def test_the_case_table_earns_its_keep() -> None:
     for case in CASES:
         narrow = _make_field(case, np.float32).control_points
         wide = _make_field(case, np.float64).control_points
-        assert not np.array_equal(narrow.astype(np.float64), wide), (
-            f"{case.label}: every control point is exactly representable in float32, so "
-            f"the bitwise claims over it are blind to the arithmetic width"
+        # Every coefficient, not merely some: one exactly representable value in the net
+        # is one fibre over which the bitwise claim cannot see the arithmetic width.
+        assert not np.any(narrow.astype(np.float64) == wide), (
+            f"{case.label}: a control point is exactly representable in float32, so the "
+            f"bitwise claims over its fibre are blind to the arithmetic width"
         )
 
     with use_backend(Backend.PYTHON):


### PR DESCRIPTION
## Context

`cpp/include/pantr/bspline/degree.hpp` did not exist: the degree family was ported on the Bézier
side only. This adds the two paths that are clean, and declares the rest as a boundary rather
than porting around it.

## Specification

**Ported.** `derivative` — the plain hodograph, non-rational, degree-lowering, periodic directions
included (that path handles them by modulo expansion and trim and never reaches the unported
periodic conversion). `elevate_degree` — Piegl & Tiller A5.9, on open directions.

**Not ported, each for a stated reason.** `reduce_degree` and periodic elevation round-trip
through conversions `structural.hpp` already declares as a deliberate boundary. `keep_degree=True`
and the rational derivative are left out because **the oracle has open defects on those paths**,
so there is nothing stable for a C++ side to be at parity with. That reason is written in the
header in the register `structural.hpp` uses, without dressing it up as mathematics.

**Parity criteria, each naming the rule it rests on.**

| kernel | claim | rule |
|---|---|---|
| hodograph coefficients | bitwise, **unconditionally** | not Rule 7, deliberately: the expression is a difference, a scale and a division with no sum of a product, so no site can contract. The claim is a property of the code, not of the host — unlike both sibling ports, which gate theirs on `__fp_contract__`. |
| elevation coefficients | bitwise, gated on `contraction_may_fuse()` | Rule 7, with Rule 10's budget on a fusing build |
| counts, degrees, flags, dtype | exact | Rule 11 |
| independent accuracy | Marsden's identity against a derived bound | Rule 10. The amplification is the **majorant** of A5.9, not a convex bound: the knot-removal step blends with a weight above one, so a finished-row bound is wrong rather than merely loose — measured exceeded by up to 687x. |

Rule 9 bites harder here than anywhere else in the port: A5.9's accumulation widths vary *within*
the kernel, because numba types each SSA version separately and `tmp1`'s four assignments
disagree. `scripts/measure_bspline_degree_widths.py` prints numba's own inferred type per site and
is re-runnable, so the width table in the header is a measurement rather than an assertion.

## Acceptance

Full suite 10885 passed / 66 skipped / 7 xfailed. The four new skips are declared, not hidden:
parametrised cases that elevate a direction C++ refuses, each pointing at its own dedicated test.
`ctest` 54/54, also clean under ASan + UBSan. ruff, ruff format, mypy (334 files), import-linter,
doctests and the `-W` docs build all green.

An independent review pass over the parity claims found one defect, fixed here: the routing that
decides whether C++ may serve a call asked `has_open_knots()`, which compares the closing run
*within tolerance*, while the C++ elevation refuses one that is not *bit-identical*. A knot vector
whose tail ties to within tolerance but not bitwise therefore reached C++ and was refused there in
different words than the oracle uses, so the error a caller saw depended on `PANTR_BACKEND` —
which this module and the header both promise it does not. Routing now uses the same bit-exact
predicate as the refusal. That also settles by construction, rather than by sweeping, the question
of whether an input exists that C++ refuses and the oracle serves wrongly: C++ no longer sees one.

## Non-goals

Nothing here fixes an oracle defect, and two were confirmed in passing and deliberately left:
A5.9 does not check that its knot vector is clamped and reads past its control array — interpreted
that raises `IndexError`, and compiled, where numba does not bounds-check, 8 of 32 swept cases
return a silently wrong elevation, in an operation that must be exact. The C++ side refuses such a
direction and the routing sends it to the oracle, so `PANTR_BACKEND` does not change what the
library accepts. Both await a decision that is not this PR's to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDsgxeS1roqbGuLYbyR2zH
