### PR TITLE
fix(bspline): refuse num_intervals=0 in the knot-vector factories

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -123,6 +123,25 @@ user-facing, and the ports change what it affects.
 - `scripts/measure_bezier_fma_bound.py`, which reproduces the bound's slack against whatever
   extension is installed, and prints how to build one that fuses.
 
+### Rejected where it used to be accepted
+- **`num_intervals=0` is refused by all three knot-vector factories.**
+  `create_uniform_open_knots` and `create_uniform_periodic_knots` documented
+  `num_intervals` as *"must be non-negative"* and their shared validator enforced exactly
+  that, so zero was inside the stated contract and neither returned a usable vector.
+  `create_uniform_periodic_knots(0, 3)` returned `[nan, nan, nan, 0.0, inf, inf, inf]` --
+  the periodic extension divides by the interval count -- announcing itself only through
+  a `RuntimeWarning` that nothing raises on, so the caller received a mostly non-finite
+  knot vector and met it somewhere downstream. `create_uniform_open_knots(0, 3)` returned
+  a finite vector with *one* interval rather than none, which constructs a perfectly
+  ordinary space and is therefore the quieter of the two. `create_cardinal_knots` had
+  always refused zero with `num_intervals must be at least 1`, so the module already
+  carried the right answer one function away; the validator now applies it to all three
+  and both docstrings say so. This is the same rule `BsplineSpace1D` applies to a knot
+  vector whose domain is a single point, moved one step earlier to where the offending
+  argument still has a name: the constructor could only report that the vector it was
+  handed spans no interval, which for the periodic case was not even the reason it
+  failed.
+
 ### Performance
 - **`interpolate_bezier` and `fit_bezier` are several times faster on a tensor-product grid.**
   Both recovered the Bernstein coefficients through a truncated-SVD pseudo-inverse that they

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -135,8 +135,11 @@ user-facing, and the ports change what it affects.
   a finite vector with *one* interval rather than none, which constructs a perfectly
   ordinary space and is therefore the quieter of the two. `create_cardinal_knots` had
   always refused zero with `num_intervals must be at least 1`, so the module already
-  carried the right answer one function away; the validator now applies it to all three
-  and both docstrings say so. This is the same rule `BsplineSpace1D` applies to a knot
+  carried the right answer one function away; the shared validator now applies that rule
+  to the two that call it, and both docstrings say so. `create_cardinal_knots` keeps its
+  own copy of the check rather than delegating, because it derives its domain from the
+  count and a zero would reach the validator as `domain=(0, 0)` and be reported against a
+  parameter the caller never passed. This is the same rule `BsplineSpace1D` applies to a knot
   vector whose domain is a single point, moved one step earlier to where the offending
   argument still has a name: the constructor could only report that the vector it was
   handed spans no interval, which for the periodic case was not even the reason it

--- a/docs/guide/spaces-knots.md
+++ b/docs/guide/spaces-knots.md
@@ -18,7 +18,9 @@ Every space has **at least one span**. The domain runs from ``knots[p]`` to
 ``knots[-p-1]``, and a vector whose in-domain knots all collapse to a single knot is
 refused at construction with a message saying so. Nothing can be evaluated, tabulated or
 located on a space with no span, so this is checked once where the space is built rather
-than by each operation in its own way.
+than by each operation in its own way. The factories below say the same thing one step
+earlier: every one of them requires ``num_intervals >= 1``, so a zero is reported against
+the argument that caused it rather than against the vector it produced.
 
 You rarely type knot vectors by hand. The factories in {mod}`pantr.bspline` build the
 standard families:

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -604,7 +604,7 @@ def _validate_knot_input(
     """Validate input parameters for knot vector generation.
 
     Args:
-        num_intervals (int_): Number of intervals in the domain. Must be at least 1:
+        num_intervals (int): Number of intervals in the domain. Must be at least 1:
             a mesh of zero intervals has no cell, so nothing is defined over it.
         degree (int): B-spline degree.
         continuity (int): Continuity level at interior knots.

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -604,7 +604,8 @@ def _validate_knot_input(
     """Validate input parameters for knot vector generation.
 
     Args:
-        num_intervals (int_): Number of intervals in the domain.
+        num_intervals (int_): Number of intervals in the domain. Must be at least 1:
+            a mesh of zero intervals has no cell, so nothing is defined over it.
         degree (int): B-spline degree.
         continuity (int): Continuity level at interior knots.
         domain (tuple[np.float32 | np.float64, np.float32 | np.float64]):
@@ -617,8 +618,8 @@ def _validate_knot_input(
     if domain[0] >= domain[1]:
         raise ValueError("domain[0] must be less than domain[1]")
 
-    if num_intervals < 0:
-        raise ValueError("num_intervals must be non-negative")
+    if num_intervals < 1:
+        raise ValueError("num_intervals must be at least 1")
 
     if degree < 0:
         raise ValueError("degree must be non-negative")

--- a/src/pantr/bspline/_bspline_space_factory.py
+++ b/src/pantr/bspline/_bspline_space_factory.py
@@ -36,7 +36,7 @@ def create_uniform_open_knots(
     ensuring the B-spline interpolates the first and last control points.
 
     Args:
-        num_intervals (int): Number of intervals in the domain. Must be non-negative.
+        num_intervals (int): Number of intervals in the domain. Must be at least 1.
         degree (int): B-spline degree. Must be non-negative.
         continuity (Optional[int]): Continuity level at interior knots.
             Must be between -1 and degree-1. Defaults to degree-1 (maximum continuity).
@@ -49,7 +49,8 @@ def create_uniform_open_knots(
         npt.NDArray[np.floating]: Open knot vector with uniform spacing.
 
     Raises:
-        ValueError: If any parameter is invalid.
+        ValueError: If any parameter is invalid, in particular if ``num_intervals``
+            is less than 1.
 
     Example:
         >>> import numpy as np
@@ -106,7 +107,7 @@ def create_uniform_periodic_knots(
     periodicity of the B-spline basis functions.
 
     Args:
-        num_intervals (int): Number of intervals in the domain. Must be non-negative.
+        num_intervals (int): Number of intervals in the domain. Must be at least 1.
         degree (int): B-spline degree. Must be non-negative.
         continuity (Optional[int]): Continuity level at interior knots.
             Must be between -1 and degree-1. Defaults to degree-1 (maximum continuity).
@@ -119,7 +120,8 @@ def create_uniform_periodic_knots(
         npt.NDArray[np.floating]: Periodic knot vector with uniform spacing.
 
     Raises:
-        ValueError: If any parameter is invalid.
+        ValueError: If any parameter is invalid, in particular if ``num_intervals``
+            is less than 1.
 
     Example:
         >>> import numpy as np

--- a/src/pantr/bspline/_bspline_space_factory.py
+++ b/src/pantr/bspline/_bspline_space_factory.py
@@ -216,6 +216,10 @@ def create_cardinal_knots(
         >>> np.allclose(create_cardinal_knots(2, 2), [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0])
         True
     """
+    # Checked here and not left to `_validate_knot_input`, which enforces the same rule
+    # for the other two factories: this one derives its domain from the count, so a zero
+    # would reach the validator as `domain=(0, 0)` and come back as "domain[0] must be
+    # less than domain[1]", naming a parameter the caller never passed.
     if num_intervals < 1:
         raise ValueError("num_intervals must be at least 1")
 

--- a/tests/test_adversarial_sweep.py
+++ b/tests/test_adversarial_sweep.py
@@ -63,17 +63,6 @@ _KNOWN_FINDINGS = frozenset(
         # `test_sweep_regressions.py::test_degree_elevation_outputs_are_mutually_consistent`.
         "elevate_degree_d0_m1_float64_random",
         "elevate_degree_d1_m2_float64_random",
-        # `num_intervals=0` is documented as legal by two knot-vector factories and
-        # rejected by a third; neither accepting factory returns a usable vector -- the
-        # periodic one returns NaN and inf, the open one returns one interval instead of
-        # none. Pinned by
-        # `test_sweep_regressions.py::test_knot_factories_agree_on_zero_intervals`.
-        "create_uniform_open_knots_d0_float64_[0,1]_n0",
-        "create_uniform_open_knots_d1_float64_[0,1]_n0",
-        "create_uniform_open_knots_d3_float64_[0,1]_n0",
-        "create_uniform_periodic_knots_d0_float64_[0,1]_n0",
-        "create_uniform_periodic_knots_d1_float64_[0,1]_n0",
-        "create_uniform_periodic_knots_d3_float64_[0,1]_n0",
         # `_de_casteljau_eval_scalar` reads `coeff[0]` with no guard, so an empty
         # coefficient array reads out of bounds. Layer 3 documents that it validates
         # nothing, and no public path reaches it with an empty array, so this is a port
@@ -95,6 +84,10 @@ cardinal extraction reads out of bounds no longer occur, so the sweep stopped re
 ``cardinal_intervals_d0_m1_float64`` and ``extraction_build_d0_m1_float64_cardinal``.
 Containment would have tolerated leaving them, but a stale entry misdescribes the state of
 the code.
+
+Six more went the same way when the knot-vector factories were made to refuse
+``num_intervals=0``: the six ``create_uniform_{open,periodic}_knots_d{0,1,3}_float64_[0,1]_n0``
+cases now decline the input, and the probe asserts that refusal with ``must_reject``.
 """
 
 

--- a/tests/test_knots_1D.py
+++ b/tests/test_knots_1D.py
@@ -47,9 +47,20 @@ class TestValidateKnotInput:
 
     def test_negative_num_intervals_error(self) -> None:
         """Reject negative interval counts."""
-        with pytest.raises(ValueError, match="num_intervals must be non-negative"):
+        with pytest.raises(ValueError, match="num_intervals must be at least 1"):
             _validate_knot_input(
                 num_intervals=-1,
+                degree=2,
+                continuity=1,
+                domain=(np.float64(0.0), np.float64(1.0)),
+                dtype=np.float64,
+            )
+
+    def test_zero_num_intervals_error(self) -> None:
+        """Reject a zero interval count: a mesh with no cell has nothing defined over it."""
+        with pytest.raises(ValueError, match="num_intervals must be at least 1"):
+            _validate_knot_input(
+                num_intervals=0,
                 degree=2,
                 continuity=1,
                 domain=(np.float64(0.0), np.float64(1.0)),
@@ -237,8 +248,13 @@ class TestCreateUniformOpenKnotVector:
 
     def test_negative_num_intervals_error(self) -> None:
         """Reject negative interval counts."""
-        with pytest.raises(ValueError, match="num_intervals must be non-negative"):
+        with pytest.raises(ValueError, match="num_intervals must be at least 1"):
             create_uniform_open_knots(-1, 2)
+
+    def test_zero_num_intervals_error(self) -> None:
+        """Reject a zero interval count, which used to return one interval instead."""
+        with pytest.raises(ValueError, match="num_intervals must be at least 1"):
+            create_uniform_open_knots(0, 3)
 
     def test_negative_degree_error(self) -> None:
         """Reject negative degrees."""
@@ -317,8 +333,13 @@ class TestCreateUniformPeriodicKnotVector:
 
     def test_negative_num_intervals_error(self) -> None:
         """Reject negative interval counts."""
-        with pytest.raises(ValueError, match="num_intervals must be non-negative"):
+        with pytest.raises(ValueError, match="num_intervals must be at least 1"):
             create_uniform_periodic_knots(-1, 2)
+
+    def test_zero_num_intervals_error(self) -> None:
+        """Reject a zero interval count, which used to return NaN and inf knots."""
+        with pytest.raises(ValueError, match="num_intervals must be at least 1"):
+            create_uniform_periodic_knots(0, 3)
 
     def test_negative_degree_error(self) -> None:
         """Reject negative degrees."""

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -53,6 +53,7 @@ from pantr.bspline import (
     Bspline,
     BsplineSpace,
     BsplineSpace1D,
+    create_cardinal_knots,
     create_uniform_open_knots,
     create_uniform_periodic_knots,
     find_roots,
@@ -603,46 +604,45 @@ def test_tanh_sinh_nodes_are_interior_and_distinct() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Zero intervals is documented as legal and produces a malformed knot vector
+# Zero intervals was documented as legal and produced a malformed knot vector
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="num_intervals=0 is documented as legal but the knot-vector factories either "
-    "return NaN and inf or silently produce one interval instead of none",
-)
 def test_knot_factories_agree_on_zero_intervals() -> None:
-    # `create_uniform_open_knots` and `create_uniform_periodic_knots` both document
-    # `num_intervals` as "must be non-negative" and both validate only `>= 0`, so zero is
-    # inside their stated contract. `create_cardinal_knots` rejects it with
+    # FIXED by requiring at least one interval in `_validate_knot_input`, the validator
+    # both accepting factories already called. Kept as a regression guard with its
+    # original triggering data, per this repository's convention that the fix PR
+    # un-xfails the tests it closes.
+    #
+    # `create_uniform_open_knots` and `create_uniform_periodic_knots` both documented
+    # `num_intervals` as "must be non-negative" and both validated only `>= 0`, so zero
+    # was inside their stated contract. `create_cardinal_knots` rejected it with
     # "num_intervals must be at least 1". Three factories in one module, two answers to
-    # whether the input is legal, and neither of the accepting two returns a usable vector:
+    # whether the input was legal, and neither of the accepting two returned a usable
+    # vector:
     #
     #   create_uniform_periodic_knots(0, 1) -> [nan, 0.0, inf]
     #   create_uniform_periodic_knots(0, 3) -> [nan, nan, nan, 0.0, inf, inf, inf]
     #   create_uniform_open_knots(0, 3)     -> [0,0,0,0, 1,1,1,1]   (one interval, not zero)
     #
-    # The periodic case comes from `np.linspace` over a zero-length span with a division by
-    # the interval count; it emits only `RuntimeWarning: invalid value encountered in add`,
-    # which nothing raises on, and the caller receives a knot vector full of NaN and inf.
-    # `BsplineSpace1D` then rejects it for the wrong reason ("at least 2*degree+2
-    # elements"), so the origin of the NaN is never reported.
+    # The periodic case came from `np.linspace` over a zero-length span with a division
+    # by the interval count; it emitted only `RuntimeWarning: invalid value encountered
+    # in add`, which nothing raises on, and the caller received a knot vector full of NaN
+    # and inf. `BsplineSpace1D` then rejected it for the wrong reason ("at least
+    # 2*degree+2 elements"), so the origin of the NaN was never reported.
     #
-    # Either answer would be defensible -- reject zero as the cardinal factory does, or
-    # return an empty-domain vector -- but the three must agree, and none may return NaN.
+    # Of the two defensible answers -- refuse zero as the cardinal factory already did,
+    # or return an empty-domain vector -- the first was taken: a mesh of zero intervals
+    # has no cell, so nothing is defined over it, and one of the three factories was
+    # already saying so.
     for degree in (1, 2, 3):
-        periodic = np.asarray(create_uniform_periodic_knots(0, degree))
-        assert np.all(np.isfinite(periodic)), (
-            f"create_uniform_periodic_knots(0, {degree}) returned non-finite knots: "
-            f"{periodic.tolist()}"
-        )
-        open_knots = np.asarray(create_uniform_open_knots(0, degree))
-        spans = int(np.unique(open_knots).size) - 1
-        assert spans == 0, (
-            f"create_uniform_open_knots(0, {degree}) returned {spans} interval(s): "
-            f"{open_knots.tolist()}"
-        )
+        for factory in (
+            create_uniform_open_knots,
+            create_uniform_periodic_knots,
+            create_cardinal_knots,
+        ):
+            with pytest.raises(ValueError, match="num_intervals must be at least 1"):
+                factory(0, degree)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/adversarial_sweep/_probes_bspline.py
+++ b/tools/adversarial_sweep/_probes_bspline.py
@@ -914,8 +914,9 @@ def _interval_count(expected: int, degree: int) -> Predicate:
     definition that fits all three factories: a periodic or cardinal vector deliberately
     extends ``degree`` further spans beyond each end, so counting spans across the whole
     array would report ``1 + 2 * degree`` for a one-interval request and flag correct
-    behavior. This is the weakest reading of what the factories promise, and it is the one
-    that separates them at ``n = 0``.
+    behavior. This is the weakest reading of what the factories promise. It used to be the
+    check that separated the three at ``n = 0`` as well; now that all three refuse that
+    input, ``must_reject`` decides it and this predicate only ever sees ``n >= 1``.
 
     Args:
         expected (int): Number of intervals requested.
@@ -2061,6 +2062,11 @@ def _factory_cases(profile: Profile) -> Iterator[Case]:
                     create_cardinal_knots,
                 ):
                     for n_intervals in (0, 1):
+                        # A `must_reject` case never reaches its invariants: `run_case`
+                        # returns on the exception, and on a return it reports
+                        # `must-reject:returned` before the checks are built. So the zero
+                        # case carries none rather than two that cannot run.
+                        rejected = n_intervals == 0
                         yield Case(
                             GROUP,
                             f"{factory.__name__}_{tag}_n{n_intervals}",
@@ -2069,12 +2075,14 @@ def _factory_cases(profile: Profile) -> Iterator[Case]:
                                 factory(n, degree, dtype=dtype)
                             ),
                             {**params, "n_intervals": n_intervals, "factory": factory.__name__},
-                            invariants=(
+                            invariants=()
+                            if rejected
+                            else (
                                 custom("knots-non-decreasing", _non_decreasing),
                                 custom("interval-count", _interval_count(n_intervals, degree)),
                             ),
-                            must_succeed=n_intervals == 1,
-                            must_reject=n_intervals == 0,
+                            must_succeed=not rejected,
+                            must_reject=rejected,
                         )
 
     if profile is not Profile.FULL:

--- a/tools/adversarial_sweep/_probes_bspline.py
+++ b/tools/adversarial_sweep/_probes_bspline.py
@@ -2049,12 +2049,12 @@ def _factory_cases(profile: Profile) -> Iterator[Case]:
                     params,
                     invariants=(custom("knots-non-decreasing", _non_decreasing),),
                 )
-                # The count corners. `must_reject` is deliberately *not* used for zero:
-                # `create_uniform_open_knots` documents `num_intervals` as "must be
-                # non-negative", so refusing it is not the contract. What is asserted
-                # instead is that whatever comes back is a usable knot vector with the
-                # requested number of intervals -- which is where the three factories
-                # part company (see `_interval_count`).
+                # The count corners. All three factories now document `num_intervals`
+                # as "must be at least 1" and enforce it, so zero is `must_reject` and
+                # one is `must_succeed`. Until the fix for the zero-interval knot
+                # vectors landed, only `create_cardinal_knots` said so, and the other
+                # two returned NaN and inf (periodic) or one interval instead of none
+                # (open) -- which is what `_interval_count` was there to catch.
                 for factory in (
                     create_uniform_open_knots,
                     create_uniform_periodic_knots,
@@ -2074,6 +2074,7 @@ def _factory_cases(profile: Profile) -> Iterator[Case]:
                                 custom("interval-count", _interval_count(n_intervals, degree)),
                             ),
                             must_succeed=n_intervals == 1,
+                            must_reject=n_intervals == 0,
                         )
 
     if profile is not Profile.FULL:


### PR DESCRIPTION
## Context

Closes #410. Two of the three knot-vector factories in `pantr.bspline` documented
`num_intervals` as *"must be non-negative"*, and their shared validator
`_validate_knot_input` enforced exactly that, so `num_intervals=0` was inside the stated
contract of both. Neither returned a usable knot vector for it:

```
create_uniform_periodic_knots(0, 1) -> [nan, 0.0, inf]
create_uniform_periodic_knots(0, 3) -> [nan, nan, nan, 0.0, inf, inf, inf]
create_uniform_open_knots(0, 3)     -> [0, 0, 0, 0, 1, 1, 1, 1]   (one interval, not none)
create_cardinal_knots(0, 3)         -> ValueError: num_intervals must be at least 1
```

The periodic extension divides by the interval count, so the whole extension goes
non-finite; the only signal is a `RuntimeWarning` nothing raises on, and `BsplineSpace1D`
then rejects the result for the wrong reason ("at least 2\*degree+2 elements"), never
naming the NaN. The open case is the quieter of the two: it returns a finite vector that
constructs a perfectly ordinary one-interval space, so the caller silently gets a mesh
they did not ask for.

The third factory in the same module has always refused zero with the right message, so
the module already carried the answer one function away.

## Specification

- `_validate_knot_input` requires `num_intervals >= 1`, with the message
  `create_cardinal_knots` already used. Both factory docstrings say so, and both `Raises:`
  sections name the refusal.
- `create_cardinal_knots` keeps its own copy of the check rather than delegating, and a
  note now says why: it derives its domain from the count, so a zero would reach the
  validator as `domain=(0, 0)` and come back as *"domain[0] must be less than domain[1]"*,
  naming a parameter the caller never passed.
- The strict-`xfail` regression test that pinned the defect is un-xfailed and rewritten to
  assert the resolution taken, keeping its original triggering data. Three unit tests are
  added beside the existing negative-count ones, following the same per-layer pattern
  (validator directly, then each public factory).
- The adversarial-sweep probe stops treating zero as in-contract and asserts the refusal
  with `must_reject`; its six now-fixed entries leave the known-findings list. The two
  invariants on the zero case are dropped, because a `must_reject` case never reaches
  them, and `_interval_count`'s docstring is corrected where it claimed to be what
  separates the factories at `n = 0`.
- Changelog entry under a new *Rejected where it used to be accepted* section, and one
  sentence in the spaces-and-knots guide.

This is the rule `BsplineSpace1D` already applies to a knot vector whose domain is a
single point, moved one step earlier to where the offending argument still has a name.

## Acceptance

- `ruff check` clean; `ruff format --check` 360 files already formatted; `mypy` Success on
  335 source files. This branch's CI runs none of the three, so all three were run by hand.
- Full suite **10903 passed / 66 skipped / 6 xfailed**, against a base of 10899 / 66 / 7:
  three new tests plus the un-xfailed regression, and no previously-passing result moved.
  The skip count is unchanged, so the C++ backend was live for the run.
- Doctest 83 passed / 7 skipped. `lint-imports` 2 contracts kept, 0 broken. Docs build with
  `-W --keep-going` succeeded with zero warnings.
- Adversarial sweep smoke profile passes; the nine zero-interval cases now grade
  `DOCUMENTED_REJECTION`. **Non-vacuity checked rather than assumed**: with the validator
  reverted, the six open/periodic cases report `must-reject:returned`. That is strictly
  stronger than what stood before, where the open factory's finite return was caught only
  by the interval-count invariant.
- The downstream consumer was censused. It calls `create_uniform_space` widely, almost
  always with literal counts; every computed count flows from a refinement sweep that
  already refuses a coarsest value below 1. The one path that can still reach zero is a
  benchmark's `--cells` flag, where the previous behavior was a silent one-cell mesh.

## Non-goals

- Folding `create_cardinal_knots` onto the shared validator. Its early check is
  load-bearing for the reason recorded above.
- Any change to what a valid `num_intervals` produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDsgxeS1roqbGuLYbyR2zH
