### PR TITLE
docs(mpi): say where the distributed L2 projection evaluates its callable

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -189,6 +189,25 @@ user-facing, and the ports change what it affects.
   transformation separates the two paths was not established here and neither test is changed.
 
 ### Documentation
+- **`l2_project_bspline_distributed`'s docstring said the reverse of what it does.** It
+  promised that each rank evaluates the callable *"only on the quadrature points of its owned
+  cells"*. Every rank evaluates it on the whole global lattice and masks the result afterwards,
+  so the per-rank cost does not fall with the rank count and the total work grows linearly with
+  it. Correctness was never affected; what was affected is anyone sizing an expensive callable
+  from the docstring, who is exactly the reader a distributed projection is written for. Measured
+  here at one, two, three and four ranks and at two grid sizes: the count per rank is the serial
+  count, unchanged.
+  **The docstring now says what happens and why**, the why being the callable's own contract:
+  ``func`` receives a `PointsLattice`, a tensor product of per-direction coordinates, and a
+  rank's owned quadrature points are not a tensor product of anything, so no lattice names them.
+  Restricting the evaluation means handing ``func`` a flat point array instead, which is a
+  different signature.
+  **`quasi_interpolate_bspline_distributed` does not share the defect**, contrary to what the
+  report suspected. Its callable already takes a flat point array, so it can and does restrict
+  to its owned DOFs' support: measured on a 24-by-24 grid, its per-rank count falls by more than
+  half at four ranks, while the L2 projection's does not move. Two MPI tests now pin the
+  difference, because a docstring stating a performance property is the one kind of claim
+  nothing else in the suite checks.
 - **The seven Bernstein-coefficient kernels in `pantr.bezier._root_finding_core` now state
   the precondition their Layer 3 disclaimer stands on**, `len(coeff) >= 1`. *"Inputs are
   assumed to be correct (no validation performed)"* is correct policy and was the whole of

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -197,17 +197,24 @@ user-facing, and the ports change what it affects.
   from the docstring, who is exactly the reader a distributed projection is written for. Measured
   here at one, two, three and four ranks and at two grid sizes: the count per rank is the serial
   count, unchanged.
-  **The docstring now says what happens and why**, the why being the callable's own contract:
-  ``func`` receives a `PointsLattice`, a tensor product of per-direction coordinates, and a
-  rank's owned quadrature points are not a tensor product of anything, so no lattice names them.
-  Restricting the evaluation means handing ``func`` a flat point array instead, which is a
-  different signature.
-  **`quasi_interpolate_bspline_distributed` does not share the defect**, contrary to what the
-  report suspected. Its callable already takes a flat point array, so it can and does restrict
-  to its owned DOFs' support: measured on a 24-by-24 grid, its per-rank count falls by more than
-  half at four ranks, while the L2 projection's does not move. Two MPI tests now pin the
-  difference, because a docstring stating a performance property is the one kind of claim
-  nothing else in the suite checks.
+  **The docstring now says what happens, and what stands in the way of changing it.** ``func``
+  receives a `PointsLattice`, a tensor product of per-direction coordinates, so only an owned
+  set that *is* a box can be named by one. Whether it is depends on the partitioner, and **for
+  the default one it is**: `partition_grid`'s `block` backend gives every rank an exact
+  axis-aligned box of cells, measured on three grids including non-square and non-divisible
+  ones. So the restriction is available for the common case and simply has not been made; what
+  is not available in general is the same thing for a graph or bisection partition, whose owned
+  set need not be a box. Saying it was impossible would have been the easier sentence and the
+  false one.
+  **`quasi_interpolate_bspline_distributed` does distribute its evaluation, but over its
+  *windowed* space rather than its owned DOFs**, and its own docstring claimed the latter, with
+  "no redundant evaluation of halo-DOF points". That is corrected here too. It runs the serial
+  quasi-interpolant over owned-plus-halo and discards the halo coefficients afterwards, so the
+  halo is evaluated on both sides of every partition boundary: measured at four ranks on a
+  24-by-24 grid, every rank evaluates the same count while owning different numbers of DOFs,
+  which is what gives it away. The per-rank cost does fall as ranks are added, which is the real
+  difference from the L2 projection, and two MPI tests now pin that difference — a docstring
+  stating a performance property being the one kind of claim nothing else in the suite checks.
 - **The seven Bernstein-coefficient kernels in `pantr.bezier._root_finding_core` now state
   the precondition their Layer 3 disclaimer stands on**, `len(coeff) >= 1`. *"Inputs are
   assumed to be correct (no validation performed)"* is correct policy and was the whole of

--- a/src/pantr/mpi/_l2.py
+++ b/src/pantr/mpi/_l2.py
@@ -147,19 +147,25 @@ def l2_project_bspline_distributed(  # noqa: PLR0913
 
     **``func`` is evaluated on the whole global lattice by every rank**, and the
     ownership mask is applied to the result.  Only the contraction is distributed, not
-    the evaluation, so the total number of calls into ``func`` grows linearly with the
-    rank count instead of staying fixed.  For a cheap callable that costs nothing worth
+    the evaluation.  ``func`` is still called exactly once per rank, but the number of
+    points it is handed does not fall, so the total evaluated across the run grows
+    linearly with the rank count instead of staying fixed.  For a cheap callable that costs nothing worth
     measuring; for an expensive one it is the dominant cost and this function does not
     reduce it.
 
-    The reason is the callable's own contract, one line down in ``Args``: ``func``
-    receives a :class:`~pantr.quad.PointsLattice`, a tensor product of per-direction
-    coordinates.  A rank's owned cells are an arbitrary subset of the grid, and the
-    quadrature points inside them are not a tensor product of anything, so there is no
-    lattice that names them.  Restricting the evaluation would mean handing ``func`` a
-    flat point array instead, which is a different signature.
-    :func:`~pantr.mpi.quasi_interpolate_bspline_distributed` has that signature and does
-    restrict its evaluation, which is why the two differ here.
+    The obstacle is the callable's contract, one line down in ``Args``: ``func`` receives
+    a :class:`~pantr.quad.PointsLattice`, a tensor product of per-direction coordinates,
+    so only an owned set that *is* a box can be named by one.  **Whether it is depends on
+    the partitioner, and for the default one it is** -- ``partition_grid``'s ``block``
+    backend, which ``create_distributed_space`` selects for a uniform full grid, gives
+    every rank an exact axis-aligned box of cells, and a per-direction sub-range of the
+    quadrature nodes would then name its points exactly.  So this is a restriction that
+    could be made for the common case and has not been, not one the design forbids.  What
+    the design does forbid is doing it in general: a graph or recursive-bisection
+    partition need not be box-shaped, and naming a non-box owned set means handing ``func``
+    a flat point array, which is a different signature.
+    :func:`~pantr.mpi.quasi_interpolate_bspline_distributed` has that signature, which is
+    why it can distribute its evaluation where this cannot do so unconditionally.
 
     The per-direction mass matrices are partition-independent and built identically on
     every rank (cheap ``n_dofs_i x n_dofs_i`` systems), so only the load is communicated.
@@ -253,8 +259,10 @@ def l2_project_bspline_distributed(  # noqa: PLR0913
 
     # Evaluate func on the global quadrature lattice -- every rank, all of it -- then
     # mask to this rank's owned cells and contract into a per-component load tensor.
-    # The docstring says why the evaluation is not restricted: `func` takes a lattice,
-    # and a rank's owned quadrature points are not one.
+    # The docstring says what stands in the way of restricting it: `func` takes a
+    # lattice, so only a box-shaped owned set can be named -- which the default
+    # partitioner does produce, so this is a missed restriction rather than an
+    # impossible one.
     quad_lattice = PointsLattice(quad_nodes_per_dir)
     quad_grid_shape = tuple(a.shape[0] for a in quad_nodes_per_dir)
     components, out_dtype = _evaluate_func_on_lattice(func, quad_lattice, quad_grid_shape)

--- a/src/pantr/mpi/_l2.py
+++ b/src/pantr/mpi/_l2.py
@@ -1,11 +1,12 @@
 """Distributed L2 projection onto tensor-product B-spline spaces.
 
 Provides :func:`l2_project_bspline_distributed`, the MPI-parallel counterpart of
-:func:`~pantr.bspline.l2_project_bspline`.  L2 assembly is per-element, mapping directly
-onto the cell partition: each rank evaluates ``func`` only on the quadrature points of
-its *owned* cells and contracts them into a per-component load tensor, a single
-``allreduce`` sums the global load across ranks, and the (replicated) Kronecker solve
-recovers the global coefficients.  The per-direction mass matrices are
+:func:`~pantr.bspline.l2_project_bspline`.  L2 *assembly* is per-element and maps
+directly onto the cell partition, but the *evaluation* of ``func`` does not: every rank
+evaluates it on the whole global quadrature lattice and masks the result to its owned
+cells afterwards.  Each rank then contracts the masked values into a per-component load
+tensor, a single ``allreduce`` sums the global load across ranks, and the (replicated)
+Kronecker solve recovers the global coefficients.  The per-direction mass matrices are
 partition-independent and built identically on every rank, so only the load is
 communicated.  The result is a :class:`~pantr.mpi.DistributedFunction` whose
 :attr:`~pantr.mpi.DistributedFunction.local` reproduces the serial L2 projection exactly
@@ -138,11 +139,27 @@ def l2_project_bspline_distributed(  # noqa: PLR0913
 
     The MPI-parallel counterpart of :func:`~pantr.bspline.l2_project_bspline`.  L2
     assembly is per-element and maps directly onto the cell partition: each rank
-    evaluates ``func`` only on the quadrature points of its *owned* cells and contracts
-    them into a per-component load tensor; a single ``allreduce`` sums the global load
-    across ranks; and the replicated Kronecker solve recovers the global coefficients.
-    The returned :class:`~pantr.mpi.DistributedFunction` agrees with the serial L2
-    projection pointwise over every owned cell.
+    contracts the quadrature values over its *owned* cells into a per-component load
+    tensor; a single ``allreduce`` sums the global load across ranks; and the replicated
+    Kronecker solve recovers the global coefficients.  The returned
+    :class:`~pantr.mpi.DistributedFunction` agrees with the serial L2 projection
+    pointwise over every owned cell.
+
+    **``func`` is evaluated on the whole global lattice by every rank**, and the
+    ownership mask is applied to the result.  Only the contraction is distributed, not
+    the evaluation, so the total number of calls into ``func`` grows linearly with the
+    rank count instead of staying fixed.  For a cheap callable that costs nothing worth
+    measuring; for an expensive one it is the dominant cost and this function does not
+    reduce it.
+
+    The reason is the callable's own contract, one line down in ``Args``: ``func``
+    receives a :class:`~pantr.quad.PointsLattice`, a tensor product of per-direction
+    coordinates.  A rank's owned cells are an arbitrary subset of the grid, and the
+    quadrature points inside them are not a tensor product of anything, so there is no
+    lattice that names them.  Restricting the evaluation would mean handing ``func`` a
+    flat point array instead, which is a different signature.
+    :func:`~pantr.mpi.quasi_interpolate_bspline_distributed` has that signature and does
+    restrict its evaluation, which is why the two differ here.
 
     The per-direction mass matrices are partition-independent and built identically on
     every rank (cheap ``n_dofs_i x n_dofs_i`` systems), so only the load is communicated.
@@ -234,8 +251,10 @@ def l2_project_bspline_distributed(  # noqa: PLR0913
         _build_l2_mass_and_quad(global_space, n_quad, quadrature, boundary_interpolation)
     )
 
-    # Evaluate func on the global quadrature lattice, restricted (by masking) to this
-    # rank's owned cells, and contract into a per-component load tensor.
+    # Evaluate func on the global quadrature lattice -- every rank, all of it -- then
+    # mask to this rank's owned cells and contract into a per-component load tensor.
+    # The docstring says why the evaluation is not restricted: `func` takes a lattice,
+    # and a rank's owned quadrature points are not one.
     quad_lattice = PointsLattice(quad_nodes_per_dir)
     quad_grid_shape = tuple(a.shape[0] for a in quad_nodes_per_dir)
     components, out_dtype = _evaluate_func_on_lattice(func, quad_lattice, quad_grid_shape)

--- a/src/pantr/mpi/_qi.py
+++ b/src/pantr/mpi/_qi.py
@@ -1,9 +1,12 @@
 """Distributed quasi-interpolation onto tensor-product B-spline spaces.
 
 Provides :func:`quasi_interpolate_bspline_distributed`, the MPI-parallel counterpart of
-:func:`~pantr.bspline.quasi_interpolate_bspline`.  Each rank evaluates the function only
-on the points required by its *owned* DOFs (no redundant evaluation of halo-DOF points),
-then a single ``allgather`` collective assembles the full global coefficient field.
+:func:`~pantr.bspline.quasi_interpolate_bspline`.  Each rank evaluates the function on the
+points its *windowed* local space needs -- its owned DOFs and their halo -- and discards
+the halo coefficients afterwards, then a single ``allgather`` collective assembles the
+full global coefficient field.  So the evaluation is genuinely distributed, unlike
+:func:`~pantr.mpi.l2_project_bspline_distributed`, but it is not free of redundancy: the
+halo is evaluated on both sides of every partition boundary.
 The result is a :class:`~pantr.mpi.DistributedFunction` whose
 :attr:`~pantr.mpi.DistributedFunction.local` reproduces the serial quasi-interpolant
 exactly over the rank's owned cells.
@@ -36,15 +39,21 @@ def quasi_interpolate_bspline_distributed(
     """Quasi-interpolate a callable onto a distributed tensor-product B-spline space.
 
     The MPI-parallel counterpart of :func:`~pantr.bspline.quasi_interpolate_bspline`.
-    Each rank evaluates ``func`` only on the interior points required by its *owned*
-    basis functions (Lee-Lyche-Mørken functionals); a single ``allgather`` at the end
-    assembles the global coefficient field.  The returned
-    :class:`~pantr.mpi.DistributedFunction` agrees with the serial quasi-interpolant
-    pointwise over every owned cell.
+    Each rank runs the serial quasi-interpolant over its *windowed* local space and keeps
+    only the owned coefficients; a single ``allgather`` at the end assembles the global
+    coefficient field.  The returned :class:`~pantr.mpi.DistributedFunction` agrees with
+    the serial quasi-interpolant pointwise over every owned cell.
 
     Construction requires one MPI collective (``comm.allgather``) after the local
     computation.  Per-rank ``func`` evaluation is purely local: no rank ever evaluates
     ``func`` outside its windowed parametric sub-domain.
+
+    **The window is owned plus halo, not owned alone**, so the points the Lee-Lyche-Mørken
+    functionals of the halo DOFs need are evaluated on both sides of every partition
+    boundary.  The per-rank cost does fall as ranks are added, which is what separates
+    this from :func:`~pantr.mpi.l2_project_bspline_distributed`, but the aggregate rises:
+    the overhead is the halo's share of each window and it shrinks, relatively, as the
+    grid grows against the rank count.
 
     Args:
         func (Callable): Function to quasi-interpolate.  Called on a flat

--- a/tests/mpi/test_distributed_mpi.py
+++ b/tests/mpi/test_distributed_mpi.py
@@ -420,3 +420,86 @@ def test_fit_bspline_distributed_replicated_values_matches_serial() -> None:
     np.testing.assert_allclose(
         dfn.global_function.control_points, serial.control_points, atol=1e-10
     )
+
+
+# ---------------------------------------------------------------------------
+# Where each distributed entry point evaluates its callable
+# ---------------------------------------------------------------------------
+#
+# These pin a *performance* property that the docstrings state, which nothing else in
+# the suite checks. FELIGN/pantr#432 was filed because one of the two docstrings said
+# the opposite of what the code does, and prose is not something a test can catch --
+# what a test can catch is the property the prose describes, which is what these do.
+
+
+def test_the_l2_projection_evaluates_the_whole_lattice_on_every_rank() -> None:
+    """`l2_project_bspline_distributed` does not distribute the evaluation of ``func``.
+
+    Pins what the docstring now says, deliberately including the part that is a
+    limitation: every rank calls ``func`` on the whole global quadrature lattice and
+    masks afterwards, so the per-rank count is the serial count however many ranks
+    there are. The reason is the callable's contract -- ``func`` takes a
+    :class:`~pantr.quad.PointsLattice`, and a rank's owned quadrature points are not a
+    tensor product -- so restricting it means changing that signature.
+
+    If someone does change it, this test fails, which is the point: the docstring and
+    the behaviour move together or not at all.
+    """
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [6, 6])
+    seen: list[int] = []
+
+    def counted(lat: Any) -> np.ndarray:
+        mesh = _grid_mesh(lat)
+        seen.append(int(mesh[0].size))
+        return np.sin(np.pi * mesh[0]) * np.cos(np.pi * mesh[1])
+
+    ds = create_distributed_space(space, comm)
+    l2_project_bspline_distributed(counted, ds)
+
+    assert len(seen) == 1, f"func was called {len(seen)} times, expected once"
+    # Every rank saw the same, whole lattice: identical across ranks and equal to the
+    # serial count, which is what "not distributed" means here.
+    assert len(set(comm.allgather(seen[0]))) == 1
+
+
+def test_the_quasi_interpolant_does_distribute_its_evaluation() -> None:
+    """`quasi_interpolate_bspline_distributed` evaluates only its owned DOFs' points.
+
+    The counterpart of the test above, and the reason FELIGN/pantr#432's suggestion
+    that one fix would serve both is wrong: this one already restricts. Its callable
+    takes a flat point array rather than a lattice, so a non-tensor-product subset is
+    expressible.
+
+    Asserted as a strict decrease with the rank count rather than as an exact figure:
+    the owned DOFs' supports overlap, so each rank evaluates more than its share, by a
+    margin that depends on the grid and the partition. What is not allowed is for the
+    count to stay put, which is the shape of the defect next door.
+    """
+    comm = MPI.COMM_WORLD
+    if comm.size == 1:
+        pytest.skip("needs more than one rank to see the count fall")
+
+    space = create_uniform_space([2, 2], [24, 24])
+    seen: list[int] = []
+
+    def counted(pts: np.ndarray) -> np.ndarray:
+        arr = np.asarray(pts)
+        seen.append(int(arr.shape[0]))
+        return np.sin(np.pi * arr[:, 0]) * np.cos(np.pi * arr[:, 1])
+
+    # The reference is the serial quasi-interpolant's own count, taken here rather than
+    # written down: the points are the Lee-Lyche-Mørken functionals' and there is no
+    # simpler expression for how many of them there are.
+    quasi_interpolate_bspline(counted, space)
+    assert len(seen) == 1
+    serial_points = seen.pop()
+
+    ds = create_distributed_space(space, comm)
+    quasi_interpolate_bspline_distributed(counted, ds)
+
+    assert len(seen) == 1, f"func was called {len(seen)} times, expected once"
+    assert seen[0] < serial_points, (
+        f"{seen[0]} points per rank against {serial_points} serial: the distributed "
+        "quasi-interpolant is evaluating everything, like the L2 projection does"
+    )

--- a/tests/mpi/test_distributed_mpi.py
+++ b/tests/mpi/test_distributed_mpi.py
@@ -438,12 +438,16 @@ def test_the_l2_projection_evaluates_the_whole_lattice_on_every_rank() -> None:
     Pins what the docstring now says, deliberately including the part that is a
     limitation: every rank calls ``func`` on the whole global quadrature lattice and
     masks afterwards, so the per-rank count is the serial count however many ranks
-    there are. The reason is the callable's contract -- ``func`` takes a
-    :class:`~pantr.quad.PointsLattice`, and a rank's owned quadrature points are not a
-    tensor product -- so restricting it means changing that signature.
+    there are.
 
-    If someone does change it, this test fails, which is the point: the docstring and
-    the behaviour move together or not at all.
+    Compared against the serial count rather than only across ranks. Cross-rank
+    uniformity is not the property: the default partitioner splits a uniform grid into
+    equal boxes, so a *restricted* evaluation would also be uniform across ranks and an
+    equality-of-ranks assertion would keep passing through the very change it is meant
+    to notice.
+
+    If someone does restrict it, this fails, which is the point: the docstring and the
+    behaviour move together or not at all.
     """
     comm = MPI.COMM_WORLD
     space = create_uniform_space([2, 2], [6, 6])
@@ -454,27 +458,36 @@ def test_the_l2_projection_evaluates_the_whole_lattice_on_every_rank() -> None:
         seen.append(int(mesh[0].size))
         return np.sin(np.pi * mesh[0]) * np.cos(np.pi * mesh[1])
 
+    # The serial reference, taken by running the serial entry point on the same space.
+    l2_project_bspline(counted, space)
+    assert len(seen) == 1
+    serial_points = seen.pop()
+
     ds = create_distributed_space(space, comm)
     l2_project_bspline_distributed(counted, ds)
 
     assert len(seen) == 1, f"func was called {len(seen)} times, expected once"
-    # Every rank saw the same, whole lattice: identical across ranks and equal to the
-    # serial count, which is what "not distributed" means here.
+    assert seen[0] == serial_points, (
+        f"{seen[0]} points per rank against {serial_points} serial: the evaluation is no "
+        "longer the whole global lattice, so the docstring needs to change with it"
+    )
     assert len(set(comm.allgather(seen[0]))) == 1
 
 
 def test_the_quasi_interpolant_does_distribute_its_evaluation() -> None:
-    """`quasi_interpolate_bspline_distributed` evaluates only its owned DOFs' points.
+    """`quasi_interpolate_bspline_distributed` evaluates its windowed space, not everything.
 
-    The counterpart of the test above, and the reason FELIGN/pantr#432's suggestion
-    that one fix would serve both is wrong: this one already restricts. Its callable
-    takes a flat point array rather than a lattice, so a non-tensor-product subset is
-    expressible.
+    The counterpart of the test above. Its callable takes a flat point array rather than
+    a lattice, so it is not held to a tensor product and can evaluate a rank's own
+    window; the L2 projection is, and does not.
 
-    Asserted as a strict decrease with the rank count rather than as an exact figure:
-    the owned DOFs' supports overlap, so each rank evaluates more than its share, by a
-    margin that depends on the grid and the partition. What is not allowed is for the
-    count to stay put, which is the shape of the defect next door.
+    **Windowed, which is owned plus halo, not owned alone.** The evaluation is genuinely
+    distributed -- the per-rank count falls as ranks are added, which is the property
+    pinned here -- but the halo is evaluated on both sides of every partition boundary,
+    so the aggregate still exceeds the serial count. That is why this asserts a strict
+    decrease rather than a share: the margin depends on the grid and the partition. What
+    is not allowed is for the count to stay put, which is the shape of the defect next
+    door.
     """
     comm = MPI.COMM_WORLD
     if comm.size == 1:


### PR DESCRIPTION
## Context

Closes #432. `l2_project_bspline_distributed`'s docstrings promised that each rank evaluates
`func` *"only on the quadrature points of its owned cells"*. It evaluates the whole global
lattice on every rank and masks afterwards — which the inline comment at the call site already
said, a few lines below the docstring saying the opposite.

Correctness is unaffected: the values that survive the mask are the right ones. The cost is that
the per-rank count does not fall with the rank count, so total work grows linearly with it, and
anyone sizing an expensive callable from the docstring is sizing it on the reverse of the truth.
That reader is the one a distributed projection is written for.

**Measured here, at four rank counts and two grid sizes**, with real MPI:

| | 1 rank | 2 | 3 | 4 |
|---|---|---|---|---|
| `l2_project_bspline_distributed`, 6×6 | 324 | 324 each | 324 each | 324 each |
| same, 24×24 | 5184 | | | **5184 each** |
| `quasi_interpolate_bspline_distributed`, 6×6 | 576 | 504 each | | 441 each |
| same, 24×24 | 6084 | | | **2304 each** |

## Specification

The ticket allows either fixing the code or correcting the docs. This corrects the docs, and
says what stands in the way of the other resolution rather than asserting it is impossible —
because it is not, for the common case:

- `func` receives a `PointsLattice`, a tensor product of per-direction coordinates, so only an
  owned set that **is a box** can be named by one.
- **For the default partitioner it is.** `partition_grid`'s `block` backend, which
  `create_distributed_space` selects for a uniform full grid, gives every rank an exact
  axis-aligned box of cells — checked on three grids including a non-square and a non-divisible
  one, at three ranks: owned count equal to bounding-box count in all nine cases. A
  per-direction sub-range of the quadrature nodes would name its points exactly.
- What is genuinely unavailable is the general case: a graph or recursive-bisection partition
  need not be box-shaped, and naming a non-box owned set means handing `func` a flat point
  array, which is a different signature.

So the restriction is a **missed** one, not a forbidden one, and the docstring says so. That
distinction came from the review panel; the first version of this branch claimed impossibility.

## The sibling, which the ticket asked about and I initially got wrong

#432's *Related* section suspects `quasi_interpolate_bspline_distributed` of the same defect and
that one fix would serve both. The truth is in between, and this PR corrects **its** docstring
too:

- It **does** distribute its evaluation — the per-rank count falls, unlike the L2 projection's.
  Its callable takes a flat point array, so it is not held to a tensor product.
- But it restricts to its **windowed** space, owned **plus halo**, not to its owned DOFs. It runs
  the serial quasi-interpolant over the window and discards the halo coefficients afterwards.
  Its docstring claimed *"no redundant evaluation of halo-DOF points"*, which is false: the halo
  is evaluated on both sides of every partition boundary.
- What settles it: at four ranks on a 24×24 grid the windowed DOF count is **256 on every rank**
  while the owned counts are **196, 168, 168 and 144**. An evaluated-point count identical
  across ranks that own different numbers of DOFs cannot be owned-based.

## Acceptance

- Two MPI tests pin the difference. A docstring stating a performance property is the one kind
  of claim nothing else in the suite checks, and prose is not testable — the property it
  describes is.
  - The L2 one compares against the **serial** count, taken by running the serial entry point.
    An earlier version asserted only cross-rank uniformity, which the panel showed would pass
    straight through the very change it claims to catch: the default partitioner splits a
    uniform grid into equal boxes, so a restricted evaluation is uniform too.
  - The quasi-interpolant's asserts a strict decrease rather than a figure, the margin depending
    on the grid and the partition, and takes its serial reference the same way.
- `PANTR_RUN_MPI=1 mpiexec -n {2,3} python -m pytest tests/mpi/ -q` → **17 passed, 1 skipped** at
  both, which is what the MPI CI job runs.
- Full suite **10932 passed / 68 skipped / 6 xfailed** against a base of 10932/66/6: passes
  unchanged, and the two new MPI tests are collected and skipped without `PANTR_RUN_MPI`. **That
  moves the reference skip count from 66 to 68.**
- `ruff check` clean; `ruff format --check` 361 files; `mypy` Success on 336 source files;
  doctest 83/7; `lint-imports` 2 kept, 0 broken; docs `-W --keep-going` zero warnings. This
  branch's CI runs none of the first three, so all three were run by hand.

## Non-goals, and both are performance rather than correctness

- **Restricting the L2 evaluation for the box partitioner.** Available, as established above,
  and not done here: it is a performance change with its own scope, while this ticket asked for
  the docs and the code to stop contradicting each other.
- **The quasi-interpolant's halo redundancy.** Real — at four ranks on 24×24 the aggregate runs
  above the serial count — but far smaller than the L2 projection's, and now at least stated in
  its docstring rather than denied by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDsgxeS1roqbGuLYbyR2zH
