### PR TITLE
docs(bezier): state the precondition the de Casteljau kernels disclaim against

### DIFF
--- a/cpp/include/pantr/bezier/root_finding.hpp
+++ b/cpp/include/pantr/bezier/root_finding.hpp
@@ -148,8 +148,11 @@ namespace detail {
 ///
 /// Mirrors `_root_finding_core._de_casteljau_eval_scalar`. No validation is performed; the
 /// Python layer guarantees the shapes. `coeff` must hold at least one coefficient, a degree-`n`
-/// polynomial having `n + 1` of them. **This function reads past a shorter span**, which is
-/// undefined behavior; the numba oracle's bounds check reports the same read as an `IndexError`.
+/// polynomial having `n + 1` of them. On an empty one the copy above writes nothing and this
+/// then reads `work[0]`, so the `work` line stops holding: sized to match `coeff`, that read is
+/// out of bounds; longer than it, the value is indeterminate. Both are undefined behavior. The
+/// numba oracle reports the same read as an `IndexError`, its workspace being a copy of `coeff`
+/// and so exactly as short.
 template <Real T>
 T de_casteljau_eval_scalar(std::span<const T> coeff, accumulator_t<T> t, std::span<T> work) {
     const auto n = static_cast<std::ptrdiff_t>(coeff.size()) - 1;
@@ -181,8 +184,11 @@ T de_casteljau_eval_scalar(std::span<const T> coeff, accumulator_t<T> t, std::sp
 ///
 /// Mirrors `_root_finding_core._de_casteljau_eval_and_deriv_scalar`. No validation is performed.
 /// `coeff` must hold at least one coefficient, a degree-`n` polynomial having `n + 1` of them.
-/// **This function reads past a shorter span**, which is undefined behavior; the numba oracle's
-/// bounds check reports the same read as an `IndexError`.
+/// On an empty one the copy above writes nothing and this then reads `work[0]` and `work[1]`, so
+/// the `work` line stops holding: sized to match `coeff`, those reads are out of bounds; longer
+/// than it, the values are indeterminate. Both are undefined behavior. The numba oracle reports
+/// the same read as an `IndexError`, its workspace being a copy of `coeff` and so exactly as
+/// short.
 template <Real T>
 accumulator_t<T> de_casteljau_eval_and_deriv_scalar(std::span<const T> coeff, accumulator_t<T> t,
                                                     std::span<T> work,
@@ -459,9 +465,9 @@ bool clip_hull_to_zero(std::span<const T> coeff, std::span<std::int64_t> chain, 
 /// \return The polished parameter, or `mid` unchanged.
 ///
 /// Mirrors `_root_finding_core._newton_polish_scalar`. No validation is performed. `coeff` must
-/// hold at least one coefficient, a degree-`n` polynomial having `n + 1` of them. **This
-/// function reads past a shorter span**, which is undefined behavior; the numba oracle's bounds
-/// check reports the same read as an `IndexError`.
+/// hold at least one coefficient, a degree-`n` polynomial having `n + 1` of them. On an empty
+/// one this inherits the undefined behavior of `de_casteljau_eval_and_deriv_scalar`, which it
+/// calls first.
 template <Real T>
 accumulator_t<T> newton_polish_scalar(std::span<const T> coeff, accumulator_t<T> mid,
                                       accumulator_t<T> lo, accumulator_t<T> hi,

--- a/cpp/include/pantr/bezier/root_finding.hpp
+++ b/cpp/include/pantr/bezier/root_finding.hpp
@@ -146,8 +146,10 @@ namespace detail {
 /// \param work Scratch of at least `coeff.size()` entries; contents are not read.
 /// \return The polynomial value, at coefficient width, as the oracle returns it.
 ///
-/// Mirrors `_root_finding_core._de_casteljau_eval_scalar`. No validation is
-/// performed; the Python layer guarantees the shapes.
+/// Mirrors `_root_finding_core._de_casteljau_eval_scalar`. No validation is performed; the
+/// Python layer guarantees the shapes. `coeff` must hold at least one coefficient, a degree-`n`
+/// polynomial having `n + 1` of them. **This function reads past a shorter span**, which is
+/// undefined behavior; the numba oracle's bounds check reports the same read as an `IndexError`.
 template <Real T>
 T de_casteljau_eval_scalar(std::span<const T> coeff, accumulator_t<T> t, std::span<T> work) {
     const auto n = static_cast<std::ptrdiff_t>(coeff.size()) - 1;
@@ -177,8 +179,10 @@ T de_casteljau_eval_scalar(std::span<const T> coeff, accumulator_t<T> t, std::sp
 /// \param out_deriv Receives the derivative.
 /// \return The polynomial value.
 ///
-/// Mirrors `_root_finding_core._de_casteljau_eval_and_deriv_scalar`. No validation is
-/// performed.
+/// Mirrors `_root_finding_core._de_casteljau_eval_and_deriv_scalar`. No validation is performed.
+/// `coeff` must hold at least one coefficient, a degree-`n` polynomial having `n + 1` of them.
+/// **This function reads past a shorter span**, which is undefined behavior; the numba oracle's
+/// bounds check reports the same read as an `IndexError`.
 template <Real T>
 accumulator_t<T> de_casteljau_eval_and_deriv_scalar(std::span<const T> coeff, accumulator_t<T> t,
                                                     std::span<T> work,
@@ -220,7 +224,10 @@ accumulator_t<T> de_casteljau_eval_and_deriv_scalar(std::span<const T> coeff, ac
 /// \param upper Right bound in (0, 1].
 /// \param out Receives `p + 1` restricted coefficients.
 ///
-/// Mirrors `_root_finding_core._restrict_scalar`. No validation is performed.
+/// Mirrors `_root_finding_core._restrict_scalar`. No validation is performed. `coeff` must hold
+/// at least one coefficient, a degree-`n` polynomial having `n + 1` of them. This function
+/// happens to survive a shorter span, but what it produces for one is unspecified and matches
+/// the oracle only by accident.
 template <Real T>
 void restrict_scalar(std::span<const T> coeff, double lower, double upper, std::span<double> out) {
     using std::abs;
@@ -270,7 +277,10 @@ void restrict_scalar(std::span<const T> coeff, double lower, double upper, std::
 /// \param t_max Sub-interval end, clamped into [0, 1].
 /// \param out Receives `coeff.size()` reparametrised coefficients.
 ///
-/// Mirrors `_root_finding_core._subdivide_scalar`. No validation is performed.
+/// Mirrors `_root_finding_core._subdivide_scalar`. No validation is performed. `coeff` must hold
+/// at least one coefficient, a degree-`n` polynomial having `n + 1` of them. This function
+/// happens to survive a shorter span, but what it produces for one is unspecified and matches
+/// the oracle only by accident.
 template <Real T>
 void subdivide_scalar(std::span<const T> coeff, double t_min, double t_max,
                       std::span<double> out) {
@@ -297,7 +307,10 @@ void subdivide_scalar(std::span<const T> coeff, double t_min, double t_max,
 /// \return The number of sign changes, which bounds the root count above by the
 ///     variation-diminishing property.
 ///
-/// Mirrors `_root_finding_core._count_sign_changes`. No validation is performed.
+/// Mirrors `_root_finding_core._count_sign_changes`. No validation is performed. `coeff` must
+/// hold at least one coefficient, a degree-`n` polynomial having `n + 1` of them. This function
+/// happens to survive a shorter span, but what it produces for one is unspecified and matches
+/// the oracle only by accident.
 template <Real T>
 int count_sign_changes(std::span<const T> coeff) {
     int changes = 0;
@@ -349,7 +362,10 @@ int count_sign_changes(std::span<const T> coeff) {
 /// \param t_hi Receives the highest.
 /// \return Whether any zero crossing was detected.
 ///
-/// Mirrors `_root_finding_core._clip_hull_to_zero`. No validation is performed.
+/// Mirrors `_root_finding_core._clip_hull_to_zero`. No validation is performed. `coeff` must
+/// hold at least one coefficient, a degree-`n` polynomial having `n + 1` of them. This function
+/// happens to survive a shorter span, but what it produces for one is unspecified and matches
+/// the oracle only by accident.
 template <Real T>
 bool clip_hull_to_zero(std::span<const T> coeff, std::span<std::int64_t> chain, double& t_lo,
                        double& t_hi) {
@@ -442,7 +458,10 @@ bool clip_hull_to_zero(std::span<const T> coeff, std::span<std::int64_t> chain, 
 /// \param out_df Receives the derivative at `mid`, whatever is returned.
 /// \return The polished parameter, or `mid` unchanged.
 ///
-/// Mirrors `_root_finding_core._newton_polish_scalar`. No validation is performed.
+/// Mirrors `_root_finding_core._newton_polish_scalar`. No validation is performed. `coeff` must
+/// hold at least one coefficient, a degree-`n` polynomial having `n + 1` of them. **This
+/// function reads past a shorter span**, which is undefined behavior; the numba oracle's bounds
+/// check reports the same read as an `IndexError`.
 template <Real T>
 accumulator_t<T> newton_polish_scalar(std::span<const T> coeff, accumulator_t<T> mid,
                                       accumulator_t<T> lo, accumulator_t<T> hi,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -129,8 +129,8 @@ user-facing, and the ports change what it affects.
   assumed to be correct (no validation performed)"* is correct policy and was the whole of
   what they said, which names no minimum: a direct caller had nothing to check its input
   against, and neither did the adversarial sweep. Three of the seven read past a shorter
-  array -- `_de_casteljau_eval_scalar`, `_de_casteljau_eval_and_deriv_scalar`, and
-  `_newton_polish_scalar` through the second -- and the other four happen to survive one and
+  array -- `_de_casteljau_eval_scalar` and `_de_casteljau_eval_and_deriv_scalar` directly,
+  and `_newton_polish_scalar` through its call into the latter -- and the other four survive one and
   return something meaningless; each docstring now says which it is, and says the behavior is
   unspecified either way rather than pinning today's. Verified by calling all seven at length
   0 under `NUMBA_BOUNDSCHECK=1` with a fresh cache. No public path reaches any of them with

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -123,6 +123,22 @@ user-facing, and the ports change what it affects.
 - `scripts/measure_bezier_fma_bound.py`, which reproduces the bound's slack against whatever
   extension is installed, and prints how to build one that fuses.
 
+### Documentation
+- **The seven Bernstein-coefficient kernels in `pantr.bezier._root_finding_core` now state
+  the precondition their Layer 3 disclaimer stands on**, `len(coeff) >= 1`. *"Inputs are
+  assumed to be correct (no validation performed)"* is correct policy and was the whole of
+  what they said, which names no minimum: a direct caller had nothing to check its input
+  against, and neither did the adversarial sweep. Three of the seven read past a shorter
+  array -- `_de_casteljau_eval_scalar`, `_de_casteljau_eval_and_deriv_scalar`, and
+  `_newton_polish_scalar` through the second -- and the other four happen to survive one and
+  return something meaningless; each docstring now says which it is, and says the behavior is
+  unspecified either way rather than pinning today's. Verified by calling all seven at length
+  0 under `NUMBA_BOUNDSCHECK=1` with a fresh cache. No public path reaches any of them with
+  an empty array: `Bezier.__init__` and `_validate_coeff_array` both reject an empty axis, and
+  those guards are unchanged. The C++ mirrors in `cpp/include/pantr/bezier/root_finding.hpp`
+  carry the same statement, since a contract the two backends state differently is a contract
+  only one of them has.
+
 ### Rejected where it used to be accepted
 - **`num_intervals=0` is refused by all three knot-vector factories.**
   `create_uniform_open_knots` and `create_uniform_periodic_knots` documented

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,6 +23,13 @@ mypy_path = src
 # how the harness reaches them, and it means both runs share one cache and one set of flags.
 exclude = (?x)(^tests/typing/cases/)
 
+# The adversarial sweep lives under `tools/` and is outside the type-checked set, which
+# is deliberate: it is a harness, not shipped code. `tests/test_adversarial_sweep.py`
+# unit-tests its classifier, so it imports the package; putting `tools` on `mypy_path`
+# instead would pull the whole harness into strict mode, which it was never written for.
+[mypy-adversarial_sweep.*]
+ignore_missing_imports = True
+
 [mypy-tests.*]
 disallow_untyped_defs = False
 disallow_untyped_decorators = False

--- a/src/pantr/bezier/_root_finding_core.py
+++ b/src/pantr/bezier/_root_finding_core.py
@@ -126,7 +126,13 @@ def _de_casteljau_eval_scalar(
         float: Polynomial value B(t).
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The precondition
+        that disclaimer stands on is ``len(coeff) >= 1``: a degree-``n`` Bernstein
+        polynomial has ``n + 1`` coefficients, and a polynomial with none is not one.
+        **This kernel reads past a shorter array.** Numba's bounds check turns that
+        into an ``IndexError`` and an ordinary build returns whatever the read found,
+        so the behavior is unspecified either way and must not be relied on; the C++
+        port of this kernel has undefined behavior there.
         For general use, call the Layer 2 helpers in ``_find_roots`` instead.
     """
     work = coeff.copy()
@@ -164,7 +170,11 @@ def _restrict_scalar(
             reparametrized to [0, 1].
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The precondition
+        that disclaimer stands on is ``len(coeff) >= 1``: a degree-``n`` Bernstein
+        polynomial has ``n + 1`` coefficients, and a polynomial with none is not one.
+        This kernel happens to survive a shorter array rather than reading past it,
+        but what it returns for one is unspecified and must not be relied on.
         For general use, call the Layer 2 helpers in ``_find_roots`` instead.
     """
     p = len(coeff) - 1
@@ -216,7 +226,13 @@ def _de_casteljau_eval_and_deriv_scalar(
         tuple[float, float]: ``(f(t), f'(t))``.
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The precondition
+        that disclaimer stands on is ``len(coeff) >= 1``: a degree-``n`` Bernstein
+        polynomial has ``n + 1`` coefficients, and a polynomial with none is not one.
+        **This kernel reads past a shorter array.** Numba's bounds check turns that
+        into an ``IndexError`` and an ordinary build returns whatever the read found,
+        so the behavior is unspecified either way and must not be relied on; the C++
+        port of this kernel has undefined behavior there.
         For general use, call the Layer 2 helpers in ``_find_roots`` instead.
     """
     n = len(coeff) - 1
@@ -262,7 +278,11 @@ def _subdivide_scalar(
         npt.NDArray[np.float64]: Bernstein coefficients reparametrized to [0, 1].
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The precondition
+        that disclaimer stands on is ``len(coeff) >= 1``: a degree-``n`` Bernstein
+        polynomial has ``n + 1`` coefficients, and a polynomial with none is not one.
+        This kernel happens to survive a shorter array rather than reading past it,
+        but what it returns for one is unspecified and must not be relied on.
         For general use, call the Layer 2 helpers in ``_find_roots`` instead.
     """
     if t_min <= 0.0 and t_max >= 1.0:
@@ -293,7 +313,11 @@ def _count_sign_changes(
         int: Number of sign changes (ignoring zero coefficients).
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The precondition
+        that disclaimer stands on is ``len(coeff) >= 1``: a degree-``n`` Bernstein
+        polynomial has ``n + 1`` coefficients, and a polynomial with none is not one.
+        This kernel happens to survive a shorter array rather than reading past it,
+        but what it returns for one is unspecified and must not be relied on.
         For general use, call the Layer 2 helpers in ``_find_roots`` instead.
     """
     changes = 0
@@ -333,7 +357,11 @@ def _clip_hull_to_zero(  # noqa: PLR0912, PLR0915
             indicates whether any zero crossing was detected.
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The precondition
+        that disclaimer stands on is ``len(coeff) >= 1``: a degree-``n`` Bernstein
+        polynomial has ``n + 1`` coefficients, and a polynomial with none is not one.
+        This kernel happens to survive a shorter array rather than reading past it,
+        but what it returns for one is unspecified and must not be relied on.
         For general use, call the Layer 2 helpers in ``_find_roots`` instead.
     """
     n = len(coeff) - 1
@@ -461,7 +489,13 @@ def _newton_polish_scalar(
             original ``mid``.
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The precondition
+        that disclaimer stands on is ``len(coeff) >= 1``: a degree-``n`` Bernstein
+        polynomial has ``n + 1`` coefficients, and a polynomial with none is not one.
+        **This kernel reads past a shorter array.** Numba's bounds check turns that
+        into an ``IndexError`` and an ordinary build returns whatever the read found,
+        so the behavior is unspecified either way and must not be relied on; the C++
+        port of this kernel has undefined behavior there.
         For general use, call the Layer 2 helpers in ``_find_roots`` instead.
     """
     f_mid, df_mid = _de_casteljau_eval_and_deriv_scalar(coeff, mid)

--- a/tests/test_adversarial_sweep.py
+++ b/tests/test_adversarial_sweep.py
@@ -63,11 +63,6 @@ _KNOWN_FINDINGS = frozenset(
         # `test_sweep_regressions.py::test_degree_elevation_outputs_are_mutually_consistent`.
         "elevate_degree_d0_m1_float64_random",
         "elevate_degree_d1_m2_float64_random",
-        # `_de_casteljau_eval_scalar` reads `coeff[0]` with no guard, so an empty
-        # coefficient array reads out of bounds. Layer 3 documents that it validates
-        # nothing, and no public path reaches it with an empty array, so this is a port
-        # note rather than a live bug: in C++ the same read is undefined behavior.
-        "de_casteljau_len0_float64",
     }
 )
 """Findings the smoke profile is expected to reproduce.
@@ -88,6 +83,12 @@ the code.
 Six more went the same way when the knot-vector factories were made to refuse
 ``num_intervals=0``: the six ``create_uniform_{open,periodic}_knots_d{0,1,3}_float64_[0,1]_n0``
 cases now decline the input, and the probe asserts that refusal with ``must_reject``.
+
+``de_casteljau_len0_float64`` left for a different reason, and it is worth keeping straight.
+Nothing about the kernel changed: an empty coefficient array still reads out of bounds. What
+changed is that the kernel now *states* the precondition it was silently assuming, so the case
+carries ``out_of_contract`` and the harness grades it as a documented rejection. The entry was
+never a bug to fix; it was a contract that had not been written down.
 """
 
 
@@ -151,3 +152,110 @@ def test_smoke_sweep_finds_nothing_new(tmp_path: pathlib.Path) -> None:
         if r["verdict"] == "BUG" and r["label"] in new
     )
     assert not new, f"the sweep found {len(new)} finding(s) not in _KNOWN_FINDINGS:\n{details}"
+
+
+# ---------------------------------------------------------------------------
+# The harness's own `out_of_contract` flag, unit-tested
+# ---------------------------------------------------------------------------
+#
+# These need no subprocess and no Numba: they exercise the classifier directly, on
+# fabricated cases. They exist because the flag's two branches are not both reachable
+# from a sweep run -- the launcher re-execs with `NUMBA_BOUNDSCHECK=1` unconditionally,
+# so a kernel that overruns always raises and the "returned anyway" branch is never
+# taken by today's cases. Untested, that branch would be free to rot.
+
+sys.path.insert(0, str(_ROOT / "tools"))
+
+from adversarial_sweep._core import (  # noqa: E402  -- needs the path insert above
+    NUMBA_OOB_MESSAGE,
+    Case,
+    Verdict,
+    classify,
+    custom,
+    run_case,
+)
+
+
+def _case(
+    *,
+    must_succeed: bool = False,
+    must_reject: bool = False,
+    out_of_contract: bool = False,
+) -> Case:
+    """Build a minimal case whose entry point documents nothing.
+
+    Args:
+        must_succeed (bool): Set the "legal by construction" flag. Defaults to False.
+        must_reject (bool): Set the "built to be refused" flag. Defaults to False.
+        out_of_contract (bool): Set the "outside the stated contract" flag. Defaults to
+            False.
+
+    Returns:
+        Case: A case over a no-op entry point.
+    """
+
+    def entry() -> int:
+        """Do nothing.
+
+        Returns:
+            int: Zero.
+        """
+        return 0
+
+    return Case(
+        "unit",
+        "probe",
+        entry,
+        lambda: 0,
+        must_succeed=must_succeed,
+        must_reject=must_reject,
+        out_of_contract=out_of_contract,
+    )
+
+
+def test_out_of_contract_turns_a_kernel_overrun_into_a_documented_rejection() -> None:
+    """The flag is what reclassifies the bounds-check hit, and only the flag."""
+    overrun = IndexError(NUMBA_OOB_MESSAGE)
+
+    verdict, kind, _ = classify(_case(), overrun)
+    assert (verdict, kind) == (Verdict.BUG, "numba-oob")
+
+    verdict, kind, _ = classify(_case(out_of_contract=True), overrun)
+    assert verdict is Verdict.DOCUMENTED_REJECTION
+    assert kind == "out-of-contract:IndexError"
+
+
+def test_an_out_of_contract_case_that_returns_is_graded_on_nothing() -> None:
+    """Its invariants describe a contract the input is outside of, so they do not run."""
+    always_fails = custom("never-holds", lambda _result: "this invariant always fails")
+
+    graded = run_case(0, Case("unit", "probe", int, lambda: 0, invariants=(always_fails,)))
+    assert graded.verdict is Verdict.BUG
+
+    ungraded = run_case(
+        0,
+        Case(
+            "unit",
+            "probe",
+            int,
+            lambda: 0,
+            invariants=(always_fails,),
+            out_of_contract=True,
+        ),
+    )
+    assert ungraded.verdict is Verdict.OK
+    assert ungraded.kind == "out-of-contract:returned"
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        ("must_succeed", "must_reject"),
+        ("must_succeed", "out_of_contract"),
+        ("must_reject", "out_of_contract"),
+    ],
+)
+def test_a_case_may_make_only_one_claim_about_its_input(first: str, second: str) -> None:
+    """An input is legal, illegal, or outside the stated contract, never two of them."""
+    with pytest.raises(ValueError, match="not two of them"):
+        _case(**{first: True, second: True})

--- a/tests/test_adversarial_sweep.py
+++ b/tests/test_adversarial_sweep.py
@@ -225,6 +225,31 @@ def test_out_of_contract_turns_a_kernel_overrun_into_a_documented_rejection() ->
     assert kind == "out-of-contract:IndexError"
 
 
+@pytest.mark.parametrize(
+    "exc",
+    [
+        IndexError(NUMBA_OOB_MESSAGE),
+        IndexError("index 3 is out of bounds for axis 0 with size 2"),
+        ValueError("some message"),
+        ZeroDivisionError("division by zero"),
+        RuntimeError("anything at all"),
+    ],
+    ids=lambda e: type(e).__name__ + ("-numba" if str(e) == NUMBA_OOB_MESSAGE else ""),
+)
+def test_an_out_of_contract_case_is_graded_on_nothing_whatever_it_raises(
+    exc: Exception,
+) -> None:
+    """The branch takes no view on the exception type, deliberately.
+
+    The behaviour of a Layer 3 kernel on out-of-contract input is unspecified, so which
+    exception escapes is unspecified too. Grading only ``IndexError`` would smuggle in a
+    promise about the failure mode that no kernel makes.
+    """
+    verdict, kind, _ = classify(_case(out_of_contract=True), exc)
+    assert verdict is Verdict.DOCUMENTED_REJECTION
+    assert kind == f"out-of-contract:{type(exc).__name__}"
+
+
 def test_an_out_of_contract_case_that_returns_is_graded_on_nothing() -> None:
     """Its invariants describe a contract the input is outside of, so they do not run."""
     always_fails = custom("never-holds", lambda _result: "this invariant always fails")

--- a/tests/test_kernel_preconditions.py
+++ b/tests/test_kernel_preconditions.py
@@ -1,0 +1,84 @@
+"""The Layer 3 kernels of ``pantr.bezier._root_finding_core`` state their preconditions.
+
+A Layer 3 kernel validates nothing, by design and by this repository's stated layering.
+That disclaimer is only meaningful next to the precondition it is disclaiming against:
+*"inputs are assumed to be correct"* names no minimum length, so a direct caller has
+nothing to check its input against, and the adversarial sweep has nothing to grade
+against either.
+
+**What this module asserts is that the precondition is written down, not what happens
+when it is broken.** The behaviour on out-of-contract input is deliberately unspecified
+-- three of these kernels read past the array and four happen not to -- and a test that
+pinned today's ``IndexError`` would freeze something the library does not promise, and
+would fail the moment a build turns bounds checking off.
+
+It is also what keeps ``adversarial_sweep``'s ``out_of_contract`` flag honest. That flag
+tells the sweep not to grade a case, on the grounds that the entry point declares the
+input illegal. Used where no such declaration exists it would be a way to silence a
+finding; this module is the check that the declaration is really there.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pantr.bezier import _root_finding_core as core
+
+_COEFFICIENT_KERNELS = (
+    core._de_casteljau_eval_scalar,
+    core._restrict_scalar,
+    core._de_casteljau_eval_and_deriv_scalar,
+    core._subdivide_scalar,
+    core._count_sign_changes,
+    core._clip_hull_to_zero,
+    core._newton_polish_scalar,
+)
+"""Every kernel in the module that takes a Bernstein coefficient array.
+
+The three that do not -- ``_have_same_sign``, ``_have_opposite_signs`` and
+``_spans_zero`` -- are deliberately absent. They take two floats, every float is in
+contract for them (their docstrings already reason about NaN and infinity), so there is
+no minimum to state and inventing one would be a false claim.
+"""
+
+
+def _docstring_of(kernel: object) -> str:
+    """Return a kernel's docstring, reaching through Numba's dispatcher wrapper.
+
+    Args:
+        kernel (object): A ``@nb_jit``-decorated kernel, or the plain function when the
+            JIT is disabled.
+
+    Returns:
+        str: The docstring, never ``None``: an undocumented kernel is itself a failure
+            this module should report rather than skip.
+    """
+    doc: object = getattr(kernel, "__doc__", None)
+    if doc is None:
+        py_func: object = getattr(kernel, "py_func", None)
+        doc = getattr(py_func, "__doc__", None)
+    assert isinstance(doc, str), f"{kernel} carries no docstring at all"
+    return doc
+
+
+@pytest.mark.parametrize(
+    "kernel", _COEFFICIENT_KERNELS, ids=lambda k: getattr(k, "__name__", str(k))
+)
+def test_a_coefficient_kernel_states_its_minimum_length(kernel: object) -> None:
+    """Each coefficient-array kernel names ``len(coeff) >= 1`` in its docstring."""
+    doc = _docstring_of(kernel)
+    assert "len(coeff) >= 1" in doc, (
+        f"{getattr(kernel, '__name__', kernel)} disclaims validation without stating the "
+        "minimum coefficient-array length it assumes"
+    )
+
+
+@pytest.mark.parametrize(
+    "kernel", _COEFFICIENT_KERNELS, ids=lambda k: getattr(k, "__name__", str(k))
+)
+def test_a_coefficient_kernel_still_disclaims_validation(kernel: object) -> None:
+    """Stating the precondition does not replace the layering disclaimer."""
+    doc = _docstring_of(kernel)
+    assert "no validation performed" in doc, (
+        f"{getattr(kernel, '__name__', kernel)} lost the Layer 3 disclaimer"
+    )

--- a/tools/adversarial_sweep/_core.py
+++ b/tools/adversarial_sweep/_core.py
@@ -131,6 +131,19 @@ class Case:
             on whether the result is finite, so an entry point that silently started
             accepting nonsense and producing a plausible number would read as ``OK``:
             the input family's intent lives in a comment and nothing checks it.
+        out_of_contract (bool): For an input the entry point's own docstring states
+            is illegal, where the entry point is a Layer 3 kernel that validates
+            nothing. Neither of the two flags above fits: the call is not required to
+            succeed, and it is not required to be refused either -- what it does is
+            **unspecified**, and pinning today's behavior would freeze something this
+            library does not promise. So a raise is reported as a documented rejection
+            and a return as ``OK``, with the declared invariants skipped, since they
+            describe a contract this input is outside of. It is only legitimate where
+            the precondition is *written down*: used on an entry point whose docstring
+            names no such precondition, this becomes a way to silence a finding, which
+            is the one thing this harness must not offer. What keeps the existing uses
+            honest is ``tests/test_kernel_preconditions.py``, which asserts the
+            precondition is stated.
         finite_inputs (bool): Whether every input is finite. When ``False`` the
             automatic finiteness check on the result is skipped.
         arrays (Mapping[str, npt.NDArray[Any]]): Input arrays to persist under
@@ -146,18 +159,30 @@ class Case:
     invariants: tuple[Invariant, ...] = ()
     must_succeed: bool = False
     must_reject: bool = False
+    out_of_contract: bool = False
     finite_inputs: bool = True
     arrays: Mapping[str, npt.NDArray[Any]] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Reject a case that claims its input is both legal and illegal.
+        """Reject a case that makes more than one claim about its input's legality.
 
         Raises:
-            ValueError: If both ``must_succeed`` and ``must_reject`` are set.
+            ValueError: If more than one of ``must_succeed``, ``must_reject`` and
+                ``out_of_contract`` is set.
         """
-        if self.must_succeed and self.must_reject:
+        claims = [
+            name
+            for name, set_ in (
+                ("must_succeed", self.must_succeed),
+                ("must_reject", self.must_reject),
+                ("out_of_contract", self.out_of_contract),
+            )
+            if set_
+        ]
+        if len(claims) > 1:
             raise ValueError(
-                f"case {self.group}/{self.label} sets both must_succeed and must_reject"
+                f"case {self.group}/{self.label} sets {' and '.join(claims)}; "
+                "an input is legal, illegal, or outside the stated contract, not two of them"
             )
 
 
@@ -514,6 +539,13 @@ def classify(case: Case, exc: Exception) -> tuple[Verdict, str, str]:
     name = type(exc).__name__
     message = str(exc).strip()
 
+    if case.out_of_contract:
+        return (
+            Verdict.DOCUMENTED_REJECTION,
+            f"out-of-contract:{name}",
+            f"{name} on input the kernel's docstring states is illegal: {message}",
+        )
+
     if isinstance(exc, IndexError) and message == NUMBA_OOB_MESSAGE:
         return Verdict.BUG, "numba-oob", "Numba bounds check: out-of-range access in a kernel"
 
@@ -680,13 +712,20 @@ def run_case(index: int, case: Case) -> Outcome:
             if verdict is Verdict.BUG:
                 detail = f"{detail}\n{_short_traceback(exc)}"
             return Outcome(index, case, verdict, kind, detail, _warning_names(caught))
-        if case.must_reject:
+        if case.must_reject or case.out_of_contract:
+            # Both stop here, for opposite reasons. A `must_reject` case that returned
+            # is the finding itself. An `out_of_contract` one is graded on nothing: its
+            # invariants describe a contract this input is outside of, so running them
+            # would be asking a question the entry point never answered.
+            rejected = case.must_reject
             return Outcome(
                 index,
                 case,
-                Verdict.BUG,
-                "must-reject:returned",
-                f"input built to be refused was accepted, returning {type(result).__name__}",
+                Verdict.BUG if rejected else Verdict.OK,
+                "must-reject:returned" if rejected else "out-of-contract:returned",
+                f"input built to be refused was accepted, returning {type(result).__name__}"
+                if rejected
+                else "",
                 _warning_names(caught),
             )
         checks = [*case.invariants]

--- a/tools/adversarial_sweep/_core.py
+++ b/tools/adversarial_sweep/_core.py
@@ -143,7 +143,10 @@ class Case:
             names no such precondition, this becomes a way to silence a finding, which
             is the one thing this harness must not offer. What keeps the existing uses
             honest is ``tests/test_kernel_preconditions.py``, which asserts the
-            precondition is stated.
+            precondition is stated. Note what the aggregate verdict counts lose: an
+            out-of-contract case that returned is counted as ``OK`` like any other, and
+            only its ``kind`` (``out-of-contract:returned``) says it was graded on
+            nothing rather than checked and found sound.
         finite_inputs (bool): Whether every input is finite. When ``False`` the
             automatic finiteness check on the result is skipped.
         arrays (Mapping[str, npt.NDArray[Any]]): Input arrays to persist under

--- a/tools/adversarial_sweep/_probes_bezier.py
+++ b/tools/adversarial_sweep/_probes_bezier.py
@@ -2700,17 +2700,17 @@ def _de_casteljau_kernel_cases(profile: Profile) -> Iterator[Case]:
                 lambda coeff=coeff: _de_casteljau_eval_scalar(coeff, 0.5),
                 {"length": length, "dtype": str(dtype), "t": 0.5},
                 arrays={"coeff": coeff},
-                # `length == 0` is the one case in this module that is deliberately
-                # *outside* the contract and so carries neither flag. This is a Layer-3
-                # kernel whose docstring says "Inputs are assumed to be correct (no
-                # validation performed)", so it owes a zero-length array nothing: the
-                # bounds-check hit it produces is the sweep proving the harness is live
-                # on a real pantr kernel, and a record for the port that this call site
-                # needs its own guard -- not a defect in the kernel. Flagging it either
-                # way would be a false claim, and neither flag could change the verdict
-                # anyway: `_core.classify` reports a Numba out-of-bounds access before
-                # it consults them. The other lengths are in contract.
+                # `length == 0` is deliberately *outside* the contract, and the
+                # kernel's docstring now says what that contract is: `len(coeff) >= 1`.
+                # Neither of the other two flags fits -- the call is not required to
+                # succeed, and it is not required to be refused either, since a Layer 3
+                # kernel validates nothing and its behavior here is unspecified. The
+                # bounds-check hit it produces under `NUMBA_BOUNDSCHECK=1` is the sweep
+                # proving the harness is live on a real pantr kernel, and a record for
+                # the port that this call site needs its own guard, not a defect. The
+                # other lengths are in contract.
                 must_succeed=length > 0,
+                out_of_contract=length == 0,
             )
 
         coeff5 = np.linspace(-1.0, 1.0, 5, dtype=dtype)

--- a/tools/adversarial_sweep/_probes_bezier.py
+++ b/tools/adversarial_sweep/_probes_bezier.py
@@ -2681,8 +2681,10 @@ def _de_casteljau_kernel_cases(profile: Profile) -> Iterator[Case]:
     """Yield direct probes of ``_de_casteljau_eval_scalar``.
 
     This Numba kernel performs no input validation whatsoever, per its own
-    docstring. A length-0 ``coeff`` is the sharpest boundscheck target: the
-    algorithm reads ``coeff[0]`` unconditionally.
+    docstring, which now also states the precondition that disclaimer stands on.
+    A length-0 ``coeff`` is the sharpest boundscheck target: the algorithm ends by
+    reading ``work[0]`` unconditionally, and ``work`` is a copy of ``coeff``, so at
+    length 0 there is nothing there to read.
 
     Args:
         profile (Profile): Sweep width.


### PR DESCRIPTION
## Context

Closes #412. The Layer 3 kernels in `pantr.bezier._root_finding_core` carry this
repository's standard disclaimer, *"Inputs are assumed to be correct (no validation
performed)"*, and that policy is right. What was missing is the precondition it disclaims
against: "assumed correct" names no minimum length, so a direct caller had nothing to check
its input against and the adversarial sweep had nothing to grade against, which is why
`de_casteljau_len0_float64` came back `BUG` on every run. A specification gap, not a
validation gap.

**The ticket's Specification names the wrong three kernels, and this PR does not follow it
literally.** It says to apply the fix to *"all three kernels in the file carrying the same
disclaimer -- `:58`, `:78` and `:103`"*. The file is unchanged since the commit the ticket
cites, and those three lines are the `Note:` blocks of `_have_same_sign`,
`_have_opposite_signs` and `_spans_zero`: three predicates taking two floats and no
coefficient array at all, so AC1's *"minimum coefficient-array length"* cannot apply to
them. Ten kernels in the file carry the disclaimer and **seven** take a coefficient array.
Those seven are what changed. The three scalar predicates are deliberately left alone: every
float is in contract for them, their docstrings already reason about NaN and infinity, and
inventing a precondition would be a false claim.

## Specification

- **The seven coefficient-array kernels state `len(coeff) >= 1`**, a degree-`n` Bernstein
  polynomial having `n + 1` coefficients. Each also says what it does on a shorter array
  and that the behavior is **unspecified** rather than pinning today's, which a build with
  bounds checking off would contradict anyway.
- **Measured, not assumed.** All seven were called at length 0 and 1 under
  `NUMBA_BOUNDSCHECK=1` with a fresh `NUMBA_CACHE_DIR`:

  | kernel | at length 0 |
  |---|---|
  | `_de_casteljau_eval_scalar` | `IndexError: index is out of bounds` |
  | `_de_casteljau_eval_and_deriv_scalar` | `IndexError: index is out of bounds` |
  | `_newton_polish_scalar` | `IndexError`, through the kernel above |
  | `_restrict_scalar` | returns an empty array |
  | `_subdivide_scalar` | returns an empty array |
  | `_count_sign_changes` | returns `0` |
  | `_clip_hull_to_zero` | returns `(0.0, 0.0, False)`, it has an `n < 1` guard |

- **The C++ mirrors carry the same statement.** A contract the two backends state
  differently is a contract only one of them has. The wording there names `work`, not
  `coeff`: `coeff` is only touched through a `std::copy` that is well defined at size 0, and
  the read that goes wrong is `work[0]`. Sized to match `coeff` that read is out of bounds;
  longer than it the value is indeterminate. Both undefined, but for different reasons, and
  the `\param work` line's *"contents are not read"* stops holding there too.
- **The sweep needed a concept it did not have.** `classify` reports a Numba out-of-bounds
  access *before* it consults any flag, so neither `must_succeed` nor `must_reject` could
  reclassify the case, as the probe's own comment already said. The new `out_of_contract`
  flag declares that the input violates a precondition the entry point **states**, so nothing
  about the outcome is graded: a raise is a documented rejection whatever its type, a return
  is `OK` with the declared invariants skipped, since they describe a contract this input is
  outside of. It is mutually exclusive with the other two flags.
- **The obvious risk is that the flag becomes a way to silence findings.** It is legitimate
  only where the precondition is written down, and `tests/test_kernel_preconditions.py` is
  what checks that it is — which is the whole reason that module exists.
- One narrow `mypy.ini` section lets the new unit tests import the harness. Putting `tools`
  on `mypy_path` was tried first and surfaced four pre-existing strict-mode errors in code
  that was never written for strict mode.

## Acceptance

- **AC1** — each of the seven states its minimum, and `tests/test_kernel_preconditions.py`
  asserts it for all seven, plus that none lost the layering disclaimer.
- **AC2** — the smoke profile reports **zero `BUG` rows across every group**, not only
  `bezier` (it was one), and the launcher exits 0 where it exited 1.
- **AC3** — the test asserts the precondition is *stated*, never what happens when it is
  broken. Pinning today's `IndexError` would freeze something the library does not promise.
- **AC4** — Layer 2 is untouched: `_find_roots.py` and `_bezier.py` have zero diff, and 168
  bezier root-finding tests pass. No validation was added to any Layer 3 kernel.
- `ruff check` clean; `ruff format --check` 361 files already formatted; `mypy` Success on
  336 source files. This branch's CI runs none of the three, so all three were run by hand.
- Full suite 10922 / 66 / 6 at the first commit against a base of 10903 / 66 / 6 — exactly
  the tests added, nothing else moved. The skip count is unchanged, so the C++ backend was
  live. Doctest 83 / 7; `lint-imports` 2 kept, 0 broken; docs `-W --keep-going` succeeded
  with zero warnings.
- The launcher re-execs with `NUMBA_BOUNDSCHECK=1` unconditionally, so the flag's
  "returned anyway" branch is unreachable from a sweep run. Unit tests over the classifier
  cover both branches, its indifference to exception type, and the mutual-exclusion guard,
  with no subprocess and no Numba.

## Related, and deliberately not done here

The ticket's *unproven suspicion* asked whether other Layer 3 kernels have the same gap. A
static census says they do: across `pantr.bezier` and `pantr.bspline`, **91** Numba kernels
take an array and carry the disclaimer, and after this PR **7** state a precondition. The
heaviest are `_extraction_kernels.py` (24), `_bspline_roots_core.py` (12) and
`_bspline_basis_kernels.py` (8). The dynamic half — which of the 84 actually overrun — is the
real work and is not done: that is 84 distinct signatures, not a one-line sweep. What this PR
leaves behind is the pattern, so a follow-up applies it rather than designing it again.

## Non-goals

- The general audit above.
- Any change to Layer 2 validation, which is correct as it stands.
- Any executable change: this touches docstrings, doc comments, sweep metadata and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDsgxeS1roqbGuLYbyR2zH
