### PR TITLE
fix(bezier): copy the control points and hand back read-only views

### DIFF
--- a/design/bspline_ownership_lifetime.md
+++ b/design/bspline_ownership_lifetime.md
@@ -610,14 +610,17 @@ between mechanisms:**
    change, but worth stating because it looks like the kind of thing a port would alter.
 2. **`Bspline(space, cp)` copies `cp`.** The C++ value type copies at construction, so
    `cp[0] = ...` after construction stops being visible. This is not new policy: the same
-   decision is already shipped for `Bezier` and recorded at
-   `tests/test_bspline_conversion.py:22-32`, which skips `test_copy_false` under the C++ backend
-   with the reason *"the C++ value copies its control points at construction, so `copy=False`
-   shares nothing under that backend"*. #398 inherits both the decision and the skip idiom.
-3. **`Bspline.control_points` becomes a read-only view.** `Bezier`'s precedent
-   (`src/pantr/bezier/_bezier.py:473-484`) is explicit: under the C++ backend it is a read-only
-   view of the object's own storage, writing raises, and it stays valid after the object is
-   dropped. Today `Bspline.control_points` is the live writable array -- verified by execution:
+   decision is already shipped for `Bezier` under **both** backends since FELIGN/pantr#375, so
+   the skip idiom this note used to point at is gone -- the assertions that were skipped under
+   C++ now run under both and assert that nothing shares. #398 inherits the decision; what it
+   no longer inherits is a reason to gate the assertion by backend.
+3. **`Bspline.control_points` becomes a read-only view.** `Bezier`'s precedent is explicit and
+   now applies to both backends (FELIGN/pantr#375): the property is a read-only view of the
+   object's own storage, writing raises, and under the C++ backend it stays valid after the
+   object is dropped. Worth copying along with it is how the Python side did it -- the stored
+   array stays writable and the *view* is what is frozen, because `Bspline` has `in_place=True`
+   methods that would otherwise turn into allocations, and the view is minted fresh per call
+   because `writeable = False` does not stop an in-place reshape of the array's metadata. Today `Bspline.control_points` is the live writable array -- verified by execution:
    `b.control_points is b._control_points` is `True` and `b.control_points[0,0] = 99` changes the
    object. **This is the one change in the milestone that will break working downstream code
    silently-turned-loud** (an `IndexError`-free `ValueError: assignment destination is read-only`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -146,7 +146,12 @@ user-facing, and the ports change what it affects.
   `create_from_bspline(..., copy=False)` and `Bspline.to_bezier(copy=False)` copy like everything
   else now, and both docstrings say so. The flag still shares when a `Bspline` receives, since
   the Python `Bspline` has the same defect and no ticket yet; `design/bspline_ownership_lifetime.md`
-  carries it.
+  carries it. `Bezier.to_bspline(copy=False)` keeps working exactly as before, and that took
+  care rather than falling out: it hands over the Bézier's own writable array rather than the
+  read-only view, because the Python `Bspline` stores what it is given and its `in_place=True`
+  methods write into it, so a frozen array would have produced a B-spline that raised on
+  `reverse(..., in_place=True)`. `shares_memory` does not catch that -- a read-only view shares
+  memory perfectly well -- so there is now a test that mutates the result.
 - **A raised ISA builds again on a host whose native target includes AVX-512.** It did not:
   Eigen's AVX512 `TrsmKernel.h` trips GCC's `-Wmaybe-uninitialized`, and the project builds
   with `-Werror`, so the build failed outright. Measured here on conda-forge GCC 14.4.0 and a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -124,6 +124,29 @@ user-facing, and the ports change what it affects.
   extension is installed, and prints how to build one that fuses.
 
 ### Fixed
+- **A `Bezier` is a value again: it copies its control points and hands back read-only views.**
+  It did neither. `__init__` stored what `numpy.asarray` returned, which does not copy an array
+  that is already float, and `control_points` handed that same object back, so a caller could
+  move a constructed Bézier by writing to the array they passed in or through the property, and
+  the object had no way to notice. Every derived result went with it -- `evaluate`, `split`,
+  `to_bspline`.
+  This is FELIGN/pantr#338's defect in a second class, and the C++ value had already fixed its
+  side, so **the two backends disagreed on a public observable**: measured before the fix, the
+  Python one aliased the caller's array and returned a writable property while the C++ one did
+  neither. They now agree exactly. The assertions that pinned the copy were running under C++
+  alone; they run under both.
+  The stored array stays writable inside the class, deliberately, and that is the one place this
+  differs from what `PointsLattice` did: `reverse`, `permute_directions` and `transform` take
+  `in_place=True` and write straight into it, so freezing the storage rather than the view would
+  have turned that flag into an allocation. What the caller receives is a fresh read-only view,
+  fresh because `writeable = False` stops writes to the data and not changes to the metadata --
+  `arr.shape = ...` reshapes a read-only array in place, and on a shared array that would leave
+  the Bézier holding the wrong rank.
+  **`copy=False` no longer shares when a `Bezier` is the receiving end**, under either backend:
+  `create_from_bspline(..., copy=False)` and `Bspline.to_bezier(copy=False)` copy like everything
+  else now, and both docstrings say so. The flag still shares when a `Bspline` receives, since
+  the Python `Bspline` has the same defect and no ticket yet; `design/bspline_ownership_lifetime.md`
+  carries it.
 - **A raised ISA builds again on a host whose native target includes AVX-512.** It did not:
   Eigen's AVX512 `TrsmKernel.h` trips GCC's `-Wmaybe-uninitialized`, and the project builds
   with `-Werror`, so the build failed outright. Measured here on conda-forge GCC 14.4.0 and a

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -77,13 +77,19 @@ class _BezierPython:
     reachable only through it. When the C++ core stops being optional this class
     goes and :class:`Bezier` collapses onto the handle.
 
-    **It aliases the caller's array, and that is a defect it keeps on purpose.**
-    ``__init__`` stores what :func:`numpy.asarray` returns and
-    :attr:`control_points` hands the same object back, so a caller can mutate a
-    constructed Bézier through either end. That is the shape of FELIGN/pantr#338,
-    the C++ implementation copies instead, and a port never edits its own oracle
-    -- so the two backends differ here, deliberately, until the ticket that fixes
-    this side lands.
+    **It copies at construction and hands out read-only views**, so a constructed
+    Bézier is a value: the caller cannot change it through the array they passed
+    in, nor by writing to :attr:`control_points`. It used to do neither, which is
+    the shape of FELIGN/pantr#338 and was left standing while the port was under
+    way, because a port does not edit its own oracle. The C++ implementation had
+    already copied and frozen, so the two backends disagreed on a public
+    observable until this side caught up.
+
+    The stored array stays **writable**, unlike :class:`~pantr.quad.PointsLattice`'s
+    frozen one, and that difference is deliberate: ``reverse``,
+    ``permute_directions`` and ``transform`` take ``in_place=True`` and write
+    straight into it, so freezing the storage rather than the view would turn the
+    flag into an allocation. Nothing outside this class reaches the array.
 
     Attributes:
         _control_points (npt.NDArray[np.float32 | np.float64]): Control point
@@ -133,7 +139,13 @@ class _BezierPython:
                     f"direction {d}, got {cp.shape[d]}."
                 )
 
-        self._control_points: _ControlPoints = cp
+        # A copy, so the array the caller still holds is not this Bezier's storage.
+        # It stays writable, unlike PointsLattice's frozen one (FELIGN/pantr#338):
+        # `reverse`, `permute_directions` and `transform` take `in_place=True` and
+        # write straight into it, which is the whole point of that flag. What the
+        # caller gets instead is a read-only view, from `control_points`. Nothing
+        # outside this class reaches the array itself.
+        self._control_points: _ControlPoints = np.ascontiguousarray(cp).copy()
         self._is_rational = is_rational
 
         if self.rank <= 0:
@@ -178,11 +190,18 @@ class _BezierPython:
         """Get the control points of the Bézier.
 
         Returns:
-            npt.NDArray[np.float32 | np.float64]: Control point array with
-            shape ``(*degrees_plus_1, rank)``. The stored array itself, not a
-            copy; see the class docstring.
+            npt.NDArray[np.float32 | np.float64]: A read-only view of the control
+            point array, shape ``(*degrees_plus_1, rank)``.
         """
-        return self._control_points
+        # A fresh view each call rather than one stored read-only array, for the
+        # reason PointsLattice records: `writeable = False` stops writes to the
+        # data and not changes to the metadata, so `arr.shape = (n, 1)` reshapes a
+        # read-only array in place and would leave this Bezier holding an array of
+        # the wrong rank while `dim` still reported the old one. A view carries its
+        # own shape, so that lands on the caller's copy instead of ours.
+        view = self._control_points.view()
+        view.flags.writeable = False
+        return view
 
     @property
     def is_rational(self) -> bool:
@@ -385,13 +404,13 @@ class Bezier:
         provenance, so the branch lives here once instead of in each of the three
         ``in_place=True`` methods.
 
-        Under the Python backend ``rebuild`` is handed the stored array itself, so
-        a helper writing into it mutates the Bézier exactly as it always has --
-        ``id(bezier.control_points)`` included, which ``tests/test_transform.py``
-        pins. Under the C++ backend the storage belongs to the C++ object and is
-        read-only, so ``rebuild`` gets a writable copy and the *implementation* is
-        replaced. Both leave this wrapper carrying the new value; only the array's
-        identity differs, and only where the oracle's aliasing is what defined it.
+        Under the Python backend ``rebuild`` is handed the stored array itself --
+        the private one, not the read-only view :attr:`control_points` returns --
+        so a helper writing into it mutates the Bézier without allocating. Under
+        the C++ backend the storage belongs to the C++ object, so ``rebuild`` gets
+        a writable copy and the *implementation* is replaced. Both leave this
+        wrapper carrying the same new value; what differs is only whether an
+        allocation happened, which no caller can observe through the value.
 
         Rebuilding the implementation reads the *active* backend, so mutating a
         Bézier inside a :func:`~pantr._backend.use_backend` block that selects a
@@ -424,7 +443,7 @@ class Bezier:
                 f"changed after this Bezier was built."
             )
         if isinstance(impl, _BezierPython):
-            impl._replace_control_points(rebuild(impl.control_points))
+            impl._replace_control_points(rebuild(impl._control_points))
         else:
             self._impl = _new_impl(rebuild(np.array(impl.control_points)), impl.is_rational)
 
@@ -474,12 +493,10 @@ class Bezier:
         """Get the control points of the Bézier.
 
         Returns:
-            npt.NDArray[np.float32 | np.float64]: Control point array with
-            shape ``(*degrees_plus_1, rank)``. Under the C++ backend this is a
-            **read-only view** of the Bézier's own storage: writing through it
-            raises, and it stays valid after the Bézier is dropped. Under the
-            Python backend it is the stored array itself, writable, which is the
-            aliasing defect the class docstring names.
+            npt.NDArray[np.float32 | np.float64]: A **read-only view** of the
+            Bézier's own control points, shape ``(*degrees_plus_1, rank)``.
+            Writing through it raises, under either backend, and under the C++
+            backend it stays valid after the Bézier is dropped.
         """
         return self._impl.control_points
 
@@ -1434,12 +1451,11 @@ def create_from_bspline(bspline: Bspline, *, copy: bool = True) -> Bezier:
     Args:
         bspline (~pantr.bspline.Bspline): A B-spline with Bézier-like
             knot structure.
-        copy (bool): If ``True`` (default), the control points are
-            deep-copied into the new Bézier. If ``False``, the Bézier
-            shares the same underlying control point array -- **under the
-            Python backend only**. The C++ value owns its storage and copies
-            at construction, so there ``copy=False`` saves nothing and shares
-            nothing.
+        copy (bool): Retained for call compatibility; it no longer changes
+            what happens. A ``Bezier`` owns its control points and copies them
+            at construction under **either** backend, so ``copy=False`` saves
+            nothing and shares nothing. It used to share under the Python
+            backend, which was the aliasing defect FELIGN/pantr#375 removed.
 
     Returns:
         Bezier: The equivalent Bézier.

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -459,15 +459,16 @@ class Bezier:
             tuple: The class, and the control points and rationality flag to
             rebuild it from.
         """
-        control_points = self.control_points
-        if not control_points.flags.writeable:
-            # The C++ backend hands out a read-only view and pickle preserves that
-            # flag (measured). Reconstructing under the Python backend would then
-            # store a read-only array, where `reverse(in_place=True)` raises. The
-            # copy is what keeps one backend's storage decision out of the wire
-            # format.
-            control_points = np.array(control_points)
-        return (type(self), (control_points, self.is_rational))
+        # No copy here, and the guard that used to make one is gone with its
+        # reason. It read the writable flag, because pickle preserves it and only
+        # the C++ backend handed out a read-only view, so reconstructing under the
+        # Python backend would have stored a frozen array that
+        # `reverse(in_place=True)` then raised on. Since FELIGN/pantr#375 both
+        # constructors copy unconditionally, so nothing that comes off the wire is
+        # ever stored as-is and the branch could not do anything but fire. What
+        # this now leans on is that copy: if a constructor ever stops making one,
+        # this needs the guard back.
+        return (type(self), (self.control_points, self.is_rational))
 
     @property
     def dim(self) -> int:
@@ -1387,7 +1388,9 @@ class Bezier:
                 B-spline shares the same underlying control point array --
                 **under the Python backend only**. The C++ value owns its
                 storage and copies at construction, so there ``copy=False``
-                saves nothing and shares nothing.
+                saves nothing and shares nothing. Sharing runs both ways:
+                mutating the returned B-spline in place writes through to this
+                Bézier's control points, which is what asking not to copy means.
 
         Returns:
             ~pantr.bspline.Bspline: Equivalent B-spline representation.
@@ -1402,7 +1405,25 @@ class Bezier:
             knots[p + 1 :] = 1.0
             spaces.append(BsplineSpace1D(knots, p))
 
-        cp = self.control_points.copy() if copy else self.control_points
+        # `copy=False` must hand over a *writable* array, not the read-only view
+        # `control_points` returns. The Python `Bspline` stores what it is given
+        # without copying and its own `in_place=True` methods write straight into
+        # it, so a frozen array would leave the caller with a B-spline that raises
+        # on `reverse(..., in_place=True)`. Reaching for the oracle's private array
+        # keeps this operation exactly as it was: `copy=False` shares, and the
+        # B-spline it produces can still be mutated in place. It does mean a
+        # B-spline taken this way can write through to this Bezier's storage, which
+        # is what `copy=False` has always meant and is a separate question from the
+        # one FELIGN/pantr#375 settled about the caller-facing property. Under the
+        # C++ backend there is no writable private array and none is needed: that
+        # `Bspline` is a C++ value and copies before it mutates.
+        impl = self._impl
+        if copy:
+            cp = self.control_points.copy()
+        elif isinstance(impl, _BezierPython):
+            cp = impl._control_points
+        else:
+            cp = impl.control_points
         return BsplineCls(BsplineSpace(spaces), cp, self.is_rational)
 
     # ------------------------------------------------------------------

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -1413,14 +1413,12 @@ class Bspline:
         form before the check.
 
         Args:
-            copy (bool): If ``True`` (default), the control points are
-                deep-copied into the new Bézier.  If ``False``, the Bézier
-                shares the same underlying control point array when possible
-                (direct extraction) or owns the freshly allocated array
-                produced by the open-form conversion -- **under the Python
-                backend only**. A C++ ``Bezier`` copies at construction, so
-                there ``copy=False`` shares nothing; that predates this
-                type's own port and is measured, not assumed.
+            copy (bool): Retained for call compatibility; it no longer changes
+                what happens. A ``Bezier`` owns its control points and copies
+                them at construction under **either** backend, so ``copy=False``
+                shares nothing. It used to share under the Python backend when a
+                direct extraction was possible, which was the aliasing defect
+                FELIGN/pantr#375 removed; the C++ side never shared.
 
         Returns:
             ~pantr.bezier.Bezier: Equivalent Bézier representation.

--- a/tests/parity/test_bezier_type.py
+++ b/tests/parity/test_bezier_type.py
@@ -14,13 +14,13 @@ Three things are checked that a field-by-field state comparison does not reach:
   control nets, and a caller writing ``pytest.raises(ValueError, match=...)``
   must not have to know which backend built the object. The messages are
   therefore compared character for character rather than by exception type.
-- **The copy at construction, and the read-only view on the way out.** The C++
-  value does not alias the caller's array at either end, which the oracle does.
-  This is the one place the two backends differ on purpose: it is
-  FELIGN/pantr#338's defect, fixed on the side the port owns, and
-  FELIGN/pantr#375 is the ticket that fixes the other. Both halves are asserted
-  here, because a criterion covering only construction leaves the other half of a
-  bidirectional defect unpinned.
+- **The copy at construction, and the read-only view on the way out.** Neither
+  value aliases the caller's array, at either end. This used to be the one place
+  the two backends differed on purpose -- FELIGN/pantr#338's defect, fixed first
+  on the side the port owns -- and FELIGN/pantr#375 closed the gap by making the
+  oracle copy too, so both assertions now run under both backends instead of
+  under C++ alone. Both halves are asserted, because a criterion covering only
+  construction leaves the other half of a bidirectional defect unpinned.
 - **The wire format.** ``__reduce__`` pickles by the constructor's arguments, so a
   pickle written under one backend loads under the other. Without that the backend
   switch would silently become a data-format switch, and a C++ handle is not
@@ -337,40 +337,55 @@ def test_error_messages_agree_verbatim(build: Any, what: str, dtype: npt.DTypeLi
     assert not oracle.startswith("<"), f"{what}: neither implementation refused it"
 
 
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
 @pytest.mark.parametrize("dtype", DTYPES)
-def test_the_cpp_value_does_not_alias_the_array_it_was_built_from(dtype: npt.DTypeLike) -> None:
+def test_a_bezier_does_not_alias_the_array_it_was_built_from(
+    dtype: npt.DTypeLike, backend: Backend
+) -> None:
     """Mutating the constructor's argument afterwards does not move the Bézier.
 
-    What this catches: the C++ constructor taking a view of the caller's buffer
-    instead of copying, which would let a validated geometry change under its
-    owner's feet -- the way in of FELIGN/pantr#338's defect.
+    What this catches: a constructor taking a view of the caller's buffer instead
+    of copying, which would let a validated geometry change under its owner's feet
+    -- the way in of FELIGN/pantr#338's defect.
+
+    Both backends, since FELIGN/pantr#375. Until then this ran under C++ only and
+    the oracle failed it, which was the divergence that ticket closed. The value is
+    checked through ``evaluate`` as well as through the stored array, because the
+    stored array is what a *port* compares while the evaluation is what a caller
+    would notice.
     """
     control_points = np.asarray([[0.0, 1.0], [2.0, 3.0]], dtype=dtype)
-    with use_backend(Backend.CPP):
+    with use_backend(backend):
         bezier = Bezier(control_points)
 
-    before = bezier.control_points.copy()
-    control_points[0, 0] = 99.0
-    assert np.array_equal(bezier.control_points, before)
-    assert not np.shares_memory(bezier.control_points, control_points)
+        at = np.asarray([0.5], dtype=dtype)
+        before = bezier.control_points.copy()
+        before_value = bezier.evaluate(at).copy()
+        control_points[0, 0] = 99.0
+        assert np.array_equal(bezier.control_points, before)
+        assert not np.shares_memory(bezier.control_points, control_points)
+        assert np.array_equal(bezier.evaluate(at), before_value)
 
 
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
 @pytest.mark.parametrize("dtype", DTYPES)
-def test_writing_through_control_points_is_refused(dtype: npt.DTypeLike) -> None:
+def test_writing_through_control_points_is_refused(dtype: npt.DTypeLike, backend: Backend) -> None:
     """The array handed out is read-only, and the Bézier is unchanged either way.
 
     What this catches: the way *out* of the same defect. A writable view would let
     a caller edit a constructed geometry through the property, which is the half a
     criterion about construction alone leaves unpinned.
+
+    Both backends, since FELIGN/pantr#375; C++ only before it.
     """
-    with use_backend(Backend.CPP):
+    with use_backend(backend):
         bezier = Bezier(np.asarray([[0.0, 1.0], [2.0, 3.0]], dtype=dtype))
 
-    handed_out = bezier.control_points
-    assert not handed_out.flags.writeable
-    with pytest.raises(ValueError, match="read-only"):
-        handed_out[0, 0] = 99.0
-    assert bezier.control_points[0, 0] == 0.0
+        handed_out = bezier.control_points
+        assert not handed_out.flags.writeable
+        with pytest.raises(ValueError, match="read-only"):
+            handed_out[0, 0] = 99.0
+        assert bezier.control_points[0, 0] == 0.0
 
 
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -181,6 +181,22 @@ class TestBezierConversion:
         bs = b.to_bspline(copy=False)
         assert np.shares_memory(b.control_points, bs.control_points)
 
+    def test_to_bspline_copy_false_hands_over_a_writable_array(self) -> None:
+        """The B-spline `copy=False` produces can still be mutated in place.
+
+        `shares_memory` alone does not catch this: a read-only *view* shares memory
+        just as well, and the Python `Bspline` stores what it is handed without
+        copying, so its own `in_place=True` methods then raise. That is exactly
+        what FELIGN/pantr#375 broke in passing when `Bezier.control_points` became
+        a read-only view, and what the private-array path in `to_bspline` exists to
+        prevent. Runs under both backends: the C++ `Bspline` copies before it
+        mutates, so it satisfies this for its own reason.
+        """
+        b = _make_bezier_1d([1.0, 2.0, 3.0])
+        bs = b.to_bspline(copy=False)
+        bs.reverse(0, in_place=True)
+        np.testing.assert_allclose(np.ravel(bs.control_points), [3.0, 2.0, 1.0])
+
     def test_from_bspline_copy_true(self) -> None:
         """Test that from_bspline with copy=True creates independent arrays."""
         b_orig = _make_bezier_1d([1.0, 2.0, 3.0])

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -12,15 +12,15 @@ from pantr.quad import PointsLattice
 _SHARING_IS_PYTHON_ONLY = pytest.mark.skipif(
     active_backend() is not Backend.PYTHON,
     reason=(
-        "This records the Python implementations' known aliasing defect rather than a "
-        "contract: both C++ values -- Bezier and Bspline -- copy their control points at "
-        "construction, so `copy=False` shares nothing under that backend, whichever of the "
-        "two is on the receiving end. FELIGN/pantr#375 is the ticket that fixes the Python "
-        "Bezier; the Python Bspline half is flagged in "
-        "design/bspline_ownership_lifetime.md and has no ticket yet. The C++ path is not "
-        "left untested by the skip -- what it does instead is asserted in "
-        "tests/parity/test_bezier_type.py and tests/parity/test_bspline_type.py, each of "
-        "which pins the copy at both ends."
+        "This records the Python Bspline's known aliasing defect rather than a contract: "
+        "both C++ values copy their control points at construction, so `copy=False` shares "
+        "nothing under that backend. FELIGN/pantr#375 fixed the Python Bezier, which now "
+        "copies too, so nothing shares when a Bezier is on the receiving end whatever the "
+        "backend -- those assertions were rewritten rather than left skipped. What remains "
+        "is the Python Bspline half, flagged in design/bspline_ownership_lifetime.md with "
+        "no ticket yet. The C++ path is not left untested by the skip -- what it does "
+        "instead is asserted in tests/parity/test_bezier_type.py and "
+        "tests/parity/test_bspline_type.py, each of which pins the copy at both ends."
     ),
 )
 """Marks an assertion that pins sharing only the Python implementations offer."""
@@ -188,13 +188,19 @@ class TestBezierConversion:
         b_back = create_from_bspline(bs, copy=True)
         assert not np.shares_memory(bs.control_points, b_back.control_points)
 
-    @_SHARING_IS_PYTHON_ONLY
-    def test_from_bspline_copy_false(self) -> None:
-        """Test that from_bspline with copy=False shares the control point array."""
+    def test_from_bspline_copy_false_still_does_not_share(self) -> None:
+        """`copy=False` shares nothing when a Bezier is the receiving end.
+
+        It used to, under the Python backend, and this assertion used to pin that
+        (`@_SHARING_IS_PYTHON_ONLY`, skipped under C++). FELIGN/pantr#375 made the
+        Python Bezier copy at construction like the C++ one, so the flag now saves
+        nothing on this side under either backend -- which is why the test runs on
+        both instead of being skipped on one.
+        """
         b_orig = _make_bezier_1d([1.0, 2.0, 3.0])
         bs = b_orig.to_bspline(copy=False)
         b_back = create_from_bspline(bs, copy=False)
-        assert np.shares_memory(bs.control_points, b_back.control_points)
+        assert not np.shares_memory(bs.control_points, b_back.control_points)
 
     def test_to_bspline_default_copies(self) -> None:
         """Test that to_bspline copies by default."""

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -22,15 +22,15 @@ from pantr.bspline.spanwise_element_extraction import SpanwiseElementExtraction
 _SHARING_IS_PYTHON_ONLY = pytest.mark.skipif(
     active_backend() is not Backend.PYTHON,
     reason=(
-        "This records the Python implementations' known aliasing defect rather than a "
-        "contract: both C++ values -- Bezier and Bspline -- copy their control points at "
-        "construction, so `copy=False` shares nothing under that backend, whichever of the "
-        "two is on the receiving end. FELIGN/pantr#375 is the ticket that fixes the Python "
-        "Bezier; the Python Bspline half is flagged in "
-        "design/bspline_ownership_lifetime.md and has no ticket yet. The C++ path is not "
-        "left untested by the skip -- what it does instead is asserted in "
-        "tests/parity/test_bezier_type.py and tests/parity/test_bspline_type.py, each of "
-        "which pins the copy at both ends."
+        "This records the Python Bspline's known aliasing defect rather than a contract: "
+        "both C++ values copy their control points at construction, so `copy=False` shares "
+        "nothing under that backend. FELIGN/pantr#375 fixed the Python Bezier, which now "
+        "copies too, so nothing shares when a Bezier is on the receiving end whatever the "
+        "backend -- those assertions were rewritten rather than left skipped. What remains "
+        "is the Python Bspline half, flagged in design/bspline_ownership_lifetime.md with "
+        "no ticket yet. The C++ path is not left untested by the skip -- what it does "
+        "instead is asserted in tests/parity/test_bezier_type.py and "
+        "tests/parity/test_bspline_type.py, each of which pins the copy at both ends."
     ),
 )
 """Marks an assertion that pins sharing only the Python implementations offer."""
@@ -580,15 +580,20 @@ class TestToBezier:
         bez = bs.to_bezier(copy=True)
         assert not np.shares_memory(bs.control_points, bez.control_points)
 
-    @_SHARING_IS_PYTHON_ONLY
-    def test_copy_false(self) -> None:
-        """Test that to_bezier with copy=False shares the control point array."""
+    def test_copy_false_still_does_not_share(self) -> None:
+        """`copy=False` shares nothing when a Bezier is the receiving end.
+
+        It used to, under the Python backend, and this assertion used to pin that
+        (`@_SHARING_IS_PYTHON_ONLY`, skipped under C++). FELIGN/pantr#375 made the
+        Python Bezier copy at construction like the C++ one, so the flag now saves
+        nothing on this side under either backend.
+        """
         knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
         space = BsplineSpace([BsplineSpace1D(knots, 2)])
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
         bs = Bspline(space, cp)
         bez = bs.to_bezier(copy=False)
-        assert np.shares_memory(bs.control_points, bez.control_points)
+        assert not np.shares_memory(bs.control_points, bez.control_points)
 
     def test_default_copies(self) -> None:
         """Test that to_bezier copies by default."""

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -18,15 +18,18 @@ if TYPE_CHECKING:
 _PYTHON_BACKEND_ONLY = pytest.mark.skipif(
     active_backend() is not Backend.PYTHON,
     reason=(
-        "This records the Python implementations' known aliasing defect rather than a "
-        "contract: both C++ values -- Bezier and Bspline -- copy their control points and "
-        "hand back a read-only view, so an in-place mutation replaces the array instead of "
-        "writing into it. FELIGN/pantr#375 is the ticket that fixes the Python Bezier; the "
-        "Python Bspline half is flagged in design/bspline_ownership_lifetime.md and has no "
-        "ticket yet. The skip loses no coverage of the C++ path: the value an in-place "
-        "mutation leaves behind is compared across both backends in "
-        "tests/parity/test_bezier_type.py and tests/parity/test_bspline_type.py, and only "
-        "the array's identity is unpinned here."
+        "This pins where an in-place mutation writes, which is not a contract and differs "
+        "by backend: a C++ value owns its storage, so `rebuild` gets a copy and the "
+        "implementation is replaced, while a Python one writes into the array it already "
+        "holds. For Bezier that survived FELIGN/pantr#375 on purpose -- it made the Python "
+        "Bezier copy the caller's array at construction and hand back read-only views, "
+        "which is what the ticket was about, and deliberately kept the storage writable so "
+        "`in_place=True` stays an in-place write rather than becoming an allocation. The "
+        "Python Bspline still aliases its caller outright, flagged in "
+        "design/bspline_ownership_lifetime.md with no ticket yet. The skip loses no "
+        "coverage of the C++ path: the value an in-place mutation leaves behind is compared "
+        "across both backends in tests/parity/test_bezier_type.py and "
+        "tests/parity/test_bspline_type.py, and only where the write landed is unpinned."
     ),
 )
 """Marks an assertion that pins aliasing only the Python implementations have."""
@@ -532,12 +535,20 @@ class TestBezierTransform:
 
     @_PYTHON_BACKEND_ONLY
     def test_inplace_no_extra_alloc(self) -> None:
-        """in_place=True writes directly into the existing array."""
+        """in_place=True writes directly into the existing array.
+
+        Asserted through ``.base`` rather than ``id(b.control_points)``, which is
+        what this used to compare. Since FELIGN/pantr#375 the property returns a
+        *fresh* read-only view on every call, so two reads never have the same
+        id and comparing them would fail whether or not the write allocated. The
+        view's base is the array the Bezier actually holds, which is the thing
+        this test is about.
+        """
         b = _make_bezier_1d([[0.0, 0.0], [1.0, 1.0]])
-        cp_id = id(b.control_points)
+        storage_id = id(b.control_points.base)
         t = AffineTransform.translation([5.0, 5.0])
         b.transform(t, in_place=True)
-        assert id(b.control_points) == cp_id
+        assert id(b.control_points.base) == storage_id
 
     def test_not_inplace_returns_new(self) -> None:
         """Default (in_place=False) returns a new Bezier."""


### PR DESCRIPTION
## Context

Closes #375. A `Bezier` was not a value. `__init__` stored what `numpy.asarray` returned, which
does not copy an array that is already float, and `control_points` handed that same object back,
so a caller could move a constructed Bézier by writing to the array they passed in **or** through
the property, and the object had no way to notice. Every derived result went with it.

**The ticket's reproduction is out of date, and the difference matters.** It says the defect
reproduces *"identically under both backends"*. Measured before this branch:

| | Python | C++ |
|---|---|---|
| property aliases the caller's input | **yes** | no |
| property is writeable | **yes** | no |
| `f(0.5)` after the caller mutates the input | **50.0** | 0.5 |

The C++ value already copied and froze. So this was not just #338's defect in a second class, it
was **the two backends disagreeing on a public observable** — which the oracle's own class
docstring recorded as deliberate, *"a defect it keeps on purpose … a port never edits its own
oracle"*, waiting for this ticket. They now agree on all four.

## Specification

`_BezierPython` copies at construction and hands out a fresh read-only view.

**The stored array deliberately stays writable**, and that is the one place this departs from what
#338 did to `PointsLattice`. `reverse`, `permute_directions` and `transform` take `in_place=True`
and write straight into it, so freezing the storage rather than the view would have turned that
flag into an allocation. `_mutate_control_points` threads the private array, not the property.

**The view is minted fresh on every call**, for the reason `PointsLattice` already records:
`writeable = False` stops writes to the *data* and not changes to the *metadata*, so
`arr.shape = …` reshapes a read-only array in place and on shared storage would leave the Bézier
holding the wrong rank while `dim` reported the old one.

## Fallout, carried here rather than left to be discovered

- **`copy=False` shares nothing when a `Bezier` receives**, under either backend now.
  `create_from_bspline(…, copy=False)` and `Bspline.to_bezier(copy=False)` copy like everything
  else; both docstrings say so instead of promising a share. The two tests that asserted sharing
  were already gated `@_SHARING_IS_PYTHON_ONLY` **and the C++ backend already returned `False`**,
  so the promise was half broken before this. They assert the opposite now and run on both
  backends. The flag still shares when a `Bspline` receives — that half has no ticket and
  `design/bspline_ownership_lifetime.md` carries it — so all three markers were rewritten to say
  which half is left.
- **`Bezier.to_bspline(copy=False)` is unchanged, and that took a fix rather than falling out.**
  The first commit broke it: the new B-spline got the read-only view, and the Python `Bspline`
  stores what it is given and writes into it, so `reverse(…, in_place=True)` on the result began
  raising. Caught by the review panel, reproduced, and confirmed working on the parent commit.
  The `copy=False` path hands over the private writable array instead, so the operation behaves
  exactly as before. `shares_memory` cannot catch this — a read-only view shares memory perfectly
  well — so there is a test that mutates the result.
- **`__reduce__`'s read-only guard is retired.** It copied to stop the C++ view being
  reconstructed as frozen storage under Python. Both halves of that reason are gone: both
  properties are read-only now, so the branch could only fire, and both constructors copy, so
  nothing off the wire is stored as-is. The note says what it leans on, so it can come back if a
  constructor ever stops copying.

## Acceptance

- **AC1/AC2/AC3** — the two aliasing assertions in `tests/parity/test_bezier_type.py` ran under
  C++ alone because the oracle failed them; they are parametrized over both backends now, which
  is the regression test. **Reverting only `_bezier.py` fails exactly the four Python
  parametrizations and passes the four C++ ones.** The construction half also checks the value
  through `evaluate`, since that is what a caller notices.
- **AC4** — `test_inplace_no_extra_alloc` compared `id(control_points)`, which cannot work once
  the property returns a fresh view each call: two reads never share an id whether or not the
  write allocated. It compares the view's `.base`, the array the Bézier actually holds. It stays
  Python-only, because under C++ an in-place mutation still replaces the storage, and the marker
  now says that instead of describing an aliasing defect.
- **AC5** — full suite **10932 passed / 66 skipped / 6 xfailed** against a base of 10927/66/6.
  `PANTR_BACKEND=cpp` full suite **10927 / 70 / 6**, the four extra skips being the Bspline-side
  Python-only tests.
- **AC6** — doctest 83 passed / 7 skipped.
- `ruff check` clean; `ruff format --check` 361 files; `mypy` Success on 336 source files;
  `lint-imports` 2 kept, 0 broken; docs `-W --keep-going` zero warnings. This branch's CI runs
  none of the first three, so all three were run by hand.

## Non-goals

- The Python `Bspline`'s identical defect. No ticket yet; `design/bspline_ownership_lifetime.md`
  records it, and this PR updates that note where the `Bezier` precedent it cites has moved.
- Deprecating or removing `copy=`, which is an API question of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDsgxeS1roqbGuLYbyR2zH
