### PR TITLE
fix(core): wait for the JIT warmup at every Layer 2 entry point that needs it

### DIFF
--- a/src/pantr/bezier/_bezier_collapse.py
+++ b/src/pantr/bezier/_bezier_collapse.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from .._numba_compat import wait_for_jit_warmup
 from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core
 from ._bezier_backend import collapse_kernel
 
@@ -58,6 +59,10 @@ def _collapse_along_axis(
         ValueError: If ``values`` does not have length ``dim - 1``.
         ValueError: If any value is outside ``[0, 1]``.
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     dim = bezier.dim
     values_arr = np.asarray(values, dtype=bezier.dtype)
 

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from .._numba_compat import wait_for_jit_warmup
 from ..bspline._bspline_degree_core import _check_bincoeff_envelope
 from ._bezier_backend import compose_kernel, product_kernel
 from ._bezier_product import _bernstein_product_coefficients_nd
@@ -60,6 +61,10 @@ def _compose_bezier(outer: Bezier, inner: Bezier) -> Bezier:
             exactness envelope of the binomial-coefficient kernel (see
             :data:`~pantr.bspline._bspline_degree_core._BINCOEFF_MAX_N`).
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     if outer.is_rational:
         raise TypeError("Composition is not supported for rational Béziers (outer is rational).")
     if inner.is_rational:

--- a/src/pantr/bezier/_bezier_eval.py
+++ b/src/pantr/bezier/_bezier_eval.py
@@ -435,15 +435,15 @@ def _evaluate_bezier_deriv(
     Raises:
         ValueError: If ``len(orders) != bezier.dim`` or any order is negative.
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     orders_tuple = tuple(orders)
     if len(orders_tuple) != bezier.dim:
         raise ValueError(f"len(orders) ({len(orders_tuple)}) must match dim ({bezier.dim}).")
     if any(o < 0 for o in orders_tuple):
         raise ValueError("All derivative orders must be non-negative.")
-
-    # Ensure the background JIT warmup has finished before calling Numba kernels that use
-    # parallel=True: numba's workqueue layer aborts the process rather than raising.
-    wait_for_jit_warmup()
 
     if bezier.dim == 1:
         return _evaluate_bezier_deriv_1d(bezier, pts, orders_tuple[0], out)

--- a/src/pantr/bezier/_bezier_eval.py
+++ b/src/pantr/bezier/_bezier_eval.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from .._numba_compat import wait_for_jit_warmup
 from ..basis._basis_utils import _validate_out_array
 from ._bezier_backend import (
     evaluate_deriv_kernel,
@@ -71,6 +72,10 @@ def _evaluate_bezier(
     Raises:
         ValueError: If the points dtype or shape does not match the Bézier.
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     if bezier.dim == 1:
         return _evaluate_bezier_1d(bezier, pts, out)
     return _evaluate_bezier_nd(bezier, pts, out)
@@ -435,6 +440,10 @@ def _evaluate_bezier_deriv(
         raise ValueError(f"len(orders) ({len(orders_tuple)}) must match dim ({bezier.dim}).")
     if any(o < 0 for o in orders_tuple):
         raise ValueError("All derivative orders must be non-negative.")
+
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
 
     if bezier.dim == 1:
         return _evaluate_bezier_deriv_1d(bezier, pts, orders_tuple[0], out)

--- a/src/pantr/bezier/_bezier_restrict.py
+++ b/src/pantr/bezier/_bezier_restrict.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
+from .._numba_compat import wait_for_jit_warmup
 from ._bezier_backend import restrict_kernel, restrict_nd_kernel
 
 if TYPE_CHECKING:
@@ -46,6 +47,10 @@ def _restrict_bezier(
         ValueError: If every direction is ``None`` or matches the full
             ``[0, 1]`` domain.
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     lower = [0.0 if bounds is None else float(bounds[0]) for bounds in bounds_per_dim]
     upper = [1.0 if bounds is None else float(bounds[1]) for bounds in bounds_per_dim]
 

--- a/src/pantr/bezier/_bezier_slice.py
+++ b/src/pantr/bezier/_bezier_slice.py
@@ -18,6 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis
+from .._numba_compat import wait_for_jit_warmup
 from ._bezier_backend import slice_kernel, slice_nd_kernel, slice_point_kernel
 
 if TYPE_CHECKING:
@@ -53,6 +54,10 @@ def _slice_bezier(
         Inputs are assumed to be correct (no validation performed).
         For general use, call :meth:`~pantr.bezier.Bezier.slice` instead.
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     if bezier.dim == 1:
         # The result is a point rather than a Bézier, so this is a different accessor
         # rather than a branch inside one: C++ cannot return either type from one

--- a/src/pantr/bezier/_bezier_split.py
+++ b/src/pantr/bezier/_bezier_split.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
+from .._numba_compat import wait_for_jit_warmup
 from ._bezier_backend import split_kernel, split_nd_kernel
 
 if TYPE_CHECKING:
@@ -49,6 +50,10 @@ def _split_bezier(
         Inputs are assumed to be correct (no validation performed).
         For general use, call :meth:`~pantr.bezier.Bezier.split` instead.
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     return split_nd_kernel()(bezier, direction, value)
 
 

--- a/src/pantr/bezier/_bezier_utils.py
+++ b/src/pantr/bezier/_bezier_utils.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from .._numba_compat import wait_for_jit_warmup
 from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core
 
 if TYPE_CHECKING:
@@ -39,6 +40,13 @@ def _tabulate_bernstein_1d_fast(
         npt.NDArray[np.float32 | np.float64]: Basis values of shape
         ``(n_pts, degree + 1)``.
     """
+    # `__init__.py` compiles the kernels on a background thread, and numba's default
+    # workqueue layer is not safe against a concurrent `parallel=True` call from another
+    # thread: the process *aborts* rather than raising. This helper is the funnel for the
+    # Bernstein path in `pantr.bezier`, so the barrier here also covers `interpolate_bezier`
+    # and `fit_bezier`, which reach no other `parallel=True` kernel.
+    wait_for_jit_warmup()
+
     basis = np.empty((pts.shape[0], degree + 1), dtype=dtype)
     _tabulate_Bernstein_basis_1D_core(np.int32(degree), pts, basis)
     return basis

--- a/src/pantr/bezier/_bezier_utils.py
+++ b/src/pantr/bezier/_bezier_utils.py
@@ -44,7 +44,9 @@ def _tabulate_bernstein_1d_fast(
     # workqueue layer is not safe against a concurrent `parallel=True` call from another
     # thread: the process *aborts* rather than raising. This helper is the funnel for the
     # Bernstein path in `pantr.bezier`, so the barrier here also covers `interpolate_bezier`
-    # and `fit_bezier`, which reach no other `parallel=True` kernel.
+    # and `fit_bezier`, which reach no other `parallel=True` kernel. It does *not* cover the
+    # barriers in `_bezier_eval`: their `dim == 1` branches reach `evaluate_kernel()` and
+    # `evaluate_deriv_kernel()`, which never come through here, so all three are needed.
     wait_for_jit_warmup()
 
     basis = np.empty((pts.shape[0], degree + 1), dtype=dtype)

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -390,12 +390,12 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
         >>> d.shape
         (1, 2, 3)
     """
-    if n_deriv < 0:
-        raise ValueError(f"n_deriv must be non-negative, got {n_deriv}")
-
     # Ensure the background JIT warmup has finished before calling Numba kernels that use
     # parallel=True: numba's workqueue layer aborts the process rather than raising.
     wait_for_jit_warmup()
+
+    if n_deriv < 0:
+        raise ValueError(f"n_deriv must be non-negative, got {n_deriv}")
 
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from .._numba_compat import wait_for_jit_warmup
 from ..basis._basis_1D import _tabulate_Bernstein_basis_1D_impl
 from ..basis._basis_backend import bernstein_deriv_core
 from ..basis._basis_core import _PARALLEL_MIN_NUM_PTS
@@ -274,6 +275,10 @@ def _tabulate_Bspline_basis_1D_impl(
         >>> first.tolist()
         [0, 1, 3, 3]
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)
 
@@ -387,6 +392,10 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
     """
     if n_deriv < 0:
         raise ValueError(f"n_deriv must be non-negative, got {n_deriv}")
+
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
 
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)

--- a/src/pantr/bspline/_bspline_eval.py
+++ b/src/pantr/bspline/_bspline_eval.py
@@ -212,12 +212,12 @@ def _evaluate_Bspline_1D(
             or if the points have an unusable shape or a dtype that does not match
             the B-spline dtype.
     """
-    if spline.dim != 1:
-        raise ValueError("B-spline must be 1D")
-
     # Ensure the background JIT warmup has finished before calling Numba kernels that use
     # parallel=True: numba's workqueue layer aborts the process rather than raising.
     wait_for_jit_warmup()
+
+    if spline.dim != 1:
+        raise ValueError("B-spline must be 1D")
 
     # Convert PointsLattice to ndarray if necessary
     pts_array: npt.NDArray[np.float32 | np.float64]
@@ -557,14 +557,14 @@ def _evaluate_Bspline_deriv_1D(
             points lattice is not 1D, or if the points have an unusable shape or a
             dtype that does not match the B-spline dtype.
     """
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
+
     if spline.dim != 1:
         raise ValueError("B-spline must be 1D")
     if n_deriv < 0:
         raise ValueError(f"n_deriv must be >= 0, got {n_deriv}")
-
-    # Ensure the background JIT warmup has finished before calling Numba kernels that use
-    # parallel=True: numba's workqueue layer aborts the process rather than raising.
-    wait_for_jit_warmup()
 
     pts_array: npt.NDArray[np.float32 | np.float64]
     if isinstance(pts, PointsLattice):

--- a/src/pantr/bspline/_bspline_eval.py
+++ b/src/pantr/bspline/_bspline_eval.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy import typing as npt
 
-from .._numba_compat import nb_jit, nb_prange
+from .._numba_compat import nb_jit, nb_prange, wait_for_jit_warmup
 from ..basis._basis_utils import _allocate_or_validate_out, _validate_out_array
 from ..quad import PointsLattice
 from ._bspline_basis_kernels import (
@@ -214,6 +214,10 @@ def _evaluate_Bspline_1D(
     """
     if spline.dim != 1:
         raise ValueError("B-spline must be 1D")
+
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
 
     # Convert PointsLattice to ndarray if necessary
     pts_array: npt.NDArray[np.float32 | np.float64]
@@ -557,6 +561,10 @@ def _evaluate_Bspline_deriv_1D(
         raise ValueError("B-spline must be 1D")
     if n_deriv < 0:
         raise ValueError(f"n_deriv must be >= 0, got {n_deriv}")
+
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
 
     pts_array: npt.NDArray[np.float32 | np.float64]
     if isinstance(pts, PointsLattice):

--- a/src/pantr/bspline/_bspline_to_beziers.py
+++ b/src/pantr/bspline/_bspline_to_beziers.py
@@ -22,7 +22,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
-from .._numba_compat import nb_jit, nb_prange
+from .._numba_compat import nb_jit, nb_prange, wait_for_jit_warmup
 from .spanwise_element_extraction import ExtractionTarget, SpanwiseElementExtraction
 
 if TYPE_CHECKING:
@@ -124,6 +124,10 @@ def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
         structure.
     """
     from ..bezier import Bezier  # noqa: PLC0415
+
+    # Ensure the background JIT warmup has finished before calling Numba kernels that use
+    # parallel=True: numba's workqueue layer aborts the process rather than raising.
+    wait_for_jit_warmup()
 
     dim = bspline.dim
 

--- a/tests/test_jit_warmup_barrier.py
+++ b/tests/test_jit_warmup_barrier.py
@@ -1,0 +1,243 @@
+"""Every Layer 2 entry point over a ``parallel=True`` kernel waits for the JIT warmup.
+
+``pantr/__init__.py`` compiles (and runs) Numba kernels on a background thread at import,
+and Numba's default workqueue threading layer is not safe against a concurrent
+``parallel=True`` call from another thread: the process *aborts* rather than raising, which
+takes the whole session with it.  ``CLAUDE.md`` states the rule that follows -- a Layer 2
+entry point over such kernels calls :func:`pantr._numba_compat.wait_for_jit_warmup` first --
+and FELIGN/pantr#418 records the gap this module closes.
+
+**These tests assert the call, not the absence of a crash, and that is deliberate.**  The
+barrier is a once-per-process event, so by the time any in-process test runs the warmup is
+long finished and nothing in-process can observe the race; a test that merely ran the entry
+point and checked it did not abort would pass whether or not the call is there.  Each case
+below patches the barrier *in the entry point's own module* together with a sentinel on the
+way to the kernel, so deleting the call from any one entry point fails exactly that case.
+The same reasoning, and the measurements behind it, are in
+``tests/test_bspline_locate.py::TestNumbaWarmup``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from typing import Any, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import Bezier, fit_bezier
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+
+# ---------------------------------------------------------------------------
+# Objects the drivers exercise
+# ---------------------------------------------------------------------------
+
+
+def _bezier_1d() -> Bezier:
+    """Build a planar quadratic Bézier curve.
+
+    Returns:
+        ~pantr.bezier.Bezier: A ``dim == 1``, ``rank == 2`` Bézier.
+    """
+    return Bezier(np.array([[0.0, 0.0], [1.0, 2.0], [2.0, 0.0]]))
+
+
+def _bezier_2d() -> Bezier:
+    """Build a bilinear Bézier surface in 3D.
+
+    Returns:
+        ~pantr.bezier.Bezier: A ``dim == 2``, ``rank == 3`` Bézier.
+    """
+    return Bezier(np.arange(12.0).reshape(2, 2, 3))
+
+
+def _general_space_1d() -> BsplineSpace1D:
+    """Build a 1D space whose knots are *not* Bézier-like.
+
+    The interior knot matters: with Bézier-like knots the tabulation takes its Bernstein
+    branch and never reaches the kernel accessor the corresponding case uses as a sentinel.
+
+    Returns:
+        ~pantr.bspline.BsplineSpace1D: A degree-2 space over ``[0, 1]`` with one interior
+        knot.
+    """
+    return BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]), 2)
+
+
+def _bspline_1d() -> Bspline:
+    """Build a scalar 1D B-spline over :func:`_general_space_1d`.
+
+    Returns:
+        ~pantr.bspline.Bspline: A ``dim == 1`` B-spline.
+    """
+    space = BsplineSpace([_general_space_1d()])
+    return Bspline(space, np.arange(1.0, space.num_total_basis + 1.0))
+
+
+_PTS: npt.NDArray[np.float64] = np.linspace(0.0, 1.0, 5)
+"""Parametric points shared by the evaluation drivers."""
+
+
+# ---------------------------------------------------------------------------
+# The census: one case per Layer 2 entry point
+# ---------------------------------------------------------------------------
+
+
+class _BarrierCase(NamedTuple):
+    """One Layer 2 entry point over ``parallel=True`` kernels, and how to drive it.
+
+    Attributes:
+        entry_point (str): ``module.function`` of the entry point, used as the test id.
+        module (str): Module whose ``wait_for_jit_warmup`` name is patched. This is the
+            entry point's own module, so the case fails if that one call is deleted even
+            when a caller elsewhere still has one.
+        sentinel (str): Attribute of ``module`` that the entry point calls on its way to a
+            ``parallel=True`` kernel. The barrier must precede it.
+        drive (Callable[[], Any]): Public-API call that reaches the entry point.
+    """
+
+    entry_point: str
+    module: str
+    sentinel: str
+    drive: Callable[[], Any]
+
+
+_CASES: tuple[_BarrierCase, ...] = (
+    # -- pantr.bezier ------------------------------------------------------
+    _BarrierCase(
+        "_bezier_utils._tabulate_bernstein_1d_fast",
+        "pantr.bezier._bezier_utils",
+        "_tabulate_Bernstein_basis_1D_core",
+        # Driven through `fit_bezier` rather than `interpolate_bezier`: the scattered path
+        # builds its Vandermonde uncached, so the helper is reached whatever ran before.
+        lambda: fit_bezier(np.zeros(4), np.array([[0.1], [0.4], [0.6], [0.9]]), degree=1, tol=None),
+    ),
+    _BarrierCase(
+        "_bezier_eval._evaluate_bezier",
+        "pantr.bezier._bezier_eval",
+        "_evaluate_bezier_1d",
+        lambda: _bezier_1d().evaluate(_PTS),
+    ),
+    _BarrierCase(
+        "_bezier_eval._evaluate_bezier_deriv",
+        "pantr.bezier._bezier_eval",
+        "_evaluate_bezier_deriv_1d",
+        lambda: _bezier_1d().evaluate_derivatives(_PTS, [1]),
+    ),
+    _BarrierCase(
+        "_bezier_slice._slice_bezier",
+        "pantr.bezier._bezier_slice",
+        "slice_nd_kernel",
+        lambda: _bezier_2d().slice(0, 0.5),
+    ),
+    _BarrierCase(
+        "_bezier_split._split_bezier",
+        "pantr.bezier._bezier_split",
+        "split_nd_kernel",
+        lambda: _bezier_2d().split(0, 0.5),
+    ),
+    _BarrierCase(
+        "_bezier_restrict._restrict_bezier",
+        "pantr.bezier._bezier_restrict",
+        "restrict_nd_kernel",
+        lambda: _bezier_2d().restrict([(0.25, 0.75), None]),
+    ),
+    _BarrierCase(
+        "_bezier_compose._compose_bezier",
+        "pantr.bezier._bezier_compose",
+        "compose_kernel",
+        lambda: _bezier_1d().compose(Bezier(np.array([[0.2], [0.8]]))),
+    ),
+    _BarrierCase(
+        "_bezier_collapse._collapse_along_axis",
+        "pantr.bezier._bezier_collapse",
+        "collapse_kernel",
+        lambda: _bezier_2d().collapse_along_axis(0, [0.5]),
+    ),
+    # -- pantr.bspline -----------------------------------------------------
+    _BarrierCase(
+        "_bspline_basis_core._tabulate_Bspline_basis_1D_impl",
+        "pantr.bspline._bspline_basis_core",
+        "bspline_basis_core",
+        lambda: _general_space_1d().tabulate_basis(_PTS),
+    ),
+    _BarrierCase(
+        "_bspline_basis_core._tabulate_Bspline_basis_deriv_1D_impl",
+        "pantr.bspline._bspline_basis_core",
+        "bspline_basis_deriv_core",
+        lambda: _general_space_1d().tabulate_basis_derivatives(_PTS, 1),
+    ),
+    _BarrierCase(
+        "_bspline_eval._evaluate_Bspline_1D",
+        "pantr.bspline._bspline_eval",
+        "_evaluate_Bspline_basis_combine_1D",
+        lambda: _bspline_1d().evaluate(_PTS),
+    ),
+    _BarrierCase(
+        "_bspline_eval._evaluate_Bspline_deriv_1D",
+        "pantr.bspline._bspline_eval",
+        "_evaluate_Bspline_deriv_1D_non_rational",
+        lambda: _bspline_1d().evaluate_derivatives(_PTS, [1]),
+    ),
+    _BarrierCase(
+        "_bspline_to_beziers._to_beziers_impl",
+        "pantr.bspline._bspline_to_beziers",
+        "_apply_bezier_extraction_1d_core",
+        lambda: _bspline_1d().to_beziers(),
+    ),
+)
+"""The Layer 2 entry points whose barrier this module pins, one case each."""
+
+
+class TestNumbaWarmupBarrier:
+    """Each Layer 2 entry point over parallel kernels reaches the barrier first."""
+
+    @pytest.mark.parametrize("case", _CASES, ids=lambda case: case.entry_point)
+    def test_the_barrier_runs_before_the_kernel_is_reached(
+        self, case: _BarrierCase, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The entry point calls the barrier, and calls it before it reaches a kernel.
+
+        Both names are patched in the entry point's *own* module namespace, so a case can
+        only pass on the call that module makes: deleting ``wait_for_jit_warmup()`` from one
+        entry point fails that entry point's case and no other.
+
+        Args:
+            case (_BarrierCase): The entry point under test.
+            monkeypatch (pytest.MonkeyPatch): Patches the two module-level names.
+        """
+        calls: list[str] = []
+        module = importlib.import_module(case.module)
+        real_sentinel = getattr(module, case.sentinel)
+
+        def record_barrier() -> None:
+            calls.append("barrier")
+
+        def record_sentinel(*args: Any, **kwargs: Any) -> Any:
+            calls.append("kernel")
+            return real_sentinel(*args, **kwargs)
+
+        monkeypatch.setattr(module, "wait_for_jit_warmup", record_barrier)
+        monkeypatch.setattr(module, case.sentinel, record_sentinel)
+
+        case.drive()
+
+        assert "barrier" in calls, f"{case.entry_point} must wait for the JIT warmup"
+        assert "kernel" in calls, (
+            f"{case.sentinel} was never reached, so this case proves nothing about "
+            f"{case.entry_point}; the driver no longer takes the intended branch"
+        )
+        assert calls.index("barrier") < calls.index("kernel"), (
+            f"the barrier must precede the first kernel call; got {calls[:3]}"
+        )
+
+    def test_every_case_names_a_distinct_entry_point(self) -> None:
+        """No two cases cover the same entry point, so the count is the coverage.
+
+        A copy-paste that left two cases pointing at one function would look like coverage
+        of two entry points while leaving one unpinned.
+        """
+        names = [case.entry_point for case in _CASES]
+        assert len(set(names)) == len(names), f"duplicate entry points in the census: {names}"


### PR DESCRIPTION
Closes #418.

## Context

A Layer 2 entry point that reaches a `parallel=True` kernel must call
`pantr._numba_compat.wait_for_jit_warmup()` first. `__init__.py` compiles on a background thread,
and Numba's default workqueue layer is not safe against a concurrent parallel call from another
thread: the process **aborts** rather than raising, so it cannot be caught and it takes the whole
run with it.

#418 names one site: `_bezier_utils` calls `_tabulate_Bernstein_basis_1D_core` unguarded, while
`basis/_basis_1D.py` calls the identical kernel and guards it, with a comment saying why. The
issue is careful to separate what it verified (the code gap) from what it did not (a crash), and
that separation is kept here: **nothing below reproduces a crash.** What is fixed is the gap.

The gap turned out to be systematic rather than local. Enumerating the kernels by AST rather than
grepping for a pattern, and tracing each to its Layer 2 funnels through the backend `_select`
dispatch and dict lookups as well as direct calls: **33 `parallel=True` kernels**, against 12
barrier call sites. Thirteen entry points were unguarded.

## Specification

Thirteen `wait_for_jit_warmup()` calls across ten modules, each the first statement of its entry
point, none inside a loop, none in Layer 3. One barrier per **entry point**, not per kernel, so
funnels are guarded once rather than at each of their callers.

The barrier goes **before** argument validation rather than after. That is not stylistic:
`_tabulate_Bspline_basis_*_impl` validates through `_is_in_domain_impl`, which is itself a Numba
call, so validate-first would break the very invariant the barrier exists to keep.

Deliberately left unguarded, each for a stated reason: the Bézier degree family, which uses the
serial Bernstein kernel by design and whose docstring says the point is to need no barrier; the
pure-NumPy paths; every backend accessor sitting below a guarded funnel; and the warmup functions
themselves, where a barrier would deadlock on the event they alone set.

No computed result changes anywhere in this diff.

## Acceptance

Fourteen tests. Each patches the barrier **and** a sentinel on the path to the kernel in the entry
point's own module, drives the public API, and asserts the barrier fired **and preceded** the
sentinel. A third assertion fails the case if the sentinel was never reached, so a driver drifting
onto another branch cannot make a case silently vacuous, and one further test refuses duplicate
entry-point names so a copy-paste cannot hide an unpinned site.

**Checked by removing each barrier in turn: 13 for 13, each failing its own case and only its
own.** Verified independently on two of them after the fact.

Full suite 10899 passed / 66 skipped / 7 xfailed. ruff, ruff format, mypy (335 files),
import-linter, doctests and the `-W` docs build all green.

## Non-goals, and two things worth someone's attention

**The rule is enforced by convention alone.** Nothing in the toolchain checks it, which is why
this census had to be done by hand and why thirteen sites had drifted. An AST check in the suite
— every Layer 2 function reaching a `parallel=True` kernel is guarded — would make it
self-maintaining and would have caught all thirteen. Not built here: it is new test
infrastructure, not this fix.

A central barrier inside the backend `_select` dispatchers looks like the tidier answer and is
not: four of the thirteen call their kernel with no accessor in between, it would fire for serial
kernels too, and it would deadlock if ever reached from the warmup thread.

Two observations found while tracing, neither touched: `_bspline_to_beziers`'s
`_warmup_numba_functions` has no caller anywhere, so that kernel is never pre-warmed — the two
equivalents elsewhere document being deliberately unwired and this one does not; and
`_bezier_collapse` calls the Bernstein kernel directly instead of the package's own helper, which
is the only reason that path needed a barrier of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDsgxeS1roqbGuLYbyR2zH
